### PR TITLE
website: Add contact page

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -802,40 +802,6 @@ exports[`AboutPage > should render the error message correctly 1`] = `
         </a>
       </div>
     </div>
-    <div
-      class="section section-normal py-spacing-y border-b border-divider overflow-hidden"
-    >
-      <div
-        class="section__title-container flex justify-between items-center gap-space-between"
-      >
-        <div
-          class="section__content flex-1"
-        >
-          <h2
-            class="section__title mb-4 relative after:w-full"
-          >
-            Contact us
-          </h2>
-          <p
-            class="section__subtitle text-bluedot-darker text-md mb-4"
-          >
-            We love hearing from people, and are keen for people to reach out to us with any questions or feedback!
-            <br />
-            <br />
-            Email us at 
-            <a
-              href="mailto:team@bluedot.org"
-            >
-              team@bluedot.org
-            </a>
-            .
-          </p>
-        </div>
-      </div>
-      <div
-        class="section__body"
-      />
-    </div>
   </div>
 </div>
 `;

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -24,10 +24,6 @@ const AboutPage = () => {
       <HistorySection />
       <TeamSection />
       <JoinUsCta />
-      <Section
-        title="Contact us"
-        subtitle={<>We love hearing from people, and are keen for people to reach out to us with any questions or feedback!<br /><br />Email us at <a href="mailto:team@bluedot.org">team@bluedot.org</a>.</>}
-      />
     </div>
   );
 };

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -1,6 +1,5 @@
 import {
   HeroSection,
-  Section,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import IntroSection from '../components/about/IntroSection';

--- a/apps/website-25/src/pages/contact.tsx
+++ b/apps/website-25/src/pages/contact.tsx
@@ -1,0 +1,30 @@
+import {
+  HeroSection,
+  Section,
+} from '@bluedot/ui';
+import Head from 'next/head';
+
+const ContactPage = () => {
+  return (
+    <div>
+      <Head>
+        <title>Contact us | BlueDot Impact</title>
+        <meta name="description" content="Contact BlueDot Impact, the team behind AI Safety Fundamentals." />
+      </Head>
+      <HeroSection
+        title="Reach out to our team"
+      />
+      <Section className="intro-section" title="Contact us">
+        <div className="intro-section__container flex lg:flex-row flex-col gap-space-between">
+          <div className="intro-section__text-container flex flex-col gap-5">
+            <p>We're BlueDot Impact, the team behind AI Safety Fundamentals. We love hearing from people, and are keen for people to reach out to us with any questions or feedback!</p>
+            <p>Email us at <a href="mailto:team@bluedot.org">team@bluedot.org</a>.</p>
+          </div>
+          <img className="intro-section__image max-w-[570px] w-full h-auto rounded-2xl" src="/images/team/team_1.jpg" alt="BlueDot Impact team" />
+        </div>
+      </Section>
+    </div>
+  );
+};
+
+export default ContactPage;

--- a/apps/website-25/src/pages/privacy-policy.tsx
+++ b/apps/website-25/src/pages/privacy-policy.tsx
@@ -13,7 +13,7 @@ const PrivacyPolicyPage = () => {
       />
       <Section>
         <p className="my-2">
-          BlueDot Impact Ltd is a UK non-profit, registered as a company limited by guarantee (company number <a href="https://find-and-update.company-information.service.gov.uk/company/14964572" {...EXTERNAL_LINK_PROPS}>14964572</a>). You can contact us via <a href="mailto:team@bluedot.org" {...EXTERNAL_LINK_PROPS}>team@bluedot.org</a>.
+          BlueDot Impact Ltd is a UK non-profit, registered as a company limited by guarantee (company number <a href="https://find-and-update.company-information.service.gov.uk/company/14964572" {...EXTERNAL_LINK_PROPS}>14964572</a>). You can contact us via <a href="/contact">the details on our contact page</a>.
         </p>
         <p className="my-2">
           We are a data controller. This means we make decisions about how your information is used, and have a responsibility to protect your rights when we do so.

--- a/libraries/ui/src/Footer.tsx
+++ b/libraries/ui/src/Footer.tsx
@@ -79,7 +79,7 @@ export const Footer: React.FC<FooterProps> = ({ className, logo }) => {
                   { href: '/about', label: 'About us' },
                   { href: 'https://donate.stripe.com/5kA3fpgjpdJv6o89AA', label: 'Support us', ...EXTERNAL_LINK_PROPS },
                   { href: '/careers', label: 'Join us' },
-                  { href: 'mailto:team@bluedot.org', label: 'Contact us' },
+                  { href: '/contact', label: 'Contact us' },
                 ]}
               />
 

--- a/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`Footer > renders default as expected 1`] = `
                 >
                   <a
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
-                    href="mailto:team@bluedot.org"
+                    href="/contact"
                   >
                     Contact us
                   </a>
@@ -525,7 +525,7 @@ exports[`Footer > renders with optional args 1`] = `
                 >
                   <a
                     class="footer__link text-bluedot-lighter hover:text-white hover:cursor-pointer"
-                    href="mailto:team@bluedot.org"
+                    href="/contact"
                   >
                     Contact us
                   </a>


### PR DESCRIPTION
# Summary

Add a contact page, given we link to this a bunch of places and is one of the things people try to find the most on our site. This is part of wider work under #295 to migrate pages that are currently only on old website.

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
| 🖥️ | ![image](https://github.com/user-attachments/assets/1a9bcfa4-e531-4513-bf36-72766f44f610) ![image](https://github.com/user-attachments/assets/608e617c-da28-4a13-889d-003007564f83) |
| 📱  | ![image](https://github.com/user-attachments/assets/9a0106cc-c4b6-4b3f-9369-5ade5fde8a38) |

Mobile looks a little cramped, but this is because we use the same components as elsewhere. When these are fixed (#299, #290, etc.) presumably this will be too.