### PR TITLE
Hide native scrollbar for SlideList

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             />
           </div>
           <div
-            class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+            class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
           >
             <div
               class="slide-list__slide flex-shrink-0"
@@ -588,7 +588,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             />
           </div>
           <div
-            class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+            class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
           >
             <div
               class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
             />
           </div>
           <div
-            class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+            class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
           >
             <div
               class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+          class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
         >
           <div
             class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`TeamSection > renders default as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+          class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
         >
           <div
             class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/careers/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/ValuesSection.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+          class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
         >
           <div
             class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+          class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
         >
           <div
             class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/GovernanceProjects.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/GovernanceProjects.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`GovernanceProjects > renders as expected 1`] = `
             />
           </div>
           <div
-            class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+            class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
           >
             <div
               class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/TestimonialSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/TestimonialSection.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`TestimonialSection > renders as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+          class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
         >
           <div
             class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+          class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
         >
           <div
             class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`CourseSection > renders as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+          class="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
         >
           <div
             class="slide-list__slide flex-shrink-0"

--- a/apps/website-25/src/components/homepage/__snapshots__/FAQSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/FAQSection.test.tsx.snap
@@ -22,10 +22,10 @@ exports[`FAQSection > renders default as expected 1`] = `
       class="section__body"
     >
       <details
-        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
+          class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -70,10 +70,10 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
+          class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -119,10 +119,10 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
+          class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -174,10 +174,10 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
+          class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"
         >
           <span
             class="collapsible__title subtitle-sm"
@@ -217,10 +217,10 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
       >
         <summary
-          class="collapsible__header flex justify-between w-full cursor-pointer list-none py-6"
+          class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"
         >
           <span
             class="collapsible__title subtitle-sm"

--- a/libraries/ui/src/SlideList.tsx
+++ b/libraries/ui/src/SlideList.tsx
@@ -200,7 +200,7 @@ export const SlideList: React.FC<SlideListProps> = ({
 
           <div
             ref={slidesRef}
-            className="slide-list__slides flex overflow-x-scroll transition-transform duration-300 gap-space-between"
+            className="slide-list__slides flex overflow-x-scroll scrollbar-hidden transition-transform duration-300 gap-space-between"
           >
             {React.Children.map(children, (child) => (
               <div

--- a/libraries/ui/src/shared.css
+++ b/libraries/ui/src/shared.css
@@ -126,6 +126,29 @@
     @apply min-h-screen flow-root bg-cream-normal text-bluedot-black antialiased
   }
 
+  .container-lined {
+    @apply border border-color-divider rounded-lg;
+  }
+
+  .container-elevated {
+    /* RGBA of var(--bluedot-cream-normal) */
+    box-shadow: 0px 4px 1.25rem 0px rgba(30, 30, 30, 0.1);
+  }
+
+  .container-dialog {
+    @apply border border-color-primary rounded-lg;
+    box-shadow: 0px 0px 32px 0px rgba(0, 0, 0, 0.25);
+  }
+
+  .scrollbar-hidden {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .scrollbar-hidden::-webkit-scrollbar {
+    display: none;
+  }
+
   /* Base section class that just applies padding and centering, suitable for nav, footer etc */
   .section-base {
     @apply w-full max-w-max-width mx-auto px-spacing-x;
@@ -134,17 +157,5 @@
   /* Class for titled sections in the body of the page */
   .section-body {
     @apply section-base py-spacing-y border-b border-color-divider overflow-hidden flex flex-col gap-spacing-y;
-  }
-
-  .container-lined {
-    @apply border border-color-divider rounded-lg;
-  }
-  .container-elevated {
-    /* RGBA of var(--bluedot-cream-normal) */
-    box-shadow: 0px 4px 1.25rem 0px rgba(30, 30, 30, 0.1);
-  }
-  .container-dialog {
-    @apply border border-color-primary rounded-lg;
-    box-shadow: 0px 0px 32px 0px rgba(0, 0, 0, 0.25);
   }
 }


### PR DESCRIPTION
# Summary

Hide native scrollbar for SlideList

## Issue
Fixes #353 

## Description

- Use CSS to visually hide native scrollbars as we have a custom scroll bar implemented
- Also reorged the Tailwind utilities in alphabetical order

I noticed SlideList Storybook has broken; opened a ticket to triage a fix for next sprint: 

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | https://github.com/user-attachments/assets/f21ca7ea-6e24-4538-adea-87516a666737 |
| 🖥️ |  https://github.com/user-attachments/assets/82d1da73-46ba-4665-bed9-f2ff05a5d026 |
| 📱  | <img width="390" alt="image" src="https://github.com/user-attachments/assets/4e61d1d1-dff2-4413-8ae2-43a318770c88" /> |

## Tests
```
 Tasks:    7 successful, 7 total
Cached:    2 cached, 7 total
  Time:    3.899s 
```