### PR TITLE
website-25: Updating staging URL to `website-25-staging.k8s.bluedot.org`

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -56,7 +56,7 @@ export const services: ServiceDefinition[] = [
         ],
       }],
     },
-    hosts: ['website-25.k8s.bluedot.org'],
+    hosts: ['website-25-staging.k8s.bluedot.org'],
   },
   {
     name: 'bluedot-website-25-production',


### PR DESCRIPTION
## Issue

Fixes #474 

## Description

I thought about setting up a redirect from `website-25` -> `website-25-staging`, but given the only people using it are a few devs a Slack message probably ought to do the trick? Less complex and less to maintain.