### PR TITLE
Update section-y according to design updates

### DIFF
--- a/apps/website-25/src/components/homepage/CommunitySection/CommunityValuesSection.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/CommunityValuesSection.tsx
@@ -21,7 +21,7 @@ const values = [
 
 const CommunityValuesSection = () => {
   return (
-    <SlideList title="Our community" maxItemsPerSlide={4} className="community-values-section">
+    <SlideList title="Our community" maxItemsPerSlide={4} className="community-values-section pb-spacing-y">
       {values.map((value) => (
         <Card {...value} className="community-values-section__value" />
       ))}

--- a/apps/website-25/src/components/homepage/CommunitySection/GovernanceProjects.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/GovernanceProjects.tsx
@@ -41,7 +41,7 @@ const projects: Project[] = [
 
 const GovernanceProjects = () => {
   return (
-    <div className="governance-projects p-6 container-lined flex flex-col gap-spacing-y">
+    <div className="governance-projects p-6 container-lined flex flex-col my-spacing-y">
       <SlideList
         title="AI Governance Projects"
         titleLevel="h3"

--- a/apps/website-25/src/components/homepage/CommunitySection/TestimonialSection.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/TestimonialSection.tsx
@@ -35,7 +35,7 @@ const TestimonialSection = () => {
       titleLevel="h3"
       maxItemsPerSlide={3}
       minItemWidth={300}
-      className="testimonial-section"
+      className="testimonial-section py-spacing-y"
     >
       {testimonials.map((testimonial) => (
         <div key={testimonial.name} className="testimonial flex flex-col h-full border rounded-radius-md p-8">

--- a/apps/website-25/src/components/homepage/CommunitySection/index.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/index.tsx
@@ -7,7 +7,7 @@ import CommunityValuesSection from './CommunityValuesSection';
 const CommunitySection = () => {
   return (
     <Section className="community-section">
-      <div className="community-section__sub-sections flex flex-col gap-spacing-y">
+      <div className="community-section__sub-sections flex flex-col">
         <CommunityValuesSection />
         <GovernanceProjects />
         <TestimonialSection />

--- a/apps/website-25/src/components/homepage/GraduateSection.tsx
+++ b/apps/website-25/src/components/homepage/GraduateSection.tsx
@@ -8,7 +8,7 @@ const faces = [
 
 const GraduateSection = () => {
   return (
-    <Section className="graduate-section">
+    <Section className="graduate-section !py-8">
       <div className="graduate-section__container flex flex-col md:flex-row gap-6 items-center">
         <div className="graduate-section__header flex items-center gap-2 shrink-0">
           <FaceTiles faces={faces} />

--- a/libraries/ui/src/Section.tsx
+++ b/libraries/ui/src/Section.tsx
@@ -21,7 +21,7 @@ export const SectionHeading: React.FC<BaseProps> = ({
   const HeadingTag = titleLevel;
   const SubtitleTag = subtitleLevel;
   return (
-    <div className={clsx('section-heading__title-container flex justify-between items-center gap-space-between', className)}>
+    <div className={clsx('section-heading__title-container flex justify-between items-center gap-space-between mb-6', className)}>
       <div className="section-heading__content flex-1 flex flex-col gap-2">
         {title && (
           <HeadingTag className="section-heading__title relative">

--- a/libraries/ui/src/SlideList.tsx
+++ b/libraries/ui/src/SlideList.tsx
@@ -144,7 +144,7 @@ export const SlideList: React.FC<SlideListProps> = ({
   return (
     <div
       className={clsx(
-        'slide-list w-full flex flex-col gap-spacing-y',
+        'slide-list w-full flex flex-col',
         className,
       )}
     >

--- a/libraries/ui/src/shared.css
+++ b/libraries/ui/src/shared.css
@@ -33,9 +33,9 @@
   --spacing-x-lg: 3rem; /* 48px */
   --spacing-x-md: 3rem; /* 48px */
   --spacing-x-sm: 1.5rem; /* 24px */
-  --spacing-y-lg: 2rem; /* 32px */
+  --spacing-y-lg: 1.5rem; /* 24px */
   --spacing-y-md: 1.5rem; /* 24px */
-  --spacing-y-sm: 0.75rem; /* 12px */
+  --spacing-y-sm: 1.5rem; /* 24px */
   --space-between-lg: 1rem; /* 16px */
   --space-between-md: 1rem; /* 16px */
   --space-between-sm: 0.5rem; /* 8px */
@@ -47,27 +47,27 @@
   --text-size-md: 1.125rem; /* 18px */
   --text-size-lg: 1.5rem; /* 24px */
   --text-size-xl: 2rem; /* 32px */
-  --spacing-x: var(--spacing-x-sm);
-  --spacing-y: var(--spacing-y-sm);
-  --space-between: var(--space-between-sm);
+  --spacing-x: var(--spacing-x-sm); /* For horizontal section padding */
+  --spacing-y: var(--spacing-y-sm); /* For vertical section padding */
+  --space-between: var(--space-between-sm); /* For space between items */
 }
 
 /* Maps to Tailwind "md" breakpoint */
 @media (width >= 48rem) {
    :root {
     --text-size-xl: 3rem; /* 48px */
-    --spacing-x: var(--spacing-x-md);
-    --spacing-y: var(--spacing-y-md);
-    --space-between: var(--space-between-md);
+    --spacing-x: var(--spacing-x-md); /* For horizontal section padding */
+    --spacing-y: var(--spacing-y-md); /* For vertical section padding */
+    --space-between: var(--space-between-md); /* For space between items */
   }
 }
 
 /* Maps to Tailwind "lg" breakpoint */
 @media (width >= 64rem) {
   :root {
-    --spacing-x: var(--spacing-x-lg);
-    --spacing-y: var(--spacing-y-lg);
-    --space-between: var(--space-between-lg);
+    --spacing-x: var(--spacing-x-lg); /* For horizontal section padding */
+    --spacing-y: var(--spacing-y-lg); /* For vertical section padding */
+    --space-between: var(--space-between-lg); /* For space between items */
   }
 }
 
@@ -133,7 +133,7 @@
 
   /* Class for titled sections in the body of the page */
   .section-body {
-    @apply section-base py-spacing-y border-b border-color-divider overflow-hidden flex flex-col gap-spacing-y;
+    @apply section-base py-spacing-y border-b border-color-divider overflow-hidden flex flex-col;
   }
 
   .container-lined {


### PR DESCRIPTION
# Summary

Update section-y according to design updates

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes # (issue)
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

- `*-section-y` refers to spacing between sections
- This has been in flux with design, and current designs are inconsistent
- Keep sm/md/lg as-is in case we need to revisit this in the future
- But align to a standard 24px approach (24px + border + 24px = approx 48px between sections)

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot
![localhost_8000_ (8)](https://github.com/user-attachments/assets/5ec947a0-d4c3-4088-9ba3-67b2e043c03a)

![localhost_8000_(iPhone 12 Pro) (3)](https://github.com/user-attachments/assets/58f85a06-4c05-42e0-8a57-1f70398c4f88)
