### PR TITLE
website-25: Add `staging` GA key to `.env.locale.template`

### DIFF
--- a/apps/website-25/.env.local.template
+++ b/apps/website-25/.env.local.template
@@ -1,6 +1,6 @@
 # Google Analytics
 # When set, Google Analytics will be enabled. Be careful not to send real data to Google Analytics. Comment out to disable.
-# NEXT_PUBLIC_GA_MEASUREMENT_ID=
+# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-1ZXWH4JT7T
 # When set, Google Analytics debug mode will be enabled. Comment out to disable.
 # See https://support.google.com/analytics/answer/7201382?hl=en
 # NEXT_PUBLIC_GA_DEBUG=true


### PR DESCRIPTION
# Summary

Use *staging* `GA_MEASUREMENT_ID` to `.env.locale.template`.

For PostHog we already have the dev/testing key on `.env.locale.template`

## Issue

Following up on #460 