### PR TITLE
Add `NEXT_PUBLIC_GA_MEASUREMENT_ID`

### DIFF
--- a/apps/website-25/Dockerfile
+++ b/apps/website-25/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_PUBLIC_GA_MEASUREMENT_ID G-C5L967C9M1
 
 # Set the correct permission for prerender cache
 RUN mkdir dist


### PR DESCRIPTION
# Summary

Add `NEXT_PUBLIC_GA_MEASUREMENT_ID` to `Dockerfile`

## Issue

Fixes #273

## Description

Enable GA on website-25.k8s.bluedot.org.
