### PR TITLE
ui: Fix utility classes for Tailwind 4

### DIFF
--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -76,43 +76,41 @@
     }
 }
 
-@layer utilities {
-    .bluedot-base {
-         @apply min-h-screen flow-root bg-cream-normal text-bluedot-black antialiased
-    }
-  
-    .container-lined {
-        @apply border border-color-divider rounded-lg;
-    }
-  
-    .container-elevated {
-        /* RGBA of var(--bluedot-cream-normal) */
-        box-shadow: 0px 4px 1.25rem 0px rgba(30, 30, 30, 0.1);
-    }
-  
-    .container-dialog {
-        @apply border border-color-primary rounded-lg;
-        box-shadow: 0px 0px 32px 0px rgba(0, 0, 0, 0.25);
-    }
-  
-    .scrollbar-hidden {
-        scrollbar-width: none;
-        -ms-overflow-style: none;
-    }
-  
-    .scrollbar-hidden::-webkit-scrollbar {
+@utility bluedot-base {
+    @apply min-h-screen flow-root bg-cream-normal text-bluedot-black antialiased
+}
+
+@utility container-lined {
+    @apply border border-color-divider rounded-lg;
+}
+
+@utility container-elevated {
+    /* RGBA of var(--bluedot-cream-normal) */
+    box-shadow: 0px 4px 1.25rem 0px rgba(30, 30, 30, 0.1);
+}
+
+@utility container-dialog {
+    @apply border border-color-primary rounded-lg;
+    box-shadow: 0px 0px 32px 0px rgba(0, 0, 0, 0.25);
+}
+
+@utility scrollbar-hidden {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
         display: none;
     }
-  
-    /* Base section class that just applies padding and centering, suitable for nav, footer etc */
-    .section-base {
-        @apply w-full max-w-max-width mx-auto px-spacing-x;
-    }
-  
-    /* Class for titled sections in the body of the page */
-    .section-body {
-        @apply w-full max-w-max-width mx-auto px-spacing-x pt-6 pb-10 border-b border-color-divider overflow-hidden flex flex-col;
-    }
+}
+
+/* Base section class that just applies padding and centering, suitable for nav, footer etc */
+@utility section-base {
+    @apply w-full max-w-max-width mx-auto px-spacing-x;
+}
+
+/* Class for titled sections in the body of the page */
+@utility section-body {
+    @apply w-full max-w-max-width mx-auto px-spacing-x pt-6 pb-10 border-b border-color-divider overflow-hidden flex flex-col;
 }
 
 :root {


### PR DESCRIPTION
# Summary

Update the syntax for utility classes for Tailwind 4, which enables them to work with the Tailwind prefixes e.g. `lg:container-lined`.

## Issue

Fixes #411

## Description

I followed these steps in the Tailwind v4 upgrade guide: https://tailwindcss.com/docs/upgrade-guide#adding-custom-utilities, which I missed in #355. I also went through all the other steps and double-checked these were applied or not relevant to our app, and I think this is the only bit we missed.

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/24f249d8-bb5e-4b2d-bc51-bddc97f9d14e" />
<img width="612" alt="image" src="https://github.com/user-attachments/assets/fd0820bf-18a2-412c-ae80-4a096fbf85eb" />