### PR TITLE
fix: prevent image stretching on about page at 1025px width (#363)

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -45,14 +45,18 @@ exports[`AboutPage > should render the error message correctly 1`] = `
               Humanity faces unprecedented challenges from transformative AI (TAI) which could profoundly reshape our future. Current AI systems already exhibit concerning behaviours, and as they become more powerful, misalignment between their actions, human intentions and societal values could lead to catastrophic outcomes.
             </p>
             <p>
-              BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field.  We’ve trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK’s AI Safety Institute. We’ve built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.
+              BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field. We've trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK's AI Safety Institute. We've built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.
             </p>
           </div>
-          <img
-            alt="BlueDot Impact team"
-            class="intro-section__image max-w-[570px] w-full h-auto rounded-2xl"
-            src="/images/team/team_1.jpg"
-          />
+          <div
+            class="intro-section__image-container w-full max-w-[570px] aspect-[4/3] relative"
+          >
+            <img
+              alt="BlueDot Impact team"
+              class="intro-section__image size-full object-cover rounded-2xl"
+              src="/images/team/team_1.jpg"
+            />
+          </div>
         </div>
       </div>
     </section>

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -45,14 +45,18 @@ exports[`CareersPage > should render the error message correctly 1`] = `
               Humanity faces unprecedented challenges from transformative AI (TAI) which could profoundly reshape our future. Current AI systems already exhibit concerning behaviours, and as they become more powerful, misalignment between their actions, human intentions and societal values could lead to catastrophic outcomes.
             </p>
             <p>
-              BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field.  We’ve trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK’s AI Safety Institute. We’ve built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.
+              BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field. We've trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK's AI Safety Institute. We've built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.
             </p>
           </div>
-          <img
-            alt="BlueDot Impact team"
-            class="intro-section__image max-w-[570px] w-full h-auto rounded-2xl"
-            src="/images/team/team_1.jpg"
-          />
+          <div
+            class="intro-section__image-container w-full max-w-[570px] aspect-[4/3] relative"
+          >
+            <img
+              alt="BlueDot Impact team"
+              class="intro-section__image size-full object-cover rounded-2xl"
+              src="/images/team/team_1.jpg"
+            />
+          </div>
         </div>
       </div>
     </section>

--- a/apps/website-25/src/components/about/IntroSection.tsx
+++ b/apps/website-25/src/components/about/IntroSection.tsx
@@ -6,13 +6,13 @@ const IntroSection = ({ title }: { title: string }) => {
       <div className="intro-section__container flex lg:flex-row flex-col gap-space-between">
         <div className="intro-section__text-container flex flex-col gap-5">
           <p>Humanity faces unprecedented challenges from transformative AI (TAI) which could profoundly reshape our future. Current AI systems already exhibit concerning behaviours, and as they become more powerful, misalignment between their actions, human intentions and societal values could lead to catastrophic outcomes.</p>
-          <p>BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field.  We've trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK's AI Safety Institute. We've built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.</p>
+          <p>BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field. We've trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK's AI Safety Institute. We've built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.</p>
         </div>
         <div className="intro-section__image-container w-full max-w-[570px] aspect-[4/3] relative">
-          <img 
-            className="intro-section__image w-full h-full object-cover rounded-2xl" 
-            src="/images/team/team_1.jpg" 
-            alt="BlueDot Impact team" 
+          <img
+            className="intro-section__image size-full object-cover rounded-2xl"
+            src="/images/team/team_1.jpg"
+            alt="BlueDot Impact team"
           />
         </div>
       </div>

--- a/apps/website-25/src/components/about/IntroSection.tsx
+++ b/apps/website-25/src/components/about/IntroSection.tsx
@@ -6,9 +6,15 @@ const IntroSection = ({ title }: { title: string }) => {
       <div className="intro-section__container flex lg:flex-row flex-col gap-space-between">
         <div className="intro-section__text-container flex flex-col gap-5">
           <p>Humanity faces unprecedented challenges from transformative AI (TAI) which could profoundly reshape our future. Current AI systems already exhibit concerning behaviours, and as they become more powerful, misalignment between their actions, human intentions and societal values could lead to catastrophic outcomes.</p>
-          <p>BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field.  We’ve trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK’s AI Safety Institute. We’ve built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.</p>
+          <p>BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field.  We've trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK's AI Safety Institute. We've built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.</p>
         </div>
-        <img className="intro-section__image max-w-[570px] w-full h-auto rounded-2xl" src="/images/team/team_1.jpg" alt="BlueDot Impact team" />
+        <div className="intro-section__image-container w-full max-w-[570px] aspect-[4/3] relative">
+          <img 
+            className="intro-section__image w-full h-full object-cover rounded-2xl" 
+            src="/images/team/team_1.jpg" 
+            alt="BlueDot Impact team" 
+          />
+        </div>
       </div>
     </Section>
   );

--- a/apps/website-25/src/components/about/__snapshots__/IntroSection.test.tsx.snap
+++ b/apps/website-25/src/components/about/__snapshots__/IntroSection.test.tsx.snap
@@ -31,14 +31,18 @@ exports[`IntroSection > renders default as expected 1`] = `
             Humanity faces unprecedented challenges from transformative AI (TAI) which could profoundly reshape our future. Current AI systems already exhibit concerning behaviours, and as they become more powerful, misalignment between their actions, human intentions and societal values could lead to catastrophic outcomes.
           </p>
           <p>
-            BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field.  We’ve trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK’s AI Safety Institute. We’ve built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.
+            BlueDot Impact exists to safeguard humanity from these risks by building and accelerating the AI safety field. We've trained over 4,000 professionals and helped hundreds land roles at organisations like Anthropic and the UK's AI Safety Institute. We've built a strong foundation of deep knowledge in how to communicate complex concepts, close relationships across the field, and expertise in talent development. However, urgency and the magnitude of AI risk demands we do much more.
           </p>
         </div>
-        <img
-          alt="BlueDot Impact team"
-          class="intro-section__image max-w-[570px] w-full h-auto rounded-2xl"
-          src="/images/team/team_1.jpg"
-        />
+        <div
+          class="intro-section__image-container w-full max-w-[570px] aspect-[4/3] relative"
+        >
+          <img
+            alt="BlueDot Impact team"
+            class="intro-section__image size-full object-cover rounded-2xl"
+            src="/images/team/team_1.jpg"
+          />
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
# Summary
Fixed image stretching issue on the about page at 1025px width by implementing proper aspect ratio controls and image containment.

## Issue
Closes #363

## Description
This PR fixes the image stretching issue by:
- Adding a container div with aspect ratio control (4:3)
- Using object-cover to maintain image proportions
- Ensuring consistent display across all screen sizes

## Developer checklist
- [x] Used proper CSS/Tailwind classes for styling
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot
The fix can be tested by reviewing the code changes and running the site locally.