### PR TITLE
Make <Card> footer a child rather than a prop

### DIFF
--- a/libraries/ui/src/Card.test.tsx
+++ b/libraries/ui/src/Card.test.tsx
@@ -40,18 +40,15 @@ describe('Card', () => {
     expect(cardElement).not.toBeNull();
   });
 
-  test('does not include ctaMetadata unless given', () => {
+  test('does not include footer unless given', () => {
     const { container } = render(<Card {...defaultProps} />);
     const ctaMetadataElement = container.querySelector('.card__footer');
     expect(ctaMetadataElement).toBeNull();
   });
 
-  test('includes ctaMetadata when given', () => {
+  test('includes footer when given', () => {
     const { container } = render(
-      <Card
-        {...defaultProps}
-        footerContent="Some metadata"
-      />,
+      <Card {...defaultProps}>A footer of some kind</Card>,
     );
     const ctaMetadataElement = container.querySelector('.card__footer');
     expect(ctaMetadataElement).not.toBeNull();

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -7,12 +7,12 @@ type CardProps = {
   imageSrc: string;
   title: string;
   subtitle?: string;
-  footerContent?: React.ReactNode;
   ctaUrl?: string;
   isEntireCardClickable?: boolean;
   isExternalUrl?: boolean;
   className?: string;
   imageClassName?: string;
+  children?: React.ReactNode;
 } & (
   | { ctaText: string; isEntireCardClickable?: false }
   | { ctaText?: string; isEntireCardClickable: true }
@@ -22,13 +22,13 @@ export const Card: React.FC<CardProps> = ({
   imageSrc,
   title,
   subtitle,
-  footerContent,
   ctaUrl,
   ctaText,
   isEntireCardClickable = false,
   isExternalUrl = false,
   className = '',
   imageClassName = '',
+  children,
 }) => {
   const Wrapper = isEntireCardClickable ? 'a' : 'div';
   const wrapperClassName = clsx(
@@ -68,9 +68,9 @@ export const Card: React.FC<CardProps> = ({
               {ctaText}
             </CTALinkOrButton>
           )}
-          {footerContent && (
+          {children && (
             <div className="card__footer flex items-center justify-between w-full">
-              {footerContent}
+              {children}
             </div>
           )}
         </div>

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -37,14 +37,14 @@ const applyByText = (applicationDeadline: string | undefined) => {
   return applicationDeadline ? `Apply by ${applicationDeadline}` : 'Apply now';
 };
 
-const FeaturedCourseCard: React.FC<CourseCardProps & { footerRow: React.ReactNode }> = ({
+const FeaturedCourseCard: React.FC<CourseCardProps> = ({
   className,
   title,
   description,
   ctaUrl,
   applicationDeadline,
   imageSrc,
-  footerRow,
+  children,
 }) => {
   const wrapperClassName = clsx(
     'course-card course-card--featured card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01]',
@@ -88,7 +88,7 @@ const FeaturedCourseCard: React.FC<CourseCardProps & { footerRow: React.ReactNod
           />
         </div>
       </div>
-      {footerRow}
+      {children}
     </a>
   );
 };
@@ -128,19 +128,21 @@ export const CourseCard: React.FC<CourseCardProps> = ({
       ctaUrl={ctaUrl}
       applicationDeadline={applicationDeadline}
       imageSrc={imageSrc}
-      footerRow={CourseCardFooter}
-    />
+    >
+      {CourseCardFooter}
+    </FeaturedCourseCard>
   ) : (
     <Card
       imageSrc={imageSrc}
       title={title}
       subtitle={description}
-      footerContent={CourseCardFooter}
       ctaUrl={ctaUrl}
       isEntireCardClickable
       isExternalUrl
       className={clsx('course-card course-card--regular container-lined p-5 max-w-[323px]', className)}
       imageClassName="course-card__image w-full h-[165px] object-cover rounded-none"
-    />
+    >
+      {CourseCardFooter}
+    </Card>
   );
 };


### PR DESCRIPTION
# Summary

This was [discussed in a previous PR](https://github.com/bluedotimpact/bluedot/pull/153#discussion_r1937127494), but I neglected to actually include the change in the version that was merged.

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes # (issue)
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [X] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [X] Added or updated Jest tests
- [x] (N/A) Added or updated Storybook stories

## Screenshot

(No visual change)

| 📸 |  |
|---------|---|
| 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    7 cached, 7 total
  Time:    228ms >>> FULL TURBO
```
