### PR TITLE
Make SlideList title styles optional

### DIFF
--- a/apps/website-25/src/components/homepage/CommunitySection/TestimonialSection.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/TestimonialSection.tsx
@@ -33,7 +33,7 @@ const TestimonialSection = () => {
   return (
     <Section>
       <SlideList
-        title="What our graduates say"
+        subtitle="What our graduates say"
         itemsPerSlide={3}
         slideClassName="gap-8"
         containerClassName="justify-center"

--- a/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/TestimonialSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/TestimonialSection.test.tsx.snap
@@ -24,11 +24,11 @@ exports[`TestimonialSection > renders as expected 1`] = `
           <div
             class="slide-list__header-content"
           >
-            <h2
-              class="slide-list__title text-4xl font-bold text-bluedot-darker"
+            <h3
+              class="slide-list__subtitle"
             >
               What our graduates say
-            </h2>
+            </h3>
           </div>
         </div>
         <div

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -25,22 +25,22 @@ exports[`CourseSection > renders default as expected 1`] = `
             class="slide-list__header-content"
           >
             <h2
-              class="slide-list__title text-4xl font-bold text-bluedot-darker"
+              class="slide-list__title"
             >
               Our courses
             </h2>
             <p
-              class="slide-list__description mt-4 text-lg text-bluedot-black"
+              class="slide-list__description mt-4"
             >
               We run inclusive, blended learning courses that cater to various expertise levels and time availability
             </p>
           </div>
           <div
-            class="slide-list__nav flex gap-2 pt-2"
+            class="slide-list__nav flex items-center gap-2 pt-2 ml-auto"
           >
             <button
               aria-label="Previous slide"
-              class="slide-list__nav-button slide-list__nav-button--prev p-3 border rounded-lg transition-colors border-charcoal-light text-black focus:outline-none focus:ring-2 focus:ring-bluedot-light focus:ring-offset-0 disabled:pointer-events-none disabled:border-charcoal-light disabled:text-charcoal-light hover:bg-bluedot-lighter hover:border-bluedot-lighter hover:text-bluedot-normal active:bg-bluedot-normal active:border-bluedot-normal active:text-black"
+              class="slide-list__nav-button p-3 border rounded-lg transition-colors border-charcoal-light text-black focus:outline-none focus:ring-2 focus:ring-bluedot-light focus:ring-offset-0 disabled:pointer-events-none disabled:border-charcoal-light disabled:text-charcoal-light hover:bg-bluedot-lighter hover:border-bluedot-lighter hover:text-bluedot-normal active:bg-bluedot-normal active:border-bluedot-normal active:text-black"
               disabled=""
               type="button"
             >
@@ -60,7 +60,7 @@ exports[`CourseSection > renders default as expected 1`] = `
             </button>
             <button
               aria-label="Next slide"
-              class="slide-list__nav-button slide-list__nav-button--next p-3 border rounded-lg transition-colors border-charcoal-light text-black focus:outline-none focus:ring-2 focus:ring-bluedot-light disabled:pointer-events-none disabled:border-charcoal-light disabled:text-charcoal-light hover:bg-bluedot-lighter hover:border-bluedot-lighter hover:text-bluedot-normal active:bg-bluedot-normal active:border-bluedot-normal active:text-black"
+              class="slide-list__nav-button p-3 border rounded-lg transition-colors border-charcoal-light text-black focus:outline-none focus:ring-2 focus:ring-bluedot-light focus:ring-offset-0 disabled:pointer-events-none disabled:border-charcoal-light disabled:text-charcoal-light hover:bg-bluedot-lighter hover:border-bluedot-lighter hover:text-bluedot-normal active:bg-bluedot-normal active:border-bluedot-normal active:text-black"
               type="button"
             >
               <svg

--- a/libraries/ui/src/SlideList.stories.tsx
+++ b/libraries/ui/src/SlideList.stories.tsx
@@ -2,8 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SlideList, SlideItem } from './SlideList';
 
 const meta = {
-  title: 'Components/SlideList',
+  title: 'ui/SlideList',
   component: SlideList,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
   parameters: {
     layout: 'centered',
   },
@@ -14,8 +16,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    title: 'Example Slides',
-    description: 'This is a description of the slides',
     children: [
       <SlideItem key="1">Slide 1</SlideItem>,
       <SlideItem key="2">Slide 2</SlideItem>,
@@ -38,7 +38,7 @@ export const WithFeaturedSlot: Story = {
 
 export const MultipleItemsPerSlide: Story = {
   args: {
-    title: 'Multiple Items Per Slide',
+    subtitle: 'Multiple Items Per Slide',
     itemsPerSlide: 2,
     children: [
       <SlideItem key="1">
@@ -59,7 +59,7 @@ export const MultipleItemsPerSlide: Story = {
 
 export const SingleSlide: Story = {
   args: {
-    title: 'Single Slide',
+    subtitle: 'Single Slide',
     description: 'Navigation buttons should be disabled',
     children: [
       <SlideItem key="1">

--- a/libraries/ui/src/SlideList.test.tsx
+++ b/libraries/ui/src/SlideList.test.tsx
@@ -114,4 +114,21 @@ describe('SlideList', () => {
     const progressBar = screen.queryByRole('progressbar');
     expect(progressBar).toBeNull();
   });
+
+  it('renders without header if no title, subtitle, or description', () => {
+    const { container } = render(
+      <SlideList>
+        <SlideItem>Slide 1</SlideItem>
+        <SlideItem>Slide 2</SlideItem>
+        <SlideItem>Slide 3</SlideItem>
+      </SlideList>,
+    );
+
+    // Header content container should not be present
+    expect(container.querySelector('.slide-list__header-content')).toBeNull();
+
+    // Navigation buttons should still be present since all content fits
+    expect(screen.getByLabelText('Previous slide')).toBeDefined();
+    expect(screen.getByLabelText('Next slide')).toBeDefined();
+  });
 });

--- a/libraries/ui/src/SlideList.tsx
+++ b/libraries/ui/src/SlideList.tsx
@@ -3,7 +3,8 @@ import clsx from 'clsx';
 
 export type SlideListProps = {
   className?: string;
-  title: string;
+  title?: string;
+  subtitle?: string;
   description?: string;
   children: React.ReactNode;
   featuredSlot?: React.ReactNode;
@@ -16,6 +17,7 @@ export type SlideListProps = {
 export const SlideList: React.FC<SlideListProps> = ({
   className,
   title,
+  subtitle,
   description,
   children,
   featuredSlot,
@@ -42,28 +44,25 @@ export const SlideList: React.FC<SlideListProps> = ({
   return (
     <section className={clsx('slide-list w-full', className)}>
       <div className="slide-list__header flex justify-between items-start mb-8">
-        <div className="slide-list__header-content">
-          <h2 className="slide-list__title text-4xl font-bold text-bluedot-darker">{title}</h2>
-          {description && (
-            <p className="slide-list__description mt-4 text-lg text-bluedot-black">{description}</p>
-          )}
-        </div>
+        {(title || subtitle || description) && (
+          <div className="slide-list__header-content">
+            {title && (
+              <h2 className="slide-list__title">{title}</h2>
+            )}
+            {subtitle && (
+              <h3 className="slide-list__subtitle">{subtitle}</h3>
+            )}
+            {description && (
+              <p className="slide-list__description mt-4">{description}</p>
+            )}
+          </div>
+        )}
         {totalSlides > 1 && (
-          <div className="slide-list__nav flex gap-2 pt-2">
-            <button
-              type="button"
+          <div className="slide-list__nav flex items-center gap-2 pt-2 ml-auto">
+            <SlideListBtn
               onClick={handlePrevious}
               disabled={currentSlide === 0}
-              className={clsx(
-                'slide-list__nav-button slide-list__nav-button--prev',
-                'p-3 border rounded-lg transition-colors',
-                'border-charcoal-light text-black',
-                'focus:outline-none focus:ring-2 focus:ring-bluedot-light focus:ring-offset-0',
-                'disabled:pointer-events-none disabled:border-charcoal-light disabled:text-charcoal-light',
-                'hover:bg-bluedot-lighter hover:border-bluedot-lighter hover:text-bluedot-normal',
-                'active:bg-bluedot-normal active:border-bluedot-normal active:text-black',
-              )}
-              aria-label="Previous slide"
+              ariaLabel="Previous slide"
             >
               <svg
                 className="slide-list__nav-icon size-5"
@@ -78,21 +77,11 @@ export const SlideList: React.FC<SlideListProps> = ({
                   d="M15 19l-7-7 7-7"
                 />
               </svg>
-            </button>
-            <button
-              type="button"
+            </SlideListBtn>
+            <SlideListBtn
               onClick={handleNext}
               disabled={currentSlide === totalSlides - 1}
-              className={clsx(
-                'slide-list__nav-button slide-list__nav-button--next',
-                'p-3 border rounded-lg transition-colors',
-                'border-charcoal-light text-black',
-                'focus:outline-none focus:ring-2 focus:ring-bluedot-light',
-                'disabled:pointer-events-none disabled:border-charcoal-light disabled:text-charcoal-light',
-                'hover:bg-bluedot-lighter hover:border-bluedot-lighter hover:text-bluedot-normal',
-                'active:bg-bluedot-normal active:border-bluedot-normal active:text-black',
-              )}
-              aria-label="Next slide"
+              ariaLabel="Next slide"
             >
               <svg
                 className="slide-list__nav-icon size-5"
@@ -107,7 +96,7 @@ export const SlideList: React.FC<SlideListProps> = ({
                   d="M9 5l7 7-7 7"
                 />
               </svg>
-            </button>
+            </SlideListBtn>
           </div>
         )}
       </div>
@@ -175,4 +164,31 @@ export const SlideItem: React.FC<{
   <div className={clsx('size-full', className)}>
     {children}
   </div>
+);
+
+export const SlideListBtn: React.FC<{
+  onClick: () => void;
+  disabled: boolean;
+  ariaLabel: string;
+  children: React.ReactNode;
+}> = ({
+  onClick, disabled, ariaLabel, children,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    className={clsx(
+      'slide-list__nav-button',
+      'p-3 border rounded-lg transition-colors',
+      'border-charcoal-light text-black',
+      'focus:outline-none focus:ring-2 focus:ring-bluedot-light focus:ring-offset-0',
+      'disabled:pointer-events-none disabled:border-charcoal-light disabled:text-charcoal-light',
+      'hover:bg-bluedot-lighter hover:border-bluedot-lighter hover:text-bluedot-normal',
+      'active:bg-bluedot-normal active:border-bluedot-normal active:text-black',
+    )}
+    aria-label={ariaLabel}
+  >
+    {children}
+  </button>
 );


### PR DESCRIPTION
# Summary

Make SlideList title styles optional

## Issue
Fixes #197 
Fixes #196 

## Description

- Update SlideList title and description to use default typography (as defined in globals.css)
- Make title, subtitle, and description optional. Add handling for right-aligned buttons even without nav header

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

https://github.com/user-attachments/assets/7b4caf62-3be0-4231-abd1-85e4e228fac5

<img width="1503" alt="Screenshot 2025-02-05 at 06 59 08" src="https://github.com/user-attachments/assets/0387f840-b9a0-4aaa-a7eb-79d24a18dd18" />
<img width="1512" alt="Screenshot 2025-02-05 at 06 59 01" src="https://github.com/user-attachments/assets/8dbb04fc-2a57-4313-88f8-3f88197ebb65" />


## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    5 cached, 7 total
  Time:    2.226s 
```
