### PR TITLE
Stronger current unit indicator in sidebar

### DIFF
--- a/apps/website-25/src/components/courses/SideBar.tsx
+++ b/apps/website-25/src/components/courses/SideBar.tsx
@@ -11,18 +11,21 @@ const SideBar: React.FC<SideBarProps> = ({
   units,
   currentUnit,
 }) => {
+  const isCurrentUnit = (unit: CourseUnit) => {
+    return currentUnit.title === unit.title;
+  };
   return (
     <div className="sidebar w-full md:w-[332px] flex flex-col">
       <div className="sidebar__content flex flex-col gap-6">
         {units.map((unit) => (
           <div
-            className="sidebar__unit border border-color-divider rounded-radius-md p-4 flex flex-col gap-2"
+            className={`sidebar__unit border ${isCurrentUnit(unit) ? 'border-color-primary' : 'border-color-divider'} rounded-radius-md p-4 flex flex-col gap-2`}
           >
             <div className="sidebar__unit-item flex flex-col gap-2">
               <p className="sidebar__title uppercase text-size-xs font-bold">{unit.title}</p>
               <a href={unit.href} className="sidebar__description subtitle-sm">{unit.description}</a>
             </div>
-            {currentUnit.title === unit.title && unit.chapters && (
+            {isCurrentUnit(unit) && unit.chapters && (
               <div className="sidebar__chapters flex flex-col gap-4 border-t-2 border-color-primary pt-4">
                 {unit.chapters.map((chapter) => (
                   <div className="sidebar__chapter">

--- a/apps/website-25/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SideBar > renders default as expected 1`] = `
       class="sidebar__content flex flex-col gap-6"
     >
       <div
-        class="sidebar__unit border border-color-divider rounded-radius-md p-4 flex flex-col gap-2"
+        class="sidebar__unit border border-color-primary rounded-radius-md p-4 flex flex-col gap-2"
       >
         <div
           class="sidebar__unit-item flex flex-col gap-2"

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`UnitLayout > renders default as expected 1`] = `
               class="sidebar__content flex flex-col gap-6"
             >
               <div
-                class="sidebar__unit border border-color-divider rounded-radius-md p-4 flex flex-col gap-2"
+                class="sidebar__unit border border-color-primary rounded-radius-md p-4 flex flex-col gap-2"
               >
                 <div
                   class="sidebar__unit-item flex flex-col gap-2"


### PR DESCRIPTION
# Summary

Stronger current unit indicator in sidebar


## Screenshot

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/d9590362-2b9b-4ee1-b838-840443dd96fb" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/fedde634-6f39-48ed-8d69-a593e1b593db" />


## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```