### PR TITLE
devex: Remove running automated tests from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,9 +23,3 @@ Fixes # (issue)
 | 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
 | 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
 | 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
-
-## Testing
-```
-$ npm run test:update
-<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
-```


### PR DESCRIPTION
These are run with CI automatically (where anyone can see the logs), and enforced in the merge requirements. Getting humans to run the task and copy over logs manually is therefore unnecessary.