### PR TITLE
website: Make nav sticky so we don't need to insert top margin to first component, size heros to match Figma

### DIFF
--- a/apps/website-25/src/__tests__/pages/__snapshots__/404.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/404.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Error404Page > should render correctly 1`] = `
       class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x 404-hero overflow-hidden"
     >
       <div
-        class="hero-section__content max-w-[865px] mt-[82px] py-16"
+        class="hero-section__content max-w-[865px] py-12"
       >
         <div
           class="404-hero__animation-container w-[400px] max-w-[80vw] aspect-2/1 shadow-[0_0_120px_120px_#011664]"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AboutPage > should render correctly 1`] = `
       class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
     >
       <div
-        class="hero-section__content max-w-[865px] mt-[82px] py-16"
+        class="hero-section__content max-w-[865px] py-12"
       >
         <div
           class="hero-section__mini-title text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"

--- a/apps/website-25/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website-25/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
       class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
     >
       <div
-        class="hero-section__content max-w-[865px] mt-[82px] py-16"
+        class="hero-section__content max-w-[865px] py-12"
       >
         <div
           class="hero-section__mini-title text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"

--- a/apps/website-25/src/components/Nav.tsx
+++ b/apps/website-25/src/components/Nav.tsx
@@ -172,7 +172,7 @@ export const Nav: React.FC<NavProps> = ({
   return (
     <nav
       className={clsx(
-        'nav fixed z-50 w-full container-elevated transition-all duration-300',
+        'nav sticky top-0 z-50 w-full container-elevated transition-all duration-300',
         isScrolled ? 'bg-color-canvas-dark **:text-white' : 'bg-color-canvas',
         className,
       )}

--- a/apps/website-25/src/components/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website-25/src/components/__snapshots__/Nav.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Nav > renders with courses 1`] = `
 <div>
   <nav
-    class="nav fixed z-50 w-full container-elevated transition-all duration-300 bg-color-canvas"
+    class="nav sticky top-0 z-50 w-full container-elevated transition-all duration-300 bg-color-canvas"
   >
     <div
       class="nav__container section-base"

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`UnitLayout > renders default as expected 1`] = `
       class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x unit__hero"
     >
       <div
-        class="hero-section__content max-w-[865px] mt-[82px] py-16"
+        class="hero-section__content max-w-[865px] py-12"
       >
         <div
           class="hero-section__mini-title text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"

--- a/apps/website-25/src/components/lander/LandingHero.tsx
+++ b/apps/website-25/src/components/lander/LandingHero.tsx
@@ -18,8 +18,7 @@ const LandingHero: React.FC<LandingHeroProps> = ({
 }) => {
   return (
     <div className={clsx('landing-hero bg-canvas flex flex-row justify-center items-center w-full px-spacing-x bg-[url("/images/lander/hero-bkg.png")] bg-cover bg-center overflow-hidden', className)}>
-      {/* Top margin is nav height (82px) */}
-      <div className="landing-hero__content max-w-[865px] mt-[82px] py-16">
+      <div className="landing-hero__content max-w-[865px] pt-32 pb-16">
         <h1 className="landing-hero__title text-center font-serif flex flex-col items-center">
           {pretitle && <span className="landing-hero__pretitle text-4xl sm:text-6xl font-normal">{pretitle}</span>}
           <span className="landing-hero__title-text text-7xl sm:text-9xl font-bold text-bluedot-dark">{title}</span>

--- a/libraries/ui/src/HeroSection.tsx
+++ b/libraries/ui/src/HeroSection.tsx
@@ -59,8 +59,7 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
 }) => {
   return (
     <div className={clsx('hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x', className)}>
-      {/* Top margin is nav height (82px) */}
-      <div className="hero-section__content max-w-[865px] mt-[82px] py-16">
+      <div className="hero-section__content max-w-[865px] py-12">
         {children}
       </div>
     </div>

--- a/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`HeroSection > renders default as expected 1`] = `
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
   >
     <div
-      class="hero-section__content max-w-[865px] mt-[82px] py-16"
+      class="hero-section__content max-w-[865px] py-12"
     />
   </div>
 </div>
@@ -18,7 +18,7 @@ exports[`HeroSection > renders with buttons 1`] = `
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
   >
     <div
-      class="hero-section__content max-w-[865px] mt-[82px] py-16"
+      class="hero-section__content max-w-[865px] py-12"
     >
       <h1
         class="hero-section__title text-on-dark text-center"
@@ -56,7 +56,7 @@ exports[`HeroSection > renders with optional yield 1`] = `
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
   >
     <div
-      class="hero-section__content max-w-[865px] mt-[82px] py-16"
+      class="hero-section__content max-w-[865px] py-12"
     >
       <p>
         This is the yield
@@ -72,7 +72,7 @@ exports[`HeroSection > renders with titles 1`] = `
     class="hero-section bg-bluedot-darker flex flex-row justify-center items-center w-full px-spacing-x"
   >
     <div
-      class="hero-section__content max-w-[865px] mt-[82px] py-16"
+      class="hero-section__content max-w-[865px] py-12"
     >
       <h1
         class="hero-section__title text-on-dark text-center"


### PR DESCRIPTION
# Summary

This means our pages don't depend on having an element with special padding at the top. And makes components like Hero more reusable across pages.

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

From figma:

<img width="486" alt="image" src="https://github.com/user-attachments/assets/a4bc7356-a1a1-4b90-aed3-0e906e5eea2c" />

Pages have minimal visual changes (there's currently ~52px of space actually there, this PR decreases it to 48px in line with Figma)

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/b1c0a830-f1c5-48e8-93cb-a6a32a583252" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/b1eaa2a4-8291-49fb-98bc-8693200d0997" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/6bb0deb3-de2d-45eb-8013-5f6ca77fa135" />
<img width="612" alt="image" src="https://github.com/user-attachments/assets/702cab8f-a60f-4672-9bb5-672a52d7c985" />
<img width="612" alt="image" src="https://github.com/user-attachments/assets/f5d08ce2-ac0a-48fe-b9f8-396140338d2d" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/ec126737-da55-47f9-9e6f-814fcd3744bf" />
<img width="612" alt="image" src="https://github.com/user-attachments/assets/6b0cbbbd-abca-4a68-b369-d1da48747ead" />
