### PR TITLE
Feat Create Callout Component for Careers page

### DIFF
--- a/apps/website-25/next-env.d.ts
+++ b/apps/website-25/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/apps/website-25/src/components/careers/CareerCallout.test.tsx
+++ b/apps/website-25/src/components/careers/CareerCallout.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import Callout from './CareersCallout';
+
+describe('Callout', () => {
+  test('renders default as expected', () => {
+    const { container } = render(<Callout />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/apps/website-25/src/components/careers/CareersCallout.tsx
+++ b/apps/website-25/src/components/careers/CareersCallout.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { CTAButton } from '@bluedot/ui';
+
+const Callout: React.FC = () => {
+  const title = 'Join us in our mission to ensure humanity safely navigates the transition to transformative AI.';
+  const ctaLabel = 'View our careers';
+  const ctaLink = '/careers';
+
+  return (
+    <div className="bg-[radial-gradient(circle_at_center,#6687FF_0%,white_100%)] rounded-lg p-8 flex flex-col items-center">
+      <h2 className="text-black font-bold text-2xl mb-4 text-center">{title}</h2>
+      <CTAButton variant="primary" onClick={() => window.open(ctaLink, '_blank')} withChevron>
+        {ctaLabel}
+      </CTAButton>
+    </div>
+  );
+};
+
+export default Callout;

--- a/apps/website-25/src/components/careers/CareersCallout.tsx
+++ b/apps/website-25/src/components/careers/CareersCallout.tsx
@@ -8,7 +8,7 @@ const Callout: React.FC = () => {
 
   return (
     <div className="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center">
-      <h2 className="callout__title text-black font-bold text-2xl mb-4 text-center">{title}</h2>
+      <h2 className="callout__title mb-4 text-center">{title}</h2>
       <CTAButton
         variant="primary"
         url={ctaLink}

--- a/apps/website-25/src/components/careers/CareersCallout.tsx
+++ b/apps/website-25/src/components/careers/CareersCallout.tsx
@@ -7,7 +7,7 @@ const Callout: React.FC = () => {
   const ctaLink = '/careers';
 
   return (
-    <div className="bg-[radial-gradient(circle_at_center,#6687FF_0%,white_100%)] rounded-lg p-8 flex flex-col items-center">
+    <div className="bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center">
       <h2 className="text-black font-bold text-2xl mb-4 text-center">{title}</h2>
       <CTAButton variant="primary" onClick={() => window.open(ctaLink, '_blank')} withChevron>
         {ctaLabel}

--- a/apps/website-25/src/components/careers/CareersCallout.tsx
+++ b/apps/website-25/src/components/careers/CareersCallout.tsx
@@ -4,14 +4,12 @@ import { CTAButton } from '@bluedot/ui';
 const Callout: React.FC = () => {
   const title = 'Join us in our mission to ensure humanity safely navigates the transition to transformative AI.';
   const ctaLabel = 'View our careers';
-  const ctaLink = '/careers';
 
   return (
     <div className="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg py-16 px-8 m-8 flex flex-col items-center">
       <h2 className="callout__title mb-4 text-center">{title}</h2>
       <CTAButton
         variant="primary"
-        url={ctaLink}
         withChevron
         className="callout__cta"
       >

--- a/apps/website-25/src/components/careers/CareersCallout.tsx
+++ b/apps/website-25/src/components/careers/CareersCallout.tsx
@@ -7,7 +7,7 @@ const Callout: React.FC = () => {
   const ctaLink = '/careers';
 
   return (
-    <div className="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center">
+    <div className="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg py-16 px-8 m-8 flex flex-col items-center">
       <h2 className="callout__title mb-4 text-center">{title}</h2>
       <CTAButton
         variant="primary"

--- a/apps/website-25/src/components/careers/CareersCallout.tsx
+++ b/apps/website-25/src/components/careers/CareersCallout.tsx
@@ -1,20 +1,25 @@
 import React from 'react';
-import { CTAButton } from '@bluedot/ui';
 
 const Callout: React.FC = () => {
   const title = 'Join us in our mission to ensure humanity safely navigates the transition to transformative AI.';
   const ctaLabel = 'View our careers';
+  const ctaLink = '/careers';
 
   return (
     <div className="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg py-16 px-8 m-8 flex flex-col items-center">
       <h2 className="callout__title mb-4 text-center">{title}</h2>
-      <CTAButton
-        variant="primary"
-        withChevron
-        className="callout__cta"
+      <button
+        type="button"
+        className="callout__cta bg-bluedot-normal text-white rounded-lg px-4 py-2 font-semibold text-base hover:bg-bluedot-darker flex items-center"
+        onClick={() => window.open(ctaLink, '_blank')}
       >
-        {ctaLabel}
-      </CTAButton>
+        <span>{ctaLabel}</span>
+        <img
+          src="/icons/chevron_white.svg"
+          alt="→"
+          className="ml-3 w-2 h-2"
+        />
+      </button>
     </div>
   );
 };

--- a/apps/website-25/src/components/careers/CareersCallout.tsx
+++ b/apps/website-25/src/components/careers/CareersCallout.tsx
@@ -7,9 +7,14 @@ const Callout: React.FC = () => {
   const ctaLink = '/careers';
 
   return (
-    <div className="bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center">
-      <h2 className="text-black font-bold text-2xl mb-4 text-center">{title}</h2>
-      <CTAButton variant="primary" onClick={() => window.open(ctaLink, '_blank')} withChevron>
+    <div className="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center">
+      <h2 className="callout__title text-black font-bold text-2xl mb-4 text-center">{title}</h2>
+      <CTAButton
+        variant="primary"
+        onClick={() => window.open(ctaLink, '_blank')}
+        withChevron
+        className="callout__cta"
+      >
         {ctaLabel}
       </CTAButton>
     </div>

--- a/apps/website-25/src/components/careers/CareersCallout.tsx
+++ b/apps/website-25/src/components/careers/CareersCallout.tsx
@@ -11,7 +11,7 @@ const Callout: React.FC = () => {
       <h2 className="callout__title text-black font-bold text-2xl mb-4 text-center">{title}</h2>
       <CTAButton
         variant="primary"
-        onClick={() => window.open(ctaLink, '_blank')}
+        url={ctaLink}
         withChevron
         className="callout__cta"
       >

--- a/apps/website-25/src/components/careers/__snapshots__/CareerCallout.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareerCallout.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`Callout > renders default as expected 1`] = `
       class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--primary bg-bluedot-normal text-white hover:bg-bluedot-normal px-4 py-2 callout__cta"
       data-testid="cta-button"
       type="button"
-      url="/careers"
     >
       <span
         class="cta-button__text"

--- a/apps/website-25/src/components/careers/__snapshots__/CareerCallout.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareerCallout.test.tsx.snap
@@ -1,0 +1,35 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Callout > renders default as expected 1`] = `
+<div>
+  <div
+    class="bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center"
+  >
+    <h2
+      class="text-black font-bold text-2xl mb-4 text-center"
+    >
+      Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
+    </h2>
+    <button
+      class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--primary bg-bluedot-normal text-white hover:bg-bluedot-normal px-4 py-2"
+      data-testid="cta-button"
+      type="button"
+    >
+      <span
+        class="cta-button__text"
+      >
+        View our careers
+      </span>
+      <span
+        class="cta-button__chevron ml-3"
+      >
+        <img
+          alt="→"
+          class="cta-button__chevron-icon w-2 h-2"
+          src="/icons/chevron_white.svg"
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/apps/website-25/src/components/careers/__snapshots__/CareerCallout.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareerCallout.test.tsx.snap
@@ -3,15 +3,15 @@
 exports[`Callout > renders default as expected 1`] = `
 <div>
   <div
-    class="bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center"
+    class="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center"
   >
     <h2
-      class="text-black font-bold text-2xl mb-4 text-center"
+      class="callout__title text-black font-bold text-2xl mb-4 text-center"
     >
       Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
     </h2>
     <button
-      class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--primary bg-bluedot-normal text-white hover:bg-bluedot-normal px-4 py-2"
+      class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--primary bg-bluedot-normal text-white hover:bg-bluedot-normal px-4 py-2 callout__cta"
       data-testid="cta-button"
       type="button"
     >

--- a/apps/website-25/src/components/careers/__snapshots__/CareerCallout.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareerCallout.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Callout > renders default as expected 1`] = `
 <div>
   <div
-    class="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg p-8 m-8 flex flex-col items-center"
+    class="callout bg-[radial-gradient(ellipse_at_30%,_#fff_0%,_#6687ff_100%)] rounded-lg py-16 px-8 m-8 flex flex-col items-center"
   >
     <h2
-      class="callout__title text-black font-bold text-2xl mb-4 text-center"
+      class="callout__title mb-4 text-center"
     >
       Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
     </h2>
@@ -14,6 +14,7 @@ exports[`Callout > renders default as expected 1`] = `
       class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base cta-button--primary bg-bluedot-normal text-white hover:bg-bluedot-normal px-4 py-2 callout__cta"
       data-testid="cta-button"
       type="button"
+      url="/careers"
     >
       <span
         class="cta-button__text"

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -4,6 +4,7 @@ import {
 import IntroSection from '../components/about/IntroSection';
 import HistorySection from '../components/about/HistorySection';
 import TeamSection from '../components/about/TeamSection';
+import CareersCallout from '../components/careers/CareersCallout';
 
 const AboutPage = () => {
   return (
@@ -14,6 +15,7 @@ const AboutPage = () => {
       <IntroSection title="Why do we exist?" />
       <HistorySection />
       <TeamSection />
+      <CareersCallout />
     </div>
   );
 };

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -4,7 +4,6 @@ import {
 import IntroSection from '../components/about/IntroSection';
 import HistorySection from '../components/about/HistorySection';
 import TeamSection from '../components/about/TeamSection';
-import CareersCallout from '../components/careers/CareersCallout';
 
 const AboutPage = () => {
   return (
@@ -15,7 +14,6 @@ const AboutPage = () => {
       <IntroSection title="Why do we exist?" />
       <HistorySection />
       <TeamSection />
-      <CareersCallout />
     </div>
   );
 };


### PR DESCRIPTION
# Summary

Create `CareersCallout` component and update About page to use it.

## Issue
Fixes #86

## Description

This PR introduces the CareersCallout component that is then used in the about page

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/)
- [x] Added new unit tests where applicable

## Screenshot

| 📸 |  |
|---------|---|
| 🖥️ | <img width="1703" alt="Screenshot 2025-01-24 at 8 54 50 AM" src="https://github.com/user-attachments/assets/60ad800e-a56a-4433-997d-672c9767394f" /> |

## Testing
```
$ npm run test:update
@bluedot/website-25:test:  Test Files  9 passed (9)
@bluedot/website-25:test:       Tests  10 passed (10)
@bluedot/website-25:test:    Start at  09:01:58
@bluedot/website-25:test:    Duration  1.36s (transform 214ms, setup 0ms, collect 3.79s, tests 129ms, environment 1.51s, prepare 597ms)
@bluedot/website-25:test:


 Tasks:    7 successful, 7 total
Cached:    6 cached, 7 total
  Time:    1.791s
```
