### PR TITLE
Add isExternalUrl options to CTALink

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -176,10 +176,10 @@ exports[`AboutPage > should render the error message correctly 1`] = `
         class="section__body"
       >
         <div
-          class="team__grid flex flex-row flex-wrap mt-16 gap-4 max-w-[1400px] mx-auto"
+          class="team__grid flex flex-row flex-wrap mt-16 max-w-[1400px] mx-auto"
         >
           <div
-            class="card flex flex-col items-start team__card"
+            class="card flex flex-col items-start team__card ml-4 mb-12"
           >
             <div
               class="card__image-container w-[323px] h-[223px] mb-3"
@@ -191,7 +191,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               />
             </div>
             <div
-              class="card__content flex flex-col gap-12"
+              class="card__content flex flex-col gap-8 w-full"
             >
               <div
                 class="card__text"
@@ -208,9 +208,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 </p>
               </div>
               <a
-                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
                 data-testid="cta-link"
                 href="https://www.linkedin.com/in/domdomegg/"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 <span
                   class="cta-button__text"
@@ -221,7 +223,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start team__card"
+            class="card flex flex-col items-start team__card ml-4 mb-12"
           >
             <div
               class="card__image-container w-[323px] h-[223px] mb-3"
@@ -233,7 +235,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               />
             </div>
             <div
-              class="card__content flex flex-col gap-12"
+              class="card__content flex flex-col gap-8 w-full"
             >
               <div
                 class="card__text"
@@ -250,9 +252,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 </p>
               </div>
               <a
-                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
                 data-testid="cta-link"
                 href="https://www.linkedin.com/in/dewierwan/"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 <span
                   class="cta-button__text"
@@ -263,7 +267,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start team__card"
+            class="card flex flex-col items-start team__card ml-4 mb-12"
           >
             <div
               class="card__image-container w-[323px] h-[223px] mb-3"
@@ -275,7 +279,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               />
             </div>
             <div
-              class="card__content flex flex-col gap-12"
+              class="card__content flex flex-col gap-8 w-full"
             >
               <div
                 class="card__text"
@@ -292,9 +296,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 </p>
               </div>
               <a
-                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
                 data-testid="cta-link"
                 href="https://linkedin.com/in/josh-landes12"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 <span
                   class="cta-button__text"
@@ -305,7 +311,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start team__card"
+            class="card flex flex-col items-start team__card ml-4 mb-12"
           >
             <div
               class="card__image-container w-[323px] h-[223px] mb-3"
@@ -317,7 +323,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               />
             </div>
             <div
-              class="card__content flex flex-col gap-12"
+              class="card__content flex flex-col gap-8 w-full"
             >
               <div
                 class="card__text"
@@ -334,9 +340,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 </p>
               </div>
               <a
-                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
                 data-testid="cta-link"
                 href="https://linkedin.com/in/anglilian"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 <span
                   class="cta-button__text"
@@ -347,7 +355,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start team__card"
+            class="card flex flex-col items-start team__card ml-4 mb-12"
           >
             <div
               class="card__image-container w-[323px] h-[223px] mb-3"
@@ -359,7 +367,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               />
             </div>
             <div
-              class="card__content flex flex-col gap-12"
+              class="card__content flex flex-col gap-8 w-full"
             >
               <div
                 class="card__text"
@@ -376,9 +384,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 </p>
               </div>
               <a
-                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
                 data-testid="cta-link"
                 href="https://linkedin.com/in/tarinrickett/"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 <span
                   class="cta-button__text"
@@ -389,7 +399,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start team__card"
+            class="card flex flex-col items-start team__card ml-4 mb-12"
           >
             <div
               class="card__image-container w-[323px] h-[223px] mb-3"
@@ -401,7 +411,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               />
             </div>
             <div
-              class="card__content flex flex-col gap-12"
+              class="card__content flex flex-col gap-8 w-full"
             >
               <div
                 class="card__text"
@@ -418,9 +428,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 </p>
               </div>
               <a
-                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
                 data-testid="cta-link"
                 href="https://www.linkedin.com/in/vioricagheorghita/"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 <span
                   class="cta-button__text"
@@ -431,7 +443,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start team__card"
+            class="card flex flex-col items-start team__card ml-4 mb-12"
           >
             <div
               class="card__image-container w-[323px] h-[223px] mb-3"
@@ -443,7 +455,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               />
             </div>
             <div
-              class="card__content flex flex-col gap-12"
+              class="card__content flex flex-col gap-8 w-full"
             >
               <div
                 class="card__text"
@@ -460,9 +472,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 </p>
               </div>
               <a
-                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+                class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
                 data-testid="cta-link"
                 href="https://linkedin.com/in/will-saunter"
+                rel="noopener noreferrer"
+                target="_blank"
               >
                 <span
                   class="cta-button__text"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -97,10 +97,12 @@ exports[`CareersPage > should render the error message correctly 1`] = `
             >
               Permanent
             </p>
-            <button
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-              data-testid="cta-button"
-              type="button"
+            <a
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+              data-testid="cta-link"
+              href="https://bluedot.org/ai-alignment-project-judge/"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -116,7 +118,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
                   src="/icons/chevron_blue.svg"
                 />
               </span>
-            </button>
+            </a>
           </div>
           <div
             class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
@@ -137,10 +139,12 @@ exports[`CareersPage > should render the error message correctly 1`] = `
             >
               Permanent
             </p>
-            <button
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-              data-testid="cta-button"
-              type="button"
+            <a
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+              data-testid="cta-link"
+              href="https://bluedot.org/ai-safety-course-operations/"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -156,7 +160,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
                   src="/icons/chevron_blue.svg"
                 />
               </span>
-            </button>
+            </a>
           </div>
           <div
             class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
@@ -177,10 +181,12 @@ exports[`CareersPage > should render the error message correctly 1`] = `
             >
               Permanent
             </p>
-            <button
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-              data-testid="cta-button"
-              type="button"
+            <a
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+              data-testid="cta-link"
+              href="https://bluedot.org/swe-contractor/"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -196,7 +202,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
                   src="/icons/chevron_blue.svg"
                 />
               </span>
-            </button>
+            </a>
           </div>
           <div
             class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
@@ -217,10 +223,12 @@ exports[`CareersPage > should render the error message correctly 1`] = `
             >
               Permanent
             </p>
-            <button
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-              data-testid="cta-button"
-              type="button"
+            <a
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+              data-testid="cta-link"
+              href="https://bluedot.org/economics-of-tai-teaching-fellow/"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -236,7 +244,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
                   src="/icons/chevron_blue.svg"
                 />
               </span>
-            </button>
+            </a>
           </div>
         </div>
       </div>

--- a/apps/website-25/src/components/about/TeamSection.tsx
+++ b/apps/website-25/src/components/about/TeamSection.tsx
@@ -48,7 +48,7 @@ const teamMembers = [
 const TeamSection = () => {
   return (
     <Section className="team" title="Our team">
-      <div className="team__grid flex flex-row flex-wrap mt-16 gap-4 max-w-[1400px] mx-auto">
+      <div className="team__grid flex flex-row flex-wrap mt-16 max-w-[1400px] mx-auto">
         {/* TODO: 01/27 Migrate this max-w-[1400px] check to Section definition or global.css when we hear back from UX  */}
         {teamMembers.map((member) => (
           <Card
@@ -57,7 +57,8 @@ const TeamSection = () => {
             title={member.name}
             subtitle={member.role}
             ctaUrl={member.linkedInUrl}
-            className="team__card"
+            isExternalUrl
+            className="team__card ml-4 mb-12"
             imageClassName="team__card-image"
           />
         ))}

--- a/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -22,10 +22,10 @@ exports[`TeamSection > renders default as expected 1`] = `
       class="section__body"
     >
       <div
-        class="team__grid flex flex-row flex-wrap mt-16 gap-4 max-w-[1400px] mx-auto"
+        class="team__grid flex flex-row flex-wrap mt-16 max-w-[1400px] mx-auto"
       >
         <div
-          class="card flex flex-col items-start team__card"
+          class="card flex flex-col items-start team__card ml-4 mb-12"
         >
           <div
             class="card__image-container w-[323px] h-[223px] mb-3"
@@ -37,7 +37,7 @@ exports[`TeamSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="card__content flex flex-col gap-12"
+            class="card__content flex flex-col gap-8 w-full"
           >
             <div
               class="card__text"
@@ -54,9 +54,11 @@ exports[`TeamSection > renders default as expected 1`] = `
               </p>
             </div>
             <a
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
               data-testid="cta-link"
               href="https://www.linkedin.com/in/domdomegg/"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -67,7 +69,7 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start team__card"
+          class="card flex flex-col items-start team__card ml-4 mb-12"
         >
           <div
             class="card__image-container w-[323px] h-[223px] mb-3"
@@ -79,7 +81,7 @@ exports[`TeamSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="card__content flex flex-col gap-12"
+            class="card__content flex flex-col gap-8 w-full"
           >
             <div
               class="card__text"
@@ -96,9 +98,11 @@ exports[`TeamSection > renders default as expected 1`] = `
               </p>
             </div>
             <a
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
               data-testid="cta-link"
               href="https://www.linkedin.com/in/dewierwan/"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -109,7 +113,7 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start team__card"
+          class="card flex flex-col items-start team__card ml-4 mb-12"
         >
           <div
             class="card__image-container w-[323px] h-[223px] mb-3"
@@ -121,7 +125,7 @@ exports[`TeamSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="card__content flex flex-col gap-12"
+            class="card__content flex flex-col gap-8 w-full"
           >
             <div
               class="card__text"
@@ -138,9 +142,11 @@ exports[`TeamSection > renders default as expected 1`] = `
               </p>
             </div>
             <a
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
               data-testid="cta-link"
               href="https://linkedin.com/in/josh-landes12"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -151,7 +157,7 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start team__card"
+          class="card flex flex-col items-start team__card ml-4 mb-12"
         >
           <div
             class="card__image-container w-[323px] h-[223px] mb-3"
@@ -163,7 +169,7 @@ exports[`TeamSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="card__content flex flex-col gap-12"
+            class="card__content flex flex-col gap-8 w-full"
           >
             <div
               class="card__text"
@@ -180,9 +186,11 @@ exports[`TeamSection > renders default as expected 1`] = `
               </p>
             </div>
             <a
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
               data-testid="cta-link"
               href="https://linkedin.com/in/anglilian"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -193,7 +201,7 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start team__card"
+          class="card flex flex-col items-start team__card ml-4 mb-12"
         >
           <div
             class="card__image-container w-[323px] h-[223px] mb-3"
@@ -205,7 +213,7 @@ exports[`TeamSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="card__content flex flex-col gap-12"
+            class="card__content flex flex-col gap-8 w-full"
           >
             <div
               class="card__text"
@@ -222,9 +230,11 @@ exports[`TeamSection > renders default as expected 1`] = `
               </p>
             </div>
             <a
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
               data-testid="cta-link"
               href="https://linkedin.com/in/tarinrickett/"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -235,7 +245,7 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start team__card"
+          class="card flex flex-col items-start team__card ml-4 mb-12"
         >
           <div
             class="card__image-container w-[323px] h-[223px] mb-3"
@@ -247,7 +257,7 @@ exports[`TeamSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="card__content flex flex-col gap-12"
+            class="card__content flex flex-col gap-8 w-full"
           >
             <div
               class="card__text"
@@ -264,9 +274,11 @@ exports[`TeamSection > renders default as expected 1`] = `
               </p>
             </div>
             <a
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
               data-testid="cta-link"
               href="https://www.linkedin.com/in/vioricagheorghita/"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"
@@ -277,7 +289,7 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start team__card"
+          class="card flex flex-col items-start team__card ml-4 mb-12"
         >
           <div
             class="card__image-container w-[323px] h-[223px] mb-3"
@@ -289,7 +301,7 @@ exports[`TeamSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="card__content flex flex-col gap-12"
+            class="card__content flex flex-col gap-8 w-full"
           >
             <div
               class="card__text"
@@ -306,9 +318,11 @@ exports[`TeamSection > renders default as expected 1`] = `
               </p>
             </div>
             <a
-              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+              class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
               data-testid="cta-link"
               href="https://linkedin.com/in/will-saunter"
+              rel="noopener noreferrer"
+              target="_blank"
             >
               <span
                 class="cta-button__text"

--- a/apps/website-25/src/components/careers/CareersSection.tsx
+++ b/apps/website-25/src/components/careers/CareersSection.tsx
@@ -4,19 +4,19 @@ const CareersSection = () => {
   return (
     <Section className="careers-section" title="Careers at BlueDot Impact">
       <div className="careers-section__container flex flex-col gap-8 my-14">
-        <JobListing title="AI Alignment Project Judge" />
-        <JobListing title="Course Operations Specialist" />
-        <JobListing title="Software Engineering Contractor" />
-        <JobListing title="Economics of Transformative AI Teaching Fellow" />
+        <JobListing title="AI Alignment Project Judge" url="https://bluedot.org/ai-alignment-project-judge/" isExternalUrl />
+        <JobListing title="Course Operations Specialist" url="https://bluedot.org/ai-safety-course-operations/" isExternalUrl />
+        <JobListing title="Software Engineering Contractor" url="https://bluedot.org/swe-contractor/" isExternalUrl />
+        <JobListing title="Economics of Transformative AI Teaching Fellow" url="https://bluedot.org/economics-of-tai-teaching-fellow/" isExternalUrl />
       </div>
     </Section>
   );
 };
 
 const JobListing = ({
-  title, location = 'London, Remote', type = 'Permanent', now,
+  title, location = 'London, Remote', type = 'Permanent', now, url, isExternalUrl = false,
 }: {
-  title: string, location?: string, type?: string, now?: boolean
+  title: string, location?: string, type?: string, now?: boolean, url?: string, isExternalUrl?: boolean
 }) => {
   return (
     <div className={
@@ -31,6 +31,8 @@ const JobListing = ({
         className="careers-section__cta-button"
         variant="secondary"
         withChevron
+        url={url}
+        isExternalUrl={isExternalUrl}
       >
         Apply now
       </CTALinkOrButton>

--- a/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
@@ -43,10 +43,12 @@ exports[`CareersSection > renders default as expected 1`] = `
           >
             Permanent
           </p>
-          <button
-            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-            data-testid="cta-button"
-            type="button"
+          <a
+            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+            data-testid="cta-link"
+            href="https://bluedot.org/ai-alignment-project-judge/"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             <span
               class="cta-button__text"
@@ -62,7 +64,7 @@ exports[`CareersSection > renders default as expected 1`] = `
                 src="/icons/chevron_blue.svg"
               />
             </span>
-          </button>
+          </a>
         </div>
         <div
           class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
@@ -83,10 +85,12 @@ exports[`CareersSection > renders default as expected 1`] = `
           >
             Permanent
           </p>
-          <button
-            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-            data-testid="cta-button"
-            type="button"
+          <a
+            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+            data-testid="cta-link"
+            href="https://bluedot.org/ai-safety-course-operations/"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             <span
               class="cta-button__text"
@@ -102,7 +106,7 @@ exports[`CareersSection > renders default as expected 1`] = `
                 src="/icons/chevron_blue.svg"
               />
             </span>
-          </button>
+          </a>
         </div>
         <div
           class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
@@ -123,10 +127,12 @@ exports[`CareersSection > renders default as expected 1`] = `
           >
             Permanent
           </p>
-          <button
-            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-            data-testid="cta-button"
-            type="button"
+          <a
+            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+            data-testid="cta-link"
+            href="https://bluedot.org/swe-contractor/"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             <span
               class="cta-button__text"
@@ -142,7 +148,7 @@ exports[`CareersSection > renders default as expected 1`] = `
                 src="/icons/chevron_blue.svg"
               />
             </span>
-          </button>
+          </a>
         </div>
         <div
           class="careers-section__location-container w-full flex flex-row items-center justify-between p-8 border-solid border rounded-2xl
@@ -163,10 +169,12 @@ exports[`CareersSection > renders default as expected 1`] = `
           >
             Permanent
           </p>
-          <button
-            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-            data-testid="cta-button"
-            type="button"
+          <a
+            class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+            data-testid="cta-link"
+            href="https://bluedot.org/economics-of-tai-teaching-fellow/"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             <span
               class="cta-button__text"
@@ -182,7 +190,7 @@ exports[`CareersSection > renders default as expected 1`] = `
                 src="/icons/chevron_blue.svg"
               />
             </span>
-          </button>
+          </a>
         </div>
       </div>
     </div>

--- a/apps/website-25/src/components/homepage/StorySection.tsx
+++ b/apps/website-25/src/components/homepage/StorySection.tsx
@@ -2,7 +2,7 @@ import { Section } from '@bluedot/ui';
 
 const StorySection = () => {
   return (
-    <Section className="story-section" title="Our story">
+    <Section className="story-section" title="Our story" ctaUrl="/about" ctaText="Learn more about us">
       <div className="story-section__container flex flex-row gap-28 my-16">
         <img className="story-section__image w-[570px] rounded-2xl" src="/images/team/team_1.jpg" alt="BlueDot Impact team" />
         <div className="story-section__text-container flex flex-col gap-5">

--- a/apps/website-25/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -12,11 +12,31 @@ exports[`StorySection > renders default as expected 1`] = `
         class="section__content flex-1"
       >
         <h2
-          class="section__title text-bluedot-normal text-[48px] mb-4 font-serif font-extrabold leading-none relative after:content-[''] after:absolute after:top-1/2 after:translate-y-[-50%] after:ml-8 after:h-[2px] after:bg-bluedot-normal after:w-[100%]"
+          class="section__title text-bluedot-normal text-[48px] mb-4 font-serif font-extrabold leading-none relative after:content-[''] after:absolute after:top-1/2 after:translate-y-[-50%] after:ml-8 after:h-[2px] after:bg-bluedot-normal after:w-[80%]"
         >
           Our story
         </h2>
       </div>
+      <a
+        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter section__cta shrink-0"
+        data-testid="cta-link"
+        href="/about"
+      >
+        <span
+          class="cta-button__text"
+        >
+          Learn more about us
+        </span>
+        <span
+          class="cta-button__chevron ml-3"
+        >
+          <img
+            alt="→"
+            class="cta-button__chevron-icon w-2 h-2"
+            src="/icons/chevron_blue.svg"
+          />
+        </span>
+      </a>
     </div>
     <div
       class="section__body"

--- a/libraries/ui/src/CTALinkOrButton.tsx
+++ b/libraries/ui/src/CTALinkOrButton.tsx
@@ -7,9 +7,10 @@ export type CTAProps = {
   withChevron?: boolean;
   children: React.ReactNode;
   url?: string;
+  isExternalUrl?: boolean;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
-const CTA_BASE_STYLES = 'cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2';
+const CTA_BASE_STYLES = 'cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit';
 
 const CTA_VARIANT_STYLES = {
   primary: 'cta-button--primary bg-bluedot-normal text-white hover:bg-bluedot-normal',
@@ -22,6 +23,7 @@ export const CTALinkOrButton: React.FC<CTAProps> = ({
   withChevron = false,
   children,
   url,
+  isExternalUrl = false,
   ...rest
 }) => {
   const commonClassNames = clsx(
@@ -34,6 +36,8 @@ export const CTALinkOrButton: React.FC<CTAProps> = ({
     return (
       <a
         href={url}
+        target={isExternalUrl ? '_blank' : undefined}
+        rel={isExternalUrl ? 'noopener noreferrer' : undefined}
         data-testid="cta-link"
         className={commonClassNames}
       >

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -6,6 +6,7 @@ interface CardProps {
   title: string;
   subtitle?: string;
   ctaUrl?: string;
+  isExternalUrl?: boolean;
   className?: string;
   imageClassName?: string;
 }
@@ -15,6 +16,7 @@ export const Card: React.FC<CardProps> = ({
   title,
   subtitle,
   ctaUrl,
+  isExternalUrl = false,
   className = '',
   imageClassName = '',
 }) => {
@@ -28,7 +30,7 @@ export const Card: React.FC<CardProps> = ({
         />
       </div>
 
-      <div className="card__content flex flex-col gap-12">
+      <div className="card__content flex flex-col gap-8 w-full">
         <div className="card__text">
           <h2 className="card__title text-2xl font-semibold text-bluedot-darker">{title}</h2>
           {subtitle && (<p className="card__subtitle text-base text-black">{subtitle}</p>)}
@@ -38,6 +40,7 @@ export const Card: React.FC<CardProps> = ({
           url={ctaUrl}
           variant="secondary"
           withChevron={false}
+          isExternalUrl={isExternalUrl}
         >
           LinkedIn
         </CTALinkOrButton>

--- a/libraries/ui/src/__snapshots__/Card.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Card.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Card > renders default as expected 1`] = `
       />
     </div>
     <div
-      class="card__content flex flex-col gap-12"
+      class="card__content flex flex-col gap-8 w-full"
     >
       <div
         class="card__text"
@@ -32,7 +32,7 @@ exports[`Card > renders default as expected 1`] = `
         </p>
       </div>
       <a
-        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
         data-testid="cta-link"
         href="https://linkedin.com/in/johndoe"
       >
@@ -62,7 +62,7 @@ exports[`Card > renders with custom className 1`] = `
       />
     </div>
     <div
-      class="card__content flex flex-col gap-12"
+      class="card__content flex flex-col gap-8 w-full"
     >
       <div
         class="card__text"
@@ -79,7 +79,7 @@ exports[`Card > renders with custom className 1`] = `
         </p>
       </div>
       <a
-        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
         data-testid="cta-link"
         href="https://linkedin.com/in/johndoe"
       >
@@ -109,7 +109,7 @@ exports[`Card > renders with custom image dimensions 1`] = `
       />
     </div>
     <div
-      class="card__content flex flex-col gap-12"
+      class="card__content flex flex-col gap-8 w-full"
     >
       <div
         class="card__text"
@@ -126,7 +126,7 @@ exports[`Card > renders with custom image dimensions 1`] = `
         </p>
       </div>
       <a
-        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
+        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter"
         data-testid="cta-link"
         href="https://linkedin.com/in/johndoe"
       >

--- a/libraries/ui/src/__snapshots__/Section.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Section.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Section > renders with all optional props 1`] = `
         </p>
       </div>
       <a
-        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter section__cta shrink-0"
+        class="cta-button flex items-center justify-center rounded-lg transition-all duration-200 font-semibold text-base px-4 py-2 w-fit cta-button--secondary bg-transparent text-bluedot-normal border border-bluedot-normal hover:bg-bluedot-lighter section__cta shrink-0"
         data-testid="cta-link"
         href="/some-path"
       >


### PR DESCRIPTION
# Summary

Add isExternalUrl options to CTALink. Update to use across pages.

## Description

- Add isExternalUrl option to CTA. Use new option in Team and JobListing
- Use new Section CTA option in home/StorySection
- Tweak some styling in Team

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/)
- [ ] Added new unit tests where applicable

## Screenshot

<img width="1532" alt="Screenshot 2025-01-28 at 14 33 54" src="https://github.com/user-attachments/assets/60d8371f-71a5-4eff-a3e3-ebf346171bf1" />
<img width="1191" alt="Screenshot 2025-01-28 at 14 34 26" src="https://github.com/user-attachments/assets/69a34815-2973-40f1-ae12-0428558e1e88" />
<img width="1146" alt="Screenshot 2025-01-28 at 14 34 34" src="https://github.com/user-attachments/assets/7caf918a-791b-4691-bd7b-4c62e1765c74" />

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    6 cached, 7 total
  Time:    1.046s 
```
