### PR TITLE
website: landing: Pass through other params to miniextension prefills

### DIFF
--- a/apps/website-25/src/components/lander/getCtaUrl.ts
+++ b/apps/website-25/src/components/lander/getCtaUrl.ts
@@ -1,6 +1,10 @@
 export const getCtaUrl = (variant: string) => {
-  const queryParams = new URLSearchParams(window.location.search);
-  queryParams.append('prefill_Variant', variant);
-  const ctaUrl = `https://web.miniextensions.com/aGd0mXnpcN1gfqlnYNZc?prefill_Topic=Let%27s%20Make%20The%20Future%20Awesome%20Course&${queryParams.toString()}`;
+  const thisPageQueryParams = new URLSearchParams(window.location.search);
+  const miniextensionsQueryParams = new URLSearchParams();
+  thisPageQueryParams.forEach((value, key) => {
+    miniextensionsQueryParams.append(`prefill_${key}`, value);
+  });
+  miniextensionsQueryParams.append('prefill_Variant', variant);
+  const ctaUrl = `https://web.miniextensions.com/aGd0mXnpcN1gfqlnYNZc?prefill_Topic=Let%27s%20Make%20The%20Future%20Awesome%20Course&${miniextensionsQueryParams.toString()}`;
   return ctaUrl;
 };


### PR DESCRIPTION
Pass through parameters to miniextensions, so they can be recorded in Airtable

For example, utm_content becomes prefill_utm_content.