### PR TITLE
website+ui: Fix missing courses in a few places

### DIFF
--- a/apps/website-25/src/components/homepage/CourseSection.tsx
+++ b/apps/website-25/src/components/homepage/CourseSection.tsx
@@ -1,63 +1,11 @@
 import {
   CourseCard,
   Section,
+  constants,
 } from '@bluedot/ui';
 import { SlideList, SlideItem } from '@bluedot/ui/src/SlideList';
 
-const featuredCourses = [
-  {
-    title: 'AI Safety: Intro to Transformative AI',
-    description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and so is the need for capable individuals to shape its trajectory. This intensive 5-day course is for those who want to rapidly develop their understanding of transformative AI and its impact on humanity.',
-    courseType: 'Crash course',
-    imageSrc: '/images/alignment-course.png',
-    ctaUrl: 'https://aisafetyfundamentals.com/intro-to-tai/',
-  },
-] as const;
-
-const courses = [
-  {
-    title: 'AI Alignment',
-    description: 'AI systems are rapidly becoming more capable and more general. Despite AI\'s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
-    courseType: 'In-depth course',
-    imageSrc: '/images/alignment-course.png',
-    ctaUrl: 'https://aisafetyfundamentals.com/alignment/',
-  },
-  {
-    title: 'AI Governance',
-    description: 'The rise of any powerful technology demands a thoughtful approach to its governance and regulation. There has been increasing interest in how AI governance can and should mitigate extreme risks from AI, but it can be difficult to get up to speed on research and ideas in this area.',
-    courseType: 'In-depth course',
-    imageSrc: '/images/governance-course.jpg',
-    ctaUrl: 'https://aisafetyfundamentals.com/governance/',
-  },
-  {
-    title: 'Economics of Transformative AI',
-    description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
-    courseType: 'In-depth course',
-    imageSrc: '/images/economics-course.png',
-    ctaUrl: 'https://aisafetyfundamentals.com/economics-of-tai/',
-  },
-  {
-    title: 'Alignment Fast Track',
-    description: 'AI systems are rapidly becoming more capable and more general. Despite AI\'s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
-    courseType: 'Crash course',
-    imageSrc: '/images/intro-course.png',
-    ctaUrl: 'https://aisafetyfundamentals.com/alignment-fast-track/',
-  },
-  {
-    title: 'Governance Fast-Track',
-    description: 'Despite AI\'s potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation.',
-    courseType: 'Crash course',
-    imageSrc: '/images/governance-course.jpg',
-    ctaUrl: 'https://aisafetyfundamentals.com/governance-fast-track/',
-  },
-  {
-    title: 'Writing Intensive',
-    description: 'This is a 5-day intensive writing course where you`ll transform your AI safety course learnings into a published article.',
-    courseType: 'Crash course',
-    imageSrc: '/images/writing-intensive.png',
-    ctaUrl: 'https://aisafetyfundamentals.com/writing/',
-  },
-] as const;
+const featuredCourse = constants.COURSES.find(course => course.title === 'AI Safety: Intro to Transformative AI')!;
 
 const CourseSection = () => {
   return (
@@ -68,7 +16,7 @@ const CourseSection = () => {
         itemsPerSlide={2}
         featuredSlot={(
           <CourseCard
-            {...featuredCourses[0]}
+            {...featuredCourse}
             cardType="Featured"
             className="h-full"
           />
@@ -76,7 +24,7 @@ const CourseSection = () => {
         slidesWrapperWidth={{ mobile: '100%', desktop: '800px' }}
         containerClassName="gap-space-between"
       >
-        {courses.map((course) => (
+        {constants.COURSES.filter(course => course != featuredCourse).map((course) => (
           <SlideItem key={course.title}>
             <CourseCard
               {...course}

--- a/apps/website-25/src/components/homepage/CourseSection.tsx
+++ b/apps/website-25/src/components/homepage/CourseSection.tsx
@@ -5,7 +5,7 @@ import {
 } from '@bluedot/ui';
 import { SlideList, SlideItem } from '@bluedot/ui/src/SlideList';
 
-const featuredCourse = constants.COURSES.find(course => course.title === 'AI Safety: Intro to Transformative AI')!;
+const featuredCourse = constants.COURSES.find((course) => course.title === 'AI Safety: Intro to Transformative AI')!;
 
 const CourseSection = () => {
   return (
@@ -24,7 +24,7 @@ const CourseSection = () => {
         slidesWrapperWidth={{ mobile: '100%', desktop: '800px' }}
         containerClassName="gap-space-between"
       >
-        {constants.COURSES.filter(course => course != featuredCourse).map((course) => (
+        {constants.COURSES.filter((course) => course !== featuredCourse).map((course) => (
           <SlideItem key={course.title}>
             <CourseCard
               {...course}

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -220,6 +220,222 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                   >
                     <a
                       class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col w-[323px] h-[466px] hover:container-elevated w-full md:w-[323px]"
+                      href="https://aisafetyfundamentals.com/alignment-fast-track/"
+                    >
+                      <div
+                        class="card__image-container w-full mb-4"
+                      >
+                        <img
+                          alt="Alignment Fast-Track"
+                          class="card__image w-full max-h-full object-cover rounded-radius-md course-card__image w-full h-[165px] object-cover rounded-none"
+                          src="/images/intro-course.png"
+                        />
+                      </div>
+                      <div
+                        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                      >
+                        <div
+                          class="card__text"
+                        >
+                          <p
+                            class="card__title subtitle-sm mb-2"
+                          >
+                            Alignment Fast-Track
+                          </p>
+                          <p
+                            class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
+                          >
+                            AI systems are rapidly becoming more capable and more general. Despite AI's potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.
+                          </p>
+                        </div>
+                        <div
+                          class="card__bottom-section flex flex-col gap-space-between"
+                        >
+                          <div
+                            class="card__footer flex items-center justify-between w-full"
+                          >
+                            <div
+                              class="course-card__footer flex justify-between w-full"
+                            >
+                              <p
+                                class="course-card__footer-left text-left text-xs text-bluedot-black"
+                              >
+                                <span
+                                  class="course-card__length font-medium"
+                                >
+                                  5 days
+                                </span>
+                              </p>
+                              <span
+                                class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text course-card__type"
+                                role="status"
+                              >
+                                Crash course
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="slide-list__slide flex-shrink-0 w-full"
+                style="width: 50%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="p-[2px]"
+                  >
+                    <a
+                      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col w-[323px] h-[466px] hover:container-elevated w-full md:w-[323px]"
+                      href="https://aisafetyfundamentals.com/governance-fast-track/"
+                    >
+                      <div
+                        class="card__image-container w-full mb-4"
+                      >
+                        <img
+                          alt="Governance Fast-Track"
+                          class="card__image w-full max-h-full object-cover rounded-radius-md course-card__image w-full h-[165px] object-cover rounded-none"
+                          src="/images/governance-course.jpg"
+                        />
+                      </div>
+                      <div
+                        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                      >
+                        <div
+                          class="card__text"
+                        >
+                          <p
+                            class="card__title subtitle-sm mb-2"
+                          >
+                            Governance Fast-Track
+                          </p>
+                          <p
+                            class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
+                          >
+                            Despite AI's potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation.
+                          </p>
+                        </div>
+                        <div
+                          class="card__bottom-section flex flex-col gap-space-between"
+                        >
+                          <div
+                            class="card__footer flex items-center justify-between w-full"
+                          >
+                            <div
+                              class="course-card__footer flex justify-between w-full"
+                            >
+                              <p
+                                class="course-card__footer-left text-left text-xs text-bluedot-black"
+                              >
+                                <span
+                                  class="course-card__length font-medium"
+                                >
+                                  5 days
+                                </span>
+                              </p>
+                              <span
+                                class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text course-card__type"
+                                role="status"
+                              >
+                                Crash course
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="slide-list__slide flex-shrink-0 w-full"
+                style="width: 50%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="p-[2px]"
+                  >
+                    <a
+                      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col w-[323px] h-[466px] hover:container-elevated w-full md:w-[323px]"
+                      href="https://aisafetyfundamentals.com/economics-of-tai/"
+                    >
+                      <div
+                        class="card__image-container w-full mb-4"
+                      >
+                        <img
+                          alt="Economics of Transformative AI Fast-Track"
+                          class="card__image w-full max-h-full object-cover rounded-radius-md course-card__image w-full h-[165px] object-cover rounded-none"
+                          src="/images/economics-course.png"
+                        />
+                      </div>
+                      <div
+                        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                      >
+                        <div
+                          class="card__text"
+                        >
+                          <p
+                            class="card__title subtitle-sm mb-2"
+                          >
+                            Economics of Transformative AI Fast-Track
+                          </p>
+                          <p
+                            class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
+                          >
+                            The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.
+                          </p>
+                        </div>
+                        <div
+                          class="card__bottom-section flex flex-col gap-space-between"
+                        >
+                          <div
+                            class="card__footer flex items-center justify-between w-full"
+                          >
+                            <div
+                              class="course-card__footer flex justify-between w-full"
+                            >
+                              <p
+                                class="course-card__footer-left text-left text-xs text-bluedot-black"
+                              >
+                                <span
+                                  class="course-card__length font-medium"
+                                >
+                                  12 weeks
+                                </span>
+                              </p>
+                              <span
+                                class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text course-card__type"
+                                role="status"
+                              >
+                                In-depth course
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="slide-list__slide flex-shrink-0 w-full"
+                style="width: 50%;"
+              >
+                <div
+                  class="size-full"
+                >
+                  <div
+                    class="p-[2px]"
+                  >
+                    <a
+                      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col w-[323px] h-[466px] hover:container-elevated w-full md:w-[323px]"
                       href="https://aisafetyfundamentals.com/alignment/"
                     >
                       <div
@@ -436,150 +652,6 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
                   >
                     <a
                       class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col w-[323px] h-[466px] hover:container-elevated w-full md:w-[323px]"
-                      href="https://aisafetyfundamentals.com/alignment-fast-track/"
-                    >
-                      <div
-                        class="card__image-container w-full mb-4"
-                      >
-                        <img
-                          alt="Alignment Fast Track"
-                          class="card__image w-full max-h-full object-cover rounded-radius-md course-card__image w-full h-[165px] object-cover rounded-none"
-                          src="/images/intro-course.png"
-                        />
-                      </div>
-                      <div
-                        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
-                      >
-                        <div
-                          class="card__text"
-                        >
-                          <p
-                            class="card__title subtitle-sm mb-2"
-                          >
-                            Alignment Fast Track
-                          </p>
-                          <p
-                            class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
-                          >
-                            AI systems are rapidly becoming more capable and more general. Despite AI's potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.
-                          </p>
-                        </div>
-                        <div
-                          class="card__bottom-section flex flex-col gap-space-between"
-                        >
-                          <div
-                            class="card__footer flex items-center justify-between w-full"
-                          >
-                            <div
-                              class="course-card__footer flex justify-between w-full"
-                            >
-                              <p
-                                class="course-card__footer-left text-left text-xs text-bluedot-black"
-                              >
-                                <span
-                                  class="course-card__length font-medium"
-                                >
-                                  5 days
-                                </span>
-                              </p>
-                              <span
-                                class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text course-card__type"
-                                role="status"
-                              >
-                                Crash course
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="slide-list__slide flex-shrink-0 w-full"
-                style="width: 50%;"
-              >
-                <div
-                  class="size-full"
-                >
-                  <div
-                    class="p-[2px]"
-                  >
-                    <a
-                      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col w-[323px] h-[466px] hover:container-elevated w-full md:w-[323px]"
-                      href="https://aisafetyfundamentals.com/governance-fast-track/"
-                    >
-                      <div
-                        class="card__image-container w-full mb-4"
-                      >
-                        <img
-                          alt="Governance Fast-Track"
-                          class="card__image w-full max-h-full object-cover rounded-radius-md course-card__image w-full h-[165px] object-cover rounded-none"
-                          src="/images/governance-course.jpg"
-                        />
-                      </div>
-                      <div
-                        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
-                      >
-                        <div
-                          class="card__text"
-                        >
-                          <p
-                            class="card__title subtitle-sm mb-2"
-                          >
-                            Governance Fast-Track
-                          </p>
-                          <p
-                            class="card__subtitle flex-grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
-                          >
-                            Despite AI's potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation.
-                          </p>
-                        </div>
-                        <div
-                          class="card__bottom-section flex flex-col gap-space-between"
-                        >
-                          <div
-                            class="card__footer flex items-center justify-between w-full"
-                          >
-                            <div
-                              class="course-card__footer flex justify-between w-full"
-                            >
-                              <p
-                                class="course-card__footer-left text-left text-xs text-bluedot-black"
-                              >
-                                <span
-                                  class="course-card__length font-medium"
-                                >
-                                  5 days
-                                </span>
-                              </p>
-                              <span
-                                class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text course-card__type"
-                                role="status"
-                              >
-                                Crash course
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="slide-list__slide flex-shrink-0 w-full"
-                style="width: 50%;"
-              >
-                <div
-                  class="size-full"
-                >
-                  <div
-                    class="p-[2px]"
-                  >
-                    <a
-                      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col w-[323px] h-[466px] hover:container-elevated w-full md:w-[323px]"
                       href="https://aisafetyfundamentals.com/writing/"
                     >
                       <div
@@ -649,7 +721,7 @@ exports[`CourseSection > renders desktop view as expected 1`] = `
               >
                 <div
                   class="slide-list__progress-bar h-full bg-bluedot-normal transition-all duration-300"
-                  style="width: 33.33333333333333%;"
+                  style="width: 25%;"
                 />
               </div>
             </div>

--- a/apps/website-25/src/pages/_app.tsx
+++ b/apps/website-25/src/pages/_app.tsx
@@ -4,20 +4,10 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
 import {
-  CookieBanner, Footer, isCurrentPath, Nav,
+  CookieBanner, Footer, isCurrentPath, Nav, constants
 } from '@bluedot/ui';
 import clsx from 'clsx';
 import { Analytics } from '../components/Analytics';
-
-// TODO: 01/27 add routing to courses when AISafetyFundamentals course is integrated, i.e.'/courses/intro-transformative-ai
-const courses = [
-  { title: 'Intro to Transformative AI', href: 'https://aisafetyfundamentals.com/intro-to-tai/' },
-  { title: 'AI Alignment Fast-Track', href: 'https://aisafetyfundamentals.com/alignment-fast-track/' },
-  { title: 'AI Alignment In-Depth', href: 'https://aisafetyfundamentals.com/alignment/' },
-  { title: 'AI Governance Fast-Track', href: 'https://aisafetyfundamentals.com/governance-fast-track/' },
-  { title: 'AI Governance In-Depth', href: 'https://aisafetyfundamentals.com/governance/' },
-  { title: 'Economics of Transformative AI Fast-Track', href: 'https://aisafetyfundamentals.com/economics-of-tai-fast-track/', isNew: true },
-];
 
 const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
   return (
@@ -32,7 +22,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
       </Head>
       <Nav
         logo="/images/logo/BlueDot_Impact_Logo.svg"
-        courses={courses}
+        courses={constants.COURSES}
       >
         <a href="/about" className={clsx('hover:text-bluedot-normal', isCurrentPath('/about') && 'font-bold')}>About</a>
         <a href="/careers" className={clsx('hover:text-bluedot-normal', isCurrentPath('/careers') && 'font-bold')}>Join us</a>

--- a/apps/website-25/src/pages/_app.tsx
+++ b/apps/website-25/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
 import {
-  CookieBanner, Footer, isCurrentPath, Nav, constants
+  CookieBanner, Footer, isCurrentPath, Nav, constants,
 } from '@bluedot/ui';
 import clsx from 'clsx';
 import { Analytics } from '../components/Analytics';

--- a/apps/website-25/tsconfig.json
+++ b/apps/website-25/tsconfig.json
@@ -3,7 +3,7 @@
   "include": [
     "next-env.d.ts",
     "src/**/*",
-    "tailwind.config.ts",
+    "tailwind.config.ts", "../../libraries/ui/src/constants.ts",
   ],
   "exclude": ["node_modules"]
 }

--- a/libraries/ui/src/CourseCard.stories.tsx
+++ b/libraries/ui/src/CourseCard.stories.tsx
@@ -17,11 +17,11 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    title: 'Alignment Fast Track',
+    title: 'Alignment Fast-Track',
     description: 'AI systems are rapidly becoming more capable and more general. Despite AI’s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
     courseType: 'Crash course',
     imageSrc: '/images/intro-course.png',
-    ctaUrl: 'https://aisafetyfundamentals.com/alignment-fast-track/',
+    href: 'https://aisafetyfundamentals.com/alignment-fast-track/',
   },
 };
 
@@ -31,7 +31,7 @@ export const Featured: Story = {
     description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and so is the need for capable individuals to shape its trajectory. This intensive 5-day course is for those who want to rapidly develop their understanding of transformative AI and its impact on humanity.',
     courseType: 'Crash course',
     imageSrc: '/images/alignment-course.png',
-    ctaUrl: 'https://aisafetyfundamentals.com/intro-to-tai/',
+    href: 'https://aisafetyfundamentals.com/intro-to-tai/',
     cardType: 'Featured',
   },
 };

--- a/libraries/ui/src/CourseCard.test.tsx
+++ b/libraries/ui/src/CourseCard.test.tsx
@@ -7,6 +7,7 @@ describe('CourseCard', () => {
     imageSrc: '/images/courses/course.jpg',
     title: 'Title',
     description: 'Description',
+    href: 'https://bluedot.org/courses/what-the-fish',
   };
 
   test('renders default as expected', () => {

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -8,8 +8,8 @@ export type CourseCardProps = React.PropsWithChildren<{
   title: string,
   description: string,
   imageSrc: string,
+  href: string,
   className?: string,
-  ctaUrl?: string,
   applicationDeadline?: string, // Expected format: "Feb 1"
   // eslint-disable-next-line react/no-unused-prop-types
   cardType?: 'Featured' | 'Regular',
@@ -41,7 +41,7 @@ const FeaturedCourseCard: React.FC<CourseCardProps> = ({
   className,
   title,
   description,
-  ctaUrl,
+  href: ctaUrl,
   applicationDeadline,
   imageSrc,
   imageClassName,
@@ -96,7 +96,7 @@ export const CourseCard: React.FC<CourseCardProps> = ({
   className,
   title,
   description,
-  ctaUrl,
+  href: ctaUrl,
   applicationDeadline,
   cardType = 'Regular',
   courseType = 'Crash course',
@@ -118,7 +118,7 @@ export const CourseCard: React.FC<CourseCardProps> = ({
         className={className}
         title={title}
         description={description}
-        ctaUrl={ctaUrl}
+        href={ctaUrl}
         applicationDeadline={applicationDeadline}
         imageSrc={imageSrc}
         imageClassName={imageClassName}

--- a/libraries/ui/src/Footer.tsx
+++ b/libraries/ui/src/Footer.tsx
@@ -83,7 +83,7 @@ export const Footer: React.FC<FooterProps> = ({ className, logo }) => {
 
               <FooterLinksSection
                 title="Explore"
-                links={COURSES.map(course => ({ href: course.href, label: course.title }))}
+                links={COURSES.map((course) => ({ href: course.href, label: course.title }))}
               />
 
               <FooterLinksSection

--- a/libraries/ui/src/Footer.tsx
+++ b/libraries/ui/src/Footer.tsx
@@ -4,6 +4,7 @@ import {
   FaXTwitter, FaYoutube, FaLinkedin,
 } from 'react-icons/fa6';
 import { EXTERNAL_LINK_PROPS } from './utils';
+import { COURSES } from './constants';
 
 export type FooterProps = React.PropsWithChildren<{
   // Optional
@@ -80,17 +81,9 @@ export const Footer: React.FC<FooterProps> = ({ className, logo }) => {
                 ]}
               />
 
-              {/* // TODO: 01/27 add routing to courses when AISafetyFundamentals course is integrated, i.e.'/courses/intro-transformative-ai */}
               <FooterLinksSection
                 title="Explore"
-                links={[
-                  { href: 'https://aisafetyfundamentals.com/intro-to-tai/', label: 'Intro to Transformative AI' },
-                  { href: 'https://aisafetyfundamentals.com/alignment-fast-track/', label: 'AI Alignment Fast Track' },
-                  { href: 'https://aisafetyfundamentals.com/alignment/', label: 'AI Alignment In-Depth' },
-                  { href: 'https://aisafetyfundamentals.com/governance/', label: 'AI Governance In-Depth' },
-                  { href: 'https://aisafetyfundamentals.com/economics-of-tai/', label: 'Economics of Transformative AI' },
-                  { href: 'https://aisafetyfundamentals.com/writing/', label: 'Writing Intensive' },
-                ]}
+                links={COURSES.map(course => ({ href: course.href, label: course.title }))}
               />
 
               <FooterLinksSection

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`CourseCard > renders Featured as expected 1`] = `
   >
     <a
       class="course-card course-card--featured card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] hover:container-elevated container-lined p-6 max-w-[656px]"
+      href="https://bluedot.org/courses/what-the-fish"
     >
       <div
         class="course-card__content block md:flex gap-space-between w-full"
@@ -82,6 +83,7 @@ exports[`CourseCard > renders default as expected 1`] = `
   >
     <a
       class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col w-[323px] h-[466px] hover:container-elevated"
+      href="https://bluedot.org/courses/what-the-fish"
     >
       <div
         class="card__image-container w-full mb-4"

--- a/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
@@ -167,7 +167,7 @@ exports[`Footer > renders default as expected 1`] = `
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
                     href="https://aisafetyfundamentals.com/intro-to-tai/"
                   >
-                    Intro to Transformative AI
+                    AI Safety: Intro to Transformative AI
                   </a>
                 </li>
                 <li
@@ -177,7 +177,27 @@ exports[`Footer > renders default as expected 1`] = `
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
                     href="https://aisafetyfundamentals.com/alignment-fast-track/"
                   >
-                    AI Alignment Fast Track
+                    Alignment Fast-Track
+                  </a>
+                </li>
+                <li
+                  class="footer__item"
+                >
+                  <a
+                    class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
+                    href="https://aisafetyfundamentals.com/governance-fast-track/"
+                  >
+                    Governance Fast-Track
+                  </a>
+                </li>
+                <li
+                  class="footer__item"
+                >
+                  <a
+                    class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
+                    href="https://aisafetyfundamentals.com/economics-of-tai/"
+                  >
+                    Economics of Transformative AI Fast-Track
                   </a>
                 </li>
                 <li
@@ -187,7 +207,7 @@ exports[`Footer > renders default as expected 1`] = `
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
                     href="https://aisafetyfundamentals.com/alignment/"
                   >
-                    AI Alignment In-Depth
+                    AI Alignment
                   </a>
                 </li>
                 <li
@@ -197,7 +217,7 @@ exports[`Footer > renders default as expected 1`] = `
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
                     href="https://aisafetyfundamentals.com/governance/"
                   >
-                    AI Governance In-Depth
+                    AI Governance
                   </a>
                 </li>
                 <li
@@ -522,7 +542,7 @@ exports[`Footer > renders with optional args 1`] = `
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
                     href="https://aisafetyfundamentals.com/intro-to-tai/"
                   >
-                    Intro to Transformative AI
+                    AI Safety: Intro to Transformative AI
                   </a>
                 </li>
                 <li
@@ -532,7 +552,27 @@ exports[`Footer > renders with optional args 1`] = `
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
                     href="https://aisafetyfundamentals.com/alignment-fast-track/"
                   >
-                    AI Alignment Fast Track
+                    Alignment Fast-Track
+                  </a>
+                </li>
+                <li
+                  class="footer__item"
+                >
+                  <a
+                    class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
+                    href="https://aisafetyfundamentals.com/governance-fast-track/"
+                  >
+                    Governance Fast-Track
+                  </a>
+                </li>
+                <li
+                  class="footer__item"
+                >
+                  <a
+                    class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
+                    href="https://aisafetyfundamentals.com/economics-of-tai/"
+                  >
+                    Economics of Transformative AI Fast-Track
                   </a>
                 </li>
                 <li
@@ -542,7 +582,7 @@ exports[`Footer > renders with optional args 1`] = `
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
                     href="https://aisafetyfundamentals.com/alignment/"
                   >
-                    AI Alignment In-Depth
+                    AI Alignment
                   </a>
                 </li>
                 <li
@@ -552,7 +592,7 @@ exports[`Footer > renders with optional args 1`] = `
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
                     href="https://aisafetyfundamentals.com/governance/"
                   >
-                    AI Governance In-Depth
+                    AI Governance
                   </a>
                 </li>
                 <li

--- a/libraries/ui/src/constants.ts
+++ b/libraries/ui/src/constants.ts
@@ -1,70 +1,70 @@
 export type Course = {
-    title: string;
-    description: string;
-    courseType: CourseType;
-    imageSrc: string;
-    href: string;
-    isNew?: boolean;
-}
+  title: string;
+  description: string;
+  courseType: CourseType;
+  imageSrc: string;
+  href: string;
+  isNew?: boolean;
+};
 
-export type CourseType = 'Crash course' | 'Self-paced' | 'In-depth course'
+export type CourseType = 'Crash course' | 'Self-paced' | 'In-depth course';
 
 export const COURSES: Course[] = [
-    {
-        title: 'AI Safety: Intro to Transformative AI',
-        description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and so is the need for capable individuals to shape its trajectory. This intensive 5-day course is for those who want to rapidly develop their understanding of transformative AI and its impact on humanity.',
-        courseType: 'Crash course',
-        imageSrc: '/images/alignment-course.png',
-        href: 'https://aisafetyfundamentals.com/intro-to-tai/',
-    },
-        {
-        title: 'Alignment Fast-Track',
-        description: 'AI systems are rapidly becoming more capable and more general. Despite AI\'s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
-        courseType: 'Crash course',
-        imageSrc: '/images/intro-course.png',
-        href: 'https://aisafetyfundamentals.com/alignment-fast-track/',
-    },
-    {
-        title: 'Governance Fast-Track',
-        description: 'Despite AI\'s potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation.',
-        courseType: 'Crash course',
-        imageSrc: '/images/governance-course.jpg',
-        href: 'https://aisafetyfundamentals.com/governance-fast-track/',
-    },
-    {
-        title: 'Economics of Transformative AI Fast-Track',
-        description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
-        courseType: 'In-depth course',
-        imageSrc: '/images/economics-course.png',
-        href: 'https://aisafetyfundamentals.com/economics-of-tai/',
-        isNew: true,
-    },
-    {
-        title: 'AI Alignment',
-        description: 'AI systems are rapidly becoming more capable and more general. Despite AI\'s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
-        courseType: 'In-depth course',
-        imageSrc: '/images/alignment-course.png',
-        href: 'https://aisafetyfundamentals.com/alignment/',
-    },
-    {
-        title: 'AI Governance',
-        description: 'The rise of any powerful technology demands a thoughtful approach to its governance and regulation. There has been increasing interest in how AI governance can and should mitigate extreme risks from AI, but it can be difficult to get up to speed on research and ideas in this area.',
-        courseType: 'In-depth course',
-        imageSrc: '/images/governance-course.jpg',
-        href: 'https://aisafetyfundamentals.com/governance/',
-    },
-    {
-        title: 'Economics of Transformative AI',
-        description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
-        courseType: 'In-depth course',
-        imageSrc: '/images/economics-course.png',
-        href: 'https://aisafetyfundamentals.com/economics-of-tai/',
-    },
-    {
-        title: 'Writing Intensive',
-        description: 'This is a 5-day intensive writing course where you`ll transform your AI safety course learnings into a published article.',
-        courseType: 'Crash course',
-        imageSrc: '/images/writing-intensive.png',
-        href: 'https://aisafetyfundamentals.com/writing/',
-    },
+  {
+    title: 'AI Safety: Intro to Transformative AI',
+    description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and so is the need for capable individuals to shape its trajectory. This intensive 5-day course is for those who want to rapidly develop their understanding of transformative AI and its impact on humanity.',
+    courseType: 'Crash course',
+    imageSrc: '/images/alignment-course.png',
+    href: 'https://aisafetyfundamentals.com/intro-to-tai/',
+  },
+  {
+    title: 'Alignment Fast-Track',
+    description: 'AI systems are rapidly becoming more capable and more general. Despite AI\'s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
+    courseType: 'Crash course',
+    imageSrc: '/images/intro-course.png',
+    href: 'https://aisafetyfundamentals.com/alignment-fast-track/',
+  },
+  {
+    title: 'Governance Fast-Track',
+    description: 'Despite AI\'s potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation.',
+    courseType: 'Crash course',
+    imageSrc: '/images/governance-course.jpg',
+    href: 'https://aisafetyfundamentals.com/governance-fast-track/',
+  },
+  {
+    title: 'Economics of Transformative AI Fast-Track',
+    description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
+    courseType: 'In-depth course',
+    imageSrc: '/images/economics-course.png',
+    href: 'https://aisafetyfundamentals.com/economics-of-tai/',
+    isNew: true,
+  },
+  {
+    title: 'AI Alignment',
+    description: 'AI systems are rapidly becoming more capable and more general. Despite AI\'s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
+    courseType: 'In-depth course',
+    imageSrc: '/images/alignment-course.png',
+    href: 'https://aisafetyfundamentals.com/alignment/',
+  },
+  {
+    title: 'AI Governance',
+    description: 'The rise of any powerful technology demands a thoughtful approach to its governance and regulation. There has been increasing interest in how AI governance can and should mitigate extreme risks from AI, but it can be difficult to get up to speed on research and ideas in this area.',
+    courseType: 'In-depth course',
+    imageSrc: '/images/governance-course.jpg',
+    href: 'https://aisafetyfundamentals.com/governance/',
+  },
+  {
+    title: 'Economics of Transformative AI',
+    description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
+    courseType: 'In-depth course',
+    imageSrc: '/images/economics-course.png',
+    href: 'https://aisafetyfundamentals.com/economics-of-tai/',
+  },
+  {
+    title: 'Writing Intensive',
+    description: 'This is a 5-day intensive writing course where you`ll transform your AI safety course learnings into a published article.',
+    courseType: 'Crash course',
+    imageSrc: '/images/writing-intensive.png',
+    href: 'https://aisafetyfundamentals.com/writing/',
+  },
 ] as const;

--- a/libraries/ui/src/constants.ts
+++ b/libraries/ui/src/constants.ts
@@ -1,0 +1,70 @@
+export type Course = {
+    title: string;
+    description: string;
+    courseType: CourseType;
+    imageSrc: string;
+    href: string;
+    isNew?: boolean;
+}
+
+export type CourseType = 'Crash course' | 'Self-paced' | 'In-depth course'
+
+export const COURSES: Course[] = [
+    {
+        title: 'AI Safety: Intro to Transformative AI',
+        description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and so is the need for capable individuals to shape its trajectory. This intensive 5-day course is for those who want to rapidly develop their understanding of transformative AI and its impact on humanity.',
+        courseType: 'Crash course',
+        imageSrc: '/images/alignment-course.png',
+        href: 'https://aisafetyfundamentals.com/intro-to-tai/',
+    },
+        {
+        title: 'Alignment Fast-Track',
+        description: 'AI systems are rapidly becoming more capable and more general. Despite AI\'s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
+        courseType: 'Crash course',
+        imageSrc: '/images/intro-course.png',
+        href: 'https://aisafetyfundamentals.com/alignment-fast-track/',
+    },
+    {
+        title: 'Governance Fast-Track',
+        description: 'Despite AI\'s potential to radically improve human society, there are still active debates about how we will wield the AI systems of today and tomorrow. The rise of this powerful technology demands a thoughtful approach to its governance and regulation.',
+        courseType: 'Crash course',
+        imageSrc: '/images/governance-course.jpg',
+        href: 'https://aisafetyfundamentals.com/governance-fast-track/',
+    },
+    {
+        title: 'Economics of Transformative AI Fast-Track',
+        description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
+        courseType: 'In-depth course',
+        imageSrc: '/images/economics-course.png',
+        href: 'https://aisafetyfundamentals.com/economics-of-tai/',
+        isNew: true,
+    },
+    {
+        title: 'AI Alignment',
+        description: 'AI systems are rapidly becoming more capable and more general. Despite AI\'s potential to radically improve human society, there are still open questions about how we build AI systems that are controllable, aligned with our intentions and interpretable.',
+        courseType: 'In-depth course',
+        imageSrc: '/images/alignment-course.png',
+        href: 'https://aisafetyfundamentals.com/alignment/',
+    },
+    {
+        title: 'AI Governance',
+        description: 'The rise of any powerful technology demands a thoughtful approach to its governance and regulation. There has been increasing interest in how AI governance can and should mitigate extreme risks from AI, but it can be difficult to get up to speed on research and ideas in this area.',
+        courseType: 'In-depth course',
+        imageSrc: '/images/governance-course.jpg',
+        href: 'https://aisafetyfundamentals.com/governance/',
+    },
+    {
+        title: 'Economics of Transformative AI',
+        description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
+        courseType: 'In-depth course',
+        imageSrc: '/images/economics-course.png',
+        href: 'https://aisafetyfundamentals.com/economics-of-tai/',
+    },
+    {
+        title: 'Writing Intensive',
+        description: 'This is a 5-day intensive writing course where you`ll transform your AI safety course learnings into a published article.',
+        courseType: 'Crash course',
+        imageSrc: '/images/writing-intensive.png',
+        href: 'https://aisafetyfundamentals.com/writing/',
+    },
+] as const;

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -30,6 +30,7 @@ export { Tag } from './Tag';
 // Utils
 
 export { EXTERNAL_LINK_PROPS } from './utils';
+export * as constants from './constants';
 
 // Legacy Components
 


### PR DESCRIPTION
# Summary

The list of courses is currently duplicated in a few places and is inconsistent with things like property naming, and which courses are included. This PR puts them in one place in ui (because they're currently hardcoded in the Footer, which is in ui).

## Issue

Fixes #308

## Description

There are several issues open for courses missing in different places, and the code seems duplicated and inconsistent about handling these without good reason.

This might not be the right list of courses to be going ahead with in the near future, but at least this gives us one place where we can update it.

Maybe in the future this moves to TinaCMS, or links in with the platform directly, so this isn't necessary. But this is a step closer to having less chaos about what courses we list.

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

The list of courses is now quite big in the header, and we might wnat to argue about the names - but I think both of these are content questions, that we can decide on quickly once we figure out which courses we are actually running (which is likely to be a much narrower subset of these). The current set of names is taken from how we're already calling them on some places in website-25.

![image](https://github.com/user-attachments/assets/505d9386-01c3-4b73-88fd-03a18b236e6f)