### PR TITLE
Handle markdown text in UnitLayout

### DIFF
--- a/apps/website-25/package.json
+++ b/apps/website-25/package.json
@@ -37,6 +37,7 @@
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",
+    "react-markdown": "^10.1.0",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/apps/website-25/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website-25/src/components/courses/UnitLayout.test.tsx
@@ -13,9 +13,8 @@ describe('UnitLayout', () => {
         course="My Test Course"
         unit={1}
         route={{ title: 'Unit 1', url: '/course/my-test-course/unit/1' } as BluedotRoute}
-      >
-        <div>Hello</div>
-      </UnitLayout>,
+        markdown="## Hello World!"
+      />,
     );
     expect(container).toMatchSnapshot();
   });
@@ -28,9 +27,8 @@ describe('UnitLayout', () => {
         course="My Test Course"
         unit={COURSE_UNITS.length}
         route={{ title: 'Last Unit', url: '/course/my-test-course/unit/1' } as BluedotRoute}
-      >
-        <div>Hello</div>
-      </UnitLayout>,
+        markdown="## Hello World!"
+      />,
     );
     expect(container.querySelector('.unit__cta-link')).toMatchSnapshot();
   });

--- a/apps/website-25/src/components/courses/UnitLayout.tsx
+++ b/apps/website-25/src/components/courses/UnitLayout.tsx
@@ -11,6 +11,7 @@ import {
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import Head from 'next/head';
 import { CourseUnit } from '@bluedot/ui/src/constants';
+import ReactMarkdown from 'react-markdown';
 import SideBar from './SideBar';
 
 type UnitLayoutProps = {
@@ -20,7 +21,7 @@ type UnitLayoutProps = {
   title: string;
   route: BluedotRoute;
   units: CourseUnit[];
-  children: React.ReactNode;
+  markdown: string;
 };
 
 const UnitLayout: React.FC<UnitLayoutProps> = ({
@@ -29,7 +30,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
   title,
   route,
   units,
-  children,
+  markdown,
 }) => {
   const unitIndex = unit - 1;
   const nextUnitIndex = unitIndex + 1;
@@ -51,7 +52,10 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
             <SideBar units={units} currentUnit={units[unitIndex]!} />
           )}
           <div className="unit__content flex flex-col flex-1 gap-4">
-            {children}
+            <ReactMarkdown>
+              {markdown}
+            </ReactMarkdown>
+
             {nextUnitIndex < units.length ? (
               <CTALinkOrButton className="unit__cta-link self-end mt-6" url={units[nextUnitIndex]!.href}>
                 Next unit

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -244,9 +244,9 @@ exports[`UnitLayout > renders default as expected 1`] = `
           <div
             class="unit__content flex flex-col flex-1 gap-4"
           >
-            <div>
-              Hello
-            </div>
+            <h2>
+              Hello World!
+            </h2>
             <a
               class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link self-end mt-6"
               data-testid="cta-link"

--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -39,7 +39,10 @@
     @apply text-color-text font-sans text-size-sm font-normal;
   }
   blockquote {
-    @apply text-color-text font-sans text-size-sm font-normal font-[650];
+    @apply border-l-4 border-bluedot-dark pl-4;
+  }
+  blockquote p {
+    @apply text-color-text font-sans text-size-md font-normal font-[650] mb-4 last:mb-0;
   }
   ul {
     @apply list-inside list-disc;

--- a/apps/website-25/src/pages/courses/future-of-ai/units/1.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai/units/1.tsx
@@ -12,48 +12,8 @@ const FutureOfAiCourseUnit1Page = () => {
       title="Beyond chatbots: the expanding frontier of AI capabilities"
       route={CURRENT_ROUTE}
       units={COURSE_UNITS}
-    >
-      <div className="unit__content-block flex flex-col gap-2">
-        <p>Just a few years ago, AI models struggled to form coherent sentences. Today, millions rely on tools like ChatGPT daily for help with work, studying, and creative projects—and these systems now extend far beyond simple chat. AI can create art, write complex code, and even guide robots through real-world tasks.</p>
-        <p>This unit explores how AI is evolving from helpful ‘tools’ into capable autonomous ‘agents’ capable of independently setting goals, making decisions, and acting on them.</p>
-      </div>
-      <div className="unit__content-block flex flex-col gap-2">
-        <h3>How current AI systems work</h3>
-        <p>Models like ChatGPT operate by predicting the next word in a sequence:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the"</p>
-          <p><strong>Prediction:</strong> "mat"</p>
-        </blockquote>
-        <p>Repeatedly doing this allows you to generate long paragraphs:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the mat"</p>
-          <p><strong>Prediction:</strong> ", watching"</p>
-          <p>[… many more times]</p>
-          <p><strong>Repeated predictions:</strong> “, watching the world outside with lazy indifference. A faint rustling in the bushes caught its attention, ears twitching, but it made no move to investigate. Instead, it stretched luxuriously, kneading the soft fabric beneath its paws, and let out a slow, satisfied purr.”</p>
-        </blockquote>
-        <p>Predicting the next word produces astonishingly sophisticated behaviour. Models built on this basic mechanism can write complex code, solve maths problems, and create original stories - a leap so dramatic it has surprised even the experts who built them.</p>
-      </div>
-      <div className="unit__content-block flex flex-col gap-2">
-        <p>Just a few years ago, AI models struggled to form coherent sentences. Today, millions rely on tools like ChatGPT daily for help with work, studying, and creative projects—and these systems now extend far beyond simple chat. AI can create art, write complex code, and even guide robots through real-world tasks.</p>
-        <p>This unit explores how AI is evolving from helpful ‘tools’ into capable autonomous ‘agents’ capable of independently setting goals, making decisions, and acting on them.</p>
-      </div>
-      <div className="unit__content-block flex flex-col gap-2">
-        <h3>How current AI systems work</h3>
-        <p>Models like ChatGPT operate by predicting the next word in a sequence:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the"</p>
-          <p><strong>Prediction:</strong> "mat"</p>
-        </blockquote>
-        <p>Repeatedly doing this allows you to generate long paragraphs:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the mat"</p>
-          <p><strong>Prediction:</strong> ", watching"</p>
-          <p>[… many more times]</p>
-          <p><strong>Repeated predictions:</strong> “, watching the world outside with lazy indifference. A faint rustling in the bushes caught its attention, ears twitching, but it made no move to investigate. Instead, it stretched luxuriously, kneading the soft fabric beneath its paws, and let out a slow, satisfied purr.”</p>
-        </blockquote>
-        <p>Predicting the next word produces astonishingly sophisticated behaviour. Models built on this basic mechanism can write complex code, solve maths problems, and create original stories - a leap so dramatic it has surprised even the experts who built them.</p>
-      </div>
-    </UnitLayout>
+      markdown={'### How current AI systems work\n\nModels like ChatGPT operate by predicting the next word in a sequence:\n\n> **Input:** "The cat sat on the"\n>\n> **Prediction:** "mat"'}
+    />
   );
 };
 

--- a/apps/website-25/src/pages/courses/future-of-ai/units/2.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai/units/2.tsx
@@ -12,28 +12,8 @@ const FutureOfAiCourseUnit2Page = () => {
       title="Artificial general intelligence: on the horizon?"
       route={CURRENT_ROUTE}
       units={COURSE_UNITS}
-    >
-      <div className="unit__content-block flex flex-col gap-2">
-        <p>Just a few years ago, AI models struggled to form coherent sentences. Today, millions rely on tools like ChatGPT daily for help with work, studying, and creative projects—and these systems now extend far beyond simple chat. AI can create art, write complex code, and even guide robots through real-world tasks.</p>
-        <p>This unit explores how AI is evolving from helpful ‘tools’ into capable autonomous ‘agents’ capable of independently setting goals, making decisions, and acting on them.</p>
-      </div>
-      <div className="unit__content-block flex flex-col gap-2">
-        <h3>How current AI systems work</h3>
-        <p>Models like ChatGPT operate by predicting the next word in a sequence:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the"</p>
-          <p><strong>Prediction:</strong> "mat"</p>
-        </blockquote>
-        <p>Repeatedly doing this allows you to generate long paragraphs:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the mat"</p>
-          <p><strong>Prediction:</strong> ", watching"</p>
-          <p>[… many more times]</p>
-          <p><strong>Repeated predictions:</strong> “, watching the world outside with lazy indifference. A faint rustling in the bushes caught its attention, ears twitching, but it made no move to investigate. Instead, it stretched luxuriously, kneading the soft fabric beneath its paws, and let out a slow, satisfied purr.”</p>
-        </blockquote>
-        <p>Predicting the next word produces astonishingly sophisticated behaviour. Models built on this basic mechanism can write complex code, solve maths problems, and create original stories - a leap so dramatic it has surprised even the experts who built them.</p>
-      </div>
-    </UnitLayout>
+      markdown={'### What is AGI?\n\nThere are many definitions of AGI, but most try to point at systems that can think and act at a level matching or exceeding human capability across a wide range of tasks.\n\nFor this course, we\'ll use the following definition:\n\n>AGI = an AI system that can do most remote jobs as well as, or better than humans.'}
+    />
   );
 };
 

--- a/apps/website-25/src/pages/courses/future-of-ai/units/3.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai/units/3.tsx
@@ -12,28 +12,8 @@ const FutureOfAiCourseUnit3Page = () => {
       title="AGI will drastically change how we live"
       route={CURRENT_ROUTE}
       units={COURSE_UNITS}
-    >
-      <div className="unit__content-block flex flex-col gap-2">
-        <p>Just a few years ago, AI models struggled to form coherent sentences. Today, millions rely on tools like ChatGPT daily for help with work, studying, and creative projects—and these systems now extend far beyond simple chat. AI can create art, write complex code, and even guide robots through real-world tasks.</p>
-        <p>This unit explores how AI is evolving from helpful ‘tools’ into capable autonomous ‘agents’ capable of independently setting goals, making decisions, and acting on them.</p>
-      </div>
-      <div className="unit__content-block flex flex-col gap-2">
-        <h3>How current AI systems work</h3>
-        <p>Models like ChatGPT operate by predicting the next word in a sequence:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the"</p>
-          <p><strong>Prediction:</strong> "mat"</p>
-        </blockquote>
-        <p>Repeatedly doing this allows you to generate long paragraphs:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the mat"</p>
-          <p><strong>Prediction:</strong> ", watching"</p>
-          <p>[… many more times]</p>
-          <p><strong>Repeated predictions:</strong> “, watching the world outside with lazy indifference. A faint rustling in the bushes caught its attention, ears twitching, but it made no move to investigate. Instead, it stretched luxuriously, kneading the soft fabric beneath its paws, and let out a slow, satisfied purr.”</p>
-        </blockquote>
-        <p>Predicting the next word produces astonishingly sophisticated behaviour. Models built on this basic mechanism can write complex code, solve maths problems, and create original stories - a leap so dramatic it has surprised even the experts who built them.</p>
-      </div>
-    </UnitLayout>
+      markdown={'**You might be living through one of the most important technological transitions in human history.** The development of AGI could transform society in profound ways.\n\nThroughout history, major technologies have changed not just what humans could do, but how we live:\n\n- Fire gave us warmth, cooking, and new tools, while also enabling violent conflict.'}
+    />
   );
 };
 

--- a/apps/website-25/src/pages/courses/future-of-ai/units/4.tsx
+++ b/apps/website-25/src/pages/courses/future-of-ai/units/4.tsx
@@ -12,28 +12,8 @@ const FutureOfAiCourseUnit4Page = () => {
       title="What can be done to prepare for AGI?"
       route={CURRENT_ROUTE}
       units={COURSE_UNITS}
-    >
-      <div className="unit__content-block flex flex-col gap-2">
-        <p>Just a few years ago, AI models struggled to form coherent sentences. Today, millions rely on tools like ChatGPT daily for help with work, studying, and creative projects—and these systems now extend far beyond simple chat. AI can create art, write complex code, and even guide robots through real-world tasks.</p>
-        <p>This unit explores how AI is evolving from helpful ‘tools’ into capable autonomous ‘agents’ capable of independently setting goals, making decisions, and acting on them.</p>
-      </div>
-      <div className="unit__content-block flex flex-col gap-2">
-        <h3>How current AI systems work</h3>
-        <p>Models like ChatGPT operate by predicting the next word in a sequence:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the"</p>
-          <p><strong>Prediction:</strong> "mat"</p>
-        </blockquote>
-        <p>Repeatedly doing this allows you to generate long paragraphs:</p>
-        <blockquote>
-          <p><strong>Input:</strong> "The cat sat on the mat"</p>
-          <p><strong>Prediction:</strong> ", watching"</p>
-          <p>[… many more times]</p>
-          <p><strong>Repeated predictions:</strong> “, watching the world outside with lazy indifference. A faint rustling in the bushes caught its attention, ears twitching, but it made no move to investigate. Instead, it stretched luxuriously, kneading the soft fabric beneath its paws, and let out a slow, satisfied purr.”</p>
-        </blockquote>
-        <p>Predicting the next word produces astonishingly sophisticated behaviour. Models built on this basic mechanism can write complex code, solve maths problems, and create original stories - a leap so dramatic it has surprised even the experts who built them.</p>
-      </div>
-    </UnitLayout>
+      markdown={'### The challenge we face\n\nLooking back at what we\'ve covered so far:\n\n- AI systems are becoming incredibly capable (Unit 1)\n- These systems may reach general human-level intelligence within years (Unit 2)\n - This could bring enormous benefits, but also unprecedented risks (Unit 3)\n\nThis leaves us with a critical question: **How do we navigate this transition safely?**'}
+    />
   );
 };
 


### PR DESCRIPTION
# Summary

Handle markdown text in UnitLayout

fixes #593 

## Description

- Because of the global.css base layer styling, we can consume markdown relatively simply
- Use [react-markdown](https://www.npmjs.com/package/react-markdown) package
- Some global.css styling tweaks to accomodate
- This solution keeps us in sync with global styling for a more scalable maintenance solution 

## Screenshot

<img width="1482" alt="Screenshot 2025-04-03 at 13 08 15" src="https://github.com/user-attachments/assets/a52ce36f-7509-4159-9be4-7a5c061d52ed" />
<img width="1479" alt="Screenshot 2025-04-03 at 13 08 09" src="https://github.com/user-attachments/assets/b3671b7c-6c69-4510-99fc-890a485c2bb4" />
<img width="1497" alt="Screenshot 2025-04-03 at 13 08 02" src="https://github.com/user-attachments/assets/d8ba6b22-3a6d-4b77-b8e1-97ab55934a9c" />
<img width="1504" alt="Screenshot 2025-04-03 at 13 07 57" src="https://github.com/user-attachments/assets/7813cb85-cfa0-4c4f-b818-4d6d2ade01d4" />

## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```