### PR TITLE
Add breadcrumbs component

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
       </div>
     </div>
     <div
-      class="breadcrumbs border-b border-color-divider w-full py-3"
+      class="breadcrumbs border-b border-color-divider w-full py-space-between"
     >
       <nav
         aria-label="Breadcrumbs"
@@ -56,7 +56,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
           class="breadcrumbs__list flex"
         >
           <li
-            class="breadcrumbs__item flex items-center text-size-xs"
+            class="breadcrumbs__item flex items-center"
           >
             <a
               class="breadcrumbs__link"
@@ -71,7 +71,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
             </span>
           </li>
           <li
-            class="breadcrumbs__item flex items-center text-size-xs"
+            class="breadcrumbs__item flex items-center"
           >
             <a
               class="breadcrumbs__link"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`AboutPage > should render the error message correctly 1`] = `
         <div
           class="hero-section__mini-title text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"
         >
-          About Us
+          About us
         </div>
         <h1
           class="hero-section__title text-on-dark text-center"
@@ -44,6 +44,44 @@ exports[`AboutPage > should render the error message correctly 1`] = `
           </a>
         </div>
       </div>
+    </div>
+    <div
+      class="breadcrumbs border-b border-color-divider w-full py-3"
+    >
+      <nav
+        aria-label="Breadcrumbs"
+        class="breadcrumbs__nav section-base"
+      >
+        <ol
+          class="breadcrumbs__list flex"
+        >
+          <li
+            class="breadcrumbs__item flex items-center text-size-xs"
+          >
+            <a
+              class="breadcrumbs__link"
+              href="/"
+            >
+              BlueDot Impact
+            </a>
+            <span
+              class="breadcrumbs__separator mx-2"
+            >
+              &gt;
+            </span>
+          </li>
+          <li
+            class="breadcrumbs__item flex items-center text-size-xs"
+          >
+            <a
+              class="breadcrumbs__link"
+              href="/about"
+            >
+              About us
+            </a>
+          </li>
+        </ol>
+      </nav>
     </div>
     <section
       class="section section-body intro-section"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -45,6 +45,44 @@ exports[`CareersPage > should render the error message correctly 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="breadcrumbs border-b border-color-divider w-full py-3"
+    >
+      <nav
+        aria-label="Breadcrumbs"
+        class="breadcrumbs__nav section-base"
+      >
+        <ol
+          class="breadcrumbs__list flex"
+        >
+          <li
+            class="breadcrumbs__item flex items-center text-size-xs"
+          >
+            <a
+              class="breadcrumbs__link"
+              href="/"
+            >
+              BlueDot Impact
+            </a>
+            <span
+              class="breadcrumbs__separator mx-2"
+            >
+              &gt;
+            </span>
+          </li>
+          <li
+            class="breadcrumbs__item flex items-center text-size-xs"
+          >
+            <a
+              class="breadcrumbs__link"
+              href="/careers"
+            >
+              Join our team
+            </a>
+          </li>
+        </ol>
+      </nav>
+    </div>
     <section
       class="section section-body culture-section"
     >
@@ -397,7 +435,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
               <a
                 class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
                 data-testid="cta-link"
-                href="/careers/swe-contractor/"
+                href="/careers/swe-contractor"
               >
                 <span
                   class="cta-button__text"
@@ -440,7 +478,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
               <a
                 class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
                 data-testid="cta-link"
-                href="/careers/ai-safety-teaching-fellow/"
+                href="/careers/ai-safety-teaching-fellow"
               >
                 <span
                   class="cta-button__text"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/careers.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
       </div>
     </div>
     <div
-      class="breadcrumbs border-b border-color-divider w-full py-3"
+      class="breadcrumbs border-b border-color-divider w-full py-space-between"
     >
       <nav
         aria-label="Breadcrumbs"
@@ -56,7 +56,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
           class="breadcrumbs__list flex"
         >
           <li
-            class="breadcrumbs__item flex items-center text-size-xs"
+            class="breadcrumbs__item flex items-center"
           >
             <a
               class="breadcrumbs__link"
@@ -71,7 +71,7 @@ exports[`CareersPage > should render the error message correctly 1`] = `
             </span>
           </li>
           <li
-            class="breadcrumbs__item flex items-center text-size-xs"
+            class="breadcrumbs__item flex items-center"
           >
             <a
               class="breadcrumbs__link"

--- a/apps/website-25/src/components/careers/CareersSection.tsx
+++ b/apps/website-25/src/components/careers/CareersSection.tsx
@@ -1,13 +1,15 @@
 import { Card, CTALinkOrButton, Section } from '@bluedot/ui';
 import { isMobile } from 'react-device-detect';
+import { CURRENT_ROUTE as SWE_CONTRACTOR } from '../../pages/careers/swe-contractor';
+import { CURRENT_ROUTE as AIS_TEACHING_FELLOW } from '../../pages/careers/ai-safety-teaching-fellow';
 
 const CareersSection = () => {
   return (
     <Section className="careers-section" title="Careers at BlueDot Impact">
       <div id="open-roles-anchor" className="invisible relative bottom-48" />
       <div className="careers-section__container flex flex-col gap-8">
-        <JobListing title="Software Engineering Contractor" url="/careers/swe-contractor/" />
-        <JobListing title="AI Safety Teaching Fellow" url="/careers/ai-safety-teaching-fellow/" />
+        <JobListing {...SWE_CONTRACTOR} />
+        <JobListing {...AIS_TEACHING_FELLOW} />
       </div>
     </Section>
   );

--- a/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
+++ b/apps/website-25/src/components/careers/__snapshots__/CareersSection.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`CareersSection > renders default as expected 1`] = `
             <a
               class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
               data-testid="cta-link"
-              href="/careers/swe-contractor/"
+              href="/careers/swe-contractor"
             >
               <span
                 class="cta-button__text"
@@ -95,7 +95,7 @@ exports[`CareersSection > renders default as expected 1`] = `
             <a
               class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
               data-testid="cta-link"
-              href="/careers/ai-safety-teaching-fellow/"
+              href="/careers/ai-safety-teaching-fellow"
             >
               <span
                 class="cta-button__text"
@@ -177,7 +177,7 @@ exports[`CareersSection > renders mobile as expected 1`] = `
                 <a
                   class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
-                  href="/careers/swe-contractor/"
+                  href="/careers/swe-contractor"
                 >
                   <span
                     class="cta-button__text"
@@ -218,7 +218,7 @@ exports[`CareersSection > renders mobile as expected 1`] = `
                 <a
                   class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
                   data-testid="cta-link"
-                  href="/careers/ai-safety-teaching-fellow/"
+                  href="/careers/ai-safety-teaching-fellow"
                 >
                   <span
                     class="cta-button__text"

--- a/apps/website-25/src/components/homepage/StorySection.tsx
+++ b/apps/website-25/src/components/homepage/StorySection.tsx
@@ -1,4 +1,5 @@
 import { CTALinkOrButton, Section } from '@bluedot/ui';
+import { ROUTES } from '../../lib/routes';
 
 const StorySection = () => {
   return (
@@ -11,7 +12,7 @@ const StorySection = () => {
           <p>Working closely with leading organisations, we rapidly develop new courses to address emerging challenges and help talented people find roles where they can have the greatest impact.</p>
           <CTALinkOrButton
             variant="secondary"
-            url="/about"
+            url={ROUTES.about.url}
             withChevron
           >
             Learn more about us

--- a/apps/website-25/src/lib/routes.ts
+++ b/apps/website-25/src/lib/routes.ts
@@ -1,0 +1,30 @@
+export type BluedotRoute = {
+  /**
+   * Title of the page, by convention this is the title that appears in the
+   * <title /> tag (e.g. "About us" in "About us | BlueDot Impact")
+   */
+  title: string;
+  /**
+   * Relative url of the route (e.g. /about, not https://bluedot.org/about)
+   */
+  url: string;
+};
+
+export const ROUTES = {
+  home: {
+    title: 'BlueDot Impact',
+    url: '/',
+  },
+  about: {
+    title: 'About us',
+    url: '/about',
+  },
+  privacyPolicy: {
+    title: 'Privacy Policy',
+    url: '/privacy-policy',
+  },
+  careers: {
+    title: 'Join our team',
+    url: '/careers',
+  },
+} as const;

--- a/apps/website-25/src/lib/routes.ts
+++ b/apps/website-25/src/lib/routes.ts
@@ -1,30 +1,31 @@
-export type BluedotRoute = {
-  /**
-   * Title of the page, by convention this is the title that appears in the
-   * <title /> tag (e.g. "About us" in "About us | BlueDot Impact")
-   */
-  title: string;
-  /**
-   * Relative url of the route (e.g. /about, not https://bluedot.org/about)
-   */
-  url: string;
+import type { BluedotRoute } from '@bluedot/ui';
+
+const home: BluedotRoute = {
+  title: 'BlueDot Impact',
+  url: '/',
+};
+
+const about: BluedotRoute = {
+  title: 'About us',
+  url: '/about',
+  parentPages: [home],
+};
+
+const privacyPolicy: BluedotRoute = {
+  title: 'Privacy Policy',
+  url: '/privacy-policy',
+  parentPages: [home],
+};
+
+const careers: BluedotRoute = {
+  title: 'Join our team',
+  url: '/careers',
+  parentPages: [home],
 };
 
 export const ROUTES = {
-  home: {
-    title: 'BlueDot Impact',
-    url: '/',
-  },
-  about: {
-    title: 'About us',
-    url: '/about',
-  },
-  privacyPolicy: {
-    title: 'Privacy Policy',
-    url: '/privacy-policy',
-  },
-  careers: {
-    title: 'Join our team',
-    url: '/careers',
-  },
+  home,
+  about,
+  privacyPolicy,
+  careers,
 } as const;

--- a/apps/website-25/src/pages/_app.tsx
+++ b/apps/website-25/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import clsx from 'clsx';
 import { useEffect } from 'react';
 import { Router } from 'next/router';
 import { Analytics } from '../components/Analytics';
+import { ROUTES } from '../lib/routes';
 
 if (typeof window !== 'undefined') {
   if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) {
@@ -58,14 +59,14 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
         logo="/images/logo/BlueDot_Impact_Logo.svg"
         courses={constants.COURSES}
       >
-        <a href="/about" className={clsx('hover:text-bluedot-normal', isCurrentPath('/about') && 'font-bold')}>About us</a>
-        <a href="/careers" className={clsx('hover:text-bluedot-normal', isCurrentPath('/careers') && 'font-bold')}>Join us</a>
+        <a href={ROUTES.about.url} className={clsx('hover:text-bluedot-normal', isCurrentPath(ROUTES.about.url) && 'font-bold')}>About us</a>
+        <a href={ROUTES.careers.url} className={clsx('hover:text-bluedot-normal', isCurrentPath(ROUTES.careers.url) && 'font-bold')}>Join us</a>
         <a href="https://bluedot.org/blog/" className="hover:text-bluedot-normal">Blog</a>
       </Nav>
       <main className="bluedot-base">
         <Component {...pageProps} />
       </main>
-      <CookieBanner />
+      <CookieBanner cookiePolicyUrl={ROUTES.privacyPolicy.url} />
       <Footer logo="/images/logo/BlueDot_Impact_Logo_White.svg" />
       <Analytics />
     </PostHogProvider>

--- a/apps/website-25/src/pages/_app.tsx
+++ b/apps/website-25/src/pages/_app.tsx
@@ -66,7 +66,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
       <main className="bluedot-base">
         <Component {...pageProps} />
       </main>
-      <CookieBanner cookiePolicyUrl={ROUTES.privacyPolicy.url} />
+      <CookieBanner />
       <Footer logo="/images/logo/BlueDot_Impact_Logo_White.svg" />
       <Analytics />
     </PostHogProvider>

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -31,7 +31,7 @@ const AboutPage = () => {
           <CTALinkOrButton url={ROUTES.careers.url} withChevron>Join the team</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
-      <Breadcrumbs items={[ROUTES.home, ROUTES.about]} />
+      <Breadcrumbs route={CURRENT_ROUTE} />
       <IntroSection />
       <BeliefsSection />
       <HistorySection />

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -4,6 +4,7 @@ import {
   HeroH1,
   HeroCTAContainer,
   Section,
+  Breadcrumbs,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
@@ -13,20 +14,29 @@ import TeamSection from '../components/about/TeamSection';
 import JoinUsCta from '../components/about/JoinUsCta';
 import BeliefsSection from '../components/about/BeliefsSection';
 
+const TITLE = 'About us';
+const ROUTE = '/about';
+
 const AboutPage = () => {
   return (
     <div>
       <Head>
-        <title>About us | BlueDot Impact</title>
+        <title>{TITLE} | BlueDot Impact</title>
         <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
       </Head>
       <HeroSection>
-        <HeroMiniTitle>About Us</HeroMiniTitle>
+        <HeroMiniTitle>{TITLE}</HeroMiniTitle>
         <HeroH1>Our mission is to ensure humanity safely navigates the transition to transformative AI.</HeroH1>
         <HeroCTAContainer>
           <CTALinkOrButton url="/careers" withChevron>Join the team</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: TITLE, href: ROUTE },
+        ]}
+      />
       <IntroSection />
       <BeliefsSection />
       <HistorySection />

--- a/apps/website-25/src/pages/about.tsx
+++ b/apps/website-25/src/pages/about.tsx
@@ -13,30 +13,25 @@ import HistorySection from '../components/about/HistorySection';
 import TeamSection from '../components/about/TeamSection';
 import JoinUsCta from '../components/about/JoinUsCta';
 import BeliefsSection from '../components/about/BeliefsSection';
+import { ROUTES } from '../lib/routes';
 
-const TITLE = 'About us';
-const ROUTE = '/about';
+const CURRENT_ROUTE = ROUTES.about;
 
 const AboutPage = () => {
   return (
     <div>
       <Head>
-        <title>{TITLE} | BlueDot Impact</title>
+        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
         <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
       </Head>
       <HeroSection>
-        <HeroMiniTitle>{TITLE}</HeroMiniTitle>
+        <HeroMiniTitle>{CURRENT_ROUTE.title}</HeroMiniTitle>
         <HeroH1>Our mission is to ensure humanity safely navigates the transition to transformative AI.</HeroH1>
         <HeroCTAContainer>
-          <CTALinkOrButton url="/careers" withChevron>Join the team</CTALinkOrButton>
+          <CTALinkOrButton url={ROUTES.careers.url} withChevron>Join the team</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
-      <Breadcrumbs
-        items={[
-          { label: 'Home', href: '/' },
-          { label: TITLE, href: ROUTE },
-        ]}
-      />
+      <Breadcrumbs items={[ROUTES.home, ROUTES.about]} />
       <IntroSection />
       <BeliefsSection />
       <HistorySection />

--- a/apps/website-25/src/pages/careers.tsx
+++ b/apps/website-25/src/pages/careers.tsx
@@ -28,7 +28,7 @@ const CareersPage = () => {
           <CTALinkOrButton url="#open-roles-anchor" withChevron>See open roles</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
-      <Breadcrumbs items={[ROUTES.home, CURRENT_ROUTE]} />
+      <Breadcrumbs route={CURRENT_ROUTE} />
       <CultureSection />
       <ValuesSection />
       <CareersSection />

--- a/apps/website-25/src/pages/careers.tsx
+++ b/apps/website-25/src/pages/careers.tsx
@@ -3,18 +3,22 @@ import {
   HeroH1,
   HeroCTAContainer,
   CTALinkOrButton,
+  Breadcrumbs,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import CareersSection from '../components/careers/CareersSection';
 import CultureSection from '../components/careers/CultureSection';
 import ValuesSection from '../components/careers/ValuesSection';
+import { ROUTES } from '../lib/routes';
+
+const CURRENT_ROUTE = ROUTES.careers;
 
 const CareersPage = () => {
   return (
     <div>
       <Head>
-        <title>Join our team | BlueDot Impact</title>
+        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
         <meta name="description" content="Join us in our mission to ensure humanity safely navigates the transition to transformative AI." />
       </Head>
       <HeroSection>
@@ -24,6 +28,7 @@ const CareersPage = () => {
           <CTALinkOrButton url="#open-roles-anchor" withChevron>See open roles</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
+      <Breadcrumbs items={[ROUTES.home, CURRENT_ROUTE]} />
       <CultureSection />
       <ValuesSection />
       <CareersSection />

--- a/apps/website-25/src/pages/careers/ai-safety-teaching-fellow.tsx
+++ b/apps/website-25/src/pages/careers/ai-safety-teaching-fellow.tsx
@@ -5,22 +5,30 @@ import {
   HeroH2,
   HeroCTAContainer,
   Section,
+  Breadcrumbs,
 } from '@bluedot/ui';
 import Head from 'next/head';
+import { BluedotRoute, ROUTES } from '../../lib/routes';
+
+export const CURRENT_ROUTE: BluedotRoute = {
+  title: 'AI Safety Teaching Fellow',
+  url: `${ROUTES.careers.url}/ai-safety-teaching-fellow`,
+};
 
 const JobPostingPage = () => {
   return (
     <div>
       <Head>
-        <title>AI Safety Teaching Fellow | BlueDot Impact</title>
+        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
       </Head>
       <HeroSection>
-        <HeroH1>AI Safety Teaching Fellow</HeroH1>
+        <HeroH1>{CURRENT_ROUTE.title}</HeroH1>
         <HeroH2>Lead expert discussions on AI safety</HeroH2>
         <HeroCTAContainer>
           <CTALinkOrButton url="https://forms.bluedot.org/D2vOoKG53VRR4HIedgcz?prefill_Role=recUVhfgJJRZVAQDw">Express interest</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
+      <Breadcrumbs items={[ROUTES.home, ROUTES.careers, CURRENT_ROUTE]} />
       <Section className="prose">
         <h2>Who we are</h2>
         <p>We're a non-profit that runs courses on some of the world's most pressing problems. We're looking for Teaching Fellows to guide discussions with students on our 5-day AI safety courses.</p>

--- a/apps/website-25/src/pages/careers/ai-safety-teaching-fellow.tsx
+++ b/apps/website-25/src/pages/careers/ai-safety-teaching-fellow.tsx
@@ -13,6 +13,7 @@ import { BluedotRoute, ROUTES } from '../../lib/routes';
 export const CURRENT_ROUTE: BluedotRoute = {
   title: 'AI Safety Teaching Fellow',
   url: `${ROUTES.careers.url}/ai-safety-teaching-fellow`,
+  parentPages: [...(ROUTES.careers.parentPages ?? []), ROUTES.careers],
 };
 
 const JobPostingPage = () => {
@@ -28,7 +29,7 @@ const JobPostingPage = () => {
           <CTALinkOrButton url="https://forms.bluedot.org/D2vOoKG53VRR4HIedgcz?prefill_Role=recUVhfgJJRZVAQDw">Express interest</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
-      <Breadcrumbs items={[ROUTES.home, ROUTES.careers, CURRENT_ROUTE]} />
+      <Breadcrumbs route={CURRENT_ROUTE} />
       <Section className="prose">
         <h2>Who we are</h2>
         <p>We're a non-profit that runs courses on some of the world's most pressing problems. We're looking for Teaching Fellows to guide discussions with students on our 5-day AI safety courses.</p>

--- a/apps/website-25/src/pages/careers/ai-safety-teaching-fellow.tsx
+++ b/apps/website-25/src/pages/careers/ai-safety-teaching-fellow.tsx
@@ -6,9 +6,10 @@ import {
   HeroCTAContainer,
   Section,
   Breadcrumbs,
+  BluedotRoute,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { BluedotRoute, ROUTES } from '../../lib/routes';
+import { ROUTES } from '../../lib/routes';
 
 export const CURRENT_ROUTE: BluedotRoute = {
   title: 'AI Safety Teaching Fellow',

--- a/apps/website-25/src/pages/careers/swe-contractor.tsx
+++ b/apps/website-25/src/pages/careers/swe-contractor.tsx
@@ -5,22 +5,30 @@ import {
   HeroH2,
   HeroCTAContainer,
   Section,
+  Breadcrumbs,
 } from '@bluedot/ui';
 import Head from 'next/head';
+import { BluedotRoute, ROUTES } from '../../lib/routes';
+
+export const CURRENT_ROUTE: BluedotRoute = {
+  title: 'Software Engineering Contractor',
+  url: `${ROUTES.careers.url}/swe-contractor`,
+};
 
 const JobPostingPage = () => {
   return (
     <div>
       <Head>
-        <title>Software Engineering Contractor | BlueDot Impact</title>
+        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
       </Head>
       <HeroSection>
-        <HeroH1>Software Engineering Contractor</HeroH1>
+        <HeroH1>{CURRENT_ROUTE.title}</HeroH1>
         <HeroH2>We’re building a database of high-trust, agile software engineers to help us out on future contractor work.</HeroH2>
         <HeroCTAContainer>
           <CTALinkOrButton url="https://web.miniextensions.com/4XjNSRhWiAUBc1UTDZS3?prefill_Role=recuN8LCYMMsZZmNC">Join our hiring pool</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
+      <Breadcrumbs items={[ROUTES.home, ROUTES.careers, CURRENT_ROUTE]} />
       <Section className="prose">
         <h2>About BlueDot Impact</h2>
         <p>We're a startup non-profit helping people create a better future for humanity by designing and running courses on some of the world's most pressing problems. We find people who could have enormous impact, motivate and equip them via our courses, and connect them with impactful opportunities.</p>

--- a/apps/website-25/src/pages/careers/swe-contractor.tsx
+++ b/apps/website-25/src/pages/careers/swe-contractor.tsx
@@ -6,13 +6,15 @@ import {
   HeroCTAContainer,
   Section,
   Breadcrumbs,
+  BluedotRoute,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { BluedotRoute, ROUTES } from '../../lib/routes';
+import { ROUTES } from '../../lib/routes';
 
 export const CURRENT_ROUTE: BluedotRoute = {
   title: 'Software Engineering Contractor',
   url: `${ROUTES.careers.url}/swe-contractor`,
+  parentPages: [...(ROUTES.careers.parentPages ?? []), ROUTES.careers],
 };
 
 const JobPostingPage = () => {
@@ -28,7 +30,7 @@ const JobPostingPage = () => {
           <CTALinkOrButton url="https://web.miniextensions.com/4XjNSRhWiAUBc1UTDZS3?prefill_Role=recuN8LCYMMsZZmNC">Join our hiring pool</CTALinkOrButton>
         </HeroCTAContainer>
       </HeroSection>
-      <Breadcrumbs items={[ROUTES.home, ROUTES.careers, CURRENT_ROUTE]} />
+      <Breadcrumbs route={CURRENT_ROUTE} />
       <Section className="prose">
         <h2>About BlueDot Impact</h2>
         <p>We're a startup non-profit helping people create a better future for humanity by designing and running courses on some of the world's most pressing problems. We find people who could have enormous impact, motivate and equip them via our courses, and connect them with impactful opportunities.</p>

--- a/apps/website-25/src/pages/index.tsx
+++ b/apps/website-25/src/pages/index.tsx
@@ -10,12 +10,15 @@ import CourseSection from '../components/homepage/CourseSection';
 import FAQSection from '../components/homepage/FAQSection';
 import GraduateSection from '../components/homepage/GraduateSection';
 import StorySection from '../components/homepage/StorySection';
+import { ROUTES } from '../lib/routes';
+
+const CURRENT_ROUTE = ROUTES.home;
 
 const HomePage = () => {
   return (
     <div>
       <Head>
-        <title>BlueDot Impact | Industry-leading free AI courses and career support</title>
+        <title>{CURRENT_ROUTE.title} | Industry-leading free AI courses and career support</title>
         <meta name="description" content="Learn for free about AI safety and how to ensure humanity safely navigates the transition to transformative AI. Join 4,000+ professionals building careers at organizations like Anthropic, OpenAI, and the UK’s AI Safety Institute." />
       </Head>
       <HeroSection className="py-12">

--- a/apps/website-25/src/pages/privacy-policy.tsx
+++ b/apps/website-25/src/pages/privacy-policy.tsx
@@ -21,7 +21,7 @@ const PrivacyPolicyPage = () => {
         <HeroH1>Privacy Policy</HeroH1>
         <HeroH2>Effective date: 30 August, 2024</HeroH2>
       </HeroSection>
-      <Breadcrumbs items={[ROUTES.home, CURRENT_ROUTE]} />
+      <Breadcrumbs route={CURRENT_ROUTE} />
       <Section className="prose">
         <p>
           BlueDot Impact Ltd is a UK non-profit, registered as a company limited by guarantee (company number <a href="https://find-and-update.company-information.service.gov.uk/company/14964572" {...EXTERNAL_LINK_PROPS}>14964572</a>). You can contact us via <a href="mailto:team@bluedot.org" {...EXTERNAL_LINK_PROPS}>team@bluedot.org</a>.

--- a/apps/website-25/src/pages/privacy-policy.tsx
+++ b/apps/website-25/src/pages/privacy-policy.tsx
@@ -4,15 +4,24 @@ import {
   HeroH1,
   HeroH2,
   Section,
+  Breadcrumbs,
 } from '@bluedot/ui';
+import Head from 'next/head';
+import { ROUTES } from '../lib/routes';
+
+const CURRENT_ROUTE = ROUTES.privacyPolicy;
 
 const PrivacyPolicyPage = () => {
   return (
     <div>
+      <Head>
+        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+      </Head>
       <HeroSection>
         <HeroH1>Privacy Policy</HeroH1>
         <HeroH2>Effective date: 30 August, 2024</HeroH2>
       </HeroSection>
+      <Breadcrumbs items={[ROUTES.home, CURRENT_ROUTE]} />
       <Section className="prose">
         <p>
           BlueDot Impact Ltd is a UK non-profit, registered as a company limited by guarantee (company number <a href="https://find-and-update.company-information.service.gov.uk/company/14964572" {...EXTERNAL_LINK_PROPS}>14964572</a>). You can contact us via <a href="mailto:team@bluedot.org" {...EXTERNAL_LINK_PROPS}>team@bluedot.org</a>.

--- a/libraries/ui/src/Breadcrumbs.stories.tsx
+++ b/libraries/ui/src/Breadcrumbs.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Breadcrumbs } from './Breadcrumbs';
+
+const meta = {
+  title: 'ui/Breadcrumbs',
+  component: Breadcrumbs,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    items: [
+      { title: 'Home', url: '/' },
+      { title: 'About us', url: '/about' },
+    ],
+  },
+} satisfies Meta<typeof Breadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/libraries/ui/src/Breadcrumbs.stories.tsx
+++ b/libraries/ui/src/Breadcrumbs.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Breadcrumbs } from './Breadcrumbs';
+import type { BluedotRoute } from './utils';
 
 const meta = {
   title: 'ui/Breadcrumbs',
@@ -8,17 +9,19 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-  args: {
-    items: [
-      { title: 'Home', url: '/' },
-      { title: 'About us', url: '/about' },
-    ],
-  },
 } satisfies Meta<typeof Breadcrumbs>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const route: BluedotRoute = {
+  title: 'About us',
+  url: '/about',
+  parentPages: [{ title: 'Home', url: '/' }],
+};
+
 export const Default: Story = {
-  args: {},
+  args: {
+    route,
+  },
 };

--- a/libraries/ui/src/Breadcrumbs.test.tsx
+++ b/libraries/ui/src/Breadcrumbs.test.tsx
@@ -3,21 +3,18 @@ import { describe, expect, test } from 'vitest';
 import { Breadcrumbs } from './Breadcrumbs';
 
 describe('Breadcrumbs', () => {
-  test('returns null if no items are given', () => {
-    const { container } = render(<Breadcrumbs items={[]} />);
-    expect(container.firstChild).toBeNull();
-  });
-
   test('renders all urls and titles in the document', () => {
-    const items = [
-      { title: 'HomePage', url: '/' },
-      { title: 'AboutPage', url: '/about' },
-    ];
+    const route = {
+      title: 'AboutPage',
+      url: '/about',
+      parentPages: [{ title: 'HomePage', url: '/' }],
+    };
 
-    const { container } = render(<Breadcrumbs items={items} />);
+    const { container } = render(<Breadcrumbs route={route} />);
 
     expect(container).toMatchSnapshot();
 
+    const items = [...(route.parentPages ?? []), route];
     items.forEach((item) => {
       const linkElement = screen.getByText(item.title);
       expect(linkElement).not.toBeNull();

--- a/libraries/ui/src/Breadcrumbs.test.tsx
+++ b/libraries/ui/src/Breadcrumbs.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
-import Breadcrumbs from './Breadcrumbs';
+import { Breadcrumbs } from './Breadcrumbs';
 
 describe('Breadcrumbs', () => {
   test('returns null if no items are given', () => {

--- a/libraries/ui/src/Breadcrumbs.test.tsx
+++ b/libraries/ui/src/Breadcrumbs.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import Breadcrumbs from './Breadcrumbs';
+
+describe('Breadcrumbs', () => {
+  test('returns null if no items are given', () => {
+    const { container } = render(<Breadcrumbs items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders all urls and titles in the document', () => {
+    const items = [
+      { title: 'HomePage', url: '/' },
+      { title: 'AboutPage', url: '/about' },
+    ];
+
+    const { container } = render(<Breadcrumbs items={items} />);
+
+    expect(container).toMatchSnapshot();
+
+    items.forEach((item) => {
+      const linkElement = screen.getByText(item.title);
+      expect(linkElement).not.toBeNull();
+      expect(linkElement.getAttribute('href')).toContain(item.url);
+    });
+  });
+});

--- a/libraries/ui/src/Breadcrumbs.tsx
+++ b/libraries/ui/src/Breadcrumbs.tsx
@@ -3,8 +3,8 @@ import clsx from 'clsx';
 
 type BreadcrumbsProps = {
   items: Array<{
-    label: string;
-    href: string;
+    title: string;
+    url: string;
   }>;
   className?: string;
 };
@@ -19,8 +19,8 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className }) =>
       >
         <ol className="breadcrumbs__list flex">
           {items.map((item, index) => (
-            <li key={item.href} className="breadcrumbs__item flex items-center text-size-xs">
-              <a className="breadcrumbs__link" href={item.href}>{item.label}</a>
+            <li key={item.url} className="breadcrumbs__item flex items-center text-size-xs">
+              <a className="breadcrumbs__link" href={item.url}>{item.title}</a>
               {index < items.length - 1 && (
                 <span className="breadcrumbs__separator mx-2">{'>'}</span>
               )}

--- a/libraries/ui/src/Breadcrumbs.tsx
+++ b/libraries/ui/src/Breadcrumbs.tsx
@@ -13,14 +13,14 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className }) =>
   if (!items.length) return null;
 
   return (
-    <div className={clsx('breadcrumbs border-b border-color-divider w-full py-3', className)}>
+    <div className={clsx('breadcrumbs border-b border-color-divider w-full py-space-between', className)}>
       <nav
         className="breadcrumbs__nav section-base"
         aria-label="Breadcrumbs"
       >
         <ol className="breadcrumbs__list flex">
           {items.map((item, index) => (
-            <li key={item.url} className="breadcrumbs__item flex items-center text-size-xs">
+            <li key={item.url} className="breadcrumbs__item flex items-center">
               <a className="breadcrumbs__link" href={item.url}>{item.title}</a>
               {index < items.length - 1 && (
                 <span className="breadcrumbs__separator mx-2">{'>'}</span>

--- a/libraries/ui/src/Breadcrumbs.tsx
+++ b/libraries/ui/src/Breadcrumbs.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import clsx from 'clsx';
+
+type BreadcrumbsProps = {
+  items: Array<{
+    label: string;
+    href: string;
+  }>;
+  className?: string;
+};
+
+// TODO: flag that py-space-between and default font is also an option
+export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className }) => {
+  return (
+    <div className={clsx('breadcrumbs border-b border-color-divider w-full py-3', className)}>
+      <nav
+        className="breadcrumbs__nav section-base"
+        aria-label="Breadcrumbs"
+      >
+        <ol className="breadcrumbs__list flex">
+          {items.map((item, index) => (
+            <li key={item.href} className="breadcrumbs__item flex items-center text-size-xs">
+              <a className="breadcrumbs__link" href={item.href}>{item.label}</a>
+              {index < items.length - 1 && (
+                <span className="breadcrumbs__separator mx-2">{'>'}</span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+    </div>
+  );
+};
+
+export default Breadcrumbs;

--- a/libraries/ui/src/Breadcrumbs.tsx
+++ b/libraries/ui/src/Breadcrumbs.tsx
@@ -11,6 +11,8 @@ type BreadcrumbsProps = {
 
 // TODO: flag that py-space-between and default font is also an option
 export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className }) => {
+  if (!items.length) return null;
+
   return (
     <div className={clsx('breadcrumbs border-b border-color-divider w-full py-3', className)}>
       <nav

--- a/libraries/ui/src/Breadcrumbs.tsx
+++ b/libraries/ui/src/Breadcrumbs.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import clsx from 'clsx';
+import type { BluedotRoute } from './utils';
 
 type BreadcrumbsProps = {
-  items: Array<{
-    title: string;
-    url: string;
-  }>;
+  route: BluedotRoute;
   className?: string;
 };
-
-export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className }) => {
-  if (!items.length) return null;
+export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ route, className }) => {
+  const items = [...(route.parentPages ?? []), route];
 
   return (
     <div className={clsx('breadcrumbs border-b border-color-divider w-full py-space-between', className)}>

--- a/libraries/ui/src/Breadcrumbs.tsx
+++ b/libraries/ui/src/Breadcrumbs.tsx
@@ -9,7 +9,6 @@ type BreadcrumbsProps = {
   className?: string;
 };
 
-// TODO: flag that py-space-between and default font is also an option
 export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className }) => {
   if (!items.length) return null;
 

--- a/libraries/ui/src/CookieBanner.test.tsx
+++ b/libraries/ui/src/CookieBanner.test.tsx
@@ -35,12 +35,12 @@ describe('CookieBanner', () => {
   });
 
   test('renders as expected', () => {
-    const { container } = render(<CookieBanner />);
+    const { container } = render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
     expect(container).toMatchSnapshot();
   });
 
   test('sets localStorage item and configures tracking when accepted', () => {
-    const { container } = render(<CookieBanner />);
+    const { container } = render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
     const acceptButton = container.querySelector('.cookie-banner__button--accept');
 
     expect(acceptButton).not.toBeNull();
@@ -52,7 +52,7 @@ describe('CookieBanner', () => {
   });
 
   test('sets localStorage item and configures tracking when rejected', () => {
-    const { container } = render(<CookieBanner />);
+    const { container } = render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
     const rejectButton = container.querySelector('.cookie-banner__button--reject');
 
     expect(rejectButton).not.toBeNull();
@@ -65,17 +65,17 @@ describe('CookieBanner', () => {
 
   test('does not render if "cookies" is already set', () => {
     localStorage.setItem('cookies', 'accepted');
-    const { container } = render(<CookieBanner />);
+    const { container } = render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
     expect(container.firstChild).toBeNull();
   });
 
   test('initializes tracking based on existing cookie consent', () => {
     localStorage.setItem('cookies', 'accepted');
-    render(<CookieBanner />);
+    render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
     expect(posthog.set_config).toHaveBeenCalledWith({ persistence: 'localStorage+cookie' });
 
     localStorage.setItem('cookies', 'rejected');
-    render(<CookieBanner />);
+    render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
     expect(posthog.set_config).toHaveBeenCalledWith({ persistence: 'memory' });
   });
 });

--- a/libraries/ui/src/CookieBanner.test.tsx
+++ b/libraries/ui/src/CookieBanner.test.tsx
@@ -35,12 +35,12 @@ describe('CookieBanner', () => {
   });
 
   test('renders as expected', () => {
-    const { container } = render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
+    const { container } = render(<CookieBanner />);
     expect(container).toMatchSnapshot();
   });
 
   test('sets localStorage item and configures tracking when accepted', () => {
-    const { container } = render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
+    const { container } = render(<CookieBanner />);
     const acceptButton = container.querySelector('.cookie-banner__button--accept');
 
     expect(acceptButton).not.toBeNull();
@@ -52,7 +52,7 @@ describe('CookieBanner', () => {
   });
 
   test('sets localStorage item and configures tracking when rejected', () => {
-    const { container } = render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
+    const { container } = render(<CookieBanner />);
     const rejectButton = container.querySelector('.cookie-banner__button--reject');
 
     expect(rejectButton).not.toBeNull();
@@ -65,17 +65,17 @@ describe('CookieBanner', () => {
 
   test('does not render if "cookies" is already set', () => {
     localStorage.setItem('cookies', 'accepted');
-    const { container } = render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
+    const { container } = render(<CookieBanner />);
     expect(container.firstChild).toBeNull();
   });
 
   test('initializes tracking based on existing cookie consent', () => {
     localStorage.setItem('cookies', 'accepted');
-    render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
+    render(<CookieBanner />);
     expect(posthog.set_config).toHaveBeenCalledWith({ persistence: 'localStorage+cookie' });
 
     localStorage.setItem('cookies', 'rejected');
-    render(<CookieBanner cookiePolicyUrl="/privacy-policy" />);
+    render(<CookieBanner />);
     expect(posthog.set_config).toHaveBeenCalledWith({ persistence: 'memory' });
   });
 });

--- a/libraries/ui/src/CookieBanner.tsx
+++ b/libraries/ui/src/CookieBanner.tsx
@@ -5,6 +5,7 @@ import posthog from 'posthog-js';
 import { CTALinkOrButton } from './CTALinkOrButton';
 
 type CookieBannerProps = {
+  cookiePolicyUrl: string,
   // Optional
   className?: string
 };
@@ -13,7 +14,7 @@ type CookieBannerProps = {
  * Sets a localStorage item called 'cookies' to 'accepted' or
  * 'rejected' when dismissed via one of the buttons.
  */
-export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
+export const CookieBanner: React.FC<CookieBannerProps> = ({ className, cookiePolicyUrl }) => {
   const [showBanner, setShowBanner] = useState(false);
 
   const setCookieConsent = useCallback(
@@ -52,7 +53,7 @@ export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
     <div className={rootClassName}>
       <p className="cookie-banner__text text-pretty">
         We use analytics cookies to improve our website and measure ad performance.{' '}
-        <a href="/privacy-policy">Cookie Policy</a>.
+        <a href={cookiePolicyUrl}>Cookie Policy</a>.
       </p>
       <div className="cookie-banner__buttons flex flex-wrap gap-space-between justify-center">
         <CTALinkOrButton

--- a/libraries/ui/src/CookieBanner.tsx
+++ b/libraries/ui/src/CookieBanner.tsx
@@ -5,7 +5,6 @@ import posthog from 'posthog-js';
 import { CTALinkOrButton } from './CTALinkOrButton';
 
 type CookieBannerProps = {
-  cookiePolicyUrl: string,
   // Optional
   className?: string
 };
@@ -14,7 +13,7 @@ type CookieBannerProps = {
  * Sets a localStorage item called 'cookies' to 'accepted' or
  * 'rejected' when dismissed via one of the buttons.
  */
-export const CookieBanner: React.FC<CookieBannerProps> = ({ className, cookiePolicyUrl }) => {
+export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
   const [showBanner, setShowBanner] = useState(false);
 
   const setCookieConsent = useCallback(
@@ -53,7 +52,7 @@ export const CookieBanner: React.FC<CookieBannerProps> = ({ className, cookiePol
     <div className={rootClassName}>
       <p className="cookie-banner__text text-pretty">
         We use analytics cookies to improve our website and measure ad performance.{' '}
-        <a href={cookiePolicyUrl}>Cookie Policy</a>.
+        <a href="https://bluedot.org/privacy-policy">Cookie Policy</a>.
       </p>
       <div className="cookie-banner__buttons flex flex-wrap gap-space-between justify-center">
         <CTALinkOrButton

--- a/libraries/ui/src/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -1,0 +1,44 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Breadcrumbs > renders all urls and titles in the document 1`] = `
+<div>
+  <div
+    class="breadcrumbs border-b border-color-divider w-full py-space-between"
+  >
+    <nav
+      aria-label="Breadcrumbs"
+      class="breadcrumbs__nav section-base"
+    >
+      <ol
+        class="breadcrumbs__list flex"
+      >
+        <li
+          class="breadcrumbs__item flex items-center"
+        >
+          <a
+            class="breadcrumbs__link"
+            href="/"
+          >
+            HomePage
+          </a>
+          <span
+            class="breadcrumbs__separator mx-2"
+          >
+            &gt;
+          </span>
+        </li>
+        <li
+          class="breadcrumbs__item flex items-center"
+        >
+          <a
+            class="breadcrumbs__link"
+            href="/about"
+          >
+            AboutPage
+          </a>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</div>
+`;

--- a/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`CookieBanner > renders as expected 1`] = `
       We use analytics cookies to improve our website and measure ad performance.
        
       <a
-        href="/privacy-policy"
+        href="https://bluedot.org/privacy-policy"
       >
         Cookie Policy
       </a>

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -29,6 +29,8 @@ export { SlideList } from './SlideList';
 
 export { Tag } from './Tag';
 
+export { Breadcrumbs } from './Breadcrumbs';
+
 // Utils
 
 export { EXTERNAL_LINK_PROPS } from './utils';

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -33,7 +33,7 @@ export { Breadcrumbs } from './Breadcrumbs';
 
 // Utils
 
-export { EXTERNAL_LINK_PROPS } from './utils';
+export { EXTERNAL_LINK_PROPS, type BluedotRoute } from './utils';
 export * as constants from './constants';
 
 // Legacy Components

--- a/libraries/ui/src/utils.ts
+++ b/libraries/ui/src/utils.ts
@@ -2,3 +2,19 @@ export const EXTERNAL_LINK_PROPS = {
   target: '_blank',
   rel: 'noopener noreferrer',
 } as const;
+
+export type BluedotRoute = {
+  /**
+   * Title of the page, by convention this is the title that appears in the
+   * <title /> tag (e.g. "About us" in "About us | BlueDot Impact")
+   */
+  title: string;
+  /**
+   * Relative url of the route (e.g. /about, not https://bluedot.org/about)
+   */
+  url: string;
+  /**
+   * Parent pages of the route (to appear in the <Breadcrumbs /> component)
+   */
+  parentPages?: Pick<BluedotRoute, 'title' | 'url'>[];
+};


### PR DESCRIPTION
# Summary

1. Added breadcrumbs component
2. Refactored all internal navigation to use predefined route urls and titles. The idea here is to make it easier to maintain consistency between the tab name, breadcrumb title, and any other places the title might appear

<!-- One line summary of your change -->

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #397 
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | ![Screenshot 2025-02-19 at 10 27 36](https://github.com/user-attachments/assets/dfd1b17a-f370-45ef-82a9-f2388f02222a) |
| 🖥️ | ![Screenshot 2025-02-19 at 10 28 00](https://github.com/user-attachments/assets/4f307da0-b0a6-427a-bd8e-fcd42d965310) |
| 📱  | ![Screenshot 2025-02-19 at 10 28 25](https://github.com/user-attachments/assets/a10620b1-60f6-44db-aed1-d072bf4a461d) |

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    4 cached, 7 total
  Time:    4.765s
```