### PR TITLE
website-proxy: Add proxy for web hosting

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -55,6 +55,9 @@ jobs:
             frontend-example:
               paths:
                 - 'apps/frontend-example/**'
+            website-proxy:
+              paths:
+                - 'apps/website-proxy/**'
             website-25:
               paths:
                 - 'apps/website-25/**'
@@ -139,6 +142,36 @@ jobs:
           VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
       - name: Deploy
         run: npm run deploy:prod --workspace apps/frontend-example
+
+  cd_website-proxy:
+    needs: ci
+    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).website-proxy.should_skip) }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: cd_website-proxy
+    timeout-minutes: 20
+    steps:
+      - name: Checkout ${{ github.sha }}
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Configure for deployment
+        run: |
+          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
+
+          mkdir -p ~/.kube
+          echo "$K8S_KUBECONFIG" > ~/.kube/config
+        env:
+          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
+          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
+      - name: Deploy
+        run: npm run deploy:prod --workspace apps/website-proxy
 
   cd_website-25:
     needs: ci

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -31,6 +31,17 @@ export const services: ServiceDefinition[] = [
     hosts: ['frontend-example.k8s.bluedot.org'],
   },
   {
+    name: 'bluedot-website-proxy',
+    targetPort: 80,
+    spec: {
+      containers: [{
+        name: 'bluedot-website-proxy',
+        image: 'sjc.vultrcr.com/bluedot/bluedot-website-proxy:latest',
+      }],
+    },
+    hosts: ['website-proxy.k8s.bluedot.org'],
+  },
+  {
     name: 'bluedot-website-25',
     targetPort: 8080,
     spec: {

--- a/apps/website-proxy/Dockerfile
+++ b/apps/website-proxy/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:stable-alpine-slim@sha256:6a3378d408c49073bdbb0243219db1072f338b979b58660577a744044515f9f7
+
+COPY src/nginx.template.conf /etc/nginx/nginx.template.conf
+ARG VERSION_TAG
+RUN envsubst '$VERSION_TAG' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
+RUN nginx -t
+
+EXPOSE 80

--- a/apps/website-proxy/README.md
+++ b/apps/website-proxy/README.md
@@ -1,0 +1,19 @@
+# website-proxy
+
+A reverse proxy to help manage our website migration. This was because we didn't implement the blog pages for the MVP, but wanted to keep those URLs active.
+
+We probably want to kill this after everything is on the new website.
+
+## Developer setup
+
+No special actions needed, just follow [the general developer setup instructions](../../README.md#developer-setup-instructions)
+
+## Deployment
+
+This app is deployed onto the K8s cluster as a docker container.
+
+To deploy a new version, simply commit to the master branch. GitHub Actions automatically handles CD.
+
+## How it works
+
+The app hosts an nginx server which proxies requests between the old Wordpress website and the [new website](../website-25/).

--- a/apps/website-proxy/package.json
+++ b/apps/website-proxy/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "@bluedot/website-proxy",
+    "version": "1.0.0",
+    "private": true,
+    "scripts": {
+        "deploy:prod": "tools/deployDocker.sh"
+    }
+}

--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -1,0 +1,26 @@
+http {
+    server {
+        listen 80;
+        add_header X-BlueDot-Version '$VERSION_TAG';
+
+        location /blog/ {
+            proxy_ssl_server_name on;
+            proxy_set_header Host bluedot.org;
+            proxy_pass http://45.76.132.116;
+        }
+
+        # Some static resources e.g. images for blog posts
+        location /u/ {
+            proxy_ssl_server_name on;
+            proxy_set_header Host bluedot.org;
+            proxy_pass http://45.76.132.116;
+        }
+
+        location / {
+            proxy_ssl_server_name on;
+            proxy_pass https://website-25.k8s.bluedot.org;
+        }
+    }
+}
+
+events {}

--- a/apps/website-proxy/tools/deployDocker.sh
+++ b/apps/website-proxy/tools/deployDocker.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cd $(dirname "${BASH_SOURCE[0]:-$0}")/..
+
+APP_NAME=$(basename "$PWD")
+REPO_URL="sjc.vultrcr.com/bluedot"
+IMAGE_NAME="bluedot-$APP_NAME"
+VERSION_TAG="$(TZ=UTC date +'%Y%m%d.%H%M%S').$(git rev-parse --short HEAD)"
+
+# Build
+APP_NAME=$APP_NAME VERSION_TAG=$VERSION_TAG npm run build --if-present
+docker build --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
+
+# Tag and push to registry
+docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:$VERSION_TAG
+docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:latest
+docker push $REPO_URL/$IMAGE_NAME:$VERSION_TAG
+docker push $REPO_URL/$IMAGE_NAME:latest
+
+# Restart nodes in cluster so they pull the new image
+kubectl rollout restart deployment $IMAGE_NAME-deployment
+kubectl rollout status deployment $IMAGE_NAME-deployment


### PR DESCRIPTION
# Summary

Add a proxy for routing traffic between old and new websites, so we can have both simultaneously on bluedot.org.

## Issue

Prepares for #295 - just need to switch the domain after testing this does in fact, work.

## Developer checklist

NB: this is not very well tested because nginx is a pain to run locally atm - will fix this later (#359)