### PR TITLE
Add missing dev dependency for frontend-example

### DIFF
--- a/apps/frontend-example/package.json
+++ b/apps/frontend-example/package.json
@@ -40,6 +40,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.14.1",
     "postcss": "^8.4.38",
+    "shx": "^0.3.4",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.3.2",
     "vitest": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.14.1",
         "postcss": "^8.4.38",
+        "shx": "^0.3.4",
         "tailwindcss": "^3.4.3",
         "typescript": "^5.3.2",
         "vitest": "^1.5.0",
@@ -12206,6 +12207,7 @@
       "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
       "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.3",
         "shelljs": "^0.8.5"


### PR DESCRIPTION
Noticed this was missing during a work test. The error I received upon `npm install` was:
```
sh: shx: command not found
npm error Lifecycle script `postinstall` failed with error:
npm error code 127
npm error path /Users/nathansherburn/Repos/bluedot-contributions/apps/login-account-proxy
npm error workspace @bluedot/login-account-proxy@1.0.0
npm error location /Users/nathansherburn/Repos/bluedot-contributions/apps/login-account-proxy
npm error command failed
npm error command sh -c shx cp -n .env.local.template .env.local
```