### PR TITLE
Add back running automated tests from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,3 +23,9 @@ Fixes # (issue)
 | 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
 | 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
 | 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
+
+## Testing
+```
+$ npm run test:update
+<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
+```


### PR DESCRIPTION
# Summary

Add back running automated tests from PR template

## Description

See https://github.com/bluedotimpact/bluedot/pull/329
> These tests currently run on CI but they do not run on commit. I find this helpful to remind developers to run testing locally before marking their PR as ready. I'm going to return this to our PR template.

## Developer checklist
N/A

## Screenshot
N/A
