### PR TITLE
storybook: Move `Homepage` stories to `Website` namespace

### DIFF
--- a/apps/website-25/src/components/homepage/CommunitySection/CommunityValuesSection.stories.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/CommunityValuesSection.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import CommunityValuesSection from './CommunityValuesSection';
 
 const meta = {
-  title: 'Homepage/CommunityValuesSection',
+  title: 'Website/CommunityValuesSection',
   component: CommunityValuesSection,
   parameters: {
     layout: 'fullscreen',

--- a/apps/website-25/src/components/homepage/CommunitySection/ProjectsSubSection.stories.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/ProjectsSubSection.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import ProjectsSubSection from './ProjectsSubSection';
 
 const meta = {
-  title: 'Homepage/ProjectsSubSection',
+  title: 'Website/ProjectsSubSection',
   component: ProjectsSubSection,
   parameters: {
     layout: 'fullscreen',

--- a/apps/website-25/src/components/homepage/CommunitySection/TestimonialSection.stories.tsx
+++ b/apps/website-25/src/components/homepage/CommunitySection/TestimonialSection.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import TestimonialSection from './TestimonialSection';
 
 const meta = {
-  title: 'Homepage/TestimonialSection',
+  title: 'Website/TestimonialSection',
   component: TestimonialSection,
   parameters: {
     layout: 'fullscreen',


### PR DESCRIPTION
# Summary

Unite `website-25` stories under common `Website` namespace 🧹.

## Issue

I stumbled upon this as part of #252.

## Description

**Goal:** Have one namespace per `app` / `library`.

## Developer checklist
- [x] ~~Used [BEM naming convention](https://getbem.com/naming/) for classNames~~ N/A
- [x] ~~Added or updated Jest tests~~ N/A
- [x] Added or updated Storybook stories

## Screenshot

![Screenshot 2025-02-26 at 16 13 42](https://github.com/user-attachments/assets/8abc9e9f-f666-4425-b7db-ee279c2ca4c5)

## Testing
```
$ npm run test:update
 Tasks:    9 successful, 9 total
Cached:    8 cached, 9 total
  Time:    3.802s 
```