### PR TITLE
course-demos: Improve sharing url view on Windows

### DIFF
--- a/apps/course-demos/src/components/ShareButton.tsx
+++ b/apps/course-demos/src/components/ShareButton.tsx
@@ -153,7 +153,7 @@ export const ShareButton: React.FC<ShareButtonProps> = ({
         </div>
 
         <div className="mt-10 flex max-w-xs">
-          <p className="w-full px-3 py-2 border rounded-md text-gray-700 select-all mr-2 whitespace-nowrap overflow-scroll">{shareUrl}</p>
+          <p className="w-full px-3 py-2 border rounded-md text-gray-700 select-all mr-2 whitespace-nowrap overflow-x-auto">{shareUrl}</p>
           <AriaButton
             onPress={handleCopyToClipboard}
             className={clsx('bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-2 rounded-md', isCopied && '!bg-green-100')}


### PR DESCRIPTION
Auto means the scrollbars only show when necessary, and limiting it to x prevents an unnecessary up/down scrollbar that appears on Windows (by default, macOS hides the scrollbar when using a trackpad even with overflow scroll).