### PR TITLE
Add SideBar component for Course Units

### DIFF
--- a/apps/website-25/src/components/courses/SideBar.test.tsx
+++ b/apps/website-25/src/components/courses/SideBar.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { COURSE_UNITS } from '@bluedot/ui/src/constants';
+import SideBar from './SideBar';
+
+describe('SideBar', () => {
+  test('renders default as expected', () => {
+    const { container } = render(<SideBar units={COURSE_UNITS} currentUnit={COURSE_UNITS[0]} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/apps/website-25/src/components/courses/SideBar.tsx
+++ b/apps/website-25/src/components/courses/SideBar.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import clsx from 'clsx';
+import { CourseUnit } from '@bluedot/ui/src/constants';
+
+type SideBarProps = {
+  // Required
+  units: CourseUnit[];
+  currentUnit: CourseUnit;
+};
+
+export const SideBar: React.FC<SideBarProps> = ({
+  units,
+  currentUnit,
+}) => {
+  return (
+    <div className="sidebar w-full md:w-[332px] flex flex-col">
+      <div className="sidebar__content flex flex-col gap-6">
+        {units.map((unit) => (
+          <div
+            className="sidebar__unit border border-color-divider rounded-radius-md p-4 flex flex-col gap-2"
+          >
+            <div className="sidebar__unit-item flex flex-col gap-2">
+              <p className="sidebar__title uppercase text-size-xs font-bold">{unit.title}</p>
+              <a href={unit.href} className="sidebar__description subtitle-sm">{unit.description}</a>
+            </div>
+            {currentUnit.title === unit.title && unit.chapters && (
+              <div className="sidebar__chapters flex flex-col gap-4 border-t-2 border-color-primary pt-4">
+                {unit.chapters.map((chapter) => (
+                  <div className="sidebar__chapter">
+                    <p className="sidebar__chapter-detail text-size-xs">
+                      <span className="sidebar__chapter-type font-bold text-color-secondary-text">{chapter.type}:</span> <span className="sidebar__chapter-title">{chapter.title}</span>
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SideBar;

--- a/apps/website-25/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -1,0 +1,194 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SideBar > renders default as expected 1`] = `
+<div>
+  <div
+    class="sidebar w-full md:w-[332px] flex flex-col"
+  >
+    <div
+      class="sidebar__content flex flex-col gap-6"
+    >
+      <div
+        class="sidebar__unit border border-color-divider rounded-radius-md p-4 flex flex-col gap-2"
+      >
+        <div
+          class="sidebar__unit-item flex flex-col gap-2"
+        >
+          <p
+            class="sidebar__title uppercase text-size-xs font-bold"
+          >
+            Unit 1
+          </p>
+          <a
+            class="sidebar__description subtitle-sm"
+            href="https://course.bluedot.org/future-of-ai/units/1"
+          >
+            Beyond chatbots: the expanding frontier of AI capabilities
+          </a>
+        </div>
+        <div
+          class="sidebar__chapters flex flex-col gap-4 border-t-2 border-color-primary pt-4"
+        >
+          <div
+            class="sidebar__chapter"
+          >
+            <p
+              class="sidebar__chapter-detail text-size-xs"
+            >
+              <span
+                class="sidebar__chapter-type font-bold text-color-secondary-text"
+              >
+                Reading
+                :
+              </span>
+               
+              <span
+                class="sidebar__chapter-title"
+              >
+                How current AI systems work
+              </span>
+            </p>
+          </div>
+          <div
+            class="sidebar__chapter"
+          >
+            <p
+              class="sidebar__chapter-detail text-size-xs"
+            >
+              <span
+                class="sidebar__chapter-type font-bold text-color-secondary-text"
+              >
+                Demo
+                :
+              </span>
+               
+              <span
+                class="sidebar__chapter-title"
+              >
+                They can build things
+              </span>
+            </p>
+          </div>
+          <div
+            class="sidebar__chapter"
+          >
+            <p
+              class="sidebar__chapter-detail text-size-xs"
+            >
+              <span
+                class="sidebar__chapter-type font-bold text-color-secondary-text"
+              >
+                Reading
+                :
+              </span>
+               
+              <span
+                class="sidebar__chapter-title"
+              >
+                The speed of progress
+              </span>
+            </p>
+          </div>
+          <div
+            class="sidebar__chapter"
+          >
+            <p
+              class="sidebar__chapter-detail text-size-xs"
+            >
+              <span
+                class="sidebar__chapter-type font-bold text-color-secondary-text"
+              >
+                Reading
+                :
+              </span>
+               
+              <span
+                class="sidebar__chapter-title"
+              >
+                From tools to agents
+              </span>
+            </p>
+          </div>
+          <div
+            class="sidebar__chapter"
+          >
+            <p
+              class="sidebar__chapter-detail text-size-xs"
+            >
+              <span
+                class="sidebar__chapter-type font-bold text-color-secondary-text"
+              >
+                Exercise
+                :
+              </span>
+               
+              <span
+                class="sidebar__chapter-title"
+              >
+                5 years ago, 5 years ahead
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sidebar__unit border border-color-divider rounded-radius-md p-4 flex flex-col gap-2"
+      >
+        <div
+          class="sidebar__unit-item flex flex-col gap-2"
+        >
+          <p
+            class="sidebar__title uppercase text-size-xs font-bold"
+          >
+            Unit 2
+          </p>
+          <a
+            class="sidebar__description subtitle-sm"
+            href="https://course.bluedot.org/future-of-ai/units/2"
+          >
+            Artificial general intelligence: on the horizon?
+          </a>
+        </div>
+      </div>
+      <div
+        class="sidebar__unit border border-color-divider rounded-radius-md p-4 flex flex-col gap-2"
+      >
+        <div
+          class="sidebar__unit-item flex flex-col gap-2"
+        >
+          <p
+            class="sidebar__title uppercase text-size-xs font-bold"
+          >
+            Unit 3
+          </p>
+          <a
+            class="sidebar__description subtitle-sm"
+            href="https://course.bluedot.org/future-of-ai/units/3"
+          >
+            AGI will drastically change how we live
+          </a>
+        </div>
+      </div>
+      <div
+        class="sidebar__unit border border-color-divider rounded-radius-md p-4 flex flex-col gap-2"
+      >
+        <div
+          class="sidebar__unit-item flex flex-col gap-2"
+        >
+          <p
+            class="sidebar__title uppercase text-size-xs font-bold"
+          >
+            Unit 4
+          </p>
+          <a
+            class="sidebar__description subtitle-sm"
+            href="https://course.bluedot.org/future-of-ai/units/4"
+          >
+            What can be done?
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/website-25/src/pages/courses/future-of-ai/units/1.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai/units/1.tsx
@@ -2,10 +2,14 @@ import {
   HeroSection,
   HeroH1,
   Breadcrumbs,
+  Section,
 } from '@bluedot/ui';
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import Head from 'next/head';
+import { COURSE_UNITS } from '@bluedot/ui/src/constants';
+import { isMobile } from 'react-device-detect';
 import { ROUTES } from '../../../../lib/routes';
+import SideBar from '../../../../components/courses/SideBar';
 
 const CURRENT_ROUTE = ROUTES.coursesFutureOfAiUnit1;
 
@@ -13,15 +17,43 @@ const FutureOfAiCourseUnit1Page = () => {
   return (
     <div>
       <Head>
-        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
-        <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
+        <title>Future of AI: Unit 1</title>
+        <meta name="description" content="Beyond chatbots: the expanding frontier of AI capabilities" />
       </Head>
       <HeroSection>
         <HeroMiniTitle>Future of AI</HeroMiniTitle>
         <HeroH1>Beyond chatbots: the expanding frontier of AI capabilities</HeroH1>
       </HeroSection>
       <Breadcrumbs route={CURRENT_ROUTE} />
-
+      <Section>
+        <div className="unit flex flex-col md:flex-row gap-12">
+          {!isMobile && (
+            <SideBar units={COURSE_UNITS} currentUnit={COURSE_UNITS[0]} />
+          )}
+          <div className="unit__content flex flex-col flex-1 gap-4">
+            <div className="unit__content-block flex flex-col gap-2">
+              <p>Just a few years ago, AI models struggled to form coherent sentences. Today, millions rely on tools like ChatGPT daily for help with work, studying, and creative projects—and these systems now extend far beyond simple chat. AI can create art, write complex code, and even guide robots through real-world tasks.</p>
+              <p>This unit explores how AI is evolving from helpful ‘tools’ into capable autonomous ‘agents’ capable of independently setting goals, making decisions, and acting on them.</p>
+            </div>
+            <div className="unit__content-block flex flex-col gap-2">
+              <h3>How current AI systems work</h3>
+              <p>Models like ChatGPT operate by predicting the next word in a sequence:</p>
+              <blockquote>
+                <p><strong>Input:</strong> "The cat sat on the"</p>
+                <p><strong>Prediction:</strong> "mat"</p>
+              </blockquote>
+              <p>Repeatedly doing this allows you to generate long paragraphs:</p>
+              <blockquote>
+                <p><strong>Input:</strong> "The cat sat on the mat"</p>
+                <p><strong>Prediction:</strong> ", watching"</p>
+                <p>[… many more times]</p>
+                <p><strong>Repeated predictions:</strong> “, watching the world outside with lazy indifference. A faint rustling in the bushes caught its attention, ears twitching, but it made no move to investigate. Instead, it stretched luxuriously, kneading the soft fabric beneath its paws, and let out a slow, satisfied purr.”</p>
+              </blockquote>
+              <p>Predicting the next word produces astonishingly sophisticated behaviour. Models built on this basic mechanism can write complex code, solve maths problems, and create original stories - a leap so dramatic it has surprised even the experts who built them.</p>
+            </div>
+          </div>
+        </div>
+      </Section>
     </div>
   );
 };

--- a/libraries/ui/src/constants.ts
+++ b/libraries/ui/src/constants.ts
@@ -9,6 +9,18 @@ export type Course = {
   isFeatured?: boolean;
 };
 
+export type CourseUnit = {
+  title: string;
+  description: string;
+  href: string;
+  chapters?: CourseChapter[];
+};
+
+export type CourseChapter = {
+  type: 'Reading' | 'Demo' | 'Quiz' | 'Exercise';
+  title: string;
+};
+
 export type CourseType = 'Crash course' | 'Self-paced' | 'In-depth course';
 
 export const COURSES: Course[] = [
@@ -45,5 +57,50 @@ export const COURSES: Course[] = [
     courseLength: '12 weeks',
     imageSrc: '/images/courses/gov.jpg',
     href: 'https://aisafetyfundamentals.com/governance/',
+  },
+] as const;
+
+export const COURSE_UNITS: CourseUnit[] = [
+  {
+    title: 'Unit 1',
+    description: 'Beyond chatbots: the expanding frontier of AI capabilities',
+    href: 'https://course.bluedot.org/future-of-ai/units/1',
+    chapters: [
+      {
+        type: 'Reading',
+        title: 'How current AI systems work',
+      },
+      {
+        type: 'Demo',
+        title: 'They can build things',
+      },
+      {
+        type: 'Reading',
+        title: 'The speed of progress',
+      },
+      {
+        type: 'Reading',
+        title: 'From tools to agents',
+      },
+      {
+        type: 'Exercise',
+        title: '5 years ago, 5 years ahead',
+      },
+    ],
+  },
+  {
+    title: 'Unit 2',
+    description: 'Artificial general intelligence: on the horizon?',
+    href: 'https://course.bluedot.org/future-of-ai/units/2',
+  },
+  {
+    title: 'Unit 3',
+    description: 'AGI will drastically change how we live',
+    href: 'https://course.bluedot.org/future-of-ai/units/3',
+  },
+  {
+    title: 'Unit 4',
+    description: 'What can be done?',
+    href: 'https://course.bluedot.org/future-of-ai/units/4',
   },
 ] as const;


### PR DESCRIPTION
# Summary

Add SideBar component for Course Units

## Description

- Create a SideBar component for rending Course Units and chapters
- Included temporary static COURSE_UNITS
- Added static content to unit page for demo purposes
- No mobile design for now

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

<img width="1466" alt="image" src="https://github.com/user-attachments/assets/d32c40b5-06ff-4931-bd58-246dabe56126" />

<img width="409" alt="Screenshot 2025-04-02 at 14 29 21" src="https://github.com/user-attachments/assets/8c015920-96cf-48e8-997e-ebb7486e6792" />

## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```