### PR TITLE
Use existing image to properly rollout `infra` changes

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -48,7 +48,7 @@ export const services: ServiceDefinition[] = [
     spec: {
       containers: [{
         name: 'bluedot-website-25-production',
-        image: 'sjc.vultrcr.com/bluedot/bluedot-website-25-production:latest',
+        image: 'sjc.vultrcr.com/bluedot/bluedot-website-25:latest',
         env: [
           { name: 'AIRTABLE_PERSONAL_ACCESS_TOKEN', valueFrom: envVarSources.airtablePat },
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: 'C04SAGM4FN1' /* #tech-prod-alerts */ },


### PR DESCRIPTION
# Summary

Use existing image (for now) to properly rollout `infra` changes.

See https://github.com/bluedotimpact/bluedot/actions/runs/13432212919/job/37526646085.

Will revert this commit once we have our production image.

## Issue

Following up on #460.