### PR TITLE
cd: set skip_after_successful_duplicate to false

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -82,6 +82,7 @@ jobs:
         with:
           paths: ${{ steps.get_paths.outputs.paths }}
           paths_ignore: '["**/README.md"]'
+          skip_after_successful_duplicate: false
 
       - name: Skip deployment
         if: steps.check_deployment.outputs.should_skip == 'true'


### PR DESCRIPTION
# Summary

This workflow runs on pull requests, which then means when pushing to master this action thinks a duplicate run has passed successfully.

Disabling this _should_ result in fkirc/skip-duplicate-actions using the backtracking algorithm detailed in [their README](https://github.com/fkirc/skip-duplicate-actions/), which I think should be doing what we want.

## Issue

Fixes (maybe) #472