### PR TITLE
Update `Tag.stories.tsx` to match new API

### DIFF
--- a/libraries/ui/src/Tag.stories.tsx
+++ b/libraries/ui/src/Tag.stories.tsx
@@ -11,10 +11,6 @@ const meta = {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: 'fullscreen',
   },
-  args: {
-    className: '',
-    label: '',
-  },
 } satisfies Meta<typeof Tag>;
 
 export default meta;
@@ -22,12 +18,12 @@ type Story = StoryObj<typeof meta>;
 
 export const CrashCourse: Story = {
   args: {
-    label: 'Crash course',
+    children: 'Crash course',
   },
 };
 
 export const InDepthCourse: Story = {
   args: {
-    label: 'In-depth course',
+    children: 'In-depth course',
   },
 };


### PR DESCRIPTION
# Summary

`label` was removed in #111

## Issue

`storybook` UI is out of date.

:info: `storybook` is quite flexible here in the sense that the `build` did not break.

## Description

Update `Tag.stories.tsx` to match new API

## Screenshot

![Screenshot 2025-01-29 at 10 04 09](https://github.com/user-attachments/assets/d2600cb5-96b3-4275-8963-f18630a8a62c)

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    5 cached, 7 total
  Time:    2.751s 
```
