### PR TITLE
Update tag in blog section to stick to the right side

### DIFF
--- a/apps/website-25/src/components/homepage/BlogSection.tsx
+++ b/apps/website-25/src/components/homepage/BlogSection.tsx
@@ -47,7 +47,7 @@ const BlogPost = ({
         <h3 className="blog-section__blog-post-title">{title}</h3>
         <div className="blog-section__blog-post-metadata w-full flex flex-col sm:flex-row mt-6 gap-6">
           <p className="blog-section__blog-post-author flex-grow">By {author}</p>
-          {tag && <Tag className="blog-section__blog-post-tag sm:self-end">{tag}</Tag>}
+          {tag && <Tag className="blog-section__blog-post-tag self-end">{tag}</Tag>}
         </div>
       </div>
     </a>

--- a/apps/website-25/src/components/homepage/__snapshots__/BlogSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/BlogSection.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`BlogSection > renders default as expected 1`] = `
                 Adam Jones
               </p>
               <span
-                class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text blog-section__blog-post-tag sm:self-end"
+                class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text blog-section__blog-post-tag self-end"
                 role="status"
               >
                 AI alignment


### PR DESCRIPTION
Update tag in blog section to stick to the right side on mobile and desktop

# Summary

<!-- One line summary of your change -->

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
No issue, but related to [website MVP](https://github.com/orgs/bluedotimpact/projects/2/views/1)

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
| 📱  | 
Before: 

<img width="516" alt="Screenshot 2025-02-08 at 9 20 38 AM" src="https://github.com/user-attachments/assets/2af342cc-e47b-48e8-843e-0d3c383a0928" />

After:

<img width="512" alt="Screenshot 2025-02-08 at 9 21 57 AM" src="https://github.com/user-attachments/assets/e3a1bf81-3f20-4d3a-b374-0019a7abf343" />
<!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |

## Testing
```
$ npm run test:update
@bluedot/website-25:test:   Snapshots  1 updated 
@bluedot/website-25:test:  Test Files  18 passed (18)
@bluedot/website-25:test:       Tests  23 passed (23)
@bluedot/website-25:test:    Start at  09:22:09
@bluedot/website-25:test:    Duration  2.36s (transform 360ms, setup 0ms, collect 12.49s, tests 343ms, environment 3.06s, prepare 1.18s)
```
