### PR TITLE
Fix card renders on TeamSection

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -431,14 +431,14 @@ exports[`AboutPage > should render the error message correctly 1`] = `
           class="team__grid flex flex-row flex-wrap mx-auto gap-x-space-between gap-y-12"
         >
           <div
-            class="card flex flex-col items-start transition-transform duration-200 team__card"
+            class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
           >
             <div
               class="card__image-container w-full mb-4"
             >
               <img
                 alt="Dewi Erwan"
-                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
                 src="/images/team/dewi.jpg"
               />
             </div>
@@ -479,14 +479,14 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start transition-transform duration-200 team__card"
+            class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
           >
             <div
               class="card__image-container w-full mb-4"
             >
               <img
                 alt="Will Saunter"
-                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
                 src="/images/team/will.jpg"
               />
             </div>
@@ -527,14 +527,14 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start transition-transform duration-200 team__card"
+            class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
           >
             <div
               class="card__image-container w-full mb-4"
             >
               <img
                 alt="Adam Jones"
-                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
                 src="/images/team/adam.jpg"
               />
             </div>
@@ -575,14 +575,14 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start transition-transform duration-200 team__card"
+            class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
           >
             <div
               class="card__image-container w-full mb-4"
             >
               <img
                 alt="Josh Landes"
-                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
                 src="/images/team/josh.jpg"
               />
             </div>
@@ -623,14 +623,14 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start transition-transform duration-200 team__card"
+            class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
           >
             <div
               class="card__image-container w-full mb-4"
             >
               <img
                 alt="Li-Lian Ang"
-                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
                 src="/images/team/lilian.jpg"
               />
             </div>
@@ -671,14 +671,14 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start transition-transform duration-200 team__card"
+            class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
           >
             <div
               class="card__image-container w-full mb-4"
             >
               <img
                 alt="Tarin Rickett"
-                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
                 src="/images/team/tarin.jpg"
               />
             </div>
@@ -719,14 +719,14 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </div>
           </div>
           <div
-            class="card flex flex-col items-start transition-transform duration-200 team__card"
+            class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
           >
             <div
               class="card__image-container w-full mb-4"
             >
               <img
                 alt="Viorica Gheorghita"
-                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+                class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
                 src="/images/team/vio.jpg"
               />
             </div>

--- a/apps/website-25/src/components/about/TeamSection.tsx
+++ b/apps/website-25/src/components/about/TeamSection.tsx
@@ -58,8 +58,8 @@ const TeamSection = () => {
             ctaUrl={member.linkedInUrl}
             ctaText="LinkedIn"
             isExternalUrl
-            className="team__card"
-            imageClassName="team__card-image"
+            className="team__card w-[323px]"
+            imageClassName="team__card-image h-[300px]"
           />
         ))}
       </div>

--- a/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -25,14 +25,14 @@ exports[`TeamSection > renders default as expected 1`] = `
         class="team__grid flex flex-row flex-wrap mx-auto gap-x-space-between gap-y-12"
       >
         <div
-          class="card flex flex-col items-start transition-transform duration-200 team__card"
+          class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
         >
           <div
             class="card__image-container w-full mb-4"
           >
             <img
               alt="Dewi Erwan"
-              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
               src="/images/team/dewi.jpg"
             />
           </div>
@@ -73,14 +73,14 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start transition-transform duration-200 team__card"
+          class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
         >
           <div
             class="card__image-container w-full mb-4"
           >
             <img
               alt="Will Saunter"
-              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
               src="/images/team/will.jpg"
             />
           </div>
@@ -121,14 +121,14 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start transition-transform duration-200 team__card"
+          class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
         >
           <div
             class="card__image-container w-full mb-4"
           >
             <img
               alt="Adam Jones"
-              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
               src="/images/team/adam.jpg"
             />
           </div>
@@ -169,14 +169,14 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start transition-transform duration-200 team__card"
+          class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
         >
           <div
             class="card__image-container w-full mb-4"
           >
             <img
               alt="Josh Landes"
-              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
               src="/images/team/josh.jpg"
             />
           </div>
@@ -217,14 +217,14 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start transition-transform duration-200 team__card"
+          class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
         >
           <div
             class="card__image-container w-full mb-4"
           >
             <img
               alt="Li-Lian Ang"
-              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
               src="/images/team/lilian.jpg"
             />
           </div>
@@ -265,14 +265,14 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start transition-transform duration-200 team__card"
+          class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
         >
           <div
             class="card__image-container w-full mb-4"
           >
             <img
               alt="Tarin Rickett"
-              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
               src="/images/team/tarin.jpg"
             />
           </div>
@@ -313,14 +313,14 @@ exports[`TeamSection > renders default as expected 1`] = `
           </div>
         </div>
         <div
-          class="card flex flex-col items-start transition-transform duration-200 team__card"
+          class="card flex flex-col items-start transition-transform duration-200 team__card w-[323px]"
         >
           <div
             class="card__image-container w-full mb-4"
           >
             <img
               alt="Viorica Gheorghita"
-              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image"
+              class="card__image w-full max-h-full object-cover rounded-radius-md team__card-image h-[300px]"
               src="/images/team/vio.jpg"
             />
           </div>


### PR DESCRIPTION
# Summary

Fix card renders on TeamSection

## Description

- When we decentralized width/heights from Card, it looks like we inadvertently introduced unrestrained card size renders on the Team page 😅 
- This is a **quick fix** ahead of further bug bashing early tomorrow AM
- We should revisit as a team to consider how we can prevent this from occurring in the future: 

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | <img width="1512" alt="image" src="https://github.com/user-attachments/assets/ecaf0e9a-3659-447e-9c65-21723486a46f" /> |
| 🖥️ | https://github.com/user-attachments/assets/82da8738-0c82-44ab-bbaa-74a97b742692 |
| 📱  | <img width="408" alt="image" src="https://github.com/user-attachments/assets/9a5ec321-db50-4508-b237-7f5592150049" /> |

## Testing
```
$ npm run test:update
 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total
  Time:    3.161s 
```
