### PR TITLE
Add `analytics.isDebugModeEnabled()` for testing analytics

### DIFF
--- a/apps/website-25/.env.local.template
+++ b/apps/website-25/.env.local.template
@@ -1,3 +1,10 @@
+# Google Analytics
+# When set, Google Analytics will be enabled. Be careful not to send real data to Google Analytics. Comment out to disable.
+# NEXT_PUBLIC_GA_MEASUREMENT_ID=
+# When set, Google Analytics debug mode will be enabled. Comment out to disable.
+# See https://support.google.com/analytics/answer/7201382?hl=en
+# NEXT_PUBLIC_GA_DEBUG=true
+
 # Airtable: https://support.airtable.com/docs/creating-and-using-api-keys-and-access-tokens
 AIRTABLE_PERSONAL_ACCESS_TOKEN=
 

--- a/apps/website-25/src/components/Analytics.tsx
+++ b/apps/website-25/src/components/Analytics.tsx
@@ -1,10 +1,11 @@
 import { GoogleAnalytics } from '@next/third-parties/google';
-import { isAnalyticsEnabled, GA_MEASUREMENT_ID } from '../lib/analytics';
+import { isAnalyticsEnabled, isDebugModeEnabled, GA_MEASUREMENT_ID } from '../lib/analytics';
 
 export const Analytics = () => {
   if (!isAnalyticsEnabled()) {
     return null;
   }
+  const debugMode = isDebugModeEnabled();
 
-  return <GoogleAnalytics gaId={`${GA_MEASUREMENT_ID}`} />;
+  return <GoogleAnalytics gaId={`${GA_MEASUREMENT_ID}`} debugMode={debugMode} />;
 };

--- a/apps/website-25/src/lib/analytics.ts
+++ b/apps/website-25/src/lib/analytics.ts
@@ -1,4 +1,9 @@
 export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+export const GA_DEBUG = process.env.NEXT_PUBLIC_GA_DEBUG;
+
+export const isDebugModeEnabled = () => {
+  return !!GA_DEBUG;
+};
 
 export const isAnalyticsEnabled = () => {
   const hasMeasurementId = !!GA_MEASUREMENT_ID;


### PR DESCRIPTION
# Summary

Add `analytics.isDebugModeEnabled` for conveniently testing Google Analytics locally.

## Issue

Follow-up to #285.

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    0 cached, 7 total
  Time:    5.099s 

```
