### PR TITLE
website-proxy: redirect `careers` to `join-us` & serve job postings from `website-25`

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -18,12 +18,52 @@ http {
             proxy_pass https://website-25-production.k8s.bluedot.org;
         }
 
-        location = /careers {
+        location = /join-us {
             proxy_pass https://website-25-production.k8s.bluedot.org;
         }
 
-        location = /careers/ {
+        location = /join-us/ {
             proxy_pass https://website-25-production.k8s.bluedot.org;
+        }
+
+        location = /join-us/swe-contractor {
+            proxy_pass https://website-25-production.k8s.bluedot.org;
+        }
+
+        location = /join-us/swe-contractor/ {
+            proxy_pass https://website-25-production.k8s.bluedot.org;
+        }
+
+        location = /join-us/ai-safety-teaching-fellow {
+            proxy_pass https://website-25-production.k8s.bluedot.org;
+        }
+
+        location = /join-us/ai-safety-teaching-fellow/ {
+            proxy_pass https://website-25-production.k8s.bluedot.org;
+        }
+
+        location = /careers {
+            return 301 $scheme://$host/join-us;
+        }
+
+        location = /careers/ {
+            return 301 $scheme://$host/join-us;
+        }
+
+        location = /careers/swe-contractor {
+            return 301 $scheme://$host/join-us/swe-contractor;
+        }
+
+        location = /careers/swe-contractor/ {
+            return 301 $scheme://$host/join-us/swe-contractor;
+        }
+
+        location = /careers/ai-safety-teaching-fellow {
+            return 301 $scheme://$host/join-us/ai-safety-teaching-fellow;
+        }
+
+        location = /careers/ai-safety-teaching-fellow/ {
+            return 301 $scheme://$host/join-us/ai-safety-teaching-fellow;
         }
 
         location = /privacy-policy {


### PR DESCRIPTION
# Summary

Redirect `careers` to `join-the-team` & serve job postings from `website-25`

## Issue

Following up on #486

## Rollout

⚠️ Wait for #486 to be released to `production` before merging ⚠️