### PR TITLE
feat: add time check warning for joining cohort sessions

### DIFF
--- a/apps/meet/src/pages/api/public/meeting-participants.ts
+++ b/apps/meet/src/pages/api/public/meeting-participants.ts
@@ -16,6 +16,7 @@ export type MeetingParticipantsRequest = {
 export type MeetingParticipantsResponse = {
   type: 'success',
   cohortClassId: string,
+  cohortClassTime: number,
   participants: {
     id: string,
     name: string,
@@ -49,6 +50,7 @@ export default apiRoute(async (
     cohort.cohortSessions
       .map((cohortClassId) => db.get(cohortClassTable, cohortClassId)),
   );
+
   const cohortClassesWithDistance = cohortClasses.map((cohortClass) => ({
     cohortClass,
     distance: Math.abs((Date.now() / 1000) - cohortClass['Start date/time']!),
@@ -84,6 +86,7 @@ export default apiRoute(async (
   res.status(200).json({
     type: 'success',
     cohortClassId: cohortClass.id,
+    cohortClassTime: cohortClass['Start date/time'] ? cohortClass['Start date/time'] : Date.now() / 1000,
     participants: [
       { id: facilitator.id, name: facilitator.name, role: 'host' as const },
       ...participants.map((participant) => ({ id: participant.id, name: participant.name, role: 'participant' as const })),


### PR DESCRIPTION
## Overview
This PR implements a time check feature to warn users when they attempt to join a cohort session outside the expected time window. It aims to improve user experience by preventing accidental early or late joins while still allowing flexibility when needed.

## Changes
- Added `cohortClassTime` to the response body of API request `meeting-participants.ts`
- Implement `checkSessionTime` function to compare current time with `cohortClassTime`
- Add dismissible warning alert for out-of-time join attempts
- Update participant join buttons to use the include the `checkSessionTime` function check
