### PR TITLE
infra: Avoiding having to manually add apps to cd_cd config

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -40,34 +40,36 @@ jobs:
       - name: Test
         run: npm run test --if-present
 
-      # Get paths that apps are dependent on, e.g. availability depends on apps/availability/** and libaries/ui/**
-      - id: get_paths_filter
+      - name: Get paths that apps are dependent on
+        # e.g. availability depends on apps/availability/** and libaries/ui/**
+        id: get_paths_filter
         run: |
           node .github/workflows/create-paths-filter.js > paths-filter.json
           FILTER=$(cat paths-filter.json)
           echo "paths_filter=$FILTER" >> $GITHUB_OUTPUT
 
-      # Figure out what apps have changed files in their paths
-      - id: modified_paths_check
+      - name: Figure out what apps have changed files in their paths
+        id: modified_paths_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
           paths_filter: ${{ steps.get_paths_filter.outputs.paths_filter }}
           paths: '["package-lock.json"]'
           paths_ignore: '["**/README.md"]'
 
-      # Arrange output into one array for CD matrix
-      - id: get_apps_to_deploy
+      - name: Arrange output into one array for CD matrix
+        id: get_apps_to_deploy
         run: |
           # Get all apps
           APPS=$(ls -d apps/*/ | cut -d'/' -f2 | jq -R -s -c 'split("\n")[:-1]')
           
-          # If should_skip is false, all apps need deployment
-          if [[ "${{ steps.modified_paths_check.outputs.should_skip }}" != "true" ]]; then
+          # If should_skip is false, it means package-lock.json changed
+          if [[ "${{ steps.modified_paths_check.outputs.should_skip }}" == "false" ]]; then
+            # Deploy all apps since common files changed
             echo "apps=$APPS" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
-          # Otherwise, filter for apps that need deployment
+
+          # Otherwise get only apps that had path changes
           PATHS_RESULT='${{ steps.modified_paths_check.outputs.paths_result }}'
           APPS_TO_DEPLOY=$(echo "$APPS" | jq -c "[.[] | select(
             . as \$app |

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -39,316 +39,86 @@ jobs:
         run: npm run build --if-present
       - name: Test
         run: npm run test --if-present
+
+      # Get paths that apps are dependent on, e.g. availability depends on apps/availability/** and libaries/ui/**
+      - id: get_paths_filter
+        run: |
+          node .github/workflows/create-paths-filter.js > paths-filter.json
+          FILTER=$(cat paths-filter.json)
+          echo "paths_filter=$FILTER" >> $GITHUB_OUTPUT
+
+      # Figure out what apps have changed files in their paths
       - id: modified_paths_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          paths_filter: |
-            availability:
-              paths:
-                - 'apps/availability/**'
-            backend:
-              paths:
-                - 'apps/backend/**'
-            bubble-proxy:
-              paths:
-                - 'apps/bubble-proxy/**'
-            frontend-example:
-              paths:
-                - 'apps/frontend-example/**'
-            website-proxy:
-              paths:
-                - 'apps/website-proxy/**'
-            website-25:
-              paths:
-                - 'apps/website-25/**'
-            storybook:
-              paths:
-                - 'apps/storybook/**'
-            infra:
-              paths:
-                - 'apps/infra/**'
-            login:
-              paths:
-                - 'apps/login/**'
-            meet:
-              paths:
-                - 'apps/meet/**'
-            miniextensions-proxy:
-              paths:
-                - 'apps/miniextensions-proxy/**'
+          paths_filter: ${{ steps.get_paths_filter.outputs.paths_filter }}
           paths: '["package-lock.json"]'
           paths_ignore: '["**/README.md"]'
-    outputs:
-      should_skip: ${{ steps.modified_paths_check.outputs.should_skip }}
-      paths_result: ${{ steps.modified_paths_check.outputs.paths_result }}
 
-  cd_infra:
+      # Arrange output into one array for CD matrix
+      - id: get_apps_to_deploy
+        run: |
+          # Get all apps
+          APPS=$(ls -d apps/*/ | cut -d'/' -f2 | jq -R -s -c 'split("\n")[:-1]')
+          
+          # If should_skip is false, all apps need deployment
+          if [[ "${{ steps.modified_paths_check.outputs.should_skip }}" != "true" ]]; then
+            echo "apps=$APPS" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Otherwise, filter for apps that need deployment
+          PATHS_RESULT='${{ steps.modified_paths_check.outputs.paths_result }}'
+          APPS_TO_DEPLOY=$(echo "$APPS" | jq -c "[.[] | select(
+            . as \$app |
+            ($PATHS_RESULT | .[\$app].should_skip) != true
+          )]")
+          echo "apps=$APPS_TO_DEPLOY" >> $GITHUB_OUTPUT
+    outputs:
+      apps_to_deploy: ${{ steps.get_apps_to_deploy.outputs.apps }}
+
+  cd:
     needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).infra.should_skip) }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: ${{ fromJson(needs.ci.outputs.apps_to_deploy) }}
     concurrency:
-      group: cd_infra
+      group: cd_${{ matrix.app }}
     timeout-minutes: 20
     steps:
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
+
       - name: Install NPM dependencies
         run: npm ci
 
-      - name: Configure for deployment
+      - name: Configure infra deployment
+        if: matrix.app == 'infra'
         run: |
           echo "$INFRA_PULUMI_PASSPHRASE" > apps/infra/passphrase.prod.txt
-
           mkdir -p ~/.aws
           echo "$INFRA_AWS_CREDENTIALS" > ~/.aws/credentials
         env:
           INFRA_PULUMI_PASSPHRASE: ${{ secrets.INFRA_PULUMI_PASSPHRASE }}
-          # See the infra README - these should actually have details for Vultr Object Storage
           INFRA_AWS_CREDENTIALS: ${{ secrets.INFRA_AWS_CREDENTIALS }}
-      - name: Deploy
-        run: npm run deploy:prod --workspace apps/infra
 
-  cd_frontend-example:
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).frontend-example.should_skip) }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: cd_frontend-example
-    timeout-minutes: 20
-    steps:
-      - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - name: Configure for deployment
+      - name: Configure k8s deployment
+        if: matrix.app != 'infra'
         run: |
           docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
-
           mkdir -p ~/.kube
           echo "$K8S_KUBECONFIG" > ~/.kube/config
         env:
           K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
           VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
+
       - name: Deploy
-        run: npm run deploy:prod --workspace apps/frontend-example
-
-  cd_website-proxy:
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).website-proxy.should_skip) }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: cd_website-proxy
-    timeout-minutes: 20
-    steps:
-      - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - name: Configure for deployment
-        run: |
-          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
-
-          mkdir -p ~/.kube
-          echo "$K8S_KUBECONFIG" > ~/.kube/config
-        env:
-          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
-          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
-      - name: Deploy
-        run: npm run deploy:prod --workspace apps/website-proxy
-
-  cd_website-25:
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).website-25.should_skip) }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: cd_website-25
-    timeout-minutes: 20
-    steps:
-      - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - name: Configure for deployment
-        run: |
-          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
-
-          mkdir -p ~/.kube
-          echo "$K8S_KUBECONFIG" > ~/.kube/config
-        env:
-          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
-          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
-      - name: Deploy
-        run: npm run deploy:prod --workspace apps/website-25
-
-  cd_storybook:
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).storybook.should_skip) }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: cd_storybook
-    timeout-minutes: 20
-    steps:
-      - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - name: Configure for deployment
-        run: |
-          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
-
-          mkdir -p ~/.kube
-          echo "$K8S_KUBECONFIG" > ~/.kube/config
-        env:
-          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
-          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
-      - name: Deploy
-        run: npm run deploy:prod --workspace apps/storybook
-
-  cd_availability:
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).availability.should_skip) }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: cd_availability
-    timeout-minutes: 20
-    steps:
-      - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - name: Configure for deployment
-        run: |
-          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
-
-          mkdir -p ~/.kube
-          echo "$K8S_KUBECONFIG" > ~/.kube/config
-        env:
-          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
-          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
-      - name: Deploy
-        run: npm run deploy:prod --workspace apps/availability
-
-  cd_login:
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).login.should_skip) }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: cd_login
-    timeout-minutes: 20
-    steps:
-      - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - name: Configure for deployment
-        run: |
-          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
-
-          mkdir -p ~/.kube
-          echo "$K8S_KUBECONFIG" > ~/.kube/config
-        env:
-          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
-          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
-      - name: Deploy
-        run: npm run deploy:prod --workspace apps/login
-
-  cd_meet:
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).meet.should_skip) }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: cd_meet
-    timeout-minutes: 20
-    steps:
-      - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - name: Configure for deployment
-        run: |
-          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
-
-          mkdir -p ~/.kube
-          echo "$K8S_KUBECONFIG" > ~/.kube/config
-        env:
-          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
-          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
-      - name: Deploy
-        run: npm run deploy:prod --workspace apps/meet
-
-  cd_miniextensions-proxy:
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && (needs.ci.outputs.should_skip != 'true' || !fromJSON(needs.ci.outputs.paths_result).miniextensions-proxy.should_skip) }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: cd_miniextensions-proxy
-    timeout-minutes: 20
-    steps:
-      - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install NPM dependencies
-        run: npm ci
-
-      - name: Configure for deployment
-        run: |
-          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
-
-          mkdir -p ~/.kube
-          echo "$K8S_KUBECONFIG" > ~/.kube/config
-        env:
-          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
-          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
-      - name: Deploy
-        run: npm run deploy:prod --workspace apps/miniextensions-proxy
+        run: npm run deploy:prod --workspace apps/${{ matrix.app }}

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -61,20 +61,21 @@ jobs:
         run: |
           # Get all apps
           APPS=$(ls -d apps/*/ | cut -d'/' -f2 | jq -R -s -c 'split("\n")[:-1]')
+          echo "👀 Found apps: $APPS"
           
-          # If should_skip is false, it means package-lock.json changed
           if [[ "${{ steps.modified_paths_check.outputs.should_skip }}" == "false" ]]; then
-            # Deploy all apps since common files changed
+            echo "📦 ALL apps will need to be deployed because package-lock.json changed"
             echo "apps=$APPS" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Otherwise get only apps that had path changes
+          echo "🔍 Checking for apps with path changes..."
           PATHS_RESULT='${{ steps.modified_paths_check.outputs.paths_result }}'
           APPS_TO_DEPLOY=$(echo "$APPS" | jq -c "[.[] | select(
             . as \$app |
             ($PATHS_RESULT | .[\$app].should_skip) != true
           )]")
+          echo "🚀 Apps needing deployment: $APPS_TO_DEPLOY"
           echo "apps=$APPS_TO_DEPLOY" >> $GITHUB_OUTPUT
     outputs:
       apps_to_deploy: ${{ steps.get_apps_to_deploy.outputs.apps }}

--- a/.github/workflows/create-paths-filter.js
+++ b/.github/workflows/create-paths-filter.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+const { execSync } = require('node:child_process');
+
+try {
+  // Run turbo dry run and parse output
+  const turboOutput = execSync('npx turbo run build --dry=json', { encoding: 'utf-8' });
+  const turboDryRun = JSON.parse(turboOutput);
+
+  // Initialize paths filter object
+  const pathsFilter = {};
+  
+  // Get all tasks for apps (not libraries)
+  const appTasks = turboDryRun.tasks.filter(task => {
+    const packageName = task.package;
+    return packageName.startsWith('@bluedot/') && task.directory.startsWith('apps/');
+  });
+  
+  appTasks.forEach(task => {
+    const appName = task.directory.replace('apps/', '');
+    const paths = new Set([`${task.directory}/**`]);
+        
+    // Add all dependencies recursively
+    const addDependencies = (deps) => {
+      deps?.forEach(dep => {
+        const depName = dep.split('#')[0]; // Remove #build suffix
+        const depTask = turboDryRun.tasks.find(t => t.package === depName);
+        
+        if (!depTask) {
+          console.error(`Could not find task for dependency ${depName}`);
+          return;
+        }
+
+        // Only add paths for internal workspace dependencies
+        if (depTask.directory.startsWith('libraries/')) {
+          const depPath = `${depTask.directory}/**`;
+          paths.add(depPath);
+          
+          // Recursively add this dependency's dependencies
+          if (depTask.dependencies) {
+            addDependencies(depTask.dependencies);
+          }
+        }
+      });
+    };
+    
+    addDependencies(task.dependencies);
+        
+    pathsFilter[appName] = {
+      paths: Array.from(paths)
+    };
+  });
+
+  // Write the paths filter to stdout
+  const result = JSON.stringify(pathsFilter, null, 2);
+  console.log(result);
+} catch (error) {
+  console.error('Error:', error);
+  process.exit(1);
+}

--- a/.github/workflows/create-paths-filter.js
+++ b/.github/workflows/create-paths-filter.js
@@ -52,7 +52,7 @@ try {
   });
 
   // Write the paths filter to stdout
-  const result = JSON.stringify(pathsFilter, null, 2);
+  const result = JSON.stringify(pathsFilter);
   console.log(result);
 } catch (error) {
   console.error('Error:', error);

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -31,8 +31,7 @@ For a standard Next.js app:
    - Copy the config for frontend-example, but put your app name in
    - You can remove secrets your app doesn't need (e.g. if it doesn't need to talk to Airtable or Slack)
    - If you need to add a secret, see [below](#adding-a-secret)
-4. Update the base `.github/workflows/ci_cd.yaml` to include your app in the `paths` and `cd_infra` section. Again, we recommending following the pattern of frontend-example.
-5. Commit your changes to the master branch
+4. Commit your changes to the master branch
 
 CI/CD might fail the first time, because there's a race condition between:
 - the infra being set up and expecting a docker container to pull


### PR DESCRIPTION
# Summary

Update GitHub Actions configuration to discover apps, rather than having to specify them explicitly

## Description

At the moment, adding a new app requires adding a block in the ci_cd.yaml for GitHub Actions.

We want to be able to easily create new apps to quickly deploy experiments etc, so the easier the process is the better. This part is also particularly fiddly so it'd be good to cut it out completely.

I've updatd the ci_cd.yaml to loops over all the apps that need deploying, and then deploys the ones that need deploying. I've also taken the opportunity to properly get the dependencies for the apps, e.g. so a change in libraries/ui results in website deploying, as one might expect (Currently apps will deploy only if you edit files within their app folder, and not their dependencies - although they will lint/build/test if dependencies are changed due to turbo. After this PR they will also deploy if dependencies are changed).

NB: I think these changes should work. But because [it's a pain to test GitHub actions locally](https://stackoverflow.com/questions/59241249/how-can-i-run-github-actions-workflows-locally), there may be some follow-ups for things that weren't immediately obvious.

## Issue

Fixes #382 