### PR TITLE
More typography fixes

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -416,11 +416,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Dewi Erwan
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -464,11 +464,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Will Saunter
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -512,11 +512,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Adam Jones
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -560,11 +560,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Josh Landes
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -608,11 +608,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Li-Lian Ang
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -656,11 +656,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Tarin Rickett
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -704,11 +704,11 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Viorica Gheorghita
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >

--- a/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -42,11 +42,11 @@ exports[`TeamSection > renders default as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Dewi Erwan
-              </h4>
+              </p>
               <p
                 class="card__subtitle "
               >
@@ -90,11 +90,11 @@ exports[`TeamSection > renders default as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Will Saunter
-              </h4>
+              </p>
               <p
                 class="card__subtitle "
               >
@@ -138,11 +138,11 @@ exports[`TeamSection > renders default as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Adam Jones
-              </h4>
+              </p>
               <p
                 class="card__subtitle "
               >
@@ -186,11 +186,11 @@ exports[`TeamSection > renders default as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Josh Landes
-              </h4>
+              </p>
               <p
                 class="card__subtitle "
               >
@@ -234,11 +234,11 @@ exports[`TeamSection > renders default as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Li-Lian Ang
-              </h4>
+              </p>
               <p
                 class="card__subtitle "
               >
@@ -282,11 +282,11 @@ exports[`TeamSection > renders default as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Tarin Rickett
-              </h4>
+              </p>
               <p
                 class="card__subtitle "
               >
@@ -330,11 +330,11 @@ exports[`TeamSection > renders default as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Viorica Gheorghita
-              </h4>
+              </p>
               <p
                 class="card__subtitle "
               >

--- a/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
@@ -238,11 +238,11 @@ exports[`CareersSection > renders mobile as expected 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   AI Alignment Project Judge
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -279,11 +279,11 @@ exports[`CareersSection > renders mobile as expected 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Course Operations Specialist
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -320,11 +320,11 @@ exports[`CareersSection > renders mobile as expected 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Software Engineering Contractor
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >
@@ -361,11 +361,11 @@ exports[`CareersSection > renders mobile as expected 1`] = `
               <div
                 class="card__text"
               >
-                <h4
-                  class="card__title mb-1"
+                <p
+                  class="card__title subtitle-sm mb-1"
                 >
                   Economics of Transformative AI Teaching Fellow
-                </h4>
+                </p>
                 <p
                   class="card__subtitle "
                 >

--- a/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/GovernanceProjects.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/GovernanceProjects.test.tsx.snap
@@ -44,11 +44,11 @@ exports[`GovernanceProjects > renders as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Contextual Constitutional AI
-              </h4>
+              </p>
               <p
                 class="card__subtitle text-base"
               >
@@ -76,11 +76,11 @@ exports[`GovernanceProjects > renders as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Safety Haven: Justifying and exploring an antitrust safe haven for AI safety research collaboration
-              </h4>
+              </p>
               <p
                 class="card__subtitle text-base"
               >
@@ -108,11 +108,11 @@ exports[`GovernanceProjects > renders as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Societal Adaptation to AI Human-Labor Automation
-              </h4>
+              </p>
               <p
                 class="card__subtitle text-base"
               >
@@ -140,11 +140,11 @@ exports[`GovernanceProjects > renders as expected 1`] = `
             <div
               class="card__text"
             >
-              <h4
-                class="card__title mb-1"
+              <p
+                class="card__title subtitle-sm mb-1"
               >
                 Are you secretly training AI? Methods for uncovering covert AI training: A framework for feasibility and future research
-              </h4>
+              </p>
               <p
                 class="card__subtitle text-base"
               >

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -239,11 +239,11 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                         <div
                           class="card__text"
                         >
-                          <h4
-                            class="card__title mb-1"
+                          <p
+                            class="card__title subtitle-sm mb-1"
                           >
                             AI Alignment
-                          </h4>
+                          </p>
                           <p
                             class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >
@@ -313,11 +313,11 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                         <div
                           class="card__text"
                         >
-                          <h4
-                            class="card__title mb-1"
+                          <p
+                            class="card__title subtitle-sm mb-1"
                           >
                             AI Governance
-                          </h4>
+                          </p>
                           <p
                             class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >
@@ -387,11 +387,11 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                         <div
                           class="card__text"
                         >
-                          <h4
-                            class="card__title mb-1"
+                          <p
+                            class="card__title subtitle-sm mb-1"
                           >
                             Economics of Transformative AI
-                          </h4>
+                          </p>
                           <p
                             class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >
@@ -461,11 +461,11 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                         <div
                           class="card__text"
                         >
-                          <h4
-                            class="card__title mb-1"
+                          <p
+                            class="card__title subtitle-sm mb-1"
                           >
                             Alignment Fast Track
-                          </h4>
+                          </p>
                           <p
                             class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >
@@ -535,11 +535,11 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                         <div
                           class="card__text"
                         >
-                          <h4
-                            class="card__title mb-1"
+                          <p
+                            class="card__title subtitle-sm mb-1"
                           >
                             Governance Fast-Track
-                          </h4>
+                          </p>
                           <p
                             class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >
@@ -609,11 +609,11 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                         <div
                           class="card__text"
                         >
-                          <h4
-                            class="card__title mb-1"
+                          <p
+                            class="card__title subtitle-sm mb-1"
                           >
                             Writing Intensive
-                          </h4>
+                          </p>
                           <p
                             class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -17,10 +17,10 @@
     @apply text-color-secondary-text font-sans text-size-md font-[650];
   }
   p, li, .body {
-    @apply text-color-text font-sans text-size-xs font-normal;
+    @apply text-color-text font-sans text-size-sm font-normal;
   }
   blockquote {
-    @apply text-color-text font-sans text-size-xs font-normal font-[650];
+    @apply text-color-text font-sans text-size-sm font-normal font-[650];
   }
   ul {
     @apply list-inside list-disc;

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -60,7 +60,7 @@ export const Card: React.FC<CardProps> = ({
 
       <div className="card__content flex flex-col gap-6 w-full flex-1 justify-between">
         <div className="card__text">
-          <h4 className="card__title mb-1">{title}</h4>
+          <p className="card__title subtitle-sm mb-1">{title}</p>
           {subtitle && (<p className={`card__subtitle ${subtitleClassName}`}>{subtitle}</p>)}
         </div>
         {showBottomSection && (

--- a/libraries/ui/src/__snapshots__/Card.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Card.test.tsx.snap
@@ -20,11 +20,11 @@ exports[`Card > renders default as expected 1`] = `
       <div
         class="card__text"
       >
-        <h4
-          class="card__title mb-1"
+        <p
+          class="card__title subtitle-sm mb-1"
         >
           John Doe
-        </h4>
+        </p>
         <p
           class="card__subtitle "
         >
@@ -72,11 +72,11 @@ exports[`Card > renders with isEntireCardClickable as expected 1`] = `
       <div
         class="card__text"
       >
-        <h4
-          class="card__title mb-1"
+        <p
+          class="card__title subtitle-sm mb-1"
         >
           John Doe
-        </h4>
+        </p>
         <p
           class="card__subtitle "
         >

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -98,11 +98,11 @@ exports[`CourseCard > renders default as expected 1`] = `
         <div
           class="card__text"
         >
-          <h4
-            class="card__title mb-1"
+          <p
+            class="card__title subtitle-sm mb-1"
           >
             Title
-          </h4>
+          </p>
           <p
             class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
           >


### PR DESCRIPTION
# Summary

More typography fixes

## Description

- Body text was too small compared to mocks. Updating to text-size-sm. Left a note in the Design System Figma board that this does not look accurate to mock usage.

## Screenshot
<img width="1512" alt="Screenshot 2025-02-11 at 16 06 47" src="https://github.com/user-attachments/assets/66ab88cc-7e1d-4276-8388-cb95ecbe63d1" />

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    5 cached, 7 total
  Time:    2.61s 
```
