### PR TITLE
room: Reliability and performance improvements

### DIFF
--- a/apps/room/public/display/setup/kiosk/kiosk.service
+++ b/apps/room/public/display/setup/kiosk/kiosk.service
@@ -8,6 +8,8 @@ After=graphical.target
 [Service]
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/home/pi/.Xauthority
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+Environment=XDG_RUNTIME_DIR=/run/user/1000
 Type=simple
 ExecStart=/bin/bash /home/pi/kiosk.sh
 Restart=always

--- a/apps/room/public/display/setup/kiosk/kiosk.sh
+++ b/apps/room/public/display/setup/kiosk/kiosk.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Place this in /home/pi/kiosk.sh and make it executable
 
+# Set DISPLAY if not already set
+if [ -z "$DISPLAY" ]; then
+  export DISPLAY=:0
+fi
+
 xset s noblank
 xset s off
 xset -dpms
@@ -8,4 +13,5 @@ xset -dpms
 sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' /home/$USER/.config/chromium/Default/Preferences
 sed -i 's/"exit_type":"Crashed"/"exit_type":"Normal"/' /home/$USER/.config/chromium/Default/Preferences
 
-/usr/bin/chromium-browser --noerrdialogs --disable-infobars --kiosk https://room.bluedot.org/display/auto
+# We use firefox instead of Google Chrome because on the Pi it works with high-resolution webcams better
+firefox --kiosk https://room.bluedot.org/display/auto

--- a/libraries/ui/src/utils/makeMakeApiRoute.ts
+++ b/libraries/ui/src/utils/makeMakeApiRoute.ts
@@ -43,16 +43,11 @@ export const makeMakeApiRoute = <AuthResult extends BaseAuthResult>({ env, verif
       res,
     ) => {
       try {
-        if (opts.requestBody?.isOptional()) {
-          // eslint-disable-next-line no-param-reassign
-          opts.requestBody = z.union([opts.requestBody, EmptyBodySchema]) as ZodType as ReqZT;
-        }
-
         const optsFull: Required<RouteOptions<ReqZT, ResZT, RequiresAuth>> = {
-          requestBody: EmptyBodySchema as ZodType as ReqZT,
           responseBody: z.literal(undefined) as ZodType as ResZT,
           requireAuth: true as RequiresAuth,
           ...opts,
+          requestBody: (opts.requestBody?.isOptional() ? z.union([opts.requestBody, EmptyBodySchema]) : EmptyBodySchema) as ZodType as ReqZT,
         };
 
         const auth = await getAuth(req, optsFull.requireAuth, verifyAndDecodeToken);


### PR DESCRIPTION
Two key changes:

1. Improve the kiosk script. The main change here is using firefox instead of Google Chrome, because it works better with higher-res webcams. I also added some environment variables to the systemd script that enables access to D-Bus, so firefox can access all the microphone/webcam devices.

2. Prevent API recursion depth errors, by modifying makeMakeApiRoute. On each request, we were modifying the requestBody schema. Because this was captured in the higher level closure it was being nested, until eventually checking it was no longer feasible and we got errors. This fixes the problem by not modifying the opts object. Should have listened to the ESLint warning in the first place 🤦