### PR TITLE
Add `z-100` to `CookieBanner`

### DIFF
--- a/libraries/ui/src/CookieBanner.tsx
+++ b/libraries/ui/src/CookieBanner.tsx
@@ -44,7 +44,7 @@ export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
   if (!showBanner) return null;
 
   const rootClassName = clsx(
-    'cookie-banner container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px]',
+    'cookie-banner container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px] z-100',
     className,
   );
 

--- a/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`CookieBanner > renders as expected 1`] = `
 <div>
   <div
-    class="cookie-banner container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px]"
+    class="cookie-banner container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px] z-100"
   >
     <p
       class="cookie-banner__text text-pretty"


### PR DESCRIPTION
# Summary

Add `z-100` to `CookieBanner`.

## Issue

Fixes #484.

## Description

We currently have `z-10` on `.slide-list__gradient-overlay` & `z-50` on `<nav>`.

I chose `z-100` to make sure that the `CookieBanner` will *always* be rendered on top of other content, ensuring proper visibility and accessibility for users.

## Developer checklist
- [x] Added or updated Jest tests

## Screenshot

ℹ️ **Storybook** did not change.

| 📸 |  |
|---------|---|
| 🖥️ | <img width="1728" alt="Screenshot 2025-02-25 at 14 45 16" src="https://github.com/user-attachments/assets/11434611-0c30-431e-b62e-d924e7841210" /> |
| 📱  |  <img width="664" alt="Screenshot 2025-02-25 at 14 44 56" src="https://github.com/user-attachments/assets/b08746a8-7bb4-43e0-9b78-7e39438d70cc" />

## Testing
```
$ npm run test:update
 Tasks:    7 successful, 7 total
Cached:    0 cached, 7 total
  Time:    6.066s 
```