### PR TITLE
course-demos: Remove whiteboard preset

### DIFF
--- a/apps/course-demos/src/pages/generate-react-component.tsx
+++ b/apps/course-demos/src/pages/generate-react-component.tsx
@@ -40,7 +40,6 @@ const DemoPage: React.FC = () => {
     '😌 Satisfying interactive simulation',
     '📚 Reading speed measuring tool',
     '🧘 Meditation timer',
-    '✏️ Whiteboard drawing canvas',
     '💪 Workout routine builder',
   ];
 


### PR DESCRIPTION
This doesn't work reliably, and the touch events sometimes are weird when embedded in an iframe on mobile.