### PR TITLE
website: Fix infinite scroll to go all the way around

### DIFF
--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -4,11 +4,11 @@
 @plugin "@tailwindcss/typography";
 
 @theme {
-  --animate-infinite-scroll: infinite-scroll 25s linear infinite;
+  --animate-infinite-scroll: infinite-scroll 50s linear infinite;
 
   @keyframes infinite-scroll {
     0% { transform: translateX(0) }
-    100% { transform: translateX(-50%) }
+    100% { transform: translateX(-100%) }
   }
 }
 


### PR DESCRIPTION
# Summary

Update animation to offset to 100% by the end, so that it lines up with the jump back to where it was. Also doubled the duration to account for the double travel so it moves the same speed.

## Issue

Fixes #416