### PR TITLE
Add CookieBanner to homepage

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -323,7 +323,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__bottom-section mt-auto flex flex-col gap-4"
               >
                 <a
-                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
                   href="https://www.linkedin.com/in/domdomegg/"
                   rel="noopener noreferrer"
@@ -371,7 +371,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__bottom-section mt-auto flex flex-col gap-4"
               >
                 <a
-                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
                   href="https://www.linkedin.com/in/dewierwan/"
                   rel="noopener noreferrer"
@@ -419,7 +419,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__bottom-section mt-auto flex flex-col gap-4"
               >
                 <a
-                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
                   href="https://linkedin.com/in/josh-landes12"
                   rel="noopener noreferrer"
@@ -467,7 +467,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__bottom-section mt-auto flex flex-col gap-4"
               >
                 <a
-                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
                   href="https://linkedin.com/in/anglilian"
                   rel="noopener noreferrer"
@@ -515,7 +515,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__bottom-section mt-auto flex flex-col gap-4"
               >
                 <a
-                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
                   href="https://linkedin.com/in/tarinrickett/"
                   rel="noopener noreferrer"
@@ -563,7 +563,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__bottom-section mt-auto flex flex-col gap-4"
               >
                 <a
-                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
                   href="https://www.linkedin.com/in/vioricagheorghita/"
                   rel="noopener noreferrer"
@@ -611,7 +611,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__bottom-section mt-auto flex flex-col gap-4"
               >
                 <a
-                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
                   href="https://linkedin.com/in/will-saunter"
                   rel="noopener noreferrer"
@@ -641,7 +641,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
           Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
         </h3>
         <a
-          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
+          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
           data-testid="cta-link"
           href="/careers"
         >

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -191,7 +191,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
               Permanent
             </p>
             <a
-              class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+              class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
               data-testid="cta-link"
               href="https://bluedot.org/ai-alignment-project-judge/"
               rel="noopener noreferrer"
@@ -232,7 +232,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
               Permanent
             </p>
             <a
-              class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+              class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
               data-testid="cta-link"
               href="https://bluedot.org/ai-safety-course-operations/"
               rel="noopener noreferrer"
@@ -273,7 +273,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
               Permanent
             </p>
             <a
-              class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+              class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
               data-testid="cta-link"
               href="https://bluedot.org/swe-contractor/"
               rel="noopener noreferrer"
@@ -314,7 +314,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
               Permanent
             </p>
             <a
-              class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+              class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
               data-testid="cta-link"
               href="https://bluedot.org/economics-of-tai-teaching-fellow/"
               rel="noopener noreferrer"

--- a/apps/website-25/src/components/about/__snapshots__/JoinUsCta.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/JoinUsCta.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`JoinUsCta > renders default as expected 1`] = `
         Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
       </h3>
       <a
-        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
+        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
         data-testid="cta-link"
         href="/careers"
       >

--- a/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__bottom-section mt-auto flex flex-col gap-4"
             >
               <a
-                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                 data-testid="cta-link"
                 href="https://www.linkedin.com/in/domdomegg/"
                 rel="noopener noreferrer"
@@ -105,7 +105,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__bottom-section mt-auto flex flex-col gap-4"
             >
               <a
-                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                 data-testid="cta-link"
                 href="https://www.linkedin.com/in/dewierwan/"
                 rel="noopener noreferrer"
@@ -153,7 +153,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__bottom-section mt-auto flex flex-col gap-4"
             >
               <a
-                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                 data-testid="cta-link"
                 href="https://linkedin.com/in/josh-landes12"
                 rel="noopener noreferrer"
@@ -201,7 +201,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__bottom-section mt-auto flex flex-col gap-4"
             >
               <a
-                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                 data-testid="cta-link"
                 href="https://linkedin.com/in/anglilian"
                 rel="noopener noreferrer"
@@ -249,7 +249,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__bottom-section mt-auto flex flex-col gap-4"
             >
               <a
-                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                 data-testid="cta-link"
                 href="https://linkedin.com/in/tarinrickett/"
                 rel="noopener noreferrer"
@@ -297,7 +297,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__bottom-section mt-auto flex flex-col gap-4"
             >
               <a
-                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                 data-testid="cta-link"
                 href="https://www.linkedin.com/in/vioricagheorghita/"
                 rel="noopener noreferrer"
@@ -345,7 +345,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__bottom-section mt-auto flex flex-col gap-4"
             >
               <a
-                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                 data-testid="cta-link"
                 href="https://linkedin.com/in/will-saunter"
                 rel="noopener noreferrer"

--- a/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`CareersSection > renders default as expected 1`] = `
             Permanent
           </p>
           <a
-            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
             data-testid="cta-link"
             href="https://bluedot.org/ai-alignment-project-judge/"
             rel="noopener noreferrer"
@@ -84,7 +84,7 @@ exports[`CareersSection > renders default as expected 1`] = `
             Permanent
           </p>
           <a
-            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
             data-testid="cta-link"
             href="https://bluedot.org/ai-safety-course-operations/"
             rel="noopener noreferrer"
@@ -125,7 +125,7 @@ exports[`CareersSection > renders default as expected 1`] = `
             Permanent
           </p>
           <a
-            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
             data-testid="cta-link"
             href="https://bluedot.org/swe-contractor/"
             rel="noopener noreferrer"
@@ -166,7 +166,7 @@ exports[`CareersSection > renders default as expected 1`] = `
             Permanent
           </p>
           <a
-            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
+            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
             data-testid="cta-link"
             href="https://bluedot.org/economics-of-tai-teaching-fellow/"
             rel="noopener noreferrer"

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`CourseSection > renders default as expected 1`] = `
                 AI Safety: Intro to Transformative AI
               </h2>
               <button
-                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
+                class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
                 data-testid="cta-button"
                 type="button"
               >

--- a/apps/website-25/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`StorySection > renders default as expected 1`] = `
             BlueDot Impact was founded in August 2022, and grew out of a non-profit supporting students at the University of Cambridge to pursue high-impact careers. To learn more, check out this podcast interview and our blog.
           </p>
           <a
-            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
+            class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
             data-testid="cta-link"
             href="/about"
           >

--- a/apps/website-25/src/pages/_app.tsx
+++ b/apps/website-25/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import '../globals.css';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
-import { Footer, Nav } from '@bluedot/ui';
+import { CookieBanner, Footer, Nav } from '@bluedot/ui';
 import { EXTERNAL_LINK_PROPS } from '@bluedot/ui/src/utils';
 
 // TODO: 01/27 add routing to courses when AISafetyFundamentals course is integrated, i.e.'/courses/intro-transformative-ai
@@ -33,6 +33,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
       <main className="bluedot-base">
         <Component {...pageProps} />
       </main>
+      <CookieBanner />
       <Footer logo="/images/logo/BlueDot_Impact_Logo_White.svg" />
     </>
   );

--- a/libraries/ui/src/CTALinkOrButton.tsx
+++ b/libraries/ui/src/CTALinkOrButton.tsx
@@ -11,7 +11,7 @@ export type CTAProps = {
   isExternalUrl?: boolean;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
-const CTA_BASE_STYLES = 'cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650]';
+const CTA_BASE_STYLES = 'cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap';
 
 const CTA_VARIANT_STYLES = {
   primary: 'cta-button--primary bg-bluedot-normal link-on-dark',

--- a/libraries/ui/src/CookieBanner.stories.tsx
+++ b/libraries/ui/src/CookieBanner.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CookieBanner } from './CookieBanner';
+
+const meta = {
+  title: 'ui/CookieBanner',
+  component: CookieBanner,
+  tags: ['autodocs'],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof CookieBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/libraries/ui/src/CookieBanner.test.tsx
+++ b/libraries/ui/src/CookieBanner.test.tsx
@@ -1,0 +1,45 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { CookieBanner } from './CookieBanner';
+
+describe('CookieBanner', () => {
+  const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+  beforeEach(() => {
+    localStorage.clear();
+    setItemSpy.mockClear();
+  });
+
+  test('renders as expected', () => {
+    const { container } = render(<CookieBanner />);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('sets localStorage item when accepted', () => {
+    const { container } = render(<CookieBanner />);
+    const acceptButton = container.querySelector('.cookie-banner__button--accept');
+
+    expect(acceptButton).not.toBeNull();
+
+    fireEvent.click(acceptButton!);
+
+    expect(setItemSpy).toHaveBeenCalledWith('cookies', 'accepted');
+  });
+
+  test('sets localStorage item when rejected', () => {
+    const { container } = render(<CookieBanner />);
+    const rejectButton = container.querySelector('.cookie-banner__button--reject');
+
+    expect(rejectButton).not.toBeNull();
+
+    fireEvent.click(rejectButton!);
+
+    expect(setItemSpy).toHaveBeenCalledWith('cookies', 'rejected');
+  });
+});

--- a/libraries/ui/src/CookieBanner.test.tsx
+++ b/libraries/ui/src/CookieBanner.test.tsx
@@ -1,5 +1,5 @@
 import {
-  beforeEach,
+  afterEach,
   describe,
   expect,
   test,
@@ -10,10 +10,12 @@ import { CookieBanner } from './CookieBanner';
 
 describe('CookieBanner', () => {
   const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+  const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
 
-  beforeEach(() => {
+  afterEach(() => {
     localStorage.clear();
     setItemSpy.mockClear();
+    getItemSpy.mockClear();
   });
 
   test('renders as expected', () => {
@@ -41,5 +43,12 @@ describe('CookieBanner', () => {
     fireEvent.click(rejectButton!);
 
     expect(setItemSpy).toHaveBeenCalledWith('cookies', 'rejected');
+  });
+
+  test('does not render if "cookies" is already set', () => {
+    getItemSpy.mockReturnValue('accepted');
+
+    const { container } = render(<CookieBanner />);
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/libraries/ui/src/CookieBanner.tsx
+++ b/libraries/ui/src/CookieBanner.tsx
@@ -1,0 +1,66 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { EXTERNAL_LINK_PROPS } from './utils';
+import { CTALinkOrButton } from './CTALinkOrButton';
+
+type CookieBannerProps = {
+  // Optional
+  className?: string
+};
+
+/**
+ * Sets a localStorage item called 'cookies' to 'accepted' or
+ * 'rejected' when dismissed via one of the buttons.
+ */
+export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
+  const [showBanner, setShowBanner] = useState(false);
+
+  const setCookieConsent = useCallback(
+    (value: 'accepted' | 'rejected') => {
+      localStorage.setItem('cookies', value);
+      setShowBanner(false);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const cookieConsent = localStorage.getItem('cookies');
+    if (cookieConsent !== 'accepted' && cookieConsent !== 'rejected') {
+      setShowBanner(true);
+    }
+  }, []);
+
+  if (!showBanner) return null;
+
+  const rootClassName = clsx(
+    'cookie-banner fixed bottom-6 right-0 mx-4 sm:mx-6 shadow-lg flex flex-col gap-5 p-6 rounded-lg bg-cream-normal w-fit max-w-[420px] border border-bluedot-normal',
+    className,
+  );
+
+  return (
+    <div className={rootClassName}>
+      <div className="cookie-banner__text text-pretty">
+        We use analytics cookies to improve our website and measure ad performance.{' '}
+        <a className="underline" href="/privacy-policy" {...EXTERNAL_LINK_PROPS}>Cookie Policy</a>.
+      </div>
+      <div className="cookie-banner__buttons flex flex-wrap gap-4 justify-center">
+        <CTALinkOrButton
+          className="cookie-banner__button--reject px-6 whitespace-nowrap"
+          variant="primary"
+          onClick={() => setCookieConsent('rejected')}
+        >
+          Reject all
+        </CTALinkOrButton>
+        <CTALinkOrButton
+          className="cookie-banner__button--accept px-6 whitespace-nowrap"
+          variant="primary"
+          onClick={() => setCookieConsent('accepted')}
+        >
+          Accept all
+        </CTALinkOrButton>
+      </div>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/libraries/ui/src/CookieBanner.tsx
+++ b/libraries/ui/src/CookieBanner.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import clsx from 'clsx';
-import { EXTERNAL_LINK_PROPS } from './utils';
 import { CTALinkOrButton } from './CTALinkOrButton';
 
 type CookieBannerProps = {

--- a/libraries/ui/src/CookieBanner.tsx
+++ b/libraries/ui/src/CookieBanner.tsx
@@ -41,7 +41,7 @@ export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
     <div className={rootClassName}>
       <div className="cookie-banner__text text-pretty">
         We use analytics cookies to improve our website and measure ad performance.{' '}
-        <a className="underline" href="/privacy-policy" {...EXTERNAL_LINK_PROPS}>Cookie Policy</a>.
+        <a className="underline" href="/privacy-policy">Cookie Policy</a>.
       </div>
       <div className="cookie-banner__buttons flex flex-wrap gap-4 justify-center">
         <CTALinkOrButton

--- a/libraries/ui/src/CookieBanner.tsx
+++ b/libraries/ui/src/CookieBanner.tsx
@@ -45,14 +45,14 @@ export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
       </div>
       <div className="cookie-banner__buttons flex flex-wrap gap-4 justify-center">
         <CTALinkOrButton
-          className="cookie-banner__button--reject px-6 whitespace-nowrap"
+          className="cookie-banner__button--reject"
           variant="primary"
           onClick={() => setCookieConsent('rejected')}
         >
           Reject all
         </CTALinkOrButton>
         <CTALinkOrButton
-          className="cookie-banner__button--accept px-6 whitespace-nowrap"
+          className="cookie-banner__button--accept"
           variant="primary"
           onClick={() => setCookieConsent('accepted')}
         >

--- a/libraries/ui/src/CookieBanner.tsx
+++ b/libraries/ui/src/CookieBanner.tsx
@@ -33,7 +33,7 @@ export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
   if (!showBanner) return null;
 
   const rootClassName = clsx(
-    'cookie-banner fixed bottom-6 right-0 mx-4 sm:mx-6 shadow-lg flex flex-col gap-5 p-6 rounded-lg bg-cream-normal w-fit max-w-[420px] border border-bluedot-normal',
+    'cookie-banner container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px]',
     className,
   );
 

--- a/libraries/ui/src/__snapshots__/Banner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Banner.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Banner > renders with input and button 1`] = `
         value=""
       />
       <button
-        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark banner__submit-btn"
+        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark banner__submit-btn"
         data-testid="cta-button"
         type="submit"
       >

--- a/libraries/ui/src/__snapshots__/CTALinkOrButton.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CTALinkOrButton.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CTALinkOrButton > renders with primary variant by default as a button 1`] = `
 <button
-  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+  class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark"
   data-testid="cta-button"
   type="button"
 >

--- a/libraries/ui/src/__snapshots__/Card.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Card.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Card > renders default as expected 1`] = `
         class="card__bottom-section mt-auto flex flex-col gap-4"
       >
         <a
-          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
           data-testid="cta-link"
           href="https://linkedin.com/in/johndoe"
         >

--- a/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
@@ -13,8 +13,6 @@ exports[`CookieBanner > renders as expected 1`] = `
       <a
         class="underline"
         href="/privacy-policy"
-        rel="noopener noreferrer"
-        target="_blank"
       >
         Cookie Policy
       </a>

--- a/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CookieBanner > renders as expected 1`] = `
+<div>
+  <div
+    class="cookie-banner fixed bottom-6 right-0 mx-4 sm:mx-6 shadow-lg flex flex-col gap-5 p-6 rounded-lg bg-cream-normal w-fit max-w-[420px] border border-bluedot-normal"
+  >
+    <div
+      class="cookie-banner__text text-pretty"
+    >
+      We use analytics cookies to improve our website and measure ad performance.
+       
+      <a
+        class="underline"
+        href="/privacy-policy"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Cookie Policy
+      </a>
+      .
+    </div>
+    <div
+      class="cookie-banner__buttons flex flex-wrap gap-4 justify-center"
+    >
+      <button
+        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--reject px-6 whitespace-nowrap"
+        data-testid="cta-button"
+        type="button"
+      >
+        <span
+          class="cta-button__text"
+        >
+          Reject all
+        </span>
+      </button>
+      <button
+        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--accept px-6 whitespace-nowrap"
+        data-testid="cta-button"
+        type="button"
+      >
+        <span
+          class="cta-button__text"
+        >
+          Accept all
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CookieBanner > renders as expected 1`] = `
 <div>
   <div
-    class="cookie-banner fixed bottom-6 right-0 mx-4 sm:mx-6 shadow-lg flex flex-col gap-5 p-6 rounded-lg bg-cream-normal w-fit max-w-[420px] border border-bluedot-normal"
+    class="cookie-banner container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px]"
   >
     <div
       class="cookie-banner__text text-pretty"

--- a/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`CookieBanner > renders as expected 1`] = `
       class="cookie-banner__buttons flex flex-wrap gap-4 justify-center"
     >
       <button
-        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--reject px-6 whitespace-nowrap"
+        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--reject"
         data-testid="cta-button"
         type="button"
       >
@@ -35,7 +35,7 @@ exports[`CookieBanner > renders as expected 1`] = `
         </span>
       </button>
       <button
-        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--accept px-6 whitespace-nowrap"
+        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--accept"
         data-testid="cta-button"
         type="button"
       >

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`CourseCard > renders Featured as expected 1`] = `
           Title
         </h2>
         <button
-          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
+          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
           data-testid="cta-button"
           type="button"
         >

--- a/libraries/ui/src/__snapshots__/Nav.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Nav.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Nav > renders with courses 1`] = `
           Login
         </a>
         <a
-          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav__primary-cta"
+          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark nav__primary-cta"
           data-testid="cta-link"
           href="https://aisafetyfundamentals.com/"
         >
@@ -155,7 +155,7 @@ exports[`Nav > renders with optional yield 1`] = `
           Login
         </a>
         <a
-          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav__primary-cta"
+          class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark nav__primary-cta"
           data-testid="cta-link"
           href="https://aisafetyfundamentals.com/"
         >

--- a/libraries/ui/src/__snapshots__/Section.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Section.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Section > renders with all optional props 1`] = `
         </p>
       </div>
       <a
-        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter section__cta shrink-0"
+        class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter section__cta shrink-0"
         data-testid="cta-link"
         href="/some-path"
       >

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -23,6 +23,8 @@ export { Tag } from './Tag';
 
 export { ValueCard } from './ValueCard';
 
+export { CookieBanner } from './CookieBanner';
+
 // Non-component exports
 
 export { EXTERNAL_LINK_PROPS } from './utils';

--- a/libraries/ui/src/shared.css
+++ b/libraries/ui/src/shared.css
@@ -68,5 +68,6 @@
   box-shadow: 0px 4px 20px 0px rgba(30, 30, 30, 0.1);
 }
 .container-dialog {
-  @apply border border-bluedot-normal rounded-lg shadow-lg
+  @apply border border-bluedot-normal rounded-lg;
+  box-shadow: 0px 0px 32px 0px rgba(0, 0, 0, 0.25);
 }

--- a/libraries/ui/src/shared.css
+++ b/libraries/ui/src/shared.css
@@ -67,3 +67,6 @@
   /* RGBA of var(--bluedot-cream-normal) */
   box-shadow: 0px 4px 20px 0px rgba(30, 30, 30, 0.1);
 }
+.container-dialog {
+  @apply border border-bluedot-normal rounded-lg shadow-lg
+}


### PR DESCRIPTION
# Summary

Adds a CookieBanner, which sets a localStorage item to "accepted" or "rejected" when dismissed (in line with how the existing bluedot website works).

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #158 

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | ![Screenshot 2025-02-03 at 20 14 52](https://github.com/user-attachments/assets/3021209a-3c12-4861-ab88-e2d65c3cf505) |
| 🖥️ | ![Screenshot 2025-02-03 at 20 14 41](https://github.com/user-attachments/assets/7548346c-3a6c-4fd0-bae1-7998636fa499) |
| 📱  | ![Screenshot 2025-02-03 at 20 14 37](https://github.com/user-attachments/assets/d1673cab-64f6-40b8-aa51-5241b8a9ece3) |

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    7 cached, 7 total
  Time:    225ms >>> FULL TURBO
```
