### PR TITLE
website-proxy: proxy to old website via HTTPS

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -6,14 +6,14 @@ http {
         location /blog/ {
             proxy_ssl_server_name on;
             proxy_set_header Host bluedot.org;
-            proxy_pass http://45.76.132.116;
+            proxy_pass https://45.76.132.116;
         }
 
         # Some static resources e.g. images for blog posts
         location /u/ {
             proxy_ssl_server_name on;
             proxy_set_header Host bluedot.org;
-            proxy_pass http://45.76.132.116;
+            proxy_pass https://45.76.132.116;
         }
 
         location / {


### PR DESCRIPTION
## Issue

Related: #360, #295

## Description

I think the old website is sending a redirect response because it doesn't like people reaching out to it over HTTP. This might fix it.