### PR TITLE
Add CourseCard tests and update testing approaches

### DIFF
--- a/apps/website-25/src/components/homepage/CourseSection.tsx
+++ b/apps/website-25/src/components/homepage/CourseSection.tsx
@@ -11,25 +11,25 @@ const CourseSection = () => {
           title="Alignment Fast Track"
           description="AI systems are rapidly becoming more capable and more general. Despite AI’s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable."
           courseType="Crash course"
-          image="/images/intro-course.png"
+          imageSrc="/images/intro-course.png"
         />
         <CourseCard
           title="Governance Fast-Track"
           description="Despite AI’s potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation."
           courseType="Crash course"
-          image="/images/governance-course.jpg"
+          imageSrc="/images/governance-course.jpg"
         />
         <CourseCard
           title="AI Alignment"
           description="AI systems are rapidly becoming more capable and more general. Despite AI’s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable."
           courseType="In-depth course"
-          image="/images/alignment-course.png"
+          imageSrc="/images/alignment-course.png"
         />
         <CourseCard
           title="AI Governance"
           description="The rise of any powerful technology demands a thoughtful approach to its governance and regulation. There has been increasing interest in how AI governance can and should mitigate extreme risks from AI, but it can be difficult to get up to speed on research and ideas in this area."
           courseType="In-depth course"
-          image="/images/governance-course.jpg"
+          imageSrc="/images/governance-course.jpg"
         />
       </div>
     </Section>

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -30,138 +30,166 @@ exports[`CourseSection > renders default as expected 1`] = `
         class="flex flex-row gap-4"
       >
         <div
-          class="border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px]"
+          class="container-lined px-6 pb-6 max-w-[323px]"
+          data-testid="course-card"
         >
           <img
             alt="Course Card Placeholder"
             class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
+            data-testid="course-card__image"
             src="/images/intro-course.png"
           />
           <h3
             class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
+            data-testid="course-card__title"
           >
             Alignment Fast Track
           </h3>
           <p
             class="text-bluedot-darker text-md mb-4 line-clamp-4"
+            data-testid="course-card__description"
           >
             AI systems are rapidly becoming more capable and more general. Despite AI’s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.
           </p>
           <div
             class="flex justify-between items-center"
+            data-testid="course-card__metadata"
           >
             <p
               class="text-left text-xs"
+              data-testid="course-card__metadata-item"
             >
               5 days
             </p>
             <span
               class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
+              data-testid="course-card__application-deadline"
               role="status"
             >
-              Crash course
+              Apply now
             </span>
           </div>
         </div>
         <div
-          class="border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px]"
+          class="container-lined px-6 pb-6 max-w-[323px]"
+          data-testid="course-card"
         >
           <img
             alt="Course Card Placeholder"
             class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
+            data-testid="course-card__image"
             src="/images/governance-course.jpg"
           />
           <h3
             class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
+            data-testid="course-card__title"
           >
             Governance Fast-Track
           </h3>
           <p
             class="text-bluedot-darker text-md mb-4 line-clamp-4"
+            data-testid="course-card__description"
           >
             Despite AI’s potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation.
           </p>
           <div
             class="flex justify-between items-center"
+            data-testid="course-card__metadata"
           >
             <p
               class="text-left text-xs"
+              data-testid="course-card__metadata-item"
             >
               5 days
             </p>
             <span
               class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
+              data-testid="course-card__application-deadline"
               role="status"
             >
-              Crash course
+              Apply now
             </span>
           </div>
         </div>
         <div
-          class="border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px]"
+          class="container-lined px-6 pb-6 max-w-[323px]"
+          data-testid="course-card"
         >
           <img
             alt="Course Card Placeholder"
             class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
+            data-testid="course-card__image"
             src="/images/alignment-course.png"
           />
           <h3
             class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
+            data-testid="course-card__title"
           >
             AI Alignment
           </h3>
           <p
             class="text-bluedot-darker text-md mb-4 line-clamp-4"
+            data-testid="course-card__description"
           >
             AI systems are rapidly becoming more capable and more general. Despite AI’s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.
           </p>
           <div
             class="flex justify-between items-center"
+            data-testid="course-card__metadata"
           >
             <p
               class="text-left text-xs"
+              data-testid="course-card__metadata-item"
             >
               12 weeks
             </p>
             <span
               class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
+              data-testid="course-card__application-deadline"
               role="status"
             >
-              In-depth course
+              Apply now
             </span>
           </div>
         </div>
         <div
-          class="border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px]"
+          class="container-lined px-6 pb-6 max-w-[323px]"
+          data-testid="course-card"
         >
           <img
             alt="Course Card Placeholder"
             class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
+            data-testid="course-card__image"
             src="/images/governance-course.jpg"
           />
           <h3
             class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
+            data-testid="course-card__title"
           >
             AI Governance
           </h3>
           <p
             class="text-bluedot-darker text-md mb-4 line-clamp-4"
+            data-testid="course-card__description"
           >
             The rise of any powerful technology demands a thoughtful approach to its governance and regulation. There has been increasing interest in how AI governance can and should mitigate extreme risks from AI, but it can be difficult to get up to speed on research and ideas in this area.
           </p>
           <div
             class="flex justify-between items-center"
+            data-testid="course-card__metadata"
           >
             <p
               class="text-left text-xs"
+              data-testid="course-card__metadata-item"
             >
               12 weeks
             </p>
             <span
               class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
+              data-testid="course-card__application-deadline"
               role="status"
             >
-              In-depth course
+              Apply now
             </span>
           </div>
         </div>

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -30,40 +30,33 @@ exports[`CourseSection > renders default as expected 1`] = `
         class="flex flex-row gap-4"
       >
         <div
-          class="container-lined px-6 pb-6 max-w-[323px]"
-          data-testid="course-card"
+          class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
         >
           <img
             alt="Course Card Placeholder"
-            class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
-            data-testid="course-card__image"
+            class="course-card__image w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
             src="/images/intro-course.png"
           />
           <h3
-            class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
-            data-testid="course-card__title"
+            class="course-card__title text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
           >
             Alignment Fast Track
           </h3>
           <p
-            class="text-bluedot-darker text-md mb-4 line-clamp-4"
-            data-testid="course-card__description"
+            class="course-card__description text-bluedot-darker text-md mb-4 line-clamp-4"
           >
             AI systems are rapidly becoming more capable and more general. Despite AI’s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.
           </p>
           <div
-            class="flex justify-between items-center"
-            data-testid="course-card__metadata"
+            class="course-card__metadata flex justify-between items-center"
           >
             <p
-              class="text-left text-xs"
-              data-testid="course-card__metadata-item"
+              class="course-card__metadata-item text-left text-xs"
             >
               5 days
             </p>
             <span
-              class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
-              data-testid="course-card__application-deadline"
+              class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light course-card__application-deadline"
               role="status"
             >
               Apply now
@@ -71,40 +64,33 @@ exports[`CourseSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="container-lined px-6 pb-6 max-w-[323px]"
-          data-testid="course-card"
+          class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
         >
           <img
             alt="Course Card Placeholder"
-            class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
-            data-testid="course-card__image"
+            class="course-card__image w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
             src="/images/governance-course.jpg"
           />
           <h3
-            class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
-            data-testid="course-card__title"
+            class="course-card__title text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
           >
             Governance Fast-Track
           </h3>
           <p
-            class="text-bluedot-darker text-md mb-4 line-clamp-4"
-            data-testid="course-card__description"
+            class="course-card__description text-bluedot-darker text-md mb-4 line-clamp-4"
           >
             Despite AI’s potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation.
           </p>
           <div
-            class="flex justify-between items-center"
-            data-testid="course-card__metadata"
+            class="course-card__metadata flex justify-between items-center"
           >
             <p
-              class="text-left text-xs"
-              data-testid="course-card__metadata-item"
+              class="course-card__metadata-item text-left text-xs"
             >
               5 days
             </p>
             <span
-              class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
-              data-testid="course-card__application-deadline"
+              class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light course-card__application-deadline"
               role="status"
             >
               Apply now
@@ -112,40 +98,33 @@ exports[`CourseSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="container-lined px-6 pb-6 max-w-[323px]"
-          data-testid="course-card"
+          class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
         >
           <img
             alt="Course Card Placeholder"
-            class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
-            data-testid="course-card__image"
+            class="course-card__image w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
             src="/images/alignment-course.png"
           />
           <h3
-            class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
-            data-testid="course-card__title"
+            class="course-card__title text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
           >
             AI Alignment
           </h3>
           <p
-            class="text-bluedot-darker text-md mb-4 line-clamp-4"
-            data-testid="course-card__description"
+            class="course-card__description text-bluedot-darker text-md mb-4 line-clamp-4"
           >
             AI systems are rapidly becoming more capable and more general. Despite AI’s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.
           </p>
           <div
-            class="flex justify-between items-center"
-            data-testid="course-card__metadata"
+            class="course-card__metadata flex justify-between items-center"
           >
             <p
-              class="text-left text-xs"
-              data-testid="course-card__metadata-item"
+              class="course-card__metadata-item text-left text-xs"
             >
               12 weeks
             </p>
             <span
-              class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
-              data-testid="course-card__application-deadline"
+              class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light course-card__application-deadline"
               role="status"
             >
               Apply now
@@ -153,40 +132,33 @@ exports[`CourseSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="container-lined px-6 pb-6 max-w-[323px]"
-          data-testid="course-card"
+          class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
         >
           <img
             alt="Course Card Placeholder"
-            class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
-            data-testid="course-card__image"
+            class="course-card__image w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
             src="/images/governance-course.jpg"
           />
           <h3
-            class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
-            data-testid="course-card__title"
+            class="course-card__title text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
           >
             AI Governance
           </h3>
           <p
-            class="text-bluedot-darker text-md mb-4 line-clamp-4"
-            data-testid="course-card__description"
+            class="course-card__description text-bluedot-darker text-md mb-4 line-clamp-4"
           >
             The rise of any powerful technology demands a thoughtful approach to its governance and regulation. There has been increasing interest in how AI governance can and should mitigate extreme risks from AI, but it can be difficult to get up to speed on research and ideas in this area.
           </p>
           <div
-            class="flex justify-between items-center"
-            data-testid="course-card__metadata"
+            class="course-card__metadata flex justify-between items-center"
           >
             <p
-              class="text-left text-xs"
-              data-testid="course-card__metadata-item"
+              class="course-card__metadata-item text-left text-xs"
             >
               12 weeks
             </p>
             <span
-              class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
-              data-testid="course-card__application-deadline"
+              class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light course-card__application-deadline"
               role="status"
             >
               Apply now

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`CourseSection > renders default as expected 1`] = `
         class="flex flex-row gap-4"
       >
         <div
-          class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
+          class="course-card container-lined px-6 pb-6 max-w-[323px]"
         >
           <img
             alt="Course Card Placeholder"
@@ -64,7 +64,7 @@ exports[`CourseSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
+          class="course-card container-lined px-6 pb-6 max-w-[323px]"
         >
           <img
             alt="Course Card Placeholder"
@@ -98,7 +98,7 @@ exports[`CourseSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
+          class="course-card container-lined px-6 pb-6 max-w-[323px]"
         >
           <img
             alt="Course Card Placeholder"
@@ -132,7 +132,7 @@ exports[`CourseSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
+          class="course-card container-lined px-6 pb-6 max-w-[323px]"
         >
           <img
             alt="Course Card Placeholder"

--- a/libraries/ui/src/CourseCard.test.tsx
+++ b/libraries/ui/src/CourseCard.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CourseCard } from './CourseCard';
+
+describe('CourseCard', () => {
+  const defaultProps = {
+    title: 'Title',
+    description: 'Description',
+  };
+
+  test('renders default as expected', () => {
+    const { container } = render(
+      <CourseCard {...defaultProps} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders Featured as expected', () => {
+    const { container } = render(
+      <CourseCard {...defaultProps} cardType="Featured" />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders with optional args', () => {
+    render(
+      <CourseCard
+        {...defaultProps}
+        applicationDeadline="Feb 1"
+        courseType="Self-paced"
+        imageSrc="/images/team/custom-size.jpg"
+      />,
+    );
+    const applicationDeadlineEl = screen.getByTestId('course-card__application-deadline');
+    expect(applicationDeadlineEl).toMatchSnapshot();
+    const courseLengthEl = screen.getByTestId('course-card__metadata-item');
+    expect(courseLengthEl).toMatchSnapshot();
+    const imgEl = screen.getByTestId('course-card__image');
+    expect(imgEl).toMatchSnapshot();
+  });
+});

--- a/libraries/ui/src/CourseCard.test.tsx
+++ b/libraries/ui/src/CourseCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, expect, test } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { CourseCard } from './CourseCard';
 
 describe('CourseCard', () => {
@@ -24,7 +24,7 @@ describe('CourseCard', () => {
   });
 
   test('renders with optional args', () => {
-    render(
+    const { container } = render(
       <CourseCard
         {...defaultProps}
         applicationDeadline="Feb 1"
@@ -32,11 +32,11 @@ describe('CourseCard', () => {
         imageSrc="/images/team/custom-size.jpg"
       />,
     );
-    const applicationDeadlineEl = screen.getByTestId('course-card__application-deadline');
+    const applicationDeadlineEl = container.querySelector('.course-card__application-deadline');
     expect(applicationDeadlineEl).toMatchSnapshot();
-    const courseLengthEl = screen.getByTestId('course-card__metadata-item');
+    const courseLengthEl = container.querySelector('.course-card__metadata-item');
     expect(courseLengthEl).toMatchSnapshot();
-    const imgEl = screen.getByTestId('course-card__image');
+    const imgEl = container.querySelector('.course-card__image');
     expect(imgEl).toMatchSnapshot();
   });
 });

--- a/libraries/ui/src/CourseCard.test.tsx
+++ b/libraries/ui/src/CourseCard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 import { CourseCard } from './CourseCard';

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import { Tag } from './Tag';
 
 export type CourseCardProps = React.PropsWithChildren<{
@@ -45,7 +46,7 @@ export const CourseCard: React.FC<CourseCardProps> = ({
   return (
     cardType === 'Featured'
       ? (
-        <div className={`course-card--featured container-lined px-8 pb-4 max-w-[646px] ${className}`}>
+        <div className={clsx('course-card--featured container-lined px-8 pb-4 max-w-[646px]', className)}>
           <p className="course-card__featured-label uppercase font-semibold">Featured course</p>
           <img
             src={imageSrc}
@@ -66,7 +67,7 @@ export const CourseCard: React.FC<CourseCardProps> = ({
         </div>
       )
       : (
-        <div className={`course-card container-lined px-6 pb-6 max-w-[323px] ${className}`}>
+        <div className={clsx('course-card container-lined px-6 pb-6 max-w-[323px]', className)}>
           <img
             src={imageSrc}
             alt="Course Card Placeholder"

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import clsx from 'clsx';
-import { LinkOrButton, LinkOrButtonProps } from './legacy/LinkOrButton';
 import { Tag } from './Tag';
 
 export type CourseCardProps = React.PropsWithChildren<{
-  className?: string,
+  // Required
   title: string,
   description: string,
-  courseType: CourseType,
+  // Optional
+  className?: string,
+  applicationDeadline?: string, // Expected format: "Feb 1"
   cardType?: 'Featured' | 'Regular',
-  image?: string
+  courseType?: CourseType,
+  imageSrc?: string
 }>;
 
 type CourseType = 'Crash course' | 'Self-paced' | 'In-depth course';
@@ -27,49 +29,64 @@ const courseLength = (courseType: CourseType) => {
   }
 };
 
+const applyByText = (applicationDeadline: string | undefined) => {
+  return applicationDeadline ? `Apply by ${applicationDeadline}` : 'Apply now';
+};
+
 export const CourseCard: React.FC<CourseCardProps> = ({
-  children, className, title, description, courseType = 'Crash course', cardType = 'Regular', image,
+  children,
+  className,
+  title,
+  description,
+  applicationDeadline,
+  cardType = 'Regular',
+  courseType = 'Crash course',
+  imageSrc,
 }) => {
   return (
     cardType === 'Featured'
       ? (
-        <div className={clsx('container-lined px-8 pb-4 max-w-[323px]', className)}>
-          <p className="uppercase font-semibold">Featured course</p>
-          <img src={image} alt="Course Card Placeholder" className="w-full h-[165px] object-cover rounded-lg" />
-          <h3 className="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none">{title}</h3>
-          <p className="text-bluedot-darker text-md mb-4 line-clamp-6">{description}</p>
-          <div className="flex justify-between items-center">
-            <p className="text-left text-xs">
+        <div data-testid="course-card--featured" className={clsx('container-lined px-8 pb-4 max-w-[646px]', className)}>
+          <p data-testid="course-card__featured-label" className="uppercase font-semibold">Featured course</p>
+          <img
+            src={imageSrc}
+            alt="Course Card Placeholder"
+            data-testid="course-card__image"
+            className="w-full h-[165px] object-cover rounded-lg"
+          />
+          <h3 data-testid="course-card__title" className="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none">{title}</h3>
+          <p data-testid="course-card__description" className="text-bluedot-darker text-md mb-4 line-clamp-6">{description}</p>
+          <div data-testid="course-card__metadata" className="flex justify-between items-center">
+            <p data-testid="course-card__metadata-item" className="text-left text-xs">
               {courseLength(courseType)}
             </p>
-            <Tag
-              label={courseType}
-            />
+            <Tag dataTestId="course-card__application-deadline">
+              {applyByText(applicationDeadline)}
+            </Tag>
           </div>
           {children}
         </div>
       )
       : (
-        <div className={clsx('border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px]', className)}>
-          <img src={image} alt="Course Card Placeholder" className="w-full h-[165px] object-cover rounded-xl mt-6 mb-12" />
-          <h3 className="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none">{title}</h3>
-          <p className="text-bluedot-darker text-md mb-4 line-clamp-4">{description}</p>
-          <div className="flex justify-between items-center">
-            <p className="text-left text-xs">
+        <div data-testid="course-card" className={clsx('container-lined px-6 pb-6 max-w-[323px]', className)}>
+          <img
+            src={imageSrc}
+            alt="Course Card Placeholder"
+            data-testid="course-card__image"
+            className="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
+          />
+          <h3 data-testid="course-card__title" className="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none">{title}</h3>
+          <p data-testid="course-card__description" className="text-bluedot-darker text-md mb-4 line-clamp-4">{description}</p>
+          <div data-testid="course-card__metadata" className="flex justify-between items-center">
+            <p data-testid="course-card__metadata-item" className="text-left text-xs">
               {courseLength(courseType)}
             </p>
-            <Tag
-              label={courseType}
-            />
+            <Tag dataTestId="course-card__application-deadline">
+              {applyByText(applicationDeadline)}
+            </Tag>
           </div>
           {children}
         </div>
       )
-  );
-};
-
-export const CourseCardButton: React.FC<LinkOrButtonProps> = ({ className, ...rest }) => {
-  return (
-    <LinkOrButton className={clsx('border border-neutral-500 rounded px-8 pb-4 text-bluedot-black transition-all duration-200 inline-block cursor-pointer data-[hovered]:border-bluedot-normal data-[hovered]:bg-bluedot-lighter data-[focus-visible]:border-bluedot-normal data-[focus-visible]:bg-bluedot-lighter data-[pressed]:border-bluedot-normal data-[pressed=true]:bg-bluedot-normal data-[pressed=true]:text-white outline-none [text-align:inherit]', className)} {...rest} />
   );
 };

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import clsx from 'clsx';
 import { Tag } from './Tag';
 
 export type CourseCardProps = React.PropsWithChildren<{
@@ -46,21 +45,20 @@ export const CourseCard: React.FC<CourseCardProps> = ({
   return (
     cardType === 'Featured'
       ? (
-        <div data-testid="course-card--featured" className={clsx('container-lined px-8 pb-4 max-w-[646px]', className)}>
-          <p data-testid="course-card__featured-label" className="uppercase font-semibold">Featured course</p>
+        <div className={`course-card--featured container-lined px-8 pb-4 max-w-[646px] ${className}`}>
+          <p className="course-card__featured-label uppercase font-semibold">Featured course</p>
           <img
             src={imageSrc}
             alt="Course Card Placeholder"
-            data-testid="course-card__image"
-            className="w-full h-[165px] object-cover rounded-lg"
+            className="course-card__image w-full h-[165px] object-cover rounded-lg"
           />
-          <h3 data-testid="course-card__title" className="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none">{title}</h3>
-          <p data-testid="course-card__description" className="text-bluedot-darker text-md mb-4 line-clamp-6">{description}</p>
-          <div data-testid="course-card__metadata" className="flex justify-between items-center">
-            <p data-testid="course-card__metadata-item" className="text-left text-xs">
+          <h3 className="course-card__title text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none">{title}</h3>
+          <p className="course-card__description text-bluedot-darker text-md mb-4 line-clamp-6">{description}</p>
+          <div className="course-card__metadata flex justify-between items-center">
+            <p className="course-card__metadata-item text-left text-xs">
               {courseLength(courseType)}
             </p>
-            <Tag dataTestId="course-card__application-deadline">
+            <Tag className="course-card__application-deadline">
               {applyByText(applicationDeadline)}
             </Tag>
           </div>
@@ -68,20 +66,19 @@ export const CourseCard: React.FC<CourseCardProps> = ({
         </div>
       )
       : (
-        <div data-testid="course-card" className={clsx('container-lined px-6 pb-6 max-w-[323px]', className)}>
+        <div className={`course-card container-lined px-6 pb-6 max-w-[323px] ${className}`}>
           <img
             src={imageSrc}
             alt="Course Card Placeholder"
-            data-testid="course-card__image"
-            className="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
+            className="course-card__image w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
           />
-          <h3 data-testid="course-card__title" className="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none">{title}</h3>
-          <p data-testid="course-card__description" className="text-bluedot-darker text-md mb-4 line-clamp-4">{description}</p>
-          <div data-testid="course-card__metadata" className="flex justify-between items-center">
-            <p data-testid="course-card__metadata-item" className="text-left text-xs">
+          <h3 className="course-card__title text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none">{title}</h3>
+          <p className="course-card__description text-bluedot-darker text-md mb-4 line-clamp-4">{description}</p>
+          <div className="course-card__metadata flex justify-between items-center">
+            <p className="course-card__metadata-item text-left text-xs">
               {courseLength(courseType)}
             </p>
-            <Tag dataTestId="course-card__application-deadline">
+            <Tag className="course-card__application-deadline">
               {applyByText(applicationDeadline)}
             </Tag>
           </div>

--- a/libraries/ui/src/Tag.test.tsx
+++ b/libraries/ui/src/Tag.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
 import { Tag } from './Tag';

--- a/libraries/ui/src/Tag.test.tsx
+++ b/libraries/ui/src/Tag.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, expect, test } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Tag } from './Tag';
 
 describe('Tag', () => {
@@ -10,15 +10,14 @@ describe('Tag', () => {
   });
 
   test('renders with optional args', () => {
-    render(
+    const { container } = render(
       <Tag
-        dataTestId="tag"
         className="custom-class"
       >
         Custom tag
       </Tag>,
     );
-    const tagEl = screen.getByTestId('tag');
+    const tagEl = container.querySelector('.custom-class');
     expect(tagEl).toMatchSnapshot();
   });
 });

--- a/libraries/ui/src/Tag.test.tsx
+++ b/libraries/ui/src/Tag.test.tsx
@@ -1,20 +1,24 @@
+import React from 'react';
 import { describe, expect, test } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Tag } from './Tag';
 
 describe('Tag', () => {
   test('renders default as expected', () => {
-    const { container } = render(<Tag label="Basic tag" />);
+    const { container } = render(<Tag>Basic tag</Tag>);
     expect(container).toMatchSnapshot();
   });
 
-  test('renders with custom className', () => {
-    const { container } = render(
+  test('renders with optional args', () => {
+    render(
       <Tag
-        label="Custom tag"
+        dataTestId="tag"
         className="custom-class"
-      />,
+      >
+        Custom tag
+      </Tag>,
     );
-    expect(container).toMatchSnapshot();
+    const tagEl = screen.getByTestId('tag');
+    expect(tagEl).toMatchSnapshot();
   });
 });

--- a/libraries/ui/src/Tag.tsx
+++ b/libraries/ui/src/Tag.tsx
@@ -4,13 +4,11 @@ import clsx from 'clsx';
 export type TagProps = {
   className?: string,
   children: React.ReactNode;
-  dataTestId?: string;
 };
 
 export const Tag: React.FC<TagProps> = ({
   className,
   children,
-  dataTestId,
 }) => {
   return (
     <span
@@ -19,7 +17,6 @@ export const Tag: React.FC<TagProps> = ({
         'tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light',
         className,
       )}
-      data-testid={dataTestId}
     >
       {children}
     </span>

--- a/libraries/ui/src/Tag.tsx
+++ b/libraries/ui/src/Tag.tsx
@@ -3,12 +3,14 @@ import clsx from 'clsx';
 
 export type TagProps = {
   className?: string,
-  label: string;
+  children: React.ReactNode;
+  dataTestId?: string;
 };
 
 export const Tag: React.FC<TagProps> = ({
   className,
-  label,
+  children,
+  dataTestId,
 }) => {
   return (
     <span
@@ -17,8 +19,9 @@ export const Tag: React.FC<TagProps> = ({
         'tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light',
         className,
       )}
+      data-testid={dataTestId}
     >
-      {label}
+      {children}
     </span>
   );
 };

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -1,0 +1,125 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CourseCard > renders Featured as expected 1`] = `
+<div>
+  <div
+    class="container-lined px-8 pb-4 max-w-[646px]"
+    data-testid="course-card--featured"
+  >
+    <p
+      class="uppercase font-semibold"
+      data-testid="course-card__featured-label"
+    >
+      Featured course
+    </p>
+    <img
+      alt="Course Card Placeholder"
+      class="w-full h-[165px] object-cover rounded-lg"
+      data-testid="course-card__image"
+    />
+    <h3
+      class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
+      data-testid="course-card__title"
+    >
+      Title
+    </h3>
+    <p
+      class="text-bluedot-darker text-md mb-4 line-clamp-6"
+      data-testid="course-card__description"
+    >
+      Description
+    </p>
+    <div
+      class="flex justify-between items-center"
+      data-testid="course-card__metadata"
+    >
+      <p
+        class="text-left text-xs"
+        data-testid="course-card__metadata-item"
+      >
+        5 days
+      </p>
+      <span
+        class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
+        data-testid="course-card__application-deadline"
+        role="status"
+      >
+        Apply now
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CourseCard > renders default as expected 1`] = `
+<div>
+  <div
+    class="container-lined px-6 pb-6 max-w-[323px]"
+    data-testid="course-card"
+  >
+    <img
+      alt="Course Card Placeholder"
+      class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
+      data-testid="course-card__image"
+    />
+    <h3
+      class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
+      data-testid="course-card__title"
+    >
+      Title
+    </h3>
+    <p
+      class="text-bluedot-darker text-md mb-4 line-clamp-4"
+      data-testid="course-card__description"
+    >
+      Description
+    </p>
+    <div
+      class="flex justify-between items-center"
+      data-testid="course-card__metadata"
+    >
+      <p
+        class="text-left text-xs"
+        data-testid="course-card__metadata-item"
+      >
+        5 days
+      </p>
+      <span
+        class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
+        data-testid="course-card__application-deadline"
+        role="status"
+      >
+        Apply now
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CourseCard > renders with optional args 1`] = `
+<span
+  class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
+  data-testid="course-card__application-deadline"
+  role="status"
+>
+  Apply by Feb 1
+</span>
+`;
+
+exports[`CourseCard > renders with optional args 2`] = `
+<p
+  class="text-left text-xs"
+  data-testid="course-card__metadata-item"
+>
+  12 weeks
+</p>
+`;
+
+exports[`CourseCard > renders with optional args 3`] = `
+<img
+  alt="Course Card Placeholder"
+  class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
+  data-testid="course-card__image"
+  src="/images/team/custom-size.jpg"
+/>
+`;

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CourseCard > renders Featured as expected 1`] = `
 <div>
   <div
-    class="course-card--featured border border-gray-300 rounded-lg px-8 pb-4 max-w-[646px] undefined"
+    class="course-card--featured container-lined px-8 pb-4 max-w-[646px]"
   >
     <p
       class="course-card__featured-label uppercase font-semibold"
@@ -46,7 +46,7 @@ exports[`CourseCard > renders Featured as expected 1`] = `
 exports[`CourseCard > renders default as expected 1`] = `
 <div>
   <div
-    class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
+    class="course-card container-lined px-6 pb-6 max-w-[323px]"
   >
     <img
       alt="Course Card Placeholder"

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -3,45 +3,37 @@
 exports[`CourseCard > renders Featured as expected 1`] = `
 <div>
   <div
-    class="container-lined px-8 pb-4 max-w-[646px]"
-    data-testid="course-card--featured"
+    class="course-card--featured border border-gray-300 rounded-lg px-8 pb-4 max-w-[646px] undefined"
   >
     <p
-      class="uppercase font-semibold"
-      data-testid="course-card__featured-label"
+      class="course-card__featured-label uppercase font-semibold"
     >
       Featured course
     </p>
     <img
       alt="Course Card Placeholder"
-      class="w-full h-[165px] object-cover rounded-lg"
-      data-testid="course-card__image"
+      class="course-card__image w-full h-[165px] object-cover rounded-lg"
     />
     <h3
-      class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
-      data-testid="course-card__title"
+      class="course-card__title text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
     >
       Title
     </h3>
     <p
-      class="text-bluedot-darker text-md mb-4 line-clamp-6"
-      data-testid="course-card__description"
+      class="course-card__description text-bluedot-darker text-md mb-4 line-clamp-6"
     >
       Description
     </p>
     <div
-      class="flex justify-between items-center"
-      data-testid="course-card__metadata"
+      class="course-card__metadata flex justify-between items-center"
     >
       <p
-        class="text-left text-xs"
-        data-testid="course-card__metadata-item"
+        class="course-card__metadata-item text-left text-xs"
       >
         5 days
       </p>
       <span
-        class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
-        data-testid="course-card__application-deadline"
+        class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light course-card__application-deadline"
         role="status"
       >
         Apply now
@@ -54,39 +46,32 @@ exports[`CourseCard > renders Featured as expected 1`] = `
 exports[`CourseCard > renders default as expected 1`] = `
 <div>
   <div
-    class="container-lined px-6 pb-6 max-w-[323px]"
-    data-testid="course-card"
+    class="course-card border border-gray-300 rounded-xl px-6 pb-6 max-w-[323px] undefined"
   >
     <img
       alt="Course Card Placeholder"
-      class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
-      data-testid="course-card__image"
+      class="course-card__image w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
     />
     <h3
-      class="text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
-      data-testid="course-card__title"
+      class="course-card__title text-bluedot-normal text-[24px] mb-4 font-serif font-extrabold leading-none"
     >
       Title
     </h3>
     <p
-      class="text-bluedot-darker text-md mb-4 line-clamp-4"
-      data-testid="course-card__description"
+      class="course-card__description text-bluedot-darker text-md mb-4 line-clamp-4"
     >
       Description
     </p>
     <div
-      class="flex justify-between items-center"
-      data-testid="course-card__metadata"
+      class="course-card__metadata flex justify-between items-center"
     >
       <p
-        class="text-left text-xs"
-        data-testid="course-card__metadata-item"
+        class="course-card__metadata-item text-left text-xs"
       >
         5 days
       </p>
       <span
-        class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
-        data-testid="course-card__application-deadline"
+        class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light course-card__application-deadline"
         role="status"
       >
         Apply now
@@ -98,8 +83,7 @@ exports[`CourseCard > renders default as expected 1`] = `
 
 exports[`CourseCard > renders with optional args 1`] = `
 <span
-  class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light"
-  data-testid="course-card__application-deadline"
+  class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light course-card__application-deadline"
   role="status"
 >
   Apply by Feb 1
@@ -108,8 +92,7 @@ exports[`CourseCard > renders with optional args 1`] = `
 
 exports[`CourseCard > renders with optional args 2`] = `
 <p
-  class="text-left text-xs"
-  data-testid="course-card__metadata-item"
+  class="course-card__metadata-item text-left text-xs"
 >
   12 weeks
 </p>
@@ -118,8 +101,7 @@ exports[`CourseCard > renders with optional args 2`] = `
 exports[`CourseCard > renders with optional args 3`] = `
 <img
   alt="Course Card Placeholder"
-  class="w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
-  data-testid="course-card__image"
+  class="course-card__image w-full h-[165px] object-cover rounded-xl mt-6 mb-12"
   src="/images/team/custom-size.jpg"
 />
 `;

--- a/libraries/ui/src/__snapshots__/Tag.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Tag.test.tsx.snap
@@ -11,13 +11,12 @@ exports[`Tag > renders default as expected 1`] = `
 </div>
 `;
 
-exports[`Tag > renders with custom className 1`] = `
-<div>
-  <span
-    class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light custom-class"
-    role="status"
-  >
-    Custom tag
-  </span>
-</div>
+exports[`Tag > renders with optional args 1`] = `
+<span
+  class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light custom-class"
+  data-testid="tag"
+  role="status"
+>
+  Custom tag
+</span>
 `;

--- a/libraries/ui/src/__snapshots__/Tag.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Tag.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`Tag > renders default as expected 1`] = `
 exports[`Tag > renders with optional args 1`] = `
 <span
   class="tag inline-flex items-center px-4 py-1.5 rounded-lg text-xs font-semibold border border-bluedot-light custom-class"
-  data-testid="tag"
   role="status"
 >
   Custom tag

--- a/libraries/ui/src/default-config/vitest.mjs
+++ b/libraries/ui/src/default-config/vitest.mjs
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 import * as dotenv from 'dotenv';
 
 /**
- * @param {import('vitest/config').UserConfig} [config] 
+ * @param {import('vitest/config').UserConfig} [config]
  * @returns {import('vitest/config').UserConfig}
  */
 export const withDefaultBlueDotVitestConfig = async (config) => defineConfig({
@@ -15,6 +15,8 @@ export const withDefaultBlueDotVitestConfig = async (config) => defineConfig({
     env: dotenv.config({ path: '.env.test' }).parsed,
 
     ...config?.test,
+
+    globals: true,
 
     exclude: [...defaultExclude, '**/.{turbo,next}/**', ...(config?.test?.exclude ?? [])],
   },

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -7,7 +7,7 @@ export { Card } from './Card';
 
 export { CTALinkOrButton } from './CTALinkOrButton';
 
-export { CourseCard, CourseCardButton } from './CourseCard';
+export { CourseCard } from './CourseCard';
 
 export { HeroSection } from './HeroSection';
 


### PR DESCRIPTION
# Summary

Add CourseCard tests and update testing approaches

## Description

- Add CourseCard tests
- Update Tag to use `{children}` instead of `{label}`
- Add BEM classes to CourseCard as needed
- Remove unused CourseCardButton
- Enabling globals configures vitest to clean up aftereach by default ([vue docs ref](https://testing-library.com/docs/vue-testing-library/setup/), [vitest docs](https://vitest.dev/config/#globals))
- Updating `image` arg to `imgSrc`

### [Documentation] Exploring migrating BEM to data-test-id attr
- So far, our standards have been to include [BEM](https://getbem.com/naming/) naming conventions as class names on all HTML elements
- The BEM naming convention is a cheap way to navigate the DOM both as devs (e.g., reading through Inspect tools to understand which components were used) and in more targeted testing against specific elements (e.g. so we dont have gigantic snapshot outputs every single time we are testing an optional arg)
- [React Screen queries](https://testing-library.com/docs/queries/about) do not support by getByClassName. **screen.getByTestId** is supported OOTB
- We can continue to use class names by querying on the container obj as-is however, e.g. `const tagEl = container.querySelector('.tag');`
- **Final call: Let's keep using BEM within className.** [dataTestId is not supported as a standard prop](https://react.dev/learn/passing-props-to-a-component) to pass through components, and adds another layer of set-up in our hierarchies.

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/)
- [x] Added new unit tests where applicable

## Screenshot
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d0a90f3e-0008-420a-bf2f-75c862cc425a" />

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    6 cached, 7 total
  Time:    1.045s
```
