### PR TITLE
[Incident] Revert Rive on homepage

### DIFF
--- a/apps/website-25/src/components/homepage/HomeHeroContent.tsx
+++ b/apps/website-25/src/components/homepage/HomeHeroContent.tsx
@@ -2,16 +2,12 @@ import {
   HeroH1,
   HeroH2,
 } from '@bluedot/ui';
-import Rive, { Fit, Layout } from '@rive-app/react-canvas';
 import clsx from 'clsx';
 
 const HomeHeroContent: React.FC<{ className?: string }> = ({ className }) => (
   <div className={clsx('home-hero-content pb-5 bg-bluedot-darker', className)}>
-    <div className="home-hero-content__animation-container w-[350px] max-w-[80vw] aspect-4/3 mx-auto">
-      <Rive
-        src="/animations/herobluedot_hero.riv"
-        layout={new Layout({ fit: Fit.Cover })}
-      />
+    <div className="home-hero-content__logo-container flex flex-col items-center gap-7 mb-8 slide-up-fade-in">
+      <img className="home-hero-content__logo-icon w-20" src="/images/logo/BlueDot_Impact_Icon_White.svg" alt="BlueDot Impact" />
     </div>
     <HeroH1 className="home-hero-content__heading slide-up-fade-in">
       The expertise you need to shape safe AI

--- a/apps/website-25/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
@@ -6,16 +6,13 @@ exports[`HomeHeroContent > renders as expected 1`] = `
     class="home-hero-content pb-5 bg-bluedot-darker"
   >
     <div
-      class="home-hero-content__animation-container w-[350px] max-w-[80vw] aspect-4/3 mx-auto"
+      class="home-hero-content__logo-container flex flex-col items-center gap-7 mb-8 slide-up-fade-in"
     >
-      <div
-        class=""
-        style="width: 100%; height: 100%;"
-      >
-        <canvas
-          style="vertical-align: top; width: 0px; height: 0px;"
-        />
-      </div>
+      <img
+        alt="BlueDot Impact"
+        class="home-hero-content__logo-icon w-20"
+        src="/images/logo/BlueDot_Impact_Icon_White.svg"
+      />
     </div>
     <h1
       class="hero-section__title text-on-dark text-center home-hero-content__heading slide-up-fade-in"


### PR DESCRIPTION
# Summary

[Incident] Revert Rive on homepage

## Description

- hero animation changes were introduced in https://github.com/bluedotimpact/bluedot/pull/507
- the [commit](https://github.com/bluedotimpact/bluedot/commit/6eac195316f73fa46ad4364bd755d013f4a532ba) was merged last week Mon Mar 31 15:47:53
- and [released](https://github.com/bluedotimpact/bluedot/releases/tag/website-release-v1.3.0) on friday
- weirdly, works in staging: https://website-25-staging.k8s.bluedot.org/

due to difficulty of reproducing the issue locally, opting for an immediate mitigation by manually reverting to previous static image. i am not reverting the entire PR, because there are additional changes which are needed.

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

https://github.com/user-attachments/assets/d18ff09c-6dc7-4a41-899d-1c9c1cd3c07e

https://github.com/user-attachments/assets/60837603-3ac6-4430-9593-832c38b8f6ee

## Testing
```
$ npm run test:update
```