### PR TITLE
Use SlideList for ValuesSection and BeliefsSection

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -75,102 +75,155 @@ exports[`AboutPage > should render the error message correctly 1`] = `
       <div
         class="section__body"
       >
-        <div
-          class="beliefs-section__container flex sm:flex-row flex-col gap-8 overflow-y-scroll"
+        <section
+          class="slide-list w-full"
         >
           <div
-            class="value-card w-full flex flex-col gap-6 py-6"
-          >
-            <div
-              class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-            >
-              <img
-                alt="AGI could arrive soon, and society is unprepared"
-                class="value-card__icon"
-                src="icons/fast.svg"
-              />
-            </div>
-            <h3
-              class="value-card__title min-h-[60px]"
-            >
-              AGI could arrive soon, and society is unprepared
-            </h3>
-            <p
-              class="value-card__description "
-            >
-              Human-level AI will likely be built within years, not decades. Our technical, political, and social systems are not prepared to handle it safely, and the default path leads to catastrophic outcomes.
-            </p>
-          </div>
+            class="slide-list__header flex flex-col md:flex-row md:justify-between md:items-start mb-8"
+          />
           <div
-            class="value-card w-full flex flex-col gap-6 py-6"
+            class="slide-list__content flex flex-col md:flex-row gap-4"
           >
             <div
-              class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+              class="slide-list__container relative overflow-hidden flex-shrink-0 w-full"
+              style="width: 100%;"
             >
-              <img
-                alt="What we do now matters"
-                class="value-card__icon"
-                src="icons/care.svg"
-              />
+              <div
+                class="slide-list__slides flex transition-transform duration-300"
+                style="transform: translateX(-0%);"
+              >
+                <div
+                  class="slide-list__slide flex-shrink-0 w-full px-2"
+                  style="width: 25%;"
+                >
+                  <div
+                    class="size-full"
+                  >
+                    <div
+                      class="value-card w-full flex flex-col gap-6 py-6"
+                    >
+                      <div
+                        class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                      >
+                        <img
+                          alt="AGI could arrive soon, and we're unprepared"
+                          class="value-card__icon"
+                          src="icons/fast.svg"
+                        />
+                      </div>
+                      <h3
+                        class="value-card__title min-h-[60px]"
+                      >
+                        AGI could arrive soon, and we're unprepared
+                      </h3>
+                      <p
+                        class="value-card__description "
+                      >
+                        Human-level AI will likely be built within years, not decades. Our technical, political, and social systems are not prepared to handle it safely, and the default path leads to catastrophic outcomes.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="slide-list__slide flex-shrink-0 w-full px-2"
+                  style="width: 25%;"
+                >
+                  <div
+                    class="size-full"
+                  >
+                    <div
+                      class="value-card w-full flex flex-col gap-6 py-6"
+                    >
+                      <div
+                        class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                      >
+                        <img
+                          alt="What we do now matters"
+                          class="value-card__icon"
+                          src="icons/care.svg"
+                        />
+                      </div>
+                      <h3
+                        class="value-card__title min-h-[60px]"
+                      >
+                        What we do now matters
+                      </h3>
+                      <p
+                        class="value-card__description "
+                      >
+                        The future of AI isn't set in stone. Our choices today will determine whether this technology helps or harms humanity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="slide-list__slide flex-shrink-0 w-full px-2"
+                  style="width: 25%;"
+                >
+                  <div
+                    class="size-full"
+                  >
+                    <div
+                      class="value-card w-full flex flex-col gap-6 py-6"
+                    >
+                      <div
+                        class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                      >
+                        <img
+                          alt="The right people at key moments rewrite history"
+                          class="value-card__icon"
+                          src="icons/solvers.svg"
+                        />
+                      </div>
+                      <h3
+                        class="value-card__title min-h-[60px]"
+                      >
+                        The right people at key moments rewrite history
+                      </h3>
+                      <p
+                        class="value-card__description "
+                      >
+                        Throughout history, capable individuals in key positions have steered powerful technologies toward better outcomes. By identifying, training, and mobilising exceptional people, we can guide AI toward a safe and beneficial future.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="slide-list__slide flex-shrink-0 w-full px-2"
+                  style="width: 25%;"
+                >
+                  <div
+                    class="size-full"
+                  >
+                    <div
+                      class="value-card w-full flex flex-col gap-6 py-6"
+                    >
+                      <div
+                        class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                      >
+                        <img
+                          alt="We need urgency, wisdom and optimism"
+                          class="value-card__icon"
+                          src="icons/network.svg"
+                        />
+                      </div>
+                      <h3
+                        class="value-card__title min-h-[60px]"
+                      >
+                        We need urgency, wisdom and optimism
+                      </h3>
+                      <p
+                        class="value-card__description "
+                      >
+                        The stakes are vast and time is short, but panic and fatalism do more harm than good. We need rapid, coordinated action informed by evidence and guided by hope.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-            <h3
-              class="value-card__title min-h-[60px]"
-            >
-              What we do now matters
-            </h3>
-            <p
-              class="value-card__description "
-            >
-              The future of AI isn't set in stone. Our choices today will determine whether this technology helps or harms humanity.
-            </p>
           </div>
-          <div
-            class="value-card w-full flex flex-col gap-6 py-6"
-          >
-            <div
-              class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-            >
-              <img
-                alt="The right people at key moments rewrite history"
-                class="value-card__icon"
-                src="icons/solvers.svg"
-              />
-            </div>
-            <h3
-              class="value-card__title min-h-[60px]"
-            >
-              The right people at key moments rewrite history
-            </h3>
-            <p
-              class="value-card__description "
-            >
-              Throughout history, capable individuals in key positions have steered powerful technologies toward better outcomes. By identifying, training, and mobilising exceptional people, we can guide AI toward a safe and beneficial future.
-            </p>
-          </div>
-          <div
-            class="value-card w-full flex flex-col gap-6 py-6"
-          >
-            <div
-              class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-            >
-              <img
-                alt="We need urgency, wisdom and optimism"
-                class="value-card__icon"
-                src="icons/network.svg"
-              />
-            </div>
-            <h3
-              class="value-card__title min-h-[60px]"
-            >
-              We need urgency, wisdom and optimism
-            </h3>
-            <p
-              class="value-card__description "
-            >
-              The stakes are vast and time is short, but panic and fatalism do more harm than good. We need rapid, coordinated action informed by evidence and guided by hope.
-            </p>
-          </div>
-        </div>
+        </section>
       </div>
     </div>
     <div

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -75,79 +75,123 @@ exports[`CareersPage > should render the error message correctly 1`] = `
       <div
         class="section__body"
       >
-        <div
-          class="flex sm:flex-row flex-col gap-8 overflow-y-scroll"
+        <section
+          class="slide-list w-full"
         >
           <div
-            class="value-card w-full flex flex-col gap-6 py-6"
-          >
-            <div
-              class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-            >
-              <img
-                alt="Think hard, act fast, fail faster"
-                class="value-card__icon"
-                src="icons/fast.svg"
-              />
-            </div>
-            <h3
-              class="value-card__title min-h-[60px]"
-            >
-              Think hard, act fast, fail faster
-            </h3>
-            <p
-              class="value-card__description "
-            >
-              We think critically about our goals and the best path to achieve them. We learn by building rapid experiments, failing fast, measuring the results, and updating.
-            </p>
-          </div>
+            class="slide-list__header flex flex-col md:flex-row md:justify-between md:items-start mb-8"
+          />
           <div
-            class="value-card w-full flex flex-col gap-6 py-6"
+            class="slide-list__content flex flex-col md:flex-row gap-4"
           >
             <div
-              class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+              class="slide-list__container relative overflow-hidden flex-shrink-0 w-full"
+              style="width: 100%;"
             >
-              <img
-                alt="Care personally, challenge directly"
-                class="value-card__icon"
-                src="icons/care.svg"
-              />
+              <div
+                class="slide-list__slides flex transition-transform duration-300"
+                style="transform: translateX(-0%);"
+              >
+                <div
+                  class="slide-list__slide flex-shrink-0 w-full px-2"
+                  style="width: 33.333333333333336%;"
+                >
+                  <div
+                    class="size-full"
+                  >
+                    <div
+                      class="value-card w-full flex flex-col gap-6 py-6"
+                    >
+                      <div
+                        class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                      >
+                        <img
+                          alt="Think hard, act fast, fail faster"
+                          class="value-card__icon"
+                          src="icons/fast.svg"
+                        />
+                      </div>
+                      <h3
+                        class="value-card__title min-h-[60px]"
+                      >
+                        Think hard, act fast, fail faster
+                      </h3>
+                      <p
+                        class="value-card__description "
+                      >
+                        We think critically about our goals and the best path to achieve them. We learn by building rapid experiments, failing fast, measuring the results, and updating.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="slide-list__slide flex-shrink-0 w-full px-2"
+                  style="width: 33.333333333333336%;"
+                >
+                  <div
+                    class="size-full"
+                  >
+                    <div
+                      class="value-card w-full flex flex-col gap-6 py-6"
+                    >
+                      <div
+                        class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                      >
+                        <img
+                          alt="Care personally, challenge directly"
+                          class="value-card__icon"
+                          src="icons/care.svg"
+                        />
+                      </div>
+                      <h3
+                        class="value-card__title min-h-[60px]"
+                      >
+                        Care personally, challenge directly
+                      </h3>
+                      <p
+                        class="value-card__description "
+                      >
+                        We care about our team and our community, and we hold everyone to high standards.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="slide-list__slide flex-shrink-0 w-full px-2"
+                  style="width: 33.333333333333336%;"
+                >
+                  <div
+                    class="size-full"
+                  >
+                    <div
+                      class="value-card w-full flex flex-col gap-6 py-6"
+                    >
+                      <div
+                        class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                      >
+                        <img
+                          alt="Obsessed with empowering problem-solvers"
+                          class="value-card__icon"
+                          src="icons/solvers.svg"
+                        />
+                      </div>
+                      <h3
+                        class="value-card__title min-h-[60px]"
+                      >
+                        Obsessed with empowering problem-solvers
+                      </h3>
+                      <p
+                        class="value-card__description "
+                      >
+                        We exist to support others to solve the world's biggest problems. We go above and beyond to accelerate our community's impact.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-            <h3
-              class="value-card__title min-h-[60px]"
-            >
-              Care personally, challenge directly
-            </h3>
-            <p
-              class="value-card__description "
-            >
-              We care about our team and our community, and we hold everyone to high standards.
-            </p>
           </div>
-          <div
-            class="value-card w-full flex flex-col gap-6 py-6"
-          >
-            <div
-              class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-            >
-              <img
-                alt="Obsessed with empowering problem-solvers"
-                class="value-card__icon"
-                src="icons/solvers.svg"
-              />
-            </div>
-            <h3
-              class="value-card__title min-h-[60px]"
-            >
-              Obsessed with empowering problem-solvers
-            </h3>
-            <p
-              class="value-card__description "
-            >
-              We exist to support others to solve the world's biggest problems. We go above and beyond to accelerate our community's impact.
-            </p>
-          </div>
-        </div>
+        </section>
       </div>
     </div>
     <div

--- a/apps/website-25/src/components/about/BeliefsSection.stories.tsx
+++ b/apps/website-25/src/components/about/BeliefsSection.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import BeliefsSection from './BeliefsSection';
+
+const meta = {
+  title: 'website/BeliefsSection',
+  component: BeliefsSection,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: 'fullscreen',
+  },
+  args: {},
+} satisfies Meta<typeof BeliefsSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/apps/website-25/src/components/about/BeliefsSection.tsx
+++ b/apps/website-25/src/components/about/BeliefsSection.tsx
@@ -1,30 +1,47 @@
 import { Section, ValueCard } from '@bluedot/ui';
+import { SlideList, SlideItem } from '@bluedot/ui/src/SlideList';
+
+const beliefs = [
+  {
+    icon: "icons/fast.svg",
+    title: "AGI could arrive soon, and we're unprepared",
+    description: "Human-level AI will likely be built within years, not decades. Our technical, political, and social systems are not prepared to handle it safely, and the default path leads to catastrophic outcomes."
+  },
+  {
+    icon: "icons/care.svg",
+    title: "What we do now matters",
+    description: "The future of AI isn't set in stone. Our choices today will determine whether this technology helps or harms humanity."
+  },
+  {
+    icon: "icons/solvers.svg",
+    title: "The right people at key moments rewrite history",
+    description: "Throughout history, capable individuals in key positions have steered powerful technologies toward better outcomes. By identifying, training, and mobilising exceptional people, we can guide AI toward a safe and beneficial future."
+  },
+  {
+    icon: "icons/network.svg",
+    title: "We need urgency, wisdom and optimism",
+    description: "The stakes are vast and time is short, but panic and fatalism do more harm than good. We need rapid, coordinated action informed by evidence and guided by hope."
+  }
+] as const;
 
 const BeliefsSection = () => {
   return (
     <Section className="beliefs-section" title="Our core beliefs">
-      <div className="beliefs-section__container flex sm:flex-row flex-col gap-8 overflow-y-scroll">
-        <ValueCard
-          icon="icons/fast.svg"
-          title="AGI could arrive soon, and society is unprepared"
-          description="Human-level AI will likely be built within years, not decades. Our technical, political, and social systems are not prepared to handle it safely, and the default path leads to catastrophic outcomes."
-        />
-        <ValueCard
-          icon="icons/care.svg"
-          title="What we do now matters"
-          description="The future of AI isn't set in stone. Our choices today will determine whether this technology helps or harms humanity."
-        />
-        <ValueCard
-          icon="icons/solvers.svg"
-          title="The right people at key moments rewrite history"
-          description="Throughout history, capable individuals in key positions have steered powerful technologies toward better outcomes. By identifying, training, and mobilising exceptional people, we can guide AI toward a safe and beneficial future."
-        />
-        <ValueCard
-          icon="icons/network.svg"
-          title="We need urgency, wisdom and optimism"
-          description="The stakes are vast and time is short, but panic and fatalism do more harm than good. We need rapid, coordinated action informed by evidence and guided by hope."
-        />
-      </div>
+      <SlideList
+        itemsPerSlide={4}
+        slidesWrapperWidth="100%"
+        slideClassName="px-2"
+      >
+        {beliefs.map((belief) => (
+          <SlideItem key={belief.title}>
+            <ValueCard
+              icon={belief.icon}
+              title={belief.title}
+              description={belief.description}
+            />
+          </SlideItem>
+        ))}
+      </SlideList>
     </Section>
   );
 };

--- a/apps/website-25/src/components/about/BeliefsSection.tsx
+++ b/apps/website-25/src/components/about/BeliefsSection.tsx
@@ -3,25 +3,25 @@ import { SlideList, SlideItem } from '@bluedot/ui/src/SlideList';
 
 const beliefs = [
   {
-    icon: "icons/fast.svg",
-    title: "AGI could arrive soon, and we're unprepared",
-    description: "Human-level AI will likely be built within years, not decades. Our technical, political, and social systems are not prepared to handle it safely, and the default path leads to catastrophic outcomes."
+    icon: 'icons/fast.svg',
+    title: 'AGI could arrive soon, and we\'re unprepared',
+    description: 'Human-level AI will likely be built within years, not decades. Our technical, political, and social systems are not prepared to handle it safely, and the default path leads to catastrophic outcomes.',
   },
   {
-    icon: "icons/care.svg",
-    title: "What we do now matters",
-    description: "The future of AI isn't set in stone. Our choices today will determine whether this technology helps or harms humanity."
+    icon: 'icons/care.svg',
+    title: 'What we do now matters',
+    description: 'The future of AI isn\'t set in stone. Our choices today will determine whether this technology helps or harms humanity.',
   },
   {
-    icon: "icons/solvers.svg",
-    title: "The right people at key moments rewrite history",
-    description: "Throughout history, capable individuals in key positions have steered powerful technologies toward better outcomes. By identifying, training, and mobilising exceptional people, we can guide AI toward a safe and beneficial future."
+    icon: 'icons/solvers.svg',
+    title: 'The right people at key moments rewrite history',
+    description: 'Throughout history, capable individuals in key positions have steered powerful technologies toward better outcomes. By identifying, training, and mobilising exceptional people, we can guide AI toward a safe and beneficial future.',
   },
   {
-    icon: "icons/network.svg",
-    title: "We need urgency, wisdom and optimism",
-    description: "The stakes are vast and time is short, but panic and fatalism do more harm than good. We need rapid, coordinated action informed by evidence and guided by hope."
-  }
+    icon: 'icons/network.svg',
+    title: 'We need urgency, wisdom and optimism',
+    description: 'The stakes are vast and time is short, but panic and fatalism do more harm than good. We need rapid, coordinated action informed by evidence and guided by hope.',
+  },
 ] as const;
 
 const BeliefsSection = () => {

--- a/apps/website-25/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
@@ -21,102 +21,155 @@ exports[`BeliefsSection > renders default as expected 1`] = `
     <div
       class="section__body"
     >
-      <div
-        class="beliefs-section__container flex sm:flex-row flex-col gap-8 overflow-y-scroll"
+      <section
+        class="slide-list w-full"
       >
         <div
-          class="value-card w-full flex flex-col gap-6 py-6"
-        >
-          <div
-            class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-          >
-            <img
-              alt="AGI could arrive soon, and society is unprepared"
-              class="value-card__icon"
-              src="icons/fast.svg"
-            />
-          </div>
-          <h3
-            class="value-card__title min-h-[60px]"
-          >
-            AGI could arrive soon, and society is unprepared
-          </h3>
-          <p
-            class="value-card__description "
-          >
-            Human-level AI will likely be built within years, not decades. Our technical, political, and social systems are not prepared to handle it safely, and the default path leads to catastrophic outcomes.
-          </p>
-        </div>
+          class="slide-list__header flex flex-col md:flex-row md:justify-between md:items-start mb-8"
+        />
         <div
-          class="value-card w-full flex flex-col gap-6 py-6"
+          class="slide-list__content flex flex-col md:flex-row gap-4"
         >
           <div
-            class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+            class="slide-list__container relative overflow-hidden flex-shrink-0 w-full"
+            style="width: 100%;"
           >
-            <img
-              alt="What we do now matters"
-              class="value-card__icon"
-              src="icons/care.svg"
-            />
+            <div
+              class="slide-list__slides flex transition-transform duration-300"
+              style="transform: translateX(-0%);"
+            >
+              <div
+                class="slide-list__slide flex-shrink-0 w-full px-2"
+                style="width: 25%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="value-card w-full flex flex-col gap-6 py-6"
+                  >
+                    <div
+                      class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                    >
+                      <img
+                        alt="AGI could arrive soon, and we're unprepared"
+                        class="value-card__icon"
+                        src="icons/fast.svg"
+                      />
+                    </div>
+                    <h3
+                      class="value-card__title min-h-[60px]"
+                    >
+                      AGI could arrive soon, and we're unprepared
+                    </h3>
+                    <p
+                      class="value-card__description "
+                    >
+                      Human-level AI will likely be built within years, not decades. Our technical, political, and social systems are not prepared to handle it safely, and the default path leads to catastrophic outcomes.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="slide-list__slide flex-shrink-0 w-full px-2"
+                style="width: 25%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="value-card w-full flex flex-col gap-6 py-6"
+                  >
+                    <div
+                      class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                    >
+                      <img
+                        alt="What we do now matters"
+                        class="value-card__icon"
+                        src="icons/care.svg"
+                      />
+                    </div>
+                    <h3
+                      class="value-card__title min-h-[60px]"
+                    >
+                      What we do now matters
+                    </h3>
+                    <p
+                      class="value-card__description "
+                    >
+                      The future of AI isn't set in stone. Our choices today will determine whether this technology helps or harms humanity.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="slide-list__slide flex-shrink-0 w-full px-2"
+                style="width: 25%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="value-card w-full flex flex-col gap-6 py-6"
+                  >
+                    <div
+                      class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                    >
+                      <img
+                        alt="The right people at key moments rewrite history"
+                        class="value-card__icon"
+                        src="icons/solvers.svg"
+                      />
+                    </div>
+                    <h3
+                      class="value-card__title min-h-[60px]"
+                    >
+                      The right people at key moments rewrite history
+                    </h3>
+                    <p
+                      class="value-card__description "
+                    >
+                      Throughout history, capable individuals in key positions have steered powerful technologies toward better outcomes. By identifying, training, and mobilising exceptional people, we can guide AI toward a safe and beneficial future.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="slide-list__slide flex-shrink-0 w-full px-2"
+                style="width: 25%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="value-card w-full flex flex-col gap-6 py-6"
+                  >
+                    <div
+                      class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                    >
+                      <img
+                        alt="We need urgency, wisdom and optimism"
+                        class="value-card__icon"
+                        src="icons/network.svg"
+                      />
+                    </div>
+                    <h3
+                      class="value-card__title min-h-[60px]"
+                    >
+                      We need urgency, wisdom and optimism
+                    </h3>
+                    <p
+                      class="value-card__description "
+                    >
+                      The stakes are vast and time is short, but panic and fatalism do more harm than good. We need rapid, coordinated action informed by evidence and guided by hope.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <h3
-            class="value-card__title min-h-[60px]"
-          >
-            What we do now matters
-          </h3>
-          <p
-            class="value-card__description "
-          >
-            The future of AI isn't set in stone. Our choices today will determine whether this technology helps or harms humanity.
-          </p>
         </div>
-        <div
-          class="value-card w-full flex flex-col gap-6 py-6"
-        >
-          <div
-            class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-          >
-            <img
-              alt="The right people at key moments rewrite history"
-              class="value-card__icon"
-              src="icons/solvers.svg"
-            />
-          </div>
-          <h3
-            class="value-card__title min-h-[60px]"
-          >
-            The right people at key moments rewrite history
-          </h3>
-          <p
-            class="value-card__description "
-          >
-            Throughout history, capable individuals in key positions have steered powerful technologies toward better outcomes. By identifying, training, and mobilising exceptional people, we can guide AI toward a safe and beneficial future.
-          </p>
-        </div>
-        <div
-          class="value-card w-full flex flex-col gap-6 py-6"
-        >
-          <div
-            class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-          >
-            <img
-              alt="We need urgency, wisdom and optimism"
-              class="value-card__icon"
-              src="icons/network.svg"
-            />
-          </div>
-          <h3
-            class="value-card__title min-h-[60px]"
-          >
-            We need urgency, wisdom and optimism
-          </h3>
-          <p
-            class="value-card__description "
-          >
-            The stakes are vast and time is short, but panic and fatalism do more harm than good. We need rapid, coordinated action informed by evidence and guided by hope.
-          </p>
-        </div>
-      </div>
+      </section>
     </div>
   </div>
 </div>

--- a/apps/website-25/src/components/careers/ValuesSection.stories.tsx
+++ b/apps/website-25/src/components/careers/ValuesSection.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ValuesSection from './ValuesSection';
+
+const meta = {
+  title: 'website/ValuesSection',
+  component: ValuesSection,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: 'fullscreen',
+  },
+  args: {},
+} satisfies Meta<typeof ValuesSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/apps/website-25/src/components/careers/ValuesSection.tsx
+++ b/apps/website-25/src/components/careers/ValuesSection.tsx
@@ -3,20 +3,20 @@ import { SlideList, SlideItem } from '@bluedot/ui/src/SlideList';
 
 const values = [
   {
-    icon: "icons/fast.svg",
-    title: "Think hard, act fast, fail faster",
-    description: "We think critically about our goals and the best path to achieve them. We learn by building rapid experiments, failing fast, measuring the results, and updating."
+    icon: 'icons/fast.svg',
+    title: 'Think hard, act fast, fail faster',
+    description: 'We think critically about our goals and the best path to achieve them. We learn by building rapid experiments, failing fast, measuring the results, and updating.',
   },
   {
-    icon: "icons/care.svg",
-    title: "Care personally, challenge directly",
-    description: "We care about our team and our community, and we hold everyone to high standards."
+    icon: 'icons/care.svg',
+    title: 'Care personally, challenge directly',
+    description: 'We care about our team and our community, and we hold everyone to high standards.',
   },
   {
-    icon: "icons/solvers.svg",
-    title: "Obsessed with empowering problem-solvers",
-    description: "We exist to support others to solve the world's biggest problems. We go above and beyond to accelerate our community's impact."
-  }
+    icon: 'icons/solvers.svg',
+    title: 'Obsessed with empowering problem-solvers',
+    description: 'We exist to support others to solve the world\'s biggest problems. We go above and beyond to accelerate our community\'s impact.',
+  },
 ] as const;
 
 const ValuesSection = () => {
@@ -25,7 +25,7 @@ const ValuesSection = () => {
       <SlideList
         itemsPerSlide={3}
         slidesWrapperWidth="100%"
-        slideClassName='px-2'
+        slideClassName="px-2"
       >
         {values.map((value) => (
           <SlideItem key={value.title}>

--- a/apps/website-25/src/components/careers/ValuesSection.tsx
+++ b/apps/website-25/src/components/careers/ValuesSection.tsx
@@ -1,25 +1,42 @@
 import { Section, ValueCard } from '@bluedot/ui';
+import { SlideList, SlideItem } from '@bluedot/ui/src/SlideList';
+
+const values = [
+  {
+    icon: "icons/fast.svg",
+    title: "Think hard, act fast, fail faster",
+    description: "We think critically about our goals and the best path to achieve them. We learn by building rapid experiments, failing fast, measuring the results, and updating."
+  },
+  {
+    icon: "icons/care.svg",
+    title: "Care personally, challenge directly",
+    description: "We care about our team and our community, and we hold everyone to high standards."
+  },
+  {
+    icon: "icons/solvers.svg",
+    title: "Obsessed with empowering problem-solvers",
+    description: "We exist to support others to solve the world's biggest problems. We go above and beyond to accelerate our community's impact."
+  }
+] as const;
 
 const ValuesSection = () => {
   return (
     <Section className="values-section" title="Our values">
-      <div className="flex sm:flex-row flex-col gap-8 overflow-y-scroll">
-        <ValueCard
-          icon="icons/fast.svg"
-          title="Think hard, act fast, fail faster"
-          description="We think critically about our goals and the best path to achieve them. We learn by building rapid experiments, failing fast, measuring the results, and updating."
-        />
-        <ValueCard
-          icon="icons/care.svg"
-          title="Care personally, challenge directly"
-          description="We care about our team and our community, and we hold everyone to high standards."
-        />
-        <ValueCard
-          icon="icons/solvers.svg"
-          title="Obsessed with empowering problem-solvers"
-          description="We exist to support others to solve the world's biggest problems. We go above and beyond to accelerate our community's impact."
-        />
-      </div>
+      <SlideList
+        itemsPerSlide={3}
+        slidesWrapperWidth="100%"
+        slideClassName='px-2'
+      >
+        {values.map((value) => (
+          <SlideItem key={value.title}>
+            <ValueCard
+              icon={value.icon}
+              title={value.title}
+              description={value.description}
+            />
+          </SlideItem>
+        ))}
+      </SlideList>
     </Section>
   );
 };

--- a/apps/website-25/src/components/careers/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/ValuesSection.test.tsx.snap
@@ -21,79 +21,123 @@ exports[`ValuesSection > renders default as expected 1`] = `
     <div
       class="section__body"
     >
-      <div
-        class="flex sm:flex-row flex-col gap-8 overflow-y-scroll"
+      <section
+        class="slide-list w-full"
       >
         <div
-          class="value-card w-full flex flex-col gap-6 py-6"
-        >
-          <div
-            class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-          >
-            <img
-              alt="Think hard, act fast, fail faster"
-              class="value-card__icon"
-              src="icons/fast.svg"
-            />
-          </div>
-          <h3
-            class="value-card__title min-h-[60px]"
-          >
-            Think hard, act fast, fail faster
-          </h3>
-          <p
-            class="value-card__description "
-          >
-            We think critically about our goals and the best path to achieve them. We learn by building rapid experiments, failing fast, measuring the results, and updating.
-          </p>
-        </div>
+          class="slide-list__header flex flex-col md:flex-row md:justify-between md:items-start mb-8"
+        />
         <div
-          class="value-card w-full flex flex-col gap-6 py-6"
+          class="slide-list__content flex flex-col md:flex-row gap-4"
         >
           <div
-            class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+            class="slide-list__container relative overflow-hidden flex-shrink-0 w-full"
+            style="width: 100%;"
           >
-            <img
-              alt="Care personally, challenge directly"
-              class="value-card__icon"
-              src="icons/care.svg"
-            />
+            <div
+              class="slide-list__slides flex transition-transform duration-300"
+              style="transform: translateX(-0%);"
+            >
+              <div
+                class="slide-list__slide flex-shrink-0 w-full px-2"
+                style="width: 33.333333333333336%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="value-card w-full flex flex-col gap-6 py-6"
+                  >
+                    <div
+                      class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                    >
+                      <img
+                        alt="Think hard, act fast, fail faster"
+                        class="value-card__icon"
+                        src="icons/fast.svg"
+                      />
+                    </div>
+                    <h3
+                      class="value-card__title min-h-[60px]"
+                    >
+                      Think hard, act fast, fail faster
+                    </h3>
+                    <p
+                      class="value-card__description "
+                    >
+                      We think critically about our goals and the best path to achieve them. We learn by building rapid experiments, failing fast, measuring the results, and updating.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="slide-list__slide flex-shrink-0 w-full px-2"
+                style="width: 33.333333333333336%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="value-card w-full flex flex-col gap-6 py-6"
+                  >
+                    <div
+                      class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                    >
+                      <img
+                        alt="Care personally, challenge directly"
+                        class="value-card__icon"
+                        src="icons/care.svg"
+                      />
+                    </div>
+                    <h3
+                      class="value-card__title min-h-[60px]"
+                    >
+                      Care personally, challenge directly
+                    </h3>
+                    <p
+                      class="value-card__description "
+                    >
+                      We care about our team and our community, and we hold everyone to high standards.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="slide-list__slide flex-shrink-0 w-full px-2"
+                style="width: 33.333333333333336%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="value-card w-full flex flex-col gap-6 py-6"
+                  >
+                    <div
+                      class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
+                    >
+                      <img
+                        alt="Obsessed with empowering problem-solvers"
+                        class="value-card__icon"
+                        src="icons/solvers.svg"
+                      />
+                    </div>
+                    <h3
+                      class="value-card__title min-h-[60px]"
+                    >
+                      Obsessed with empowering problem-solvers
+                    </h3>
+                    <p
+                      class="value-card__description "
+                    >
+                      We exist to support others to solve the world's biggest problems. We go above and beyond to accelerate our community's impact.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <h3
-            class="value-card__title min-h-[60px]"
-          >
-            Care personally, challenge directly
-          </h3>
-          <p
-            class="value-card__description "
-          >
-            We care about our team and our community, and we hold everyone to high standards.
-          </p>
         </div>
-        <div
-          class="value-card w-full flex flex-col gap-6 py-6"
-        >
-          <div
-            class="value-card__icon-wrapper size-[50px] flex items-center justify-center"
-          >
-            <img
-              alt="Obsessed with empowering problem-solvers"
-              class="value-card__icon"
-              src="icons/solvers.svg"
-            />
-          </div>
-          <h3
-            class="value-card__title min-h-[60px]"
-          >
-            Obsessed with empowering problem-solvers
-          </h3>
-          <p
-            class="value-card__description "
-          >
-            We exist to support others to solve the world's biggest problems. We go above and beyond to accelerate our community's impact.
-          </p>
-        </div>
-      </div>
+      </section>
     </div>
   </div>
 </div>

--- a/apps/website-25/src/components/homepage/CommunitySection/TestimonialSection.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/TestimonialSection.tsx
@@ -35,7 +35,7 @@ const TestimonialSection = () => {
       <SlideList
         subtitle="What our graduates say"
         itemsPerSlide={3}
-        slideClassName="gap-8"
+        slideClassName="px-2"
         containerClassName="justify-center"
         slidesWrapperWidth="100%"
       >

--- a/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/TestimonialSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/TestimonialSection.test.tsx.snap
@@ -40,10 +40,10 @@ exports[`TestimonialSection > renders as expected 1`] = `
           >
             <div
               class="slide-list__slides flex transition-transform duration-300"
-              style="transform: translateX(-0%); gap: 0.25rem;"
+              style="transform: translateX(-0%);"
             >
               <div
-                class="slide-list__slide flex-shrink-0 w-full gap-8"
+                class="slide-list__slide flex-shrink-0 w-full px-2"
                 style="width: 33.333333333333336%;"
               >
                 <div
@@ -90,7 +90,7 @@ exports[`TestimonialSection > renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide flex-shrink-0 w-full gap-8"
+                class="slide-list__slide flex-shrink-0 w-full px-2"
                 style="width: 33.333333333333336%;"
               >
                 <div
@@ -137,7 +137,7 @@ exports[`TestimonialSection > renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide flex-shrink-0 w-full gap-8"
+                class="slide-list__slide flex-shrink-0 w-full px-2"
                 style="width: 33.333333333333336%;"
               >
                 <div

--- a/apps/website-25/src/components/homepage/CourseSection.tsx
+++ b/apps/website-25/src/components/homepage/CourseSection.tsx
@@ -61,7 +61,6 @@ const CourseSection = () => {
         )}
         slidesWrapperWidth={{ mobile: '100%', desktop: '800px' }}
         containerClassName="gap-4"
-        slideClassName="gap-4"
       >
         {courses.map((course) => (
           <SlideItem key={course.title}>

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -206,10 +206,10 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
           >
             <div
               class="slide-list__slides flex transition-transform duration-300"
-              style="transform: translateX(-0%); gap: 0.25rem;"
+              style="transform: translateX(-0%);"
             >
               <div
-                class="slide-list__slide flex-shrink-0 w-full gap-4"
+                class="slide-list__slide flex-shrink-0 w-full"
                 style="width: 50%;"
               >
                 <div
@@ -283,7 +283,7 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide flex-shrink-0 w-full gap-4"
+                class="slide-list__slide flex-shrink-0 w-full"
                 style="width: 50%;"
               >
                 <div
@@ -357,7 +357,7 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide flex-shrink-0 w-full gap-4"
+                class="slide-list__slide flex-shrink-0 w-full"
                 style="width: 50%;"
               >
                 <div
@@ -431,7 +431,7 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide flex-shrink-0 w-full gap-4"
+                class="slide-list__slide flex-shrink-0 w-full"
                 style="width: 50%;"
               >
                 <div

--- a/libraries/ui/src/SlideList.tsx
+++ b/libraries/ui/src/SlideList.tsx
@@ -176,7 +176,6 @@ export const SlideList: React.FC<SlideListProps> = ({
             className="slide-list__slides flex transition-transform duration-300"
             style={{
               transform: `translateX(-${currentSlide * 100}%)`,
-              gap: '0.25rem',
             }}
           >
             {React.Children.map(children, (child) => (


### PR DESCRIPTION
# Summary

This PR uses SlideList for ValuesSection and BeliefsSection according to the current pattern. This still isn't ideal for responsiveness, because SlideList currently only switches between showing all items and showing only 1 item, so on intermediate screen widths the elements are still squished.

I have a followup PR (#239) to expand/collapse SlideList based on the width of the element rather than the overall screen size, which will fix the above problem. I just need to fix the tests on that.

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #169 
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [X] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [X] Added or updated Jest tests
- [X] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | ![Screenshot 2025-02-10 at 07 45 56](https://github.com/user-attachments/assets/2f984892-c3e5-494a-8f22-4efd72c7647c)|
| | ![Screenshot 2025-02-10 at 07 46 06](https://github.com/user-attachments/assets/09ead6c7-86b0-4e47-a142-306f4853c852)|
| 🖥️ | ![Screenshot 2025-02-10 at 07 42 12](https://github.com/user-attachments/assets/29f8c6ec-696b-4329-84fe-63f275b2e41a) |
| | ![Screenshot 2025-02-10 at 07 42 48](https://github.com/user-attachments/assets/207a8025-832d-4024-8647-4f8c2b0e1162) |
| 📱  | ![Screenshot 2025-02-10 at 07 42 29](https://github.com/user-attachments/assets/1da45116-97e3-4d45-a749-704ce5e054e8) |
| | ![Screenshot 2025-02-10 at 07 43 07](https://github.com/user-attachments/assets/fced2ee9-f4d0-4215-a9c2-dfffaa884199) |

`CourseSection` to test for visual regression (Note: the "Featured" card still needs to be made responsive, but that wasn't introduced in this PR):

| 📸 |  |
|---------|---|
| 🖥️ | ![Screenshot 2025-02-10 at 16 45 39](https://github.com/user-attachments/assets/e922b1d3-9fff-403b-9215-100c33fcae93) |
| 📱  | ![Screenshot 2025-02-10 at 16 51 49](https://github.com/user-attachments/assets/6ba4ec81-c4f0-43d2-b6b5-797e2119f68a) |
| | ![Screenshot 2025-02-10 at 16 48 56](https://github.com/user-attachments/assets/2264bb95-9b64-48cc-bab8-8d948e533d89) |

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    5 cached, 7 total
  Time:    4.911s
```
