### PR TITLE
ui: Collapsible: Improve text target size, simplify margin and padding stacking

### DIFF
--- a/apps/website-25/src/components/homepage/__snapshots__/FAQSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/FAQSection.test.tsx.snap
@@ -22,10 +22,10 @@ exports[`FAQSection > renders default as expected 1`] = `
       class="section__body"
     >
       <details
-        class="collapsible max-w-max-width border-b border-color-divider pb-10 my-10 last:border-none last:pb-0 last:my-6 group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none"
+          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -51,7 +51,7 @@ exports[`FAQSection > renders default as expected 1`] = `
           </span>
         </summary>
         <div
-          class="collapsible__content mt-6"
+          class="collapsible__content pb-6"
         >
           <p>
             Check you are the 
@@ -70,10 +70,10 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider pb-10 my-10 last:border-none last:pb-0 last:my-6 group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none"
+          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -99,7 +99,7 @@ exports[`FAQSection > renders default as expected 1`] = `
           </span>
         </summary>
         <div
-          class="collapsible__content mt-6"
+          class="collapsible__content pb-6"
         >
           <p>
             We are excited that you want to 
@@ -119,10 +119,10 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider pb-10 my-10 last:border-none last:pb-0 last:my-6 group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none"
+          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -148,7 +148,7 @@ exports[`FAQSection > renders default as expected 1`] = `
           </span>
         </summary>
         <div
-          class="collapsible__content mt-6"
+          class="collapsible__content pb-6"
         >
           <p>
             BlueDot Impact is primarily funded by 
@@ -174,10 +174,10 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider pb-10 my-10 last:border-none last:pb-0 last:my-6 group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none"
+          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -203,7 +203,7 @@ exports[`FAQSection > renders default as expected 1`] = `
           </span>
         </summary>
         <div
-          class="collapsible__content mt-6"
+          class="collapsible__content pb-6"
         >
           <p>
             We love to hear from potential collaborators so please 
@@ -217,10 +217,10 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider pb-10 my-10 last:border-none last:pb-0 last:my-6 group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none"
+          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -246,7 +246,7 @@ exports[`FAQSection > renders default as expected 1`] = `
           </span>
         </summary>
         <div
-          class="collapsible__content mt-6"
+          class="collapsible__content pb-6"
         >
           <p>
             Please see more information about our job openings 

--- a/libraries/ui/src/Collapsible.tsx
+++ b/libraries/ui/src/Collapsible.tsx
@@ -13,8 +13,8 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
   children, className, title,
 }) => {
   return (
-    <details className={clsx('collapsible max-w-max-width border-b border-color-divider pb-10 my-10 last:border-none last:pb-0 last:my-6 group', className)}>
-      <summary className="collapsible__header flex justify-between w-full cursor-pointer list-none">
+    <details className={clsx('collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group', className)}>
+      <summary className="collapsible__header flex justify-between w-full cursor-pointer list-none py-6">
         <span className="collapsible__title subtitle-sm">{title}</span>
         <span className="collapsible__button flex items-center">
           <svg
@@ -27,7 +27,7 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
           </svg>
         </span>
       </summary>
-      <div className="collapsible__content mt-6">
+      <div className="collapsible__content pb-6">
         {children}
       </div>
     </details>

--- a/libraries/ui/src/__snapshots__/Collapsible.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Collapsible.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Collapsible > renders to snapshot 1`] = `
 <div>
   <details
-    class="collapsible max-w-max-width border-b border-color-divider pb-10 my-10 last:border-none last:pb-0 last:my-6 group"
+    class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group"
   >
     <summary
-      class="collapsible__header flex justify-between w-full cursor-pointer list-none"
+      class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
     >
       <span
         class="collapsible__title subtitle-sm"
@@ -32,7 +32,7 @@ exports[`Collapsible > renders to snapshot 1`] = `
       </span>
     </summary>
     <div
-      class="collapsible__content mt-6"
+      class="collapsible__content pb-6"
     >
       <p>
         Test Content


### PR DESCRIPTION
# Summary

Collapsible: Improve text target size, simplify margin and padding stacking. This makes it easier to hit the click target when navigating, and reduces the complexity of using these Collapisble components elsewhere.

## Issue

Fixes #288

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

No visual changes

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/b2c77931-8896-480e-86ee-2b6a6d5d57d1" />

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/3306180a-2c4b-4ba1-b3cf-ae50cb49ea90" />