### PR TITLE
Add test coverage for `about`- & `careers`-page

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -1,0 +1,368 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AboutPage > should render the error message correctly 1`] = `
+<div>
+  <div>
+    <div
+      class="hero-section bg-[radial-gradient(circle_at_center,#6687FF_0%,white_100%)] flex flex-row justify-center items-center w-full min-h-[570px]"
+    >
+      <div
+        class="hero-section__content max-w-[600px]"
+      >
+        <h1
+          class="hero-section__title text-bluedot-darker text-[48px] text-center mb-4 font-serif font-extrabold leading-none"
+        >
+          Our mission is to ensure humanity safely navigates the transition to transformative AI.
+        </h1>
+      </div>
+    </div>
+    <div
+      class="section mx-16 my-8 max-w-full overflow-hidden intro-section"
+    >
+      <div
+        class="section__heading ml-4"
+      >
+        <h2
+          class="section__title text-bluedot-normal text-[48px] mb-4 font-serif font-extrabold leading-none
+            relative after:content-[''] after:absolute after:top-1/2 after:ml-3 after:h-[2px] after:w-full after:bg-bluedot-normal"
+        >
+          Why do we exist?
+        </h2>
+      </div>
+      <div
+        class="intro-section__container flex flex-row gap-28 my-16"
+      >
+        <div
+          class="intro-section__text-container flex flex-col gap-5"
+        >
+          <p>
+            Humanity faces unprecedented challenges from transformative AI (TAI), which could profoundly reshape our future. Current AI systems already exhibit concerning behaviours, and as they become more powerful, misalignment between their actions, human intentions and societal values could lead to catastrophic outcomes.
+          </p>
+          <p>
+            BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field. Thus far, we’ve trained over 3,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK’s AI Safety Institute. We’ve built a strong foundation, including deep knowledge of how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, the urgency and magnitude of AI risks demand we do much more.
+          </p>
+        </div>
+        <img
+          alt="BlueDot Impact team"
+          class="intro-section__image w-[570px] rounded-2xl"
+          src="/images/team/team_1.jpg"
+        />
+      </div>
+    </div>
+    <div
+      class="section mx-16 my-8 max-w-full overflow-hidden history-section"
+    >
+      <div
+        class="section__heading ml-4"
+      >
+        <h2
+          class="section__title text-bluedot-normal text-[48px] mb-4 font-serif font-extrabold leading-none
+            relative after:content-[''] after:absolute after:top-1/2 after:ml-3 after:h-[2px] after:w-full after:bg-bluedot-normal"
+        >
+          Our History
+        </h2>
+      </div>
+      <div
+        class="history-section__container flex flex-col gap-8 my-14"
+      >
+        <div
+          class="history-section__event-container w-full flex flex-row gap-12 p-8 border-solid border rounded-2xl
+          border-gray-200"
+        >
+          <strong
+            class="history-section__year"
+          >
+            2021
+          </strong>
+          <p
+            class="history-section__event-title"
+          >
+            A non-profit supporting students at the University of Cambridge to pursue high-impact careers
+          </p>
+        </div>
+        <div
+          class="history-section__event-container w-full flex flex-row gap-12 p-8 border-solid border rounded-2xl
+          border-gray-200"
+        >
+          <strong
+            class="history-section__year"
+          >
+            2022
+          </strong>
+          <p
+            class="history-section__event-title"
+          >
+            Growing into a new start-up called “BlueDot Impact” and moved headquarters to London
+          </p>
+        </div>
+        <div
+          class="history-section__event-container w-full flex flex-row gap-12 p-8 border-solid border rounded-2xl
+          border-gray-200"
+        >
+          <strong
+            class="history-section__year"
+          >
+            2023
+          </strong>
+          <p
+            class="history-section__event-title"
+          >
+            BlueDot Impact is now running 1 training course every 4 months and trains over xxx people in AI Safety and Biosecurity
+          </p>
+        </div>
+        <div
+          class="history-section__event-container w-full flex flex-row gap-12 p-8 border-solid border rounded-2xl
+          border-gray-200"
+        >
+          <strong
+            class="history-section__year"
+          >
+            2024
+          </strong>
+          <p
+            class="history-section__event-title"
+          >
+            BlueDot Impact is now running courses every 6 weeks and trains over 2500 professionals in AI Safety and Biosecurity
+          </p>
+        </div>
+        <div
+          class="history-section__event-container w-full flex flex-row gap-12 p-8 border-solid border rounded-2xl
+          bg-bluedot-lighter border-bluedot-light"
+        >
+          <strong
+            class="history-section__year"
+          >
+            2025
+          </strong>
+          <p
+            class="history-section__event-title"
+          >
+            BlueDot is now running multiple courses in parallel every week! We are scaling the team to accelerate our impact!
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="section mx-16 my-8 max-w-full overflow-hidden team-section"
+    >
+      <div
+        class="section__heading ml-4"
+      >
+        <h2
+          class="section__title text-bluedot-normal text-[48px] mb-4 font-serif font-extrabold leading-none
+            relative after:content-[''] after:absolute after:top-1/2 after:ml-3 after:h-[2px] after:w-full after:bg-bluedot-normal"
+        >
+          Our team
+        </h2>
+      </div>
+      <div
+        class="team-section__container flex flex-row flex-wrap mt-16 gap-4"
+      >
+        <div
+          class="team-member pb-6 w-[323px]"
+        >
+          <img
+            alt="Course Card Placeholder"
+            class="team-member__image w-full h-[223px] object-cover rounded-xl mb-3"
+            src="/images/team/adam.jpg"
+          />
+          <h2
+            class="team-member__name"
+          >
+            Adam Jones
+          </h2>
+          <p
+            class="team-member__title mb-4"
+          >
+            AI Safety
+          </p>
+          <div
+            class="team-member__links flex justify-between items-center"
+          >
+            <a
+              class="team-member__link text-center text-xs text-bluedot-normal border border-bluedot-normal rounded-lg px-4 py-2 font-semibold"
+              href="https://www.linkedin.com/in/domdomegg/"
+            >
+              LinkedIn
+            </a>
+          </div>
+        </div>
+        <div
+          class="team-member pb-6 w-[323px]"
+        >
+          <img
+            alt="Course Card Placeholder"
+            class="team-member__image w-full h-[223px] object-cover rounded-xl mb-3"
+            src="/images/team/dewi.jpg"
+          />
+          <h2
+            class="team-member__name"
+          >
+            Dewi Erwan
+          </h2>
+          <p
+            class="team-member__title mb-4"
+          >
+            CEO
+          </p>
+          <div
+            class="team-member__links flex justify-between items-center"
+          >
+            <a
+              class="team-member__link text-center text-xs text-bluedot-normal border border-bluedot-normal rounded-lg px-4 py-2 font-semibold"
+              href="https://www.linkedin.com/in/dewierwan/"
+            >
+              LinkedIn
+            </a>
+          </div>
+        </div>
+        <div
+          class="team-member pb-6 w-[323px]"
+        >
+          <img
+            alt="Course Card Placeholder"
+            class="team-member__image w-full h-[223px] object-cover rounded-xl mb-3"
+            src="/images/team/josh.jpg"
+          />
+          <h2
+            class="team-member__name"
+          >
+            Josh Landes
+          </h2>
+          <p
+            class="team-member__title mb-4"
+          >
+            Community Manager
+          </p>
+          <div
+            class="team-member__links flex justify-between items-center"
+          >
+            <a
+              class="team-member__link text-center text-xs text-bluedot-normal border border-bluedot-normal rounded-lg px-4 py-2 font-semibold"
+              href="https://www.linkedin.com/in/josh-landes12/"
+            >
+              LinkedIn
+            </a>
+          </div>
+        </div>
+        <div
+          class="team-member pb-6 w-[323px]"
+        >
+          <img
+            alt="Course Card Placeholder"
+            class="team-member__image w-full h-[223px] object-cover rounded-xl mb-3"
+            src="/images/team/lilian.jpg"
+          />
+          <h2
+            class="team-member__name"
+          >
+            Li-Lian Ang
+          </h2>
+          <p
+            class="team-member__title mb-4"
+          >
+            Product
+          </p>
+          <div
+            class="team-member__links flex justify-between items-center"
+          >
+            <a
+              class="team-member__link text-center text-xs text-bluedot-normal border border-bluedot-normal rounded-lg px-4 py-2 font-semibold"
+              href="https://www.linkedin.com/in/anglilian/"
+            >
+              LinkedIn
+            </a>
+          </div>
+        </div>
+        <div
+          class="team-member pb-6 w-[323px]"
+        >
+          <img
+            alt="Course Card Placeholder"
+            class="team-member__image w-full h-[223px] object-cover rounded-xl mb-3"
+            src="/images/team/tarin.jpg"
+          />
+          <h2
+            class="team-member__name"
+          >
+            Tarin Rickett
+          </h2>
+          <p
+            class="team-member__title mb-4"
+          >
+            Engineering
+          </p>
+          <div
+            class="team-member__links flex justify-between items-center"
+          >
+            <a
+              class="team-member__link text-center text-xs text-bluedot-normal border border-bluedot-normal rounded-lg px-4 py-2 font-semibold"
+              href="https://www.linkedin.com/in/tarin-rickett/"
+            >
+              LinkedIn
+            </a>
+          </div>
+        </div>
+        <div
+          class="team-member pb-6 w-[323px]"
+        >
+          <img
+            alt="Course Card Placeholder"
+            class="team-member__image w-full h-[223px] object-cover rounded-xl mb-3"
+            src="/images/team/vio.jpg"
+          />
+          <h2
+            class="team-member__name"
+          >
+            Viorica  Gheroghita
+          </h2>
+          <p
+            class="team-member__title mb-4"
+          >
+            Product
+          </p>
+          <div
+            class="team-member__links flex justify-between items-center"
+          >
+            <a
+              class="team-member__link text-center text-xs text-bluedot-normal border border-bluedot-normal rounded-lg px-4 py-2 font-semibold"
+              href="https://www.linkedin.com/in/vioricagheorghita/"
+            >
+              LinkedIn
+            </a>
+          </div>
+        </div>
+        <div
+          class="team-member pb-6 w-[323px]"
+        >
+          <img
+            alt="Course Card Placeholder"
+            class="team-member__image w-full h-[223px] object-cover rounded-xl mb-3"
+            src="/images/team/will.jpg"
+          />
+          <h2
+            class="team-member__name"
+          >
+            Will Saunter
+          </h2>
+          <p
+            class="team-member__title mb-4"
+          >
+            Co-founder
+          </p>
+          <div
+            class="team-member__links flex justify-between items-center"
+          >
+            <a
+              class="team-member__link text-center text-xs text-bluedot-normal border border-bluedot-normal rounded-lg px-4 py-2 font-semibold"
+              href="https://www.linkedin.com/in/will-saunter/"
+            >
+              LinkedIn
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -1,0 +1,232 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CareersPage > should render the error message correctly 1`] = `
+<div>
+  <div>
+    <div
+      class="hero-section bg-[radial-gradient(circle_at_center,#6687FF_0%,white_100%)] flex flex-row justify-center items-center w-full min-h-[570px]"
+    >
+      <div
+        class="hero-section__content max-w-[600px]"
+      >
+        <h1
+          class="hero-section__title text-bluedot-darker text-[48px] text-center mb-4 font-serif font-extrabold leading-none"
+        >
+          Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
+        </h1>
+      </div>
+    </div>
+    <div
+      class="section mx-16 my-8 max-w-full overflow-hidden intro-section"
+    >
+      <div
+        class="section__heading ml-4"
+      >
+        <h2
+          class="section__title text-bluedot-normal text-[48px] mb-4 font-serif font-extrabold leading-none
+            relative after:content-[''] after:absolute after:top-1/2 after:ml-3 after:h-[2px] after:w-full after:bg-bluedot-normal"
+        >
+          Our culture
+        </h2>
+      </div>
+      <div
+        class="intro-section__container flex flex-row gap-28 my-16"
+      >
+        <div
+          class="intro-section__text-container flex flex-col gap-5"
+        >
+          <p>
+            Humanity faces unprecedented challenges from transformative AI (TAI), which could profoundly reshape our future. Current AI systems already exhibit concerning behaviours, and as they become more powerful, misalignment between their actions, human intentions and societal values could lead to catastrophic outcomes.
+          </p>
+          <p>
+            BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field. Thus far, we’ve trained over 3,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK’s AI Safety Institute. We’ve built a strong foundation, including deep knowledge of how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, the urgency and magnitude of AI risks demand we do much more.
+          </p>
+        </div>
+        <img
+          alt="BlueDot Impact team"
+          class="intro-section__image w-[570px] rounded-2xl"
+          src="/images/team/team_1.jpg"
+        />
+      </div>
+    </div>
+    <div
+      class="section mx-16 my-8 max-w-full overflow-hidden careers-section"
+    >
+      <div
+        class="section__heading ml-4"
+      >
+        <h2
+          class="section__title text-bluedot-normal text-[48px] mb-4 font-serif font-extrabold leading-none
+            relative after:content-[''] after:absolute after:top-1/2 after:ml-3 after:h-[2px] after:w-full after:bg-bluedot-normal"
+        >
+          Careers at BlueDot Impact
+        </h2>
+      </div>
+      <div
+        class="careers-section__container flex flex-col gap-8 my-14"
+      >
+        <div
+          class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
+          border-gray-200"
+        >
+          <strong
+            class="careers-section__title basis-[33%]"
+          >
+            AI Alignment Project Judge
+          </strong>
+          <p
+            class="careers-section__location"
+          >
+            London, Remote
+          </p>
+          <p
+            class="careers-section__type"
+          >
+            Permanent
+          </p>
+          <button
+            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter px-4 py-2 careers-section__cta-button"
+            data-testid="cta-button"
+            type="button"
+          >
+            <span
+              class="cta-button__text"
+            >
+              Apply now
+            </span>
+            <span
+              class="cta-button__chevron ml-3"
+            >
+              <img
+                alt="→"
+                class="cta-button__chevron-icon w-2 h-2"
+                src="/icons/chevron_blue.svg"
+              />
+            </span>
+          </button>
+        </div>
+        <div
+          class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
+          border-gray-200"
+        >
+          <strong
+            class="careers-section__title basis-[33%]"
+          >
+            Course Operations Specialist
+          </strong>
+          <p
+            class="careers-section__location"
+          >
+            London, Remote
+          </p>
+          <p
+            class="careers-section__type"
+          >
+            Permanent
+          </p>
+          <button
+            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter px-4 py-2 careers-section__cta-button"
+            data-testid="cta-button"
+            type="button"
+          >
+            <span
+              class="cta-button__text"
+            >
+              Apply now
+            </span>
+            <span
+              class="cta-button__chevron ml-3"
+            >
+              <img
+                alt="→"
+                class="cta-button__chevron-icon w-2 h-2"
+                src="/icons/chevron_blue.svg"
+              />
+            </span>
+          </button>
+        </div>
+        <div
+          class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
+          border-gray-200"
+        >
+          <strong
+            class="careers-section__title basis-[33%]"
+          >
+            Software Engineering Contractor
+          </strong>
+          <p
+            class="careers-section__location"
+          >
+            London, Remote
+          </p>
+          <p
+            class="careers-section__type"
+          >
+            Permanent
+          </p>
+          <button
+            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter px-4 py-2 careers-section__cta-button"
+            data-testid="cta-button"
+            type="button"
+          >
+            <span
+              class="cta-button__text"
+            >
+              Apply now
+            </span>
+            <span
+              class="cta-button__chevron ml-3"
+            >
+              <img
+                alt="→"
+                class="cta-button__chevron-icon w-2 h-2"
+                src="/icons/chevron_blue.svg"
+              />
+            </span>
+          </button>
+        </div>
+        <div
+          class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
+          border-gray-200"
+        >
+          <strong
+            class="careers-section__title basis-[33%]"
+          >
+            Economics of Transformative AI Teaching Fellow
+          </strong>
+          <p
+            class="careers-section__location"
+          >
+            London, Remote
+          </p>
+          <p
+            class="careers-section__type"
+          >
+            Permanent
+          </p>
+          <button
+            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter px-4 py-2 careers-section__cta-button"
+            data-testid="cta-button"
+            type="button"
+          >
+            <span
+              class="cta-button__text"
+            >
+              Apply now
+            </span>
+            <span
+              class="cta-button__chevron ml-3"
+            >
+              <img
+                alt="→"
+                class="cta-button__chevron-icon w-2 h-2"
+                src="/icons/chevron_blue.svg"
+              />
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/website-25/src/__tests__/pages/about.test.tsx
+++ b/apps/website-25/src/__tests__/pages/about.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import AboutPage from '../../pages/about';
+
+describe('AboutPage', () => {
+  test('should render the error message correctly', () => {
+    const { container } = render(<AboutPage />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/apps/website-25/src/__tests__/pages/careers.test.tsx
+++ b/apps/website-25/src/__tests__/pages/careers.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import CareersPage from '../../pages/careers';
+
+describe('CareersPage', () => {
+  test('should render the error message correctly', () => {
+    const { container } = render(<CareersPage />);
+    expect(container).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
# Summary

Working version of #57 😇☺️.

# Issue 

See #60.

## Description

### What
Placed the two `pages` tests into a `__tests__` directory.

### Why
Looking at the [`with-vitest`-example](https://github.com/vercel/next.js/tree/canary/examples/with-vitest) referenced by NextJS docs this seems to be the way to go.

### Other options

For colocating tests next to their source files (even for `pages`) we could migrate to the [`app`-router](https://nextjs.org/docs/app), see #60 for more information.

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    0 cached, 7 total
  Time:    3.51s 
```
