### PR TITLE
cd: Reduce unnecessary CD runs

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -40,45 +40,13 @@ jobs:
       - name: Test
         run: npm run test --if-present
 
-      - name: Get paths that apps are dependent on
-        # e.g. availability depends on apps/availability/** and libaries/ui/**
-        id: get_paths_filter
+      - name: Get all apps
+        id: get_apps
         run: |
-          node .github/workflows/create-paths-filter.js > paths-filter.json
-          FILTER=$(cat paths-filter.json)
-          echo "paths_filter=$FILTER" >> $GITHUB_OUTPUT
-
-      - name: Figure out what apps have changed files in their paths
-        id: modified_paths_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          paths_filter: ${{ steps.get_paths_filter.outputs.paths_filter }}
-          paths: '["package-lock.json"]'
-          paths_ignore: '["**/README.md"]'
-
-      - name: Arrange output into one array for CD matrix
-        id: get_apps_to_deploy
-        run: |
-          # Get all apps
           APPS=$(ls -d apps/*/ | cut -d'/' -f2 | jq -R -s -c 'split("\n")[:-1]')
-          echo "👀 Found apps: $APPS"
-          
-          if [[ "${{ steps.modified_paths_check.outputs.should_skip }}" == "false" ]]; then
-            echo "📦 ALL apps will need to be deployed because package-lock.json changed"
-            echo "apps=$APPS" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "🔍 Checking for apps with path changes..."
-          PATHS_RESULT='${{ steps.modified_paths_check.outputs.paths_result }}'
-          APPS_TO_DEPLOY=$(echo "$APPS" | jq -c "[.[] | select(
-            . as \$app |
-            ($PATHS_RESULT | .[\$app].should_skip) != true
-          )]")
-          echo "🚀 Apps needing deployment: $APPS_TO_DEPLOY"
-          echo "apps=$APPS_TO_DEPLOY" >> $GITHUB_OUTPUT
+          echo "apps=$APPS" >> $GITHUB_OUTPUT
     outputs:
-      apps_to_deploy: ${{ steps.get_apps_to_deploy.outputs.apps }}
+      apps: ${{ steps.get_apps.outputs.apps }}
 
   cd:
     needs: ci
@@ -87,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: ${{ fromJson(needs.ci.outputs.apps_to_deploy) }}
+        app: ${{ fromJson(needs.ci.outputs.apps) }}
     concurrency:
       group: cd_${{ matrix.app }}
     timeout-minutes: 20
@@ -104,8 +72,27 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
+      - name: Get app dependency paths
+        id: get_paths
+        run: |
+          PATHS=$(node .github/workflows/get-app-paths.js ${{ matrix.app }})
+          echo "paths=$PATHS" >> $GITHUB_OUTPUT
+
+      - name: Check if app needs deployment
+        id: check_deployment
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          paths: ${{ steps.get_paths.outputs.paths }}
+          paths_ignore: '["**/README.md"]'
+
+      - name: Skip deployment
+        if: steps.check_deployment.outputs.should_skip == 'true'
+        run: |
+          echo "Skipping deployment - no relevant changes detected"
+          exit 0
+
       - name: Configure infra deployment
-        if: matrix.app == 'infra'
+        if: steps.check_deployment.outputs.should_skip != 'true' && matrix.app == 'infra'
         run: |
           echo "$INFRA_PULUMI_PASSPHRASE" > apps/infra/passphrase.prod.txt
           mkdir -p ~/.aws
@@ -115,7 +102,7 @@ jobs:
           INFRA_AWS_CREDENTIALS: ${{ secrets.INFRA_AWS_CREDENTIALS }}
 
       - name: Configure k8s deployment
-        if: matrix.app != 'infra'
+        if: steps.check_deployment.outputs.should_skip != 'true' && matrix.app != 'infra'
         run: |
           docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
           mkdir -p ~/.kube
@@ -125,4 +112,5 @@ jobs:
           VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Deploy
+        if: steps.check_deployment.outputs.should_skip != 'true'
         run: npm run deploy:prod --workspace apps/${{ matrix.app }}

--- a/.github/workflows/get-app-paths.js
+++ b/.github/workflows/get-app-paths.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+const { execSync } = require('node:child_process');
+
+try {
+  // Get the app name from command line argument
+  const appName = process.argv[2];
+  if (!appName) {
+    console.error('App name must be provided as argument');
+    process.exit(1);
+  }
+
+  // Run turbo dry run and parse output
+  const turboOutput = execSync('npx turbo run build --dry=json', { encoding: 'utf-8' });
+  const turboDryRun = JSON.parse(turboOutput);
+
+  // Find the app's task
+  const appTask = turboDryRun.tasks.find(task => {
+    return task.package.startsWith('@bluedot/') && task.directory === `apps/${appName}`;
+  });
+
+  if (!appTask) {
+    console.error(`Could not find task for app ${appName}`);
+    process.exit(1);
+  }
+
+  // Initialize paths set with the app's own directory
+  const paths = new Set([`apps/${appName}/**`]);
+  paths.add('package-lock.json'); // Always include package-lock.json
+
+  // Add all dependencies recursively
+  const addDependencies = (deps) => {
+    deps?.forEach(dep => {
+      const depName = dep.split('#')[0]; // Remove #build suffix
+      const depTask = turboDryRun.tasks.find(t => t.package === depName);
+      
+      if (!depTask) {
+        console.error(`Could not find task for dependency ${depName}`);
+        return;
+      }
+
+      // Only add paths for internal workspace dependencies
+      if (depTask.directory.startsWith('libraries/')) {
+        const depPath = `${depTask.directory}/**`;
+        paths.add(depPath);
+        
+        // Recursively add this dependency's dependencies
+        if (depTask.dependencies) {
+          addDependencies(depTask.dependencies);
+        }
+      }
+    });
+  };
+  
+  addDependencies(appTask.dependencies);
+
+  // Output the paths array in the format needed for skip-duplicate-actions
+  console.log(JSON.stringify(Array.from(paths)));
+} catch (error) {
+  console.error('Error:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
Moves the skip-duplicate-actions check to the CD flow, which _should_ reduce the number of deploy attempts. This will in turn reduce the number of failed workflows as a result of Vultr 504 errors.