### PR TITLE
website-proxy: 301 redirect `www.bluedot.org` to `bluedot.org`

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -9,7 +9,7 @@ http {
     }
 
     server {
-        listen 8080;
+        listen 8080 default_server;
         add_header X-BlueDot-Version '$VERSION_TAG';
 
         # Specific routes to website-25

--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -4,6 +4,13 @@ http {
     server {
         listen 8080;
         add_header X-BlueDot-Version '$VERSION_TAG';
+        server_name www.bluedot.org;
+        return 301 $scheme://bluedot.org$request_uri;
+    }
+
+    server {
+        listen 8080;
+        add_header X-BlueDot-Version '$VERSION_TAG';
 
         # Specific routes to website-25
         location = / {


### PR DESCRIPTION
# Summary

Add 301 permanent redirect from `www.bluedot.org` to `bluedot.org`

## Issue

Fixes #487

## Testing

I've verified my solution through Claude and cross-referenced it with [this gist](https://gist.github.com/EmranAhmed/946a74c0331832040844) 😇, though I couldn't test the `nginx.template.conf` locally.

## Screenshot

📸 **No visual changes**

## Testing
```
$ npm run test:update
 Tasks:    9 successful, 9 total
Cached:    4 cached, 9 total
  Time:    5.404s 
```