### PR TITLE
libraries/ui/makeMakeApiRoute: Add streaming response support to makeMakeApiRoute

### DIFF
--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -35,7 +35,7 @@ export { asError } from './utils/asError';
 export { useAuthStore, withAuth, type Auth } from './utils/auth';
 export { EXTERNAL_LINK_PROPS } from './utils/externalLinkProps';
 export {
-  makeMakeApiRoute, type Handler, type MakeMakeApiRouteEnv, type RouteOptions,
+  makeMakeApiRoute, StreamingResponseSchema, type Handler, type MakeMakeApiRouteEnv, type RouteOptions,
 } from './utils/makeMakeApiRoute';
 export { slackAlert } from './utils/slackAlert';
 export { validateEnv } from './utils/validateEnv';


### PR DESCRIPTION
# Summary

libraries/ui: Add streaming response support to makeMakeApiRoute

## Description

This just disables response schema checking if the response is supposed to be a streaming response. Users of makeMakeApi route are expected to use the special 'StreamingResponseSchema' response body to enable this.

This is primarily for course-demos, where we're likely to want more AI streaming demos. Being able to use makeMakeApiRoute for these gives us things like authentication, request validation, nice typings, and error handling "for free", which cleans up the API code considerably.

In future we could try to make this even nicer - but it's already a good improvement.

## Testing

I haven't added automated tests yet because they're a bit fiddly and currently a proper test would require pulling in all the ai deps into libraries/ui which I am hesitant to do atm. Given this is only used in course-demos, I am okay taking this risk. I have tested course-demos generates code fine locally.