### PR TITLE
proxies+backend: standardise on exposing port 8080 across app containers

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -8,7 +8,7 @@ const start = async () => {
     const instance = await getInstance();
     await instance.listen({
       // eslint-disable-next-line turbo/no-undeclared-env-vars
-      port: process.env.PORT ? parseInt(process.env.PORT) : 8001,
+      port: process.env.PORT ? parseInt(process.env.PORT) : 8080,
       host: '0.0.0.0',
     }).then((address) => {
       console.log(`Server listening on ${address}`);

--- a/apps/bubble-proxy/Dockerfile
+++ b/apps/bubble-proxy/Dockerfile
@@ -6,4 +6,4 @@ ARG VERSION_TAG
 RUN envsubst '$VERSION_TAG' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
 RUN nginx -t
 
-EXPOSE 80
+EXPOSE 8080

--- a/apps/bubble-proxy/src/nginx.template.conf
+++ b/apps/bubble-proxy/src/nginx.template.conf
@@ -5,7 +5,7 @@ http {
     }
 
     server {
-        listen 80;
+        listen 8080;
         add_header X-BlueDot-Version '$VERSION_TAG';
 
         # Handle paths that shouldn't be changed

--- a/apps/frontend-example/src/lib/queryClient.ts
+++ b/apps/frontend-example/src/lib/queryClient.ts
@@ -4,7 +4,7 @@ import { contract } from '@bluedot/backend-contract';
 import { useAuthStore } from './authStore';
 
 export const client = initQueryClient(contract, {
-  baseUrl: 'http://localhost:8001',
+  baseUrl: 'http://localhost:8080',
   baseHeaders: {},
   credentials: 'omit',
   api: async (args: ApiFetcherArgs) => {

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -32,7 +32,7 @@ export const services: ServiceDefinition[] = [
   },
   {
     name: 'bluedot-website-proxy',
-    targetPort: 80,
+    targetPort: 8080,
     spec: {
       containers: [{
         name: 'bluedot-website-proxy',
@@ -59,7 +59,7 @@ export const services: ServiceDefinition[] = [
   },
   {
     name: 'bluedot-storybook',
-    targetPort: 80,
+    targetPort: 8080,
     spec: {
       containers: [{
         name: 'bluedot-storybook',
@@ -70,7 +70,7 @@ export const services: ServiceDefinition[] = [
   },
   {
     name: 'bluedot-miniextensions-proxy',
-    targetPort: 80,
+    targetPort: 8080,
     spec: {
       containers: [{
         name: 'bluedot-miniextensions-proxy',
@@ -81,7 +81,7 @@ export const services: ServiceDefinition[] = [
   },
   {
     name: 'bluedot-posthog-proxy',
-    targetPort: 80,
+    targetPort: 8080,
     spec: {
       containers: [{
         name: 'bluedot-posthog-proxy',
@@ -143,7 +143,7 @@ export const services: ServiceDefinition[] = [
   },
   // {
   //   name: 'bluedot-bubble-proxy',
-  //   targetPort: 80,
+  //   targetPort: 8080,
   //   spec: {
   //     containers: [{
   //       name: 'bluedot-bubble-proxy',
@@ -157,7 +157,7 @@ export const services: ServiceDefinition[] = [
   // },
   // {
   //   name: 'bluedot-backend',
-  //   targetPort: 8001,
+  //   targetPort: 8080,
   //   spec: {
   //     containers: [{
   //       name: 'bluedot-backend',

--- a/apps/miniextensions-proxy/Dockerfile
+++ b/apps/miniextensions-proxy/Dockerfile
@@ -5,4 +5,4 @@ ARG VERSION_TAG
 RUN envsubst '$VERSION_TAG' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
 RUN nginx -t
 
-EXPOSE 80
+EXPOSE 8080

--- a/apps/miniextensions-proxy/src/nginx.template.conf
+++ b/apps/miniextensions-proxy/src/nginx.template.conf
@@ -1,6 +1,6 @@
 http {
     server {
-        listen 80;
+        listen 8080;
         add_header X-BlueDot-Version '$VERSION_TAG';
 
         # Redirect the course hub homepage back to the main website

--- a/apps/posthog-proxy/Dockerfile
+++ b/apps/posthog-proxy/Dockerfile
@@ -5,4 +5,4 @@ ARG VERSION_TAG
 RUN envsubst '$VERSION_TAG' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
 RUN nginx -t
 
-EXPOSE 80
+EXPOSE 8080

--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -1,6 +1,6 @@
 http {
     server {
-        listen 80;
+        listen 8080;
         add_header X-BlueDot-Version '$VERSION_TAG';
 
         # Redirect the course hub homepage back to the main website

--- a/apps/storybook/Dockerfile
+++ b/apps/storybook/Dockerfile
@@ -7,4 +7,4 @@ ARG VERSION_TAG
 RUN envsubst '$VERSION_TAG' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
 RUN nginx -t
 
-EXPOSE 80
+EXPOSE 8080

--- a/apps/storybook/src/nginx.template.conf
+++ b/apps/storybook/src/nginx.template.conf
@@ -2,7 +2,7 @@ http {
     include /etc/nginx/mime.types;
     
     server {
-        listen 80;
+        listen 8080;
         add_header X-BlueDot-Version '$VERSION_TAG';
 
         location / {

--- a/apps/website-25/src/lib/queryClient.ts
+++ b/apps/website-25/src/lib/queryClient.ts
@@ -4,7 +4,7 @@ import { contract } from '@bluedot/backend-contract';
 import { useAuthStore } from './authStore';
 
 export const client = initQueryClient(contract, {
-  baseUrl: 'http://localhost:8001',
+  baseUrl: 'http://localhost:8080',
   baseHeaders: {},
   credentials: 'omit',
   api: async (args: ApiFetcherArgs) => {

--- a/apps/website-proxy/Dockerfile
+++ b/apps/website-proxy/Dockerfile
@@ -5,4 +5,4 @@ ARG VERSION_TAG
 RUN envsubst '$VERSION_TAG' < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
 RUN nginx -t
 
-EXPOSE 80
+EXPOSE 8080

--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -2,7 +2,7 @@ http {
     proxy_ssl_server_name on;
 
     server {
-        listen 80;
+        listen 8080;
         add_header X-BlueDot-Version '$VERSION_TAG';
 
         # Specific routes to website-25


### PR DESCRIPTION
# Summary

Currently, different app containers run on different ports by default. This adds unnecessary complexity, which we could avoid by picking a port and standardising it.

I've chosen 8080 given most apps are on it, and this means we avoid touching website-25.

This came up while exploring trying to make it easier to run containers locally, related to #359