### PR TITLE
Introduce Courses and Future of AI skeleton pages

### DIFF
--- a/apps/website-25/src/lib/routes.ts
+++ b/apps/website-25/src/lib/routes.ts
@@ -29,10 +29,24 @@ const contact: BluedotRoute = {
   parentPages: [home],
 };
 
+const courses: BluedotRoute = {
+  title: 'Courses',
+  url: '/courses',
+  parentPages: [home],
+};
+
+const coursesFutureOfAi: BluedotRoute = {
+  title: 'Future of AI',
+  url: '/courses/future-of-ai',
+  parentPages: [courses],
+};
+
 export const ROUTES = {
   home,
   about,
   privacyPolicy,
   joinUs,
   contact,
+  courses,
+  coursesFutureOfAi,
 } as const;

--- a/apps/website-25/src/lib/routes.ts
+++ b/apps/website-25/src/lib/routes.ts
@@ -38,7 +38,13 @@ const courses: BluedotRoute = {
 const coursesFutureOfAi: BluedotRoute = {
   title: 'Future of AI',
   url: '/courses/future-of-ai',
-  parentPages: [courses],
+  parentPages: [home, courses],
+};
+
+const coursesFutureOfAiUnit1: BluedotRoute = {
+  title: 'Unit 1',
+  url: '/courses/future-of-ai/units/1',
+  parentPages: [home, courses, coursesFutureOfAi],
 };
 
 export const ROUTES = {
@@ -49,4 +55,5 @@ export const ROUTES = {
   contact,
   courses,
   coursesFutureOfAi,
+  coursesFutureOfAiUnit1,
 } as const;

--- a/apps/website-25/src/pages/courses.tsx
+++ b/apps/website-25/src/pages/courses.tsx
@@ -1,0 +1,41 @@
+import {
+  HeroSection,
+  HeroH1,
+  Breadcrumbs,
+  CourseCard,
+  Section,
+} from '@bluedot/ui';
+import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
+import Head from 'next/head';
+import { ROUTES } from '../lib/routes';
+
+const CURRENT_ROUTE = ROUTES.courses;
+
+const CoursePage = () => {
+  return (
+    <div>
+      <Head>
+        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
+      </Head>
+      <HeroSection>
+        <HeroMiniTitle>{CURRENT_ROUTE.title}</HeroMiniTitle>
+        <HeroH1>The expertise you need to shape safe AI</HeroH1>
+      </HeroSection>
+      <Breadcrumbs route={CURRENT_ROUTE} />
+      <Section>
+        <CourseCard
+          title="Future of AI"
+          description="No jargon, no coding, no pre-requisites – just bring your curiosity for how AI will reshape your world."
+          imageSrc="/images/courses/future-of-ai.png"
+          href={ROUTES.coursesFutureOfAi.url}
+          courseType="Self-paced"
+          courseLength="2 hours"
+          cardType="Featured"
+        />
+      </Section>
+    </div>
+  );
+};
+
+export default CoursePage;

--- a/apps/website-25/src/pages/courses.tsx
+++ b/apps/website-25/src/pages/courses.tsx
@@ -4,6 +4,7 @@ import {
   Breadcrumbs,
   CourseCard,
   Section,
+  constants,
 } from '@bluedot/ui';
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import Head from 'next/head';
@@ -15,24 +16,27 @@ const CoursePage = () => {
   return (
     <div>
       <Head>
-        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
-        <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
+        <title>AI safety courses with certificates</title>
+        <meta name="description" content="Courses that support you to develop the knowledge, community and network needed to pursue a high-impact career." />
       </Head>
       <HeroSection>
         <HeroMiniTitle>{CURRENT_ROUTE.title}</HeroMiniTitle>
         <HeroH1>The expertise you need to shape safe AI</HeroH1>
       </HeroSection>
       <Breadcrumbs route={CURRENT_ROUTE} />
-      <Section>
-        <CourseCard
-          title="Future of AI"
-          description="No jargon, no coding, no pre-requisites – just bring your curiosity for how AI will reshape your world."
-          imageSrc="/images/courses/future-of-ai.png"
-          href={ROUTES.coursesFutureOfAi.url}
-          courseType="Self-paced"
-          courseLength="2 hours"
-          cardType="Featured"
-        />
+      <Section
+        className="course-serp"
+      >
+        <div className="course-serp__content flex flex-row flex-wrap gap-space-between items-stretch">
+          {constants.COURSES.map((course) => (
+            <div className="max-w-[350px]">
+              <CourseCard
+                key={course.title}
+                {...course}
+              />
+            </div>
+          ))}
+        </div>
       </Section>
     </div>
   );

--- a/apps/website-25/src/pages/courses/future-of-ai.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai.tsx
@@ -1,0 +1,34 @@
+import {
+  HeroSection,
+  HeroCTAContainer,
+  HeroH1,
+  CTALinkOrButton,
+  Breadcrumbs,
+} from '@bluedot/ui';
+import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
+import Head from 'next/head';
+import { ROUTES } from '../../lib/routes';
+
+const CURRENT_ROUTE = ROUTES.coursesFutureOfAi;
+
+const FutureOfAiCoursePage = () => {
+  return (
+    <div>
+      <Head>
+        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
+      </Head>
+      <HeroSection>
+        <HeroMiniTitle>{CURRENT_ROUTE.title}</HeroMiniTitle>
+        <HeroH1>No jargon, no coding, no pre-requisites – just bring your curiosity for how AI will reshape your world.</HeroH1>
+        <HeroCTAContainer>
+          <CTALinkOrButton url={ROUTES.joinUs.url}>Start learning for free</CTALinkOrButton>
+        </HeroCTAContainer>
+      </HeroSection>
+      <Breadcrumbs route={CURRENT_ROUTE} />
+
+    </div>
+  );
+};
+
+export default FutureOfAiCoursePage;

--- a/apps/website-25/src/pages/courses/future-of-ai/index.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai/index.tsx
@@ -2,12 +2,12 @@ import {
   HeroSection,
   HeroCTAContainer,
   HeroH1,
+  HeroH2,
   CTALinkOrButton,
   Breadcrumbs,
 } from '@bluedot/ui';
-import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import Head from 'next/head';
-import { ROUTES } from '../../lib/routes';
+import { ROUTES } from '../../../lib/routes';
 
 const CURRENT_ROUTE = ROUTES.coursesFutureOfAi;
 
@@ -16,11 +16,11 @@ const FutureOfAiCoursePage = () => {
     <div>
       <Head>
         <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
-        <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
+        <meta name="description" content="Future-proof your career" />
       </Head>
       <HeroSection>
-        <HeroMiniTitle>{CURRENT_ROUTE.title}</HeroMiniTitle>
-        <HeroH1>No jargon, no coding, no pre-requisites – just bring your curiosity for how AI will reshape your world.</HeroH1>
+        <HeroH1>Future of AI</HeroH1>
+        <HeroH2>No jargon, no coding, no pre-requisites – just bring your curiosity for how AI will reshape your world.</HeroH2>
         <HeroCTAContainer>
           <CTALinkOrButton url={ROUTES.joinUs.url}>Start learning for free</CTALinkOrButton>
         </HeroCTAContainer>

--- a/apps/website-25/src/pages/courses/future-of-ai/units/1.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai/units/1.tsx
@@ -1,0 +1,29 @@
+import {
+  HeroSection,
+  HeroH1,
+  Breadcrumbs,
+} from '@bluedot/ui';
+import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
+import Head from 'next/head';
+import { ROUTES } from '../../../../lib/routes';
+
+const CURRENT_ROUTE = ROUTES.coursesFutureOfAiUnit1;
+
+const FutureOfAiCourseUnit1Page = () => {
+  return (
+    <div>
+      <Head>
+        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
+      </Head>
+      <HeroSection>
+        <HeroMiniTitle>Future of AI</HeroMiniTitle>
+        <HeroH1>Beyond chatbots: the expanding frontier of AI capabilities</HeroH1>
+      </HeroSection>
+      <Breadcrumbs route={CURRENT_ROUTE} />
+
+    </div>
+  );
+};
+
+export default FutureOfAiCourseUnit1Page;


### PR DESCRIPTION
# Summary

Introduce Courses and Future of AI skeleton pages

## Issue
#584 

## Description

Add /courses and /courses/future-of-ai (These should cause no namespacing issues as http://bluedot.org/courses and https://bluedot.org/courses/future-of-ai/ do not currently exist). Include Unit 1 as example Unit course under /courses/future-of-ai/unit/1

This follows the site architecture and meta tag recommendations from our [SEO Audit](https://docs.google.com/document/d/1zswDry2NWi0qmSY_8SBj3hTClL6En0g27D_WLibAIzE/edit?tab=t.0#bookmark=kix.s5b55k1xbk3t)

## Screenshot

### Courses (search engine results page, SERP)
<img width="1512" alt="Screenshot 2025-04-02 at 10 35 58" src="https://github.com/user-attachments/assets/f9d1decf-80bc-4a67-b13c-13c9d7789d82" />
<img width="373" alt="Screenshot 2025-04-02 at 10 36 06" src="https://github.com/user-attachments/assets/cd08db7c-76bc-4378-8da1-da0a967540eb" />

### Future of AI
<img width="1537" alt="Screenshot 2025-04-02 at 12 46 18" src="https://github.com/user-attachments/assets/80ff521f-6042-405a-9bdc-dd3a34b70ede" />
<img width="1510" alt="Screenshot 2025-04-02 at 12 46 12" src="https://github.com/user-attachments/assets/8e44d330-f944-4b3c-91a3-0e6102061c8c" />


## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```