### PR TITLE
Add `fontSize`-aliases & use them on `globals.css`

### DIFF
--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -102,11 +102,11 @@ exports[`CourseSection > renders default as expected 1`] = `
                   >
                     Featured course
                   </p>
-                  <h2
-                    class="course-card__title text-2xl font-semibold text-bluedot-darker mb-6"
+                  <h3
+                    class="course-card__title mb-6"
                   >
                     AI Safety: Intro to Transformative AI
-                  </h2>
+                  </h3>
                   <button
                     class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
                     data-testid="cta-button"

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -5,7 +5,7 @@
 
 @layer base {
   h1 {
-    @apply text-color-secondary-text font-sans text-5xl font-[700] leading-[1.25];
+    @apply text-color-secondary-text font-sans text-5xl font-bold leading-tight;
   }
   h2, .title {
     @apply text-color-secondary-text font-sans text-5xl font-[700] leading-[1.5];

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -5,19 +5,19 @@
 
 @layer base {
   h1 {
-    @apply text-color-secondary-text font-sans text-5xl font-bold leading-tight;
+    @apply text-color-secondary-text font-sans text-design-xl font-bold leading-tight;
   }
   h2, .title {
-    @apply text-color-secondary-text font-sans text-5xl font-bold leading-normal;
+    @apply text-color-secondary-text font-sans text-design-xl font-bold leading-normal;
   }
   h3, .subtitle {
-    @apply text-color-secondary-text font-sans text-2xl font-[650] leading-normal;
+    @apply text-color-secondary-text font-sans text-design-l font-[650] leading-normal;
   }
   h4 {
     @apply text-color-secondary-text font-sans text-xl font-[650];
   }
   p, li, .body {
-    @apply text-color-text font-sans text-sm font-normal leading-normal;
+    @apply text-color-text font-sans text-design-m font-normal leading-normal;
   }
   ul {
     @apply list-inside list-disc;

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -17,7 +17,7 @@
     @apply text-color-secondary-text font-sans text-xl font-[650];
   }
   p, li, .body {
-    @apply text-color-text font-sans text-sm font-[400] leading-[1.5];
+    @apply text-color-text font-sans text-sm font-normal leading-normal;
   }
   ul {
     @apply list-inside list-disc;

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -5,19 +5,19 @@
 
 @layer base {
   h1 {
-    @apply text-color-secondary-text font-sans text-design-xl font-bold leading-tight;
+    @apply text-color-secondary-text font-sans text-size-xl font-bold leading-tight;
   }
   h2, .title {
-    @apply text-color-secondary-text font-sans text-design-xl font-bold leading-normal;
+    @apply text-color-secondary-text font-sans text-size-xl font-bold leading-normal;
   }
   h3, .subtitle {
-    @apply text-color-secondary-text font-sans text-design-l font-[650] leading-normal;
+    @apply text-color-secondary-text font-sans text-size-l font-[650] leading-normal;
   }
   h4 {
     @apply text-color-secondary-text font-sans text-xl font-[650];
   }
   p, li, .body {
-    @apply text-color-text font-sans text-design-m font-normal leading-normal;
+    @apply text-color-text font-sans text-size-m font-normal leading-normal;
   }
   ul {
     @apply list-inside list-disc;

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -8,7 +8,7 @@
     @apply text-color-secondary-text font-sans text-5xl font-bold leading-tight;
   }
   h2, .title {
-    @apply text-color-secondary-text font-sans text-5xl font-[700] leading-[1.5];
+    @apply text-color-secondary-text font-sans text-5xl font-bold leading-normal;
   }
   h3, .subtitle {
     @apply text-color-secondary-text font-sans text-2xl font-[650] leading-[1.5];

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -11,7 +11,7 @@
     @apply text-color-secondary-text font-sans text-5xl font-bold leading-normal;
   }
   h3, .subtitle {
-    @apply text-color-secondary-text font-sans text-2xl font-[650] leading-[1.5];
+    @apply text-color-secondary-text font-sans text-2xl font-[650] leading-normal;
   }
   h4 {
     @apply text-color-secondary-text font-sans text-xl font-[650];

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -61,9 +61,9 @@ const FeaturedCourseCard: React.FC<CourseCardProps> = ({
           <p className="course-card__featured-label uppercase font-[650] text-xs mb-3">
             Featured course
           </p>
-          <h2 className="course-card__title text-2xl font-semibold text-bluedot-darker mb-6">
+          <h3 className="course-card__title mb-6">
             {title}
-          </h2>
+          </h3>
           <CTALinkOrButton
             className="course-card__cta mb-6 px-6"
             variant="primary"

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -18,11 +18,11 @@ exports[`CourseCard > renders Featured as expected 1`] = `
         >
           Featured course
         </p>
-        <h2
-          class="course-card__title text-2xl font-semibold text-bluedot-darker mb-6"
+        <h3
+          class="course-card__title mb-6"
         >
           Title
-        </h2>
+        </h3>
         <button
           class="cta-button flex items-center justify-center rounded transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
           data-testid="cta-button"

--- a/libraries/ui/src/default-config/tailwind.ts
+++ b/libraries/ui/src/default-config/tailwind.ts
@@ -67,10 +67,10 @@ export const withDefaultBlueDotTailwindConfig = (config: Partial<Config> & { con
         },
         fontSize: {
           /* Design System Font Sizes */
-          'design-s': ['0.75rem' /* 12px */, { lineHeight: '1rem' /* 16px */ }], // equivalent to xs
-          'design-m': ['0.875rem' /* 14px */, { lineHeight: '1.25rem' /* 20px */ }], // equivalent to sm
-          'design-l': ['1.5rem' /* 24px */, { lineHeight: '2rem' /* 32px */ }], // equivalent to 2xl
-          'design-xl': ['3rem' /* 48px */, { lineHeight: '1' }], // equivalent to 5xl
+          'size-s': ['0.75rem' /* 12px */, { lineHeight: '1rem' /* 16px */ }], // equivalent to xs
+          'size-m': ['0.875rem' /* 14px */, { lineHeight: '1.25rem' /* 20px */ }], // equivalent to sm
+          'size-l': ['1.5rem' /* 24px */, { lineHeight: '2rem' /* 32px */ }], // equivalent to 2xl
+          'size-xl': ['3rem' /* 48px */, { lineHeight: '1' }], // equivalent to 5xl
           ...config.theme?.extend?.fontSize,
         },
         spacing: {

--- a/libraries/ui/src/default-config/tailwind.ts
+++ b/libraries/ui/src/default-config/tailwind.ts
@@ -65,6 +65,14 @@ export const withDefaultBlueDotTailwindConfig = (config: Partial<Config> & { con
           serif: '"Reckless Neue", ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
           ...config.theme?.extend?.fontFamily,
         },
+        fontSize: {
+          /* Design System Font Sizes */
+          'design-s': ['0.75rem' /* 12px */, { lineHeight: '1rem' /* 16px */ }], // equivalent to xs
+          'design-m': ['0.875rem' /* 14px */, { lineHeight: '1.25rem' /* 20px */ }], // equivalent to sm
+          'design-l': ['1.5rem' /* 24px */, { lineHeight: '2rem' /* 32px */ }], // equivalent to 2xl
+          'design-xl': ['3rem' /* 48px */, { lineHeight: '1' }], // equivalent to 5xl
+          ...config.theme?.extend?.fontSize,
+        },
         spacing: {
           'max-width': '1440px',
           'min-width': '388px',


### PR DESCRIPTION
# Summary

Add `fontSize`-aliases & use them on `globals.css`.

## Issue

Fixes #133.
Fixes #132.
Fixes #131.

## Description

* Use *semantically correct* `<h3>` on `FeaturedCourseCard`.
* Introduce `design-s`, ..., `design-xl` aliases equivalent to [Figma](https://www.figma.com/design/s4dNR4ELGKPbja6GkHLVJy/Website-Laura's-Working-File?node-id=879-4824&p=f&t=NUaQQCvz92d5wYqY-0).
* 📸  No visual changes.

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    5 cached, 7 total
  Time:    3.385s 
```
