### PR TITLE
Fix tab navigation in Nav

### DIFF
--- a/apps/website-25/src/components/Nav.stories.tsx
+++ b/apps/website-25/src/components/Nav.stories.tsx
@@ -39,8 +39,5 @@ export const Default: Story = {
 export const Customized: Story = {
   args: {
     logo: imgSrc,
-    children: [
-      <><a href="#">Support Us</a><a href="#">About</a><a href="#">Join us</a><a href="#">Blog</a></>,
-    ],
   },
 };

--- a/apps/website-25/src/components/Nav.tsx
+++ b/apps/website-25/src/components/Nav.tsx
@@ -48,13 +48,13 @@ const ExploreSection: React.FC<{
   >
     <div
       className={clsx(
-        'nav-explore-section___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden text-pretty',
+        'nav-explore-section___dropdown-content flex flex-col gap-[14px] text-pretty px-6',
         innerClassName,
       )}
     >
       <h3 className="nav-explore-section__dropdown-title font-bold">Our courses</h3>
       {courses?.map((course) => (
-        <a key={course.href} href={course.href} className="nav-explore-section__dropdown-link">
+        <a key={course.href} href={course.href} tabIndex={expanded ? 0 : -1} className="nav-explore-section__dropdown-link">
           {course.isNew && (
             <span className="nav-explore-section__new-badge text-bluedot-normal font-black pr-2">
               New!
@@ -82,10 +82,25 @@ const NavLinks: React.FC<{
   className,
   isScrolled,
 }) => {
+  const navLinkContainerClasses = clsx(
+    'nav-links grid [&>*]:w-fit items-center',
+    exploreSectionInline ? 'grid-cols-1 gap-y-9' : 'grid-cols-subgrid grid-rows-subgrid row-[1/3] col-[3/7]',
+    className,
+  );
   const navLinkClasses = clsx('nav-link-animation', isScrolled && 'nav-link-animation-dark');
 
+  const exploreSection = (
+    <ExploreSection
+      expanded={exploreExpanded}
+      courses={courses}
+      className="nav-links__explore-section col-span-full row-[2]"
+      innerClassName={exploreSectionInline ? 'pt-6' : 'pb-9'}
+      isScrolled={isScrolled}
+    />
+  );
+
   return (
-    <div className={clsx('nav-links flex gap-9 [&>*]:w-fit', className)}>
+    <div className={navLinkContainerClasses}>
       <div>
         <button
           type="button"
@@ -95,16 +110,11 @@ const NavLinks: React.FC<{
           Explore
           <DropdownIcon expanded={exploreExpanded} />
         </button>
-        {exploreSectionInline && (
-          <ExploreSection
-            expanded={exploreExpanded}
-            courses={courses}
-            className="nav-links__explore-section"
-            innerClassName="pl-6 pt-6"
-            isScrolled={isScrolled}
-          />
-        )}
+        {exploreSectionInline && exploreSection}
       </div>
+      {/* `exploreSection` is placed here in the DOM to make it the next step after "Explore"
+          when tabbing through the header. Visually, it is moved below by setting row-[2] */}
+      {!exploreSectionInline && exploreSection}
       <a href={ROUTES.about.url} className={clsx('nav-links__link', navLinkClasses, isCurrentPath(ROUTES.about.url) && 'font-bold')}>About us</a>
       <a href={ROUTES.joinUs.url} className={clsx('nav-links__link', navLinkClasses, isCurrentPath(ROUTES.joinUs.url) && 'font-bold')}>Join us</a>
       <a href="https://bluedot.org/blog/" className={clsx('nav-links__link', navLinkClasses)}>Blog</a>
@@ -171,8 +181,8 @@ export const Nav: React.FC<NavProps> = ({
     >
       <ClickAwayListener onClickAway={() => setExpandedSections('none')}>
         <div className="nav__container section-base">
-          <div className="nav__bar w-full grid grid-cols-2 lg:grid-cols-[20%_60%_20%] items-center h-[72px] sm:h-[100px]">
-            <a href="/" className="nav__logo-link shrink-0 w-[200px]">
+          <div className="nav__bar w-full grid grid-cols-2 gap-x-9 lg:grid-cols-[20%_1fr_auto_auto_auto_auto_1fr_20%] items-center grid-rows-[72px] sm:grid-rows-[100px]">
+            <a href="/" className="nav__logo-link shrink-0 w-[200px] col-[1]">
               {logo ? (
                 <img
                   className={clsx(
@@ -191,9 +201,9 @@ export const Nav: React.FC<NavProps> = ({
               exploreExpanded={exploreExpanded}
               courses={courses}
               isScrolled={isScrolled}
-              className="nav__links--desktop hidden lg:flex mx-auto"
+              className="nav__links--desktop hidden lg:grid mx-auto"
             />
-            <div className="nav__actions flex gap-space-between ml-auto">
+            <div className="nav__actions flex gap-space-between ml-auto col-[8]">
               <CTAButtons className="nav__login--tablet-desktop gap-6 hidden sm:flex" />
               <HamburgerButton
                 open={navExpanded}
@@ -206,18 +216,9 @@ export const Nav: React.FC<NavProps> = ({
           <div
             className={clsx(
               'nav__drawer transition-[max-height,opacity] duration-300 relative overflow-hidden px-3',
-              navExpanded ? 'max-h-[700px] opacity-100' : 'max-h-0 opacity-0',
+              navExpanded ? 'max-h-[800px] opacity-100' : 'max-h-0 opacity-0',
             )}
           >
-            {/* Desktop Explore section */}
-            <ExploreSection
-              expanded={exploreExpanded}
-              courses={courses}
-              className="nav__drawer-content--desktop"
-              innerClassName="pb-10 hidden lg:flex mx-auto"
-              isScrolled={isScrolled}
-            />
-            {/* Mobile & Tablet content (including Explore) */}
             <div className="nav__drawer-content--mobile-tablet flex flex-col grow font-medium pb-8 pt-2 lg:hidden">
               <NavLinks
                 onToggleExplore={onToggleExplore}

--- a/apps/website-25/src/components/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website-25/src/components/__snapshots__/Nav.test.tsx.snap
@@ -9,10 +9,10 @@ exports[`Nav > renders with courses 1`] = `
       class="nav__container section-base"
     >
       <div
-        class="nav__bar w-full grid grid-cols-2 lg:grid-cols-[20%_60%_20%] items-center h-[72px] sm:h-[100px]"
+        class="nav__bar w-full grid grid-cols-2 gap-x-9 lg:grid-cols-[20%_1fr_auto_auto_auto_auto_1fr_20%] items-center grid-rows-[72px] sm:grid-rows-[100px]"
       >
         <a
-          class="nav__logo-link shrink-0 w-[200px]"
+          class="nav__logo-link shrink-0 w-[200px] col-[1]"
           href="/"
         >
           <img
@@ -22,7 +22,7 @@ exports[`Nav > renders with courses 1`] = `
           />
         </a>
         <div
-          class="nav-links flex gap-9 [&>*]:w-fit nav__links--desktop hidden lg:flex mx-auto"
+          class="nav-links grid [&>*]:w-fit items-center grid-cols-subgrid grid-rows-subgrid row-[1/3] col-[3/7] nav__links--desktop hidden lg:grid mx-auto"
         >
           <div>
             <button
@@ -45,6 +45,38 @@ exports[`Nav > renders with courses 1`] = `
               </svg>
             </button>
           </div>
+          <div
+            class="nav-explore-section__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 nav-links__explore-section col-span-full row-[2]"
+          >
+            <div
+              class="nav-explore-section___dropdown-content flex flex-col gap-[14px] text-pretty px-6 pb-9"
+            >
+              <h3
+                class="nav-explore-section__dropdown-title font-bold"
+              >
+                Our courses
+              </h3>
+              <a
+                class="nav-explore-section__dropdown-link"
+                href="/course1"
+                tabindex="-1"
+              >
+                Course 1
+              </a>
+              <a
+                class="nav-explore-section__dropdown-link"
+                href="/course2"
+                tabindex="-1"
+              >
+                <span
+                  class="nav-explore-section__new-badge text-bluedot-normal font-black pr-2"
+                >
+                  New!
+                </span>
+                Course 2
+              </a>
+            </div>
+          </div>
           <a
             class="nav-links__link nav-link-animation"
             href="/about"
@@ -65,7 +97,7 @@ exports[`Nav > renders with courses 1`] = `
           </a>
         </div>
         <div
-          class="nav__actions flex gap-space-between ml-auto"
+          class="nav__actions flex gap-space-between ml-auto col-[8]"
         >
           <div
             class="nav__cta-container nav__login--tablet-desktop gap-6 hidden sm:flex"
@@ -122,40 +154,10 @@ exports[`Nav > renders with courses 1`] = `
         class="nav__drawer transition-[max-height,opacity] duration-300 relative overflow-hidden px-3 max-h-0 opacity-0"
       >
         <div
-          class="nav-explore-section__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 nav__drawer-content--desktop"
-        >
-          <div
-            class="nav-explore-section___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden text-pretty pb-10 hidden lg:flex mx-auto"
-          >
-            <h3
-              class="nav-explore-section__dropdown-title font-bold"
-            >
-              Our courses
-            </h3>
-            <a
-              class="nav-explore-section__dropdown-link"
-              href="/course1"
-            >
-              Course 1
-            </a>
-            <a
-              class="nav-explore-section__dropdown-link"
-              href="/course2"
-            >
-              <span
-                class="nav-explore-section__new-badge text-bluedot-normal font-black pr-2"
-              >
-                New!
-              </span>
-              Course 2
-            </a>
-          </div>
-        </div>
-        <div
           class="nav__drawer-content--mobile-tablet flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
         >
           <div
-            class="nav-links flex gap-9 [&>*]:w-fit nav__links--mobile-tablet flex-col"
+            class="nav-links grid [&>*]:w-fit items-center grid-cols-1 gap-y-9 nav__links--mobile-tablet flex-col"
           >
             <div>
               <button
@@ -178,10 +180,10 @@ exports[`Nav > renders with courses 1`] = `
                 </svg>
               </button>
               <div
-                class="nav-explore-section__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 nav-links__explore-section"
+                class="nav-explore-section__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 nav-links__explore-section col-span-full row-[2]"
               >
                 <div
-                  class="nav-explore-section___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden text-pretty pl-6 pt-6"
+                  class="nav-explore-section___dropdown-content flex flex-col gap-[14px] text-pretty px-6 pt-6"
                 >
                   <h3
                     class="nav-explore-section__dropdown-title font-bold"
@@ -191,12 +193,14 @@ exports[`Nav > renders with courses 1`] = `
                   <a
                     class="nav-explore-section__dropdown-link"
                     href="/course1"
+                    tabindex="-1"
                   >
                     Course 1
                   </a>
                   <a
                     class="nav-explore-section__dropdown-link"
                     href="/course2"
+                    tabindex="-1"
                   >
                     <span
                       class="nav-explore-section__new-badge text-bluedot-normal font-black pr-2"


### PR DESCRIPTION
# Summary

This makes it so that after you open the Explore menu, you can tab into it immediately. There should be no significant visual change along with this (I have just aligned the desktop explore section with the Explore button rather than centering it in the page).

https://github.com/user-attachments/assets/8ccf9006-8120-453c-9ea9-074caffaf457

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #286 
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [X] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [X] [N/A] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | There is a bug in the storybook at the moment which causes some tailwind breakpoint classes to be applied in the wrong order (e.g. flex overrides lg:hidden). This was already there, but I haven't been able to fix it so the story is still broken: ![Screenshot 2025-03-12 at 10 40 08](https://github.com/user-attachments/assets/78da954a-e1b2-4f56-9345-839b7d1fed4f) |
| 🖥️ | ![Screenshot 2025-03-12 at 10 43 05](https://github.com/user-attachments/assets/f52df93d-559c-4e8d-b66f-be71801428a9) |
| 📱  | ![Screenshot 2025-03-12 at 10 43 27](https://github.com/user-attachments/assets/67e5fa4a-770d-4a23-9909-6420fce77f6f) |

## Testing
```
$ npm run test:update
 Tasks:    10 successful, 10 total
Cached:    1 cached, 10 total
  Time:    11.207s
```