### PR TITLE
Add multistage deploy for `website-25`

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -115,4 +115,4 @@ jobs:
 
       - name: Deploy
         if: steps.check_deployment.outputs.should_skip != 'true'
-        run: npm run deploy:prod --workspace apps/${{ matrix.app }}
+        run: npm run deploy:cd --workspace apps/${{ matrix.app }}

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -1,0 +1,39 @@
+name: website_deploy_production
+
+on:
+  push:
+    tags:
+      - website-release*
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Install turbo
+        id: install_turbo
+        run: |
+          npm install --global turbo
+
+      - name: Checkout ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Configure k8s deployment
+        run: |
+          docker login https://sjc.vultrcr.com/bluedot -u dbaa58f3-01f1-4fcc-9c14-93cc28f524e0 -p $VULTR_CONTAINER_REGISTRY_PASSWORD
+          mkdir -p ~/.kube
+          echo "$K8S_KUBECONFIG" > ~/.kube/config
+        env:
+          K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
+          VULTR_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.VULTR_CONTAINER_REGISTRY_PASSWORD }}
+
+      - name: Deploy production
+        run: npm run deploy:multistage:production --workspace apps/website-25

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Inside each package folder, the common files you'll find are:
   - `npm run lint`: Check for lint issues. Visual Studio Code should usually highlight these for you already.
   - `npm run build`: Build the application. This usually finds any type errors, which Visual Studio Code should usually highlight for you already.
   - `npm run postinstall`: Perform any extra steps to setup the application for development. Usually things like creating configuration files for local development. You usually don't need to run this manually, as it runs when you run `npm install`.
-  - `npm run deploy:cd`: Actually deploy the app into the production (real-world) environment. You usually don't need to run this manually, as it is run by CD tooling when you merge your changes into the master branch.
+  - `npm run deploy:cd`: Actually deploy the app, usually into the production (real-world) environment. You usually don't need to run this manually, as it is run by CD tooling when you merge your changes into the master branch.
 - `README.md`: documentation to explain what the package does, how to use it, and how to contribute
 - `src`: most of the code usually lives here. You usually want to edit files in this folder.
   - `pages`: pages in the web app. For example `pages/some-page.tsx` usually corresponds to `app.bluedot.org/some-page`. The `api` folder contains API routes rather than webpages ([learn more in the Next.js docs](https://nextjs.org/docs/pages/building-your-application/routing/api-routes)).

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Inside each package folder, the common files you'll find are:
   - `npm run lint`: Check for lint issues. Visual Studio Code should usually highlight these for you already.
   - `npm run build`: Build the application. This usually finds any type errors, which Visual Studio Code should usually highlight for you already.
   - `npm run postinstall`: Perform any extra steps to setup the application for development. Usually things like creating configuration files for local development. You usually don't need to run this manually, as it runs when you run `npm install`.
-  - `npm run deploy:prod`: Actually deploy the app into the production (real-world) environment. You usually don't need to run this manually, as it is run by CD tooling when you merge your changes into the master branch.
+  - `npm run deploy:cd`: Actually deploy the app into the production (real-world) environment. You usually don't need to run this manually, as it is run by CD tooling when you merge your changes into the master branch.
 - `README.md`: documentation to explain what the package does, how to use it, and how to contribute
 - `src`: most of the code usually lives here. You usually want to edit files in this folder.
   - `pages`: pages in the web app. For example `pages/some-page.tsx` usually corresponds to `app.bluedot.org/some-page`. The `api` folder contains API routes rather than webpages ([learn more in the Next.js docs](https://nextjs.org/docs/pages/building-your-application/routing/api-routes)).

--- a/apps/availability/package.json
+++ b/apps/availability/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "deploy:prod": "docker-scripts deploy"
+    "deploy:cd": "docker-scripts deploy"
   },
   "dependencies": {
     "@bluedot/ui": "*",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,7 @@
         "start": "tsup --watch --onSuccess \"npm run kanel && NODE_ENV=development node dist/index.js\"",
         "start:docker": "docker-scripts start",
         "build": "tsc && tsup && cp ../../package-lock.json dist_tools",
-        "deploy:prod": "echo \"warn: app is deprecated, not deploying\"",
+        "deploy:cd": "echo \"warn: app is deprecated, not deploying\"",
         "kanel": "tsup tools/kanel.ts --outDir dist_tools --external kanel --external kanel-kysely && NODE_ENV=development node dist_tools/kanel.js",
         "resetdb": "dropdb --host=localhost --port=5432 --force postgres && createdb --host=localhost --port=5432 postgres",
         "createLock": "tsup tools/createLock.ts --outDir dist_tools --external @npmcli/arborist && NODE_ENV=development node dist_tools/createLock.js",

--- a/apps/bubble-proxy/package.json
+++ b/apps/bubble-proxy/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "deploy:prod": "echo \"warn: app is deprecated, not deploying\"",
+        "deploy:cd": "echo \"warn: app is deprecated, not deploying\"",
         "start": "docker-scripts start"
     },
     "dependencies": {

--- a/apps/frontend-example/package.json
+++ b/apps/frontend-example/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "deploy:prod": "docker-scripts deploy"
+    "deploy:cd": "docker-scripts deploy"
   },
   "dependencies": {
     "@bluedot/backend-contract": "*",

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -30,8 +30,8 @@ This package handles deploying our apps to the internet. Here's how code becomes
 
 2. Initial deployment:
    - When you push code to both your app and infra, CI/CD runs:
-     - your app's `deploy:prod` script, which builds and uploads your container to Vultr using [docker-scripts](../../libraries/docker-scripts/)
-     - the infra package's `deploy:prod` script runs, which uses Pulumi to create/update the Kubernetes resources for your app (e.g. an ingress, deployment, service, SSL certificate)
+     - your app's `deploy:cd` script, which builds and uploads your container to Vultr using [docker-scripts](../../libraries/docker-scripts/)
+     - the infra package's `deploy:cd` script runs, which uses Pulumi to create/update the Kubernetes resources for your app (e.g. an ingress, deployment, service, SSL certificate)
 
 3. Future deployments:
    - When you push code to your app, CI/CD:

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npm run postinstall:install_pulumi && npm run postinstall:create_passphrase_file",
     "postinstall:install_pulumi": "command -v pulumi >/dev/null 2>&1 || curl -fsSL https://get.pulumi.com | sh",
     "postinstall:create_passphrase_file": "touch passphrase.prod.txt",
-    "deploy:prod": "PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi up --stack prod --yes",
+    "deploy:cd": "PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi up --stack prod --yes",
     "config:secret": "PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi config set --secret",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -44,6 +44,21 @@ export const services: ServiceDefinition[] = [
     hosts: ['website-25.k8s.bluedot.org'],
   },
   {
+    name: 'bluedot-website-25-production',
+    spec: {
+      containers: [{
+        name: 'bluedot-website-25-production',
+        image: 'sjc.vultrcr.com/bluedot/bluedot-website-25-production:latest',
+        env: [
+          { name: 'AIRTABLE_PERSONAL_ACCESS_TOKEN', valueFrom: envVarSources.airtablePat },
+          { name: 'ALERTS_SLACK_CHANNEL_ID', value: 'C04SAGM4FN1' /* #tech-prod-alerts */ },
+          { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
+        ],
+      }],
+    },
+    hosts: ['website-25-production.k8s.bluedot.org'],
+  },
+  {
     name: 'bluedot-storybook',
     spec: {
       containers: [{

--- a/apps/login-account-proxy/package.json
+++ b/apps/login-account-proxy/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "deploy:prod": "docker-scripts deploy"
+    "deploy:cd": "docker-scripts deploy"
   },
   "dependencies": {
     "@bluedot/ui": "*",

--- a/apps/login/package.json
+++ b/apps/login/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "start:docker": "docker-scripts start",
         "build": "tools/getBluedotKeycloakTheme.sh",
-        "deploy:prod": "docker-scripts deploy"
+        "deploy:cd": "docker-scripts deploy"
     },
     "dependencies": {
         "@bluedot/docker-scripts": "*"

--- a/apps/meet/package.json
+++ b/apps/meet/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "deploy:prod": "docker-scripts deploy"
+    "deploy:cd": "docker-scripts deploy"
   },
   "dependencies": {
     "@bluedot/ui": "*",

--- a/apps/miniextensions-proxy/package.json
+++ b/apps/miniextensions-proxy/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "deploy:prod": "docker-scripts deploy",
+        "deploy:cd": "docker-scripts deploy",
         "start": "docker-scripts start"
     },
     "dependencies": {

--- a/apps/posthog-proxy/package.json
+++ b/apps/posthog-proxy/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "deploy:prod": "docker-scripts deploy",
+        "deploy:cd": "docker-scripts deploy",
         "start": "docker-scripts start"
     },
     "dependencies": {

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -8,7 +8,7 @@
     "build": "storybook build --output-dir dist",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "deploy:prod": "docker-scripts deploy"
+    "deploy:cd": "docker-scripts deploy"
   },
   "dependencies": {
     "@bluedot/ui": "*",

--- a/apps/website-25/.env.production.template
+++ b/apps/website-25/.env.production.template
@@ -1,2 +1,3 @@
+# This file will be picked up by the deploy script for production environment.
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-C5L967C9M1
 NEXT_PUBLIC_POSTHOG_KEY=phc_NVqRwH6xZ0MiP9I5a9tx3l9zsTWBvMI1YEbvbCOXDcI

--- a/apps/website-25/.env.staging.template
+++ b/apps/website-25/.env.staging.template
@@ -1,0 +1,3 @@
+# This file will be picked up by the deploy script for staging environment.
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-C5L967C9M1
+NEXT_PUBLIC_POSTHOG_KEY=phc_NVqRwH6xZ0MiP9I5a9tx3l9zsTWBvMI1YEbvbCOXDcI

--- a/apps/website-25/package.json
+++ b/apps/website-25/package.json
@@ -11,6 +11,7 @@
     "test": "vitest --run",
     "test:update": "npm run test -- -u",
     "test:watch": "vitest",
+    "deploy:cd": "npm run deploy:multistage:staging",
     "deploy:multistage:production": "docker-scripts multistage-deploy-production",
     "deploy:multistage:staging": "docker-scripts multistage-deploy-staging"
   },

--- a/apps/website-25/package.json
+++ b/apps/website-25/package.json
@@ -11,7 +11,8 @@
     "test": "vitest --run",
     "test:update": "npm run test -- -u",
     "test:watch": "vitest",
-    "deploy:prod": "docker-scripts deploy"
+    "deploy:multistage:production": "docker-scripts multistage-deploy-production",
+    "deploy:multistage:staging": "docker-scripts multistage-deploy-staging"
   },
   "dependencies": {
     "@bluedot/backend-contract": "*",

--- a/apps/website-proxy/package.json
+++ b/apps/website-proxy/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "deploy:prod": "docker-scripts deploy",
+        "deploy:cd": "docker-scripts deploy",
         "start": "docker-scripts start"
     },
     "dependencies": {

--- a/libraries/docker-scripts/README.md
+++ b/libraries/docker-scripts/README.md
@@ -8,7 +8,7 @@ Scripts for making running and deploying docker containers easy.
 2. Add the following scripts in package.json:
    ```
    "start": "docker-scripts start",
-   "deploy:prod": "docker-scripts deploy",
+   "deploy:cd": "docker-scripts deploy",
    ```
    (if there's already a start script, use `start:docker` instead)
 3. Create a `Dockerfile` next to your app root that exposes port 8080 as the main web service
@@ -20,6 +20,13 @@ You might also want to see the instructions in [infra](../../apps/infra/README.m
 `docker-scripts start`: This will run your docker container. You can then access the web service at [localhost:8000](http://localhost:8000).
 
 `docker-scripts deploy`: This will deploy your app to production, however it's configured in [`infra`](../../apps/infra/). Specifically, it'll build your app and container, tag and push it to Vultr container registry, and bounce the k8s deployment.
+
+### Multistage Deployments
+
+`website-25` has a multistage deployment, which means it has a staging and a production environment.
+
+To deploy to staging, use `docker-scripts multistage-deploy-staging`.
+To deploy to production, use `docker-scripts multistage-deploy-production`.
 
 ## Developer setup
 

--- a/libraries/docker-scripts/src/index.js
+++ b/libraries/docker-scripts/src/index.js
@@ -9,8 +9,8 @@ const command = process.argv[2] || '<blank>';
 
 // Map commands to script files
 const scriptMap = {
-  'multistage:deploy:production': 'multistage/deploy-production.sh',
-  'multistage:deploy:staging': 'multistage/deploy-staging.sh',
+  'multistage-deploy-production': 'multistage/deploy-production.sh',
+  'multistage-deploy-staging': 'multistage/deploy-staging.sh',
   start: 'start.sh',
   deploy: 'deploy.sh',
 };

--- a/libraries/docker-scripts/src/index.js
+++ b/libraries/docker-scripts/src/index.js
@@ -9,6 +9,8 @@ const command = process.argv[2] || '<blank>';
 
 // Map commands to script files
 const scriptMap = {
+  'multistage:deploy:production': 'multistage/deploy-production.sh',
+  'multistage:deploy:staging': 'multistage/deploy-staging.sh',
   start: 'start.sh',
   deploy: 'deploy.sh',
 };

--- a/libraries/docker-scripts/src/multistage/deploy-production.sh
+++ b/libraries/docker-scripts/src/multistage/deploy-production.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+APP_NAME=$(basename "$PWD")
+REPO_URL="sjc.vultrcr.com/bluedot"
+IMAGE_NAME="bluedot-$APP_NAME-production"
+VERSION_TAG="$(TZ=UTC date +'%Y%m%d.%H%M%S').$(git rev-parse --short HEAD)"
+
+# Use the corresponding env file for production environment.
+cp .env.production.template .env.production
+
+# Build
+APP_NAME=$APP_NAME VERSION_TAG=$VERSION_TAG npm run build --if-present
+docker build --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
+
+# Tag and push to registry
+docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:$VERSION_TAG
+docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:latest
+docker push $REPO_URL/$IMAGE_NAME:$VERSION_TAG
+docker push $REPO_URL/$IMAGE_NAME:latest
+
+# Restart nodes in cluster so they pull the new image
+kubectl rollout restart deployment $IMAGE_NAME-deployment
+kubectl rollout status deployment $IMAGE_NAME-deployment

--- a/libraries/docker-scripts/src/multistage/deploy-staging.sh
+++ b/libraries/docker-scripts/src/multistage/deploy-staging.sh
@@ -9,10 +9,11 @@ VERSION_TAG="$(TZ=UTC date +'%Y%m%d.%H%M%S').$(git rev-parse --short HEAD)"
 # Use the corresponding env file for staging environment.
 cp .env.staging.template .env.production
 
+# TODO: Commented out for now because staging == production. See "Rollout" on #460.
 # Add no index robots.txt to the public folder.
-mkdir -p public
-echo "User-agent: *
-Disallow: /" > public/robots.txt
+# mkdir -p public
+#echo "User-agent: *
+#Disallow: /" > public/robots.txt
 
 # Build
 APP_NAME=$APP_NAME VERSION_TAG=$VERSION_TAG npm run build --if-present

--- a/libraries/docker-scripts/src/multistage/deploy-staging.sh
+++ b/libraries/docker-scripts/src/multistage/deploy-staging.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+APP_NAME=$(basename "$PWD")
+REPO_URL="sjc.vultrcr.com/bluedot"
+IMAGE_NAME="bluedot-$APP_NAME"
+VERSION_TAG="$(TZ=UTC date +'%Y%m%d.%H%M%S').$(git rev-parse --short HEAD)"
+
+# Use the corresponding env file for staging environment.
+cp .env.staging.template .env.production
+
+# Add no index robots.txt to the public folder.
+mkdir -p public
+echo "User-agent: *
+Disallow: /" > public/robots.txt
+
+# Build
+APP_NAME=$APP_NAME VERSION_TAG=$VERSION_TAG npm run build --if-present
+docker build --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
+
+# Tag and push to registry
+docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:$VERSION_TAG
+docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:latest
+docker push $REPO_URL/$IMAGE_NAME:$VERSION_TAG
+docker push $REPO_URL/$IMAGE_NAME:latest
+
+# Restart nodes in cluster so they pull the new image
+kubectl rollout restart deployment $IMAGE_NAME-deployment
+kubectl rollout status deployment $IMAGE_NAME-deployment


### PR DESCRIPTION
# Summary

* Add `bluedot-website-25-production`-container
* Introduce *multistage* deployment workflow for `website-25`

## Issue

Fixes #58, but will require a few follow ups to actually the switch to the new production environment. See `### Rollout` ⬇️.

## Description

### Deployment Workflow

* **staging** Push to `master` triggers a deploy to `bluedot-website-25`. _This is the current behavior._
* **production** Push a `website-release*`-tag to `master` to trigger a deploy to `bluedot-website-25-production`. 

We can even choose to make it a convention to create `GitHub Releases` for production deploys.

<img width="962" alt="Screenshot 2025-02-19 at 11 01 42" src="https://github.com/user-attachments/assets/8156ba92-8645-42bd-b9df-d6760d4abee8" />

That way we can add a quick description of the release & keep a transparent history of releases.

### Rollout

* [x] **Before merging** comment out the `no index robots.txt`-code in `deploy-staging.sh`, see 4f2dcdb05f6e0d30db1fb12312af1488f4a7ad63.
* [ ] Merge this pr. No visual changes. Check that everything is working as before.
* [ ] Push a tag (or create a release) to trigger our first production deploy.
* [ ] Check that the new production container is working.
* [ ] **Make the switch**: Update the proxy to point to the new production container.
* [ ] Re-enable `no index robots.txt`-code in `deploy-staging.sh`.
* [ ] Change stanging env vars in `.env.staging.template` to point to staging GA & Posthog.
* [ ] Use staging tracking keys for dev, i.e. update `env.local.template`
* [ ] That's it 🎉 - Double-check that the GA & PostHog keys are correct on both environments.

ℹ️ I prepared a branch implementing the steps outlined above over at https://github.com/janraasch/bluedot/pull/1.

### Reasoning

This implementation draws inspiration from [Next.js - Examples - with-docker-multi-env](https://github.com/vercel/next.js/tree/canary/examples/with-docker-multi-env). While it requires separate builds (both npm run build and Docker image creation) for staging and production environments, it preserves Next.js's built-in optimization of inlining frontend environment variables. The solution maintains code simplicity without introducing additional dependencies. I believe this approach offers a balanced trade-off, and may be extended nicely to other multistage apps in the future. Happy to get your feedback ❤️!

## Developer checklist

Testing GitHub actions before merging is ~~hard~~ impossible? 😇. Since we introduce a new workflow & only made a small change to the existing `ci_cd`-workflow, we should be good to go after thorough code review 👀 🤝.

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    4 cached, 7 total
  Time:    4.992s 
```