### PR TITLE
devex: Fix package.json for eslint-config linking to eslint-plugin-custom

### DIFF
--- a/libraries/eslint-config/package.json
+++ b/libraries/eslint-config/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "src/index.js",
   "devDependencies": {
-    "@bluedot/eslint-plugin-bluedot-custom": "*",
+    "@bluedot/eslint-plugin-custom": "*",
     "@types/eslint": "^8.44.8",
     "eslint-config-domdomegg": "^1.2.3",
     "eslint-config-turbo": "^2.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1910,7 +1910,7 @@
       "name": "@bluedot/eslint-config",
       "version": "0.0.0",
       "devDependencies": {
-        "@bluedot/eslint-plugin-bluedot-custom": "*",
+        "@bluedot/eslint-plugin-custom": "*",
         "@types/eslint": "^8.44.8",
         "eslint-config-domdomegg": "^1.2.3",
         "eslint-config-turbo": "^2.2.3",
@@ -1977,7 +1977,7 @@
     "libraries/eslint-plugin-bluedot-custom": {
       "name": "@bluedot/eslint-plugin-bluedot-custom",
       "version": "0.0.0",
-      "dev": true
+      "extraneous": true
     },
     "libraries/eslint-plugin-custom": {
       "name": "@bluedot/eslint-plugin-custom",
@@ -4321,10 +4321,6 @@
     },
     "node_modules/@bluedot/eslint-config": {
       "resolved": "libraries/eslint-config",
-      "link": true
-    },
-    "node_modules/@bluedot/eslint-plugin-bluedot-custom": {
-      "resolved": "libraries/eslint-plugin-bluedot-custom",
       "link": true
     },
     "node_modules/@bluedot/eslint-plugin-custom": {


### PR DESCRIPTION
# Summary

devex: Fix package.json for eslint-config linking to eslint-plugin-custom

This was causing mysterious npm errors when installing packages, but only sometimes, such as:

```
npm error Cannot read properties of undefined (reading 'extraneous')
```

The package name for our custom eslint plugin was wrong in eslint-config's package.json. I figured this out by editing the NPM source code to print out more details of the error, and it was consistently when resolving the @bluedot/eslint-config package. I'm fairly certain this was the cause of the problem, but I can't be certain - we'll see if the bug reappears.