### PR TITLE
Add routing for 404 page to website-proxy

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -49,6 +49,12 @@ http {
             proxy_pass https://website-25-production.k8s.bluedot.org;
         }
 
+        # Redirect 404 errors to the same route on the new website
+        error_page 404 = @website_25_404;
+        location @website_25_404 {
+            proxy_pass https://website-25-production.k8s.bluedot.org$request_uri;
+        }
+
         # Default all other traffic to old site
         location / {
             proxy_ssl_name bluedot.org;


### PR DESCRIPTION
**This should not merged before #475 **

# Summary

The location block should make it so that:
- If a route isn't explicitly directed to the new site (https://website-25-production.k8s.bluedot.org), it tries directing it to the old site (https://45.76.132.116)
  - If this returns a 404, it redirects to the same route on the new site. This may or may not return a 404, if it does it will display the page added in #475
- If a route is directed to the new site and still returns a 404, it should do an internal redirect to the same page and then return this

I haven't tested this yet, @janraasch is there a good way of testing this nginx config that you have been using? If not I will test up a quick test server and try it out 

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #391 
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [X] [N/A] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [X] [N/A] Added or updated Jest tests
- [X] [N/A] Added or updated Storybook stories