### PR TITLE
website-proxy: Include additional new website resources

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -1,5 +1,5 @@
 http {
-    proxy_ssl_server_name off;
+    proxy_ssl_server_name on;
 
     server {
         listen 80;
@@ -22,8 +22,24 @@ http {
             proxy_pass https://website-25.k8s.bluedot.org;
         }
 
+        # Asset folders that are necessary for the new website to work
+        # Before adding a prefix here, verify it is not used on the old website
+        location /_next {
+            proxy_pass https://website-25.k8s.bluedot.org;
+        }
+        location /fonts {
+            proxy_pass https://website-25.k8s.bluedot.org;
+        }
+        location /images {
+            proxy_pass https://website-25.k8s.bluedot.org;
+        }
+        location /icons {
+            proxy_pass https://website-25.k8s.bluedot.org;
+        }
+
         # Default all other traffic to old site
         location / {
+            proxy_ssl_name bluedot.org;
             proxy_set_header Host bluedot.org;
             proxy_pass https://45.76.132.116;
         }


### PR DESCRIPTION
Include additional new website resources. I've verified these don't appear to be used by the old website, and the key pages e.g. `/blog/` render correctly.

This is needed to have the fonts and images etc. load for the new website.