### PR TITLE
website-proxy: Disable all routes

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -6,36 +6,36 @@ http {
         add_header X-BlueDot-Version '$VERSION_TAG';
 
         # Specific routes to website-25
-        location = / {
-            proxy_pass https://website-25.k8s.bluedot.org;
-        }
+        # location = / {
+        #     proxy_pass https://website-25.k8s.bluedot.org;
+        # }
 
-        location = /about {
-            proxy_pass https://website-25.k8s.bluedot.org;
-        }
+        # location = /about {
+        #     proxy_pass https://website-25.k8s.bluedot.org;
+        # }
 
-        location = /careers {
-            proxy_pass https://website-25.k8s.bluedot.org;
-        }
+        # location = /careers {
+        #     proxy_pass https://website-25.k8s.bluedot.org;
+        # }
 
-        location = /privacy-policy {
-            proxy_pass https://website-25.k8s.bluedot.org;
-        }
+        # location = /privacy-policy {
+        #     proxy_pass https://website-25.k8s.bluedot.org;
+        # }
 
         # Asset folders that are necessary for the new website to work
         # Before adding a prefix here, verify it is not used on the old website
-        location /_next {
-            proxy_pass https://website-25.k8s.bluedot.org;
-        }
-        location /fonts {
-            proxy_pass https://website-25.k8s.bluedot.org;
-        }
-        location /images {
-            proxy_pass https://website-25.k8s.bluedot.org;
-        }
-        location /icons {
-            proxy_pass https://website-25.k8s.bluedot.org;
-        }
+        # location /_next {
+        #     proxy_pass https://website-25.k8s.bluedot.org;
+        # }
+        # location /fonts {
+        #     proxy_pass https://website-25.k8s.bluedot.org;
+        # }
+        # location /images {
+        #     proxy_pass https://website-25.k8s.bluedot.org;
+        # }
+        # location /icons {
+        #     proxy_pass https://website-25.k8s.bluedot.org;
+        # }
 
         # Default all other traffic to old site
         location / {


### PR DESCRIPTION
This is in preparation for phased deployment where we only add the about page on Monday, and then the other pages once we have confirmed that works.

Also see https://www.notion.so/bluedot-impact/plan-for-deployment-on-Monday-199f8e69035380839ab9d169f4a740ff