### PR TITLE
Update default typography on `<h1>` & `<h2>`

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -25,11 +25,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
         <div
           class="section__content flex-1"
         >
-          <h2
+          <h1
             class="section__title mb-4 relative after:w-full"
           >
             Why do we exist?
-          </h2>
+          </h1>
         </div>
       </div>
       <div
@@ -65,11 +65,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
         <div
           class="section__content flex-1"
         >
-          <h2
+          <h1
             class="section__title mb-4 relative after:w-full"
           >
             Our core beliefs
-          </h2>
+          </h1>
         </div>
       </div>
       <div
@@ -182,11 +182,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
         <div
           class="section__content flex-1"
         >
-          <h2
+          <h1
             class="section__title mb-4 relative after:w-full"
           >
             Our history
-          </h2>
+          </h1>
         </div>
       </div>
       <div
@@ -277,11 +277,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
         <div
           class="section__content flex-1"
         >
-          <h2
+          <h1
             class="section__title mb-4 relative after:w-full"
           >
             Our team
-          </h2>
+          </h1>
         </div>
       </div>
       <div
@@ -309,7 +309,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__text"
               >
                 <h2
-                  class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                  class="card__title text-2xl text-bluedot-darker mb-1"
                 >
                   Adam Jones
                 </h2>
@@ -357,7 +357,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__text"
               >
                 <h2
-                  class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                  class="card__title text-2xl text-bluedot-darker mb-1"
                 >
                   Dewi Erwan
                 </h2>
@@ -405,7 +405,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__text"
               >
                 <h2
-                  class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                  class="card__title text-2xl text-bluedot-darker mb-1"
                 >
                   Josh Landes
                 </h2>
@@ -453,7 +453,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__text"
               >
                 <h2
-                  class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                  class="card__title text-2xl text-bluedot-darker mb-1"
                 >
                   Li-Lian Ang
                 </h2>
@@ -501,7 +501,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__text"
               >
                 <h2
-                  class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                  class="card__title text-2xl text-bluedot-darker mb-1"
                 >
                   Tarin Rickett
                 </h2>
@@ -549,7 +549,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__text"
               >
                 <h2
-                  class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                  class="card__title text-2xl text-bluedot-darker mb-1"
                 >
                   Viorica Gheorghita
                 </h2>
@@ -597,7 +597,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
                 class="card__text"
               >
                 <h2
-                  class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                  class="card__title text-2xl text-bluedot-darker mb-1"
                 >
                   Will Saunter
                 </h2>

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -25,11 +25,11 @@ exports[`CareersPage > should render the error message correctly 1`] = `
         <div
           class="section__content flex-1"
         >
-          <h2
+          <h1
             class="section__title mb-4 relative after:w-full"
           >
             Our culture
-          </h2>
+          </h1>
         </div>
       </div>
       <div
@@ -65,11 +65,11 @@ exports[`CareersPage > should render the error message correctly 1`] = `
         <div
           class="section__content flex-1"
         >
-          <h2
+          <h1
             class="section__title mb-4 relative after:w-full"
           >
             Our values
-          </h2>
+          </h1>
         </div>
       </div>
       <div
@@ -159,11 +159,11 @@ exports[`CareersPage > should render the error message correctly 1`] = `
         <div
           class="section__content flex-1"
         >
-          <h2
+          <h1
             class="section__title mb-4 relative after:w-full"
           >
             Careers at BlueDot Impact
-          </h2>
+          </h1>
         </div>
       </div>
       <div

--- a/apps/website-25/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`BeliefsSection > renders default as expected 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-full"
         >
           Our core beliefs
-        </h2>
+        </h1>
       </div>
     </div>
     <div

--- a/apps/website-25/src/components/about/__snapshots__/HistorySection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/HistorySection.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`HistorySection > renders default as expected 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-full"
         >
           Our history
-        </h2>
+        </h1>
       </div>
     </div>
     <div

--- a/apps/website-25/src/components/about/__snapshots__/IntroSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/IntroSection.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`IntroSection > renders default as expected 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-full"
         >
           Hello, World
-        </h2>
+        </h1>
       </div>
     </div>
     <div

--- a/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`TeamSection > renders default as expected 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-full"
         >
           Our team
-        </h2>
+        </h1>
       </div>
     </div>
     <div
@@ -43,7 +43,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__text"
             >
               <h2
-                class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                class="card__title text-2xl text-bluedot-darker mb-1"
               >
                 Adam Jones
               </h2>
@@ -91,7 +91,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__text"
             >
               <h2
-                class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                class="card__title text-2xl text-bluedot-darker mb-1"
               >
                 Dewi Erwan
               </h2>
@@ -139,7 +139,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__text"
             >
               <h2
-                class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                class="card__title text-2xl text-bluedot-darker mb-1"
               >
                 Josh Landes
               </h2>
@@ -187,7 +187,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__text"
             >
               <h2
-                class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                class="card__title text-2xl text-bluedot-darker mb-1"
               >
                 Li-Lian Ang
               </h2>
@@ -235,7 +235,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__text"
             >
               <h2
-                class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                class="card__title text-2xl text-bluedot-darker mb-1"
               >
                 Tarin Rickett
               </h2>
@@ -283,7 +283,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__text"
             >
               <h2
-                class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                class="card__title text-2xl text-bluedot-darker mb-1"
               >
                 Viorica Gheorghita
               </h2>
@@ -331,7 +331,7 @@ exports[`TeamSection > renders default as expected 1`] = `
               class="card__text"
             >
               <h2
-                class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                class="card__title text-2xl text-bluedot-darker mb-1"
               >
                 Will Saunter
               </h2>

--- a/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`CareersSection > renders default as expected 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-full"
         >
           Careers at BlueDot Impact
-        </h2>
+        </h1>
       </div>
     </div>
     <div

--- a/apps/website-25/src/components/careers/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/ValuesSection.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`ValuesSection > renders default as expected 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-full"
         >
           Our values
-        </h2>
+        </h1>
       </div>
     </div>
     <div

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`CourseSection > renders default as expected 1`] = `
                     Featured course
                   </p>
                   <h2
-                    class="course-card__title text-2xl font-semibold text-bluedot-darker mb-6"
+                    class="course-card__title text-2xl text-bluedot-darker mb-6"
                   >
                     AI Safety: Intro to Transformative AI
                   </h2>
@@ -204,7 +204,7 @@ exports[`CourseSection > renders default as expected 1`] = `
                           class="card__text"
                         >
                           <h2
-                            class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                            class="card__title text-2xl text-bluedot-darker mb-1"
                           >
                             Alignment Fast Track
                           </h2>
@@ -284,7 +284,7 @@ exports[`CourseSection > renders default as expected 1`] = `
                           class="card__text"
                         >
                           <h2
-                            class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                            class="card__title text-2xl text-bluedot-darker mb-1"
                           >
                             Governance Fast-Track
                           </h2>
@@ -368,7 +368,7 @@ exports[`CourseSection > renders default as expected 1`] = `
                           class="card__text"
                         >
                           <h2
-                            class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                            class="card__title text-2xl text-bluedot-darker mb-1"
                           >
                             AI Alignment
                           </h2>
@@ -448,7 +448,7 @@ exports[`CourseSection > renders default as expected 1`] = `
                           class="card__text"
                         >
                           <h2
-                            class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+                            class="card__title text-2xl text-bluedot-darker mb-1"
                           >
                             AI Governance
                           </h2>

--- a/apps/website-25/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`StorySection > renders default as expected 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-full"
         >
           Our story
-        </h2>
+        </h1>
       </div>
     </div>
     <div

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -5,9 +5,12 @@
   h1 {
     @apply text-bluedot-darker font-sans text-5xl font-bold leading-tight;
   }
+  /* TODO: Where is the title class used? */
+  /* TODO: Introduce font-demibold for font-[650] */
   h2, .title {
     @apply text-bluedot-darker font-sans text-2xl font-[650] leading-normal;
   }
+  /* TODO: Where is the subtitle class used? */
   h3, .subtitle {
     @apply text-bluedot-darker font-sans text-2xl font-[650] leading-[1.5];
   }

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -6,7 +6,7 @@
     @apply text-bluedot-darker font-sans text-5xl font-bold leading-tight;
   }
   h2, .title {
-    @apply text-bluedot-darker font-sans text-5xl font-[700] leading-[1.5];
+    @apply text-bluedot-darker font-sans text-2xl font-[650] leading-normal;
   }
   h3, .subtitle {
     @apply text-bluedot-darker font-sans text-2xl font-[650] leading-[1.5];

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -3,7 +3,7 @@
 
 @layer base {
   h1 {
-    @apply text-bluedot-darker font-sans text-5xl font-[700] leading-[1.25];
+    @apply text-bluedot-darker font-sans text-5xl font-bold leading-tight;
   }
   h2, .title {
     @apply text-bluedot-darker font-sans text-5xl font-[700] leading-[1.5];

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -55,7 +55,7 @@ export const Card: React.FC<CardProps> = ({
 
       <div className="card__content flex flex-col gap-6 w-full flex-1 justify-between">
         <div className="card__text">
-          <h2 className="card__title text-2xl font-[650] text-bluedot-darker mb-1">{title}</h2>
+          <h2 className="card__title text-2xl text-bluedot-darker mb-1">{title}</h2>
           {subtitle && (<p className={`card__subtitle text-sm text-bluedot-black ${subtitleClassName}`}>{subtitle}</p>)}
         </div>
         <div className="card__bottom-section mt-auto flex flex-col gap-4">

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -61,7 +61,7 @@ const FeaturedCourseCard: React.FC<CourseCardProps & { footerRow: React.ReactNod
           <p className="course-card__featured-label uppercase font-[650] text-xs mb-3">
             Featured course
           </p>
-          <h2 className="course-card__title text-2xl font-semibold text-bluedot-darker mb-6">
+          <h2 className="course-card__title text-2xl text-bluedot-darker mb-6">
             {title}
           </h2>
           <CTALinkOrButton

--- a/libraries/ui/src/Section.tsx
+++ b/libraries/ui/src/Section.tsx
@@ -18,7 +18,7 @@ export const Section: React.FC<SectionProps> = ({
       <div className="section__title-container flex justify-between items-center gap-4">
         <div className="section__content flex-1">
           {title && (
-            <h2 className={clsx(
+            <h1 className={clsx(
               'section__title mb-4 relative',
               ctaText && ctaUrl
                 ? 'after:w-4/5'
@@ -26,7 +26,7 @@ export const Section: React.FC<SectionProps> = ({
             )}
             >
               {title}
-            </h2>
+            </h1>
           )}
           {subtitle && (
             <p className="section__subtitle text-bluedot-darker text-md mb-4">{subtitle}</p>

--- a/libraries/ui/src/__snapshots__/Card.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Card.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Card > renders default as expected 1`] = `
         class="card__text"
       >
         <h2
-          class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+          class="card__title text-2xl text-bluedot-darker mb-1"
         >
           John Doe
         </h2>
@@ -73,7 +73,7 @@ exports[`Card > renders with isEntireCardClickable as expected 1`] = `
         class="card__text"
       >
         <h2
-          class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+          class="card__title text-2xl text-bluedot-darker mb-1"
         >
           John Doe
         </h2>

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`CourseCard > renders Featured as expected 1`] = `
           Featured course
         </p>
         <h2
-          class="course-card__title text-2xl font-semibold text-bluedot-darker mb-6"
+          class="course-card__title text-2xl text-bluedot-darker mb-6"
         >
           Title
         </h2>
@@ -105,7 +105,7 @@ exports[`CourseCard > renders default as expected 1`] = `
         class="card__text"
       >
         <h2
-          class="card__title text-2xl font-[650] text-bluedot-darker mb-1"
+          class="card__title text-2xl text-bluedot-darker mb-1"
         >
           Title
         </h2>

--- a/libraries/ui/src/__snapshots__/Section.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Section.test.tsx.snap
@@ -11,11 +11,11 @@ exports[`Section > renders default as expected 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-full"
         >
           This is the title
-        </h2>
+        </h1>
       </div>
     </div>
     <div
@@ -36,11 +36,11 @@ exports[`Section > renders with all optional props 1`] = `
       <div
         class="section__content flex-1"
       >
-        <h2
+        <h1
           class="section__title mb-4 relative after:w-4/5"
         >
           This is the title
-        </h2>
+        </h1>
         <p
           class="section__subtitle text-bluedot-darker text-md mb-4"
         >


### PR DESCRIPTION
**🚧 work in progress 🚧**

# Summary

Update typography on `<h1>` & `<h2>` to match [Figma Typography](https://www.figma.com/design/s4dNR4ELGKPbja6GkHLVJy/Website-Laura's-Working-File?node-id=7760-3924&m=dev).

## Issue

Part of #132.

## To-dos & Questions

* [ ] Do we currently use `.subtitle` & `.title` classes? If not, remove.
* [ ] Check `leading`-values: Currently those are not used on `Card` & `CourseCard` bc. they overwrite this using `text-2xl` which carries it's own `line-height`.

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |

## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```
