### PR TITLE
website: Add CTA support to HeroSection, add CTAs

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
       class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
     >
       <div
-        class="hero-section__content max-w-[865px] mt-[82px] py-28"
+        class="hero-section__content max-w-[865px] mt-[82px] py-16"
       >
         <h1
           class="hero-section__title text-on-dark text-center"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -14,6 +14,30 @@ exports[`AboutPage > should render the error message correctly 1`] = `
         >
           Our mission is to ensure humanity safely navigates the transition to transformative AI.
         </h1>
+        <div
+          class="flex justify-center mt-8"
+        >
+          <a
+            class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark"
+            data-testid="cta-link"
+            href="/careers"
+          >
+            <span
+              class="cta-button__text"
+            >
+              Join the team
+            </span>
+            <span
+              class="cta-button__chevron ml-3"
+            >
+              <img
+                alt="→"
+                class="cta-button__chevron-icon size-2"
+                src="/icons/chevron_white.svg"
+              />
+            </span>
+          </a>
+        </div>
       </div>
     </div>
     <section

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
       class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
     >
       <div
-        class="hero-section__content max-w-[865px] mt-[82px] py-28"
+        class="hero-section__content max-w-[865px] mt-[82px] py-16"
       >
         <h1
           class="hero-section__title text-on-dark text-center"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -14,6 +14,30 @@ exports[`CareersPage > should render the error message correctly 1`] = `
         >
           Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
         </h1>
+        <div
+          class="flex justify-center mt-8"
+        >
+          <a
+            class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark"
+            data-testid="cta-link"
+            href="#open-roles-anchor"
+          >
+            <span
+              class="cta-button__text"
+            >
+              See open roles
+            </span>
+            <span
+              class="cta-button__chevron ml-3"
+            >
+              <img
+                alt="→"
+                class="cta-button__chevron-icon size-2"
+                src="/icons/chevron_white.svg"
+              />
+            </span>
+          </a>
+        </div>
       </div>
     </div>
     <section
@@ -305,6 +329,10 @@ exports[`CareersPage > should render the error message correctly 1`] = `
       <div
         class="section__body"
       >
+        <div
+          class="invisible relative bottom-48"
+          id="open-roles-anchor"
+        />
         <div
           class="careers-section__container flex flex-col gap-8"
         >

--- a/apps/website-25/src/components/careers/CareersSection.tsx
+++ b/apps/website-25/src/components/careers/CareersSection.tsx
@@ -4,6 +4,7 @@ import { isMobile } from 'react-device-detect';
 const CareersSection = () => {
   return (
     <Section className="careers-section" title="Careers at BlueDot Impact">
+      <div id="open-roles-anchor" className="invisible relative bottom-48" />
       <div className="careers-section__container flex flex-col gap-8">
         <JobListing title="Software Engineering Contractor" url="/careers/swe-contractor/" />
         <JobListing title="AI Safety Teaching Fellow" url="/careers/ai-safety-teaching-fellow/" />

--- a/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
@@ -22,6 +22,10 @@ exports[`CareersSection > renders default as expected 1`] = `
       class="section__body"
     >
       <div
+        class="invisible relative bottom-48"
+        id="open-roles-anchor"
+      />
+      <div
         class="careers-section__container flex flex-col gap-8"
       >
         <div
@@ -137,6 +141,10 @@ exports[`CareersSection > renders mobile as expected 1`] = `
     <div
       class="section__body"
     >
+      <div
+        class="invisible relative bottom-48"
+        id="open-roles-anchor"
+      />
       <div
         class="careers-section__container flex flex-col gap-8"
       >

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -1,4 +1,5 @@
 import {
+  HeroH1,
   HeroSection,
   Section,
 } from '@bluedot/ui';
@@ -16,9 +17,9 @@ const AboutPage = () => {
         <title>Join our team | BlueDot Impact</title>
         <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
       </Head>
-      <HeroSection
-        title="Our mission is to ensure humanity safely navigates the transition to transformative AI."
-      />
+      <HeroSection>
+        <HeroH1>Our mission is to ensure humanity safely navigates the transition to transformative AI.</HeroH1>
+      </HeroSection>
       <IntroSection title="Why do we exist?" />
       <BeliefsSection />
       <HistorySection />

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -1,6 +1,8 @@
 import {
-  HeroH1,
+  CTALinkOrButton,
   HeroSection,
+  HeroH1,
+  HeroCTAContainer,
   Section,
 } from '@bluedot/ui';
 import Head from 'next/head';
@@ -19,6 +21,9 @@ const AboutPage = () => {
       </Head>
       <HeroSection>
         <HeroH1>Our mission is to ensure humanity safely navigates the transition to transformative AI.</HeroH1>
+        <HeroCTAContainer>
+          <CTALinkOrButton url="/careers" withChevron>Join the team</CTALinkOrButton>
+        </HeroCTAContainer>
       </HeroSection>
       <IntroSection title="Why do we exist?" />
       <BeliefsSection />

--- a/apps/website-25/src/pages/careers.tsx
+++ b/apps/website-25/src/pages/careers.tsx
@@ -1,6 +1,8 @@
 import {
   HeroSection,
   HeroH1,
+  HeroCTAContainer,
+  CTALinkOrButton,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import IntroSection from '../components/about/IntroSection';
@@ -16,6 +18,9 @@ const CareersPage = () => {
       </Head>
       <HeroSection>
         <HeroH1>Join us in our mission to ensure humanity safely navigates the transition to transformative AI.</HeroH1>
+        <HeroCTAContainer>
+          <CTALinkOrButton url="#open-roles-anchor" withChevron>See open roles</CTALinkOrButton>
+        </HeroCTAContainer>
       </HeroSection>
       <IntroSection title="Our culture" />
       <ValuesSection />

--- a/apps/website-25/src/pages/careers.tsx
+++ b/apps/website-25/src/pages/careers.tsx
@@ -1,5 +1,6 @@
 import {
   HeroSection,
+  HeroH1,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import IntroSection from '../components/about/IntroSection';
@@ -13,9 +14,9 @@ const CareersPage = () => {
         <title>Join the team at BlueDot Impact</title>
         <meta name="description" content="Join us in our mission to ensure humanity safely navigates the transition to transformative AI." />
       </Head>
-      <HeroSection
-        title="Join us in our mission to ensure humanity safely navigates the transition to transformative AI."
-      />
+      <HeroSection>
+        <HeroH1>Join us in our mission to ensure humanity safely navigates the transition to transformative AI.</HeroH1>
+      </HeroSection>
       <IntroSection title="Our culture" />
       <ValuesSection />
       <CareersSection />

--- a/apps/website-25/src/pages/careers/ai-safety-teaching-fellow.tsx
+++ b/apps/website-25/src/pages/careers/ai-safety-teaching-fellow.tsx
@@ -1,6 +1,9 @@
 import {
   CTALinkOrButton,
   HeroSection,
+  HeroH1,
+  HeroH2,
+  HeroCTAContainer,
   Section,
 } from '@bluedot/ui';
 import Head from 'next/head';
@@ -12,11 +15,11 @@ const JobPostingPage = () => {
         <title>AI Safety Teaching Fellow | BlueDot Impact</title>
       </Head>
       <HeroSection>
-        <h1 className="hero-section__title text-on-dark text-center">AI Safety Teaching Fellow</h1>
-        <h2 className="hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4">Lead expert discussions on AI safety</h2>
-        <div className="flex justify-center mt-8">
+        <HeroH1>AI Safety Teaching Fellow</HeroH1>
+        <HeroH2>Lead expert discussions on AI safety</HeroH2>
+        <HeroCTAContainer>
           <CTALinkOrButton url="https://forms.bluedot.org/D2vOoKG53VRR4HIedgcz?prefill_Role=recUVhfgJJRZVAQDw">Express interest</CTALinkOrButton>
-        </div>
+        </HeroCTAContainer>
       </HeroSection>
       <Section className="prose">
         <h2>Who we are</h2>

--- a/apps/website-25/src/pages/careers/swe-contractor.tsx
+++ b/apps/website-25/src/pages/careers/swe-contractor.tsx
@@ -1,6 +1,9 @@
 import {
   CTALinkOrButton,
   HeroSection,
+  HeroH1,
+  HeroH2,
+  HeroCTAContainer,
   Section,
 } from '@bluedot/ui';
 import Head from 'next/head';
@@ -12,11 +15,11 @@ const JobPostingPage = () => {
         <title>Software Engineering Contractor | BlueDot Impact</title>
       </Head>
       <HeroSection>
-        <h1 className="hero-section__title text-on-dark text-center">Software Engineering Contractor</h1>
-        <h2 className="hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4">We’re building a database of high-trust, agile software engineers to help us out on future contractor work.</h2>
-        <div className="flex justify-center mt-8">
+        <HeroH1>Software Engineering Contractor</HeroH1>
+        <HeroH2>We’re building a database of high-trust, agile software engineers to help us out on future contractor work.</HeroH2>
+        <HeroCTAContainer>
           <CTALinkOrButton url="https://web.miniextensions.com/4XjNSRhWiAUBc1UTDZS3?prefill_Role=recuN8LCYMMsZZmNC">Join our hiring pool</CTALinkOrButton>
-        </div>
+        </HeroCTAContainer>
       </HeroSection>
       <Section className="prose">
         <h2>About BlueDot Impact</h2>

--- a/apps/website-25/src/pages/index.tsx
+++ b/apps/website-25/src/pages/index.tsx
@@ -18,7 +18,7 @@ const HomePage = () => {
         <title>BlueDot Impact | Industry-leading free AI courses and career support</title>
         <meta name="description" content="Learn for free about AI safety and how to ensure humanity safely navigates the transition to transformative AI. Join 4,000+ professionals building careers at organizations like Anthropic, OpenAI, and the UK’s AI Safety Institute." />
       </Head>
-      <HeroSection>
+      <HeroSection className="py-12">
         <div className="hero-section__logo-container flex flex-col items-center gap-7 mb-3">
           <img className="hero-section__logo-icon w-20 mb-20" src="/images/logo/BlueDot_Impact_Icon_White.svg" alt="BlueDot Impact" />
         </div>

--- a/apps/website-25/src/pages/index.tsx
+++ b/apps/website-25/src/pages/index.tsx
@@ -1,5 +1,7 @@
 import {
   HeroSection,
+  HeroH1,
+  HeroH2,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import BlogSection from '../components/homepage/BlogSection';
@@ -16,13 +18,12 @@ const HomePage = () => {
         <title>BlueDot Impact | Industry-leading free AI courses and career support</title>
         <meta name="description" content="Learn for free about AI safety and how to ensure humanity safely navigates the transition to transformative AI. Join 4,000+ professionals building careers at organizations like Anthropic, OpenAI, and the UK’s AI Safety Institute." />
       </Head>
-      <HeroSection
-        title="The expertise you need to shape safe AI "
-        subtitle="We run the world's most trusted AI Safety educational courses, career services and support community. Our programs are developed in collaboration with AI Safety world experts."
-      >
+      <HeroSection>
         <div className="hero-section__logo-container flex flex-col items-center gap-7 mb-3">
           <img className="hero-section__logo-icon w-20 mb-20" src="/images/logo/BlueDot_Impact_Icon_White.svg" alt="BlueDot Impact" />
         </div>
+        <HeroH1>The expertise you need to shape safe AI</HeroH1>
+        <HeroH2>We run the world's most trusted AI Safety educational courses, career services and support community. Our programs are developed in collaboration with AI Safety world experts.</HeroH2>
       </HeroSection>
       <GraduateSection />
       <CourseSection />

--- a/apps/website-25/src/pages/privacy-policy.tsx
+++ b/apps/website-25/src/pages/privacy-policy.tsx
@@ -1,16 +1,18 @@
 import {
   EXTERNAL_LINK_PROPS,
   HeroSection,
+  HeroH1,
+  HeroH2,
   Section,
 } from '@bluedot/ui';
 
 const PrivacyPolicyPage = () => {
   return (
     <div>
-      <HeroSection
-        title="Privacy Policy"
-        subtitle="Effective date: 30 August, 2024"
-      />
+      <HeroSection>
+        <HeroH1>Privacy Policy</HeroH1>
+        <HeroH2>Effective date: 30 August, 2024</HeroH2>
+      </HeroSection>
       <Section>
         <p className="my-2">
           BlueDot Impact Ltd is a UK non-profit, registered as a company limited by guarantee (company number <a href="https://find-and-update.company-information.service.gov.uk/company/14964572" {...EXTERNAL_LINK_PROPS}>14964572</a>). You can contact us via <a href="mailto:team@bluedot.org" {...EXTERNAL_LINK_PROPS}>team@bluedot.org</a>.

--- a/libraries/ui/src/HeroSection.stories.tsx
+++ b/libraries/ui/src/HeroSection.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import React from 'react';
+
+import {
+  HeroSection, HeroH1, HeroH2, HeroCTAContainer,
+} from './HeroSection';
+import { CTALinkOrButton } from './CTALinkOrButton';
+
+const meta = {
+  title: 'ui/HeroSection',
+  component: HeroSection,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof HeroSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <HeroSection>
+      <HeroH1>Welcome to Bluedot</HeroH1>
+      <HeroH2>Discover amazing possibilities</HeroH2>
+    </HeroSection>
+  ),
+};
+
+export const WithCustomClasses: Story = {
+  render: () => (
+    <HeroSection className="min-h-[500px]">
+      <HeroH1 className="text-4xl">Custom Hero Title</HeroH1>
+      <HeroH2 className="italic">With custom styling</HeroH2>
+      <HeroCTAContainer className="gap-4">
+        <CTALinkOrButton variant="primary" withChevron>
+          Primary CTA
+        </CTALinkOrButton>
+        <CTALinkOrButton variant="secondary">
+          Secondary CTA
+        </CTALinkOrButton>
+      </HeroCTAContainer>
+    </HeroSection>
+  ),
+};
+
+export const WithLink: Story = {
+  render: () => (
+    <HeroSection>
+      <HeroH1>Hero with Link</HeroH1>
+      <HeroH2>Click below to explore</HeroH2>
+      <HeroCTAContainer>
+        <CTALinkOrButton
+          variant="primary"
+          withChevron
+          url="https://example.com"
+          isExternalUrl
+        >
+          Learn More
+        </CTALinkOrButton>
+      </HeroCTAContainer>
+    </HeroSection>
+  ),
+};

--- a/libraries/ui/src/HeroSection.test.tsx
+++ b/libraries/ui/src/HeroSection.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import { HeroSection } from './HeroSection';
+import {
+  HeroSection, HeroH1, HeroH2, HeroCTAContainer,
+} from './HeroSection';
+import { CTALinkOrButton } from './CTALinkOrButton';
 
 describe('HeroSection', () => {
   test('renders default as expected', () => {
@@ -8,12 +11,25 @@ describe('HeroSection', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('renders with optional args', () => {
+  test('renders with titles', () => {
     const { container } = render(
-      <HeroSection
-        title="This is the title"
-        subtitle="This is the subtitle"
-      />,
+      <HeroSection>
+        <HeroH1>This is the title</HeroH1>
+        <HeroH2>This is the subtitle</HeroH2>
+      </HeroSection>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders with buttons', () => {
+    const { container } = render(
+      <HeroSection>
+        <HeroH1>This is the title</HeroH1>
+        <HeroH2>This is the subtitle</HeroH2>
+        <HeroCTAContainer>
+          <CTALinkOrButton url="https://example.com">Do a thing</CTALinkOrButton>
+        </HeroCTAContainer>
+      </HeroSection>,
     );
     expect(container).toMatchSnapshot();
   });

--- a/libraries/ui/src/HeroSection.tsx
+++ b/libraries/ui/src/HeroSection.tsx
@@ -1,29 +1,59 @@
 import React from 'react';
 import clsx from 'clsx';
 
+export type HeroH1Props = React.PropsWithChildren<{
+  className?: string,
+}>;
+
+export const HeroH1: React.FC<HeroH1Props> = ({
+  children, className,
+}) => {
+  return (
+    <h1 className={clsx('hero-section__title text-on-dark text-center', className)}>{children}</h1>
+  );
+};
+
+export type HeroH2Props = React.PropsWithChildren<{
+  className?: string,
+}>;
+
+export const HeroH2: React.FC<HeroH2Props> = ({
+  children, className,
+}) => {
+  return (
+    <h2 className={clsx('hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4', className)}>{children}</h2>
+  );
+};
+
+type HeroCTAContainerProps = React.PropsWithChildren<{
+  className?: string,
+}>;
+
+export const HeroCTAContainer: React.FC<HeroCTAContainerProps> = ({
+  className,
+  children,
+}) => {
+  return (
+    <div className={clsx('flex justify-center mt-8', className)}>
+      {children}
+    </div>
+  );
+};
+
 export type HeroSectionProps = React.PropsWithChildren<{
   className?: string,
-  title?: string,
-  subtitle?: string
 }>;
 
 export const HeroSection: React.FC<HeroSectionProps> = ({
-  className, title, subtitle, children,
+  className,
+  children,
 }) => {
   return (
     <div className={clsx('hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x', className)}>
       {/* Top margin is nav height (82px) */}
       <div className="hero-section__content max-w-[865px] mt-[82px] py-28">
         {children}
-        {title && (
-          <h1 className="hero-section__title text-on-dark text-center">{title}</h1>
-        )}
-        {subtitle && (
-          <h2 className="hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4">{subtitle}</h2>
-        )}
       </div>
     </div>
   );
 };
-
-export default HeroSection;

--- a/libraries/ui/src/HeroSection.tsx
+++ b/libraries/ui/src/HeroSection.tsx
@@ -51,7 +51,7 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
   return (
     <div className={clsx('hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x', className)}>
       {/* Top margin is nav height (82px) */}
-      <div className="hero-section__content max-w-[865px] mt-[82px] py-28">
+      <div className="hero-section__content max-w-[865px] mt-[82px] py-16">
         {children}
       </div>
     </div>

--- a/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`HeroSection > renders default as expected 1`] = `
 </div>
 `;
 
-exports[`HeroSection > renders with optional args 1`] = `
+exports[`HeroSection > renders with buttons 1`] = `
 <div>
   <div
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
@@ -30,6 +30,21 @@ exports[`HeroSection > renders with optional args 1`] = `
       >
         This is the subtitle
       </h2>
+      <div
+        class="flex justify-center mt-8"
+      >
+        <a
+          class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark"
+          data-testid="cta-link"
+          href="https://example.com"
+        >
+          <span
+            class="cta-button__text"
+          >
+            Do a thing
+          </span>
+        </a>
+      </div>
     </div>
   </div>
 </div>
@@ -46,6 +61,29 @@ exports[`HeroSection > renders with optional yield 1`] = `
       <p>
         This is the yield
       </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`HeroSection > renders with titles 1`] = `
+<div>
+  <div
+    class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
+  >
+    <div
+      class="hero-section__content max-w-[865px] mt-[82px] py-28"
+    >
+      <h1
+        class="hero-section__title text-on-dark text-center"
+      >
+        This is the title
+      </h1>
+      <h2
+        class="hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4"
+      >
+        This is the subtitle
+      </h2>
     </div>
   </div>
 </div>

--- a/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`HeroSection > renders default as expected 1`] = `
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
   >
     <div
-      class="hero-section__content max-w-[865px] mt-[82px] py-28"
+      class="hero-section__content max-w-[865px] mt-[82px] py-16"
     />
   </div>
 </div>
@@ -18,7 +18,7 @@ exports[`HeroSection > renders with buttons 1`] = `
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
   >
     <div
-      class="hero-section__content max-w-[865px] mt-[82px] py-28"
+      class="hero-section__content max-w-[865px] mt-[82px] py-16"
     >
       <h1
         class="hero-section__title text-on-dark text-center"
@@ -56,7 +56,7 @@ exports[`HeroSection > renders with optional yield 1`] = `
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
   >
     <div
-      class="hero-section__content max-w-[865px] mt-[82px] py-28"
+      class="hero-section__content max-w-[865px] mt-[82px] py-16"
     >
       <p>
         This is the yield
@@ -72,7 +72,7 @@ exports[`HeroSection > renders with titles 1`] = `
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
   >
     <div
-      class="hero-section__content max-w-[865px] mt-[82px] py-28"
+      class="hero-section__content max-w-[865px] mt-[82px] py-16"
     >
       <h1
         class="hero-section__title text-on-dark text-center"

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -13,7 +13,9 @@ export { CourseCard } from './CourseCard';
 
 export { CTALinkOrButton } from './CTALinkOrButton';
 
-export { HeroSection } from './HeroSection';
+export {
+  HeroSection, HeroH1, HeroH2, HeroCTAContainer,
+} from './HeroSection';
 
 export { FaceTiles } from './FaceTiles';
 


### PR DESCRIPTION
# Summary

Adds CTAs to HeroSections, cleans up hero-related components

## Issue

Fixes #343, fixes #310, fixes #301

## Description

- Changed Hero-related components to be composable
- Added CTA Hero component
- Used this to simplify the job posting pages
- Added CTAs to the various pages that are missing them
- Updated the padding so it's more similar to the Figma designs
- Added storybook stories

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

![image](https://github.com/user-attachments/assets/2a890d7b-571b-4df2-95b1-0ca996c9e123)
![image](https://github.com/user-attachments/assets/4980e471-e00f-4f87-973c-02c8677f4f5a)
![image](https://github.com/user-attachments/assets/769d84e8-049a-4732-bd69-f7e195276631)
![image](https://github.com/user-attachments/assets/c83eb6c7-0d96-4945-928a-a80cd7fec659)