### PR TITLE
Course card should not open in external URL

### DIFF
--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -134,7 +134,6 @@ export const CourseCard: React.FC<CourseCardProps> = ({
         subtitle={description}
         ctaUrl={ctaUrl}
         isEntireCardClickable
-        isExternalUrl
         className={clsx(
           'course-card course-card--regular container-lined p-5',
           'flex flex-col w-[323px] h-[466px] hover:container-elevated',


### PR DESCRIPTION
# Summary

<!-- One line summary of your change -->
Course card should not open in external URL

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #281 
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |

## Testing
```
$ npm run test:update
@bluedot/website-25:test:       Tests  24 passed (24)
@bluedot/website-25:test:    Start at  09:18:55
@bluedot/website-25:test:    Duration  3.11s (transform 442ms, setup 0ms, collect 11.21s, tests 388ms, environment 5.09s, prepare 2.18s)
@bluedot/website-25:test: 
```
