### PR TITLE
website: Fix Safari collapsible marker

### DIFF
--- a/libraries/ui/src/Collapsible.tsx
+++ b/libraries/ui/src/Collapsible.tsx
@@ -13,8 +13,8 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
   children, className, title,
 }) => {
   return (
-    <details className={clsx('collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group', className)}>
-      <summary className="collapsible__header flex justify-between w-full cursor-pointer list-none py-6">
+    <details className={clsx('collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden', className)}>
+      <summary className="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left">
         <span className="collapsible__title subtitle-sm">{title}</span>
         <span className="collapsible__button flex items-center">
           <svg

--- a/libraries/ui/src/__snapshots__/Collapsible.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Collapsible.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Collapsible > renders to snapshot 1`] = `
 <div>
   <details
-    class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group"
+    class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden"
   >
     <summary
-      class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
+      class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"
     >
       <span
         class="collapsible__title subtitle-sm"


### PR DESCRIPTION
# Summary

Use the webkit specific prefix for managing the marker on Safari

## Issue

Fixes #349

## Description

eugh classic Safari not being standards compliant :(

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

![image](https://github.com/user-attachments/assets/994234f0-92cc-49b8-9892-2ee3e4569ec1)

![image](https://github.com/user-attachments/assets/9bf9a844-6218-444e-9848-49cb683e6278)

