### PR TITLE
Sticky breadcrumbs on Unit pages

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/404.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/404.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Error404Page > should render correctly 1`] = `
       </div>
     </div>
     <div
-      class="breadcrumbs border-b border-color-divider w-full py-space-between"
+      class="breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between"
     >
       <nav
         aria-label="Breadcrumbs"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`AboutPage > should render correctly 1`] = `
       </div>
     </div>
     <div
-      class="breadcrumbs border-b border-color-divider w-full py-space-between"
+      class="breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between"
     >
       <nav
         aria-label="Breadcrumbs"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
       </div>
     </div>
     <div
-      class="breadcrumbs border-b border-color-divider w-full py-space-between"
+      class="breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between"
     >
       <nav
         aria-label="Breadcrumbs"

--- a/apps/website-25/src/components/courses/UnitLayout.tsx
+++ b/apps/website-25/src/components/courses/UnitLayout.tsx
@@ -44,7 +44,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
         <HeroMiniTitle>{course}</HeroMiniTitle>
         <HeroH1>{title}</HeroH1>
       </HeroSection>
-      <Breadcrumbs className="unit__breadcrumbs" route={route} />
+      <Breadcrumbs className="unit__breadcrumbs sticky top-[72px] md:top-[100px] z-10" route={route} />
       <Section className="unit__main">
         <div className="unit__content-container flex flex-col md:flex-row gap-12">
           {!isMobile && (

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`UnitLayout > renders default as expected 1`] = `
       </div>
     </div>
     <div
-      class="breadcrumbs border-b border-color-divider w-full py-space-between unit__breadcrumbs"
+      class="breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between unit__breadcrumbs sticky top-[72px] md:top-[100px] z-10"
     >
       <nav
         aria-label="Breadcrumbs"

--- a/apps/website-25/src/pages/courses/future-of-ai/units/1.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai/units/1.tsx
@@ -33,6 +33,26 @@ const FutureOfAiCourseUnit1Page = () => {
         </blockquote>
         <p>Predicting the next word produces astonishingly sophisticated behaviour. Models built on this basic mechanism can write complex code, solve maths problems, and create original stories - a leap so dramatic it has surprised even the experts who built them.</p>
       </div>
+      <div className="unit__content-block flex flex-col gap-2">
+        <p>Just a few years ago, AI models struggled to form coherent sentences. Today, millions rely on tools like ChatGPT daily for help with work, studying, and creative projects—and these systems now extend far beyond simple chat. AI can create art, write complex code, and even guide robots through real-world tasks.</p>
+        <p>This unit explores how AI is evolving from helpful ‘tools’ into capable autonomous ‘agents’ capable of independently setting goals, making decisions, and acting on them.</p>
+      </div>
+      <div className="unit__content-block flex flex-col gap-2">
+        <h3>How current AI systems work</h3>
+        <p>Models like ChatGPT operate by predicting the next word in a sequence:</p>
+        <blockquote>
+          <p><strong>Input:</strong> "The cat sat on the"</p>
+          <p><strong>Prediction:</strong> "mat"</p>
+        </blockquote>
+        <p>Repeatedly doing this allows you to generate long paragraphs:</p>
+        <blockquote>
+          <p><strong>Input:</strong> "The cat sat on the mat"</p>
+          <p><strong>Prediction:</strong> ", watching"</p>
+          <p>[… many more times]</p>
+          <p><strong>Repeated predictions:</strong> “, watching the world outside with lazy indifference. A faint rustling in the bushes caught its attention, ears twitching, but it made no move to investigate. Instead, it stretched luxuriously, kneading the soft fabric beneath its paws, and let out a slow, satisfied purr.”</p>
+        </blockquote>
+        <p>Predicting the next word produces astonishingly sophisticated behaviour. Models built on this basic mechanism can write complex code, solve maths problems, and create original stories - a leap so dramatic it has surprised even the experts who built them.</p>
+      </div>
     </UnitLayout>
   );
 };

--- a/libraries/ui/src/Breadcrumbs.tsx
+++ b/libraries/ui/src/Breadcrumbs.tsx
@@ -26,7 +26,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ route, className }) =>
   const items = [...(route.parentPages ?? []), route];
 
   return (
-    <div className={clsx('breadcrumbs border-b border-color-divider w-full py-space-between', className)}>
+    <div className={clsx('breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between', className)}>
       <nav
         className="breadcrumbs__nav section-base"
         aria-label="Breadcrumbs"

--- a/libraries/ui/src/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Breadcrumbs > renders all urls and titles in the document 1`] = `
 <div>
   <div
-    class="breadcrumbs border-b border-color-divider w-full py-space-between"
+    class="breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between"
   >
     <nav
       aria-label="Breadcrumbs"


### PR DESCRIPTION
# Summary

Sticky breadcrumbs on Unit pages

Fixes #595 

## Description

- MVP Sticky breadcrumbs on course content scroll
- Ideally, both Breadcrumbs and SideBar should stay sticky while course content is scrolled. See references: Ex: https://www.acnestudios.com/uk/en/layered-print-t-shirt-dark-mauve/AL0454-CJD.html?g=man , https://jsfiddle.net/dibdab/1xsv8v35/3/
- Timeboxing for efficiency 

## Screenshot

https://github.com/user-attachments/assets/4c70d1df-2a38-472e-adea-e6ad27f827d2

https://github.com/user-attachments/assets/90ec96be-8b9a-4a6e-9a64-ab58e7e001e8

### Other pages unaffected

<img width="1497" alt="Screenshot 2025-04-02 at 16 47 33" src="https://github.com/user-attachments/assets/41c3949a-893c-435a-be21-1de5dc7ff04d" />

## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```