### PR TITLE
Add `Figma for VS Code` extension to recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "streetsidesoftware.code-spell-checker",
         "dbaeumer.vscode-eslint",
-        "bradlc.vscode-tailwindcss"
+        "bradlc.vscode-tailwindcss",
+        "figma.figma-vscode-extension"
     ]
 }


### PR DESCRIPTION
# Summary

Add `Figma for VS Code` extension to workspace recommendations.

## Issue

Following up on #93.

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    4 cached, 7 total
  Time:    3.701s
```
