### PR TITLE
website: Add Embed and Callout components

### DIFF
--- a/apps/website-25/src/components/courses/Callout.stories.tsx
+++ b/apps/website-25/src/components/courses/Callout.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Callout from './Callout';
+
+const meta = {
+  title: 'website/Callout',
+  component: Callout,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: 'fullscreen',
+  },
+  args: {},
+} satisfies Meta<typeof Callout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BasicCallout: Story = {
+  args: {
+    title: 'Bonus content: Want to know something cool?',
+    children: 'Voyager 1\'s famous "Pale Blue Dot" photograph traveled nearly 6 billion kilometers through space, taking over five hours at light speed to reach Earth—capturing our entire planet as a tiny speck against the vastness of space.',
+  },
+};
+
+export const MdxCallout: Story = {
+  args: {
+    title: 'Markdown Example',
+    children: `## Formatted Content
+
+Any content passed to the callout is automatically handled as **MDX** so you can use:
+
+- Bullet points
+- *Italic text*
+- [Links](https://example.com)
+
+And other components from \`MarkdownExtendedRenderer\`!
+
+<Embed url="https://www.youtube.com/embed/dQw4w9WgXcQ" />
+    `,
+  },
+};
+
+export const CustomStylesCallout: Story = {
+  args: {
+    title: 'Want to know how this was done?',
+    children: 'The `className` prop was used to apply custom styles to the callout container.',
+    className: '!bg-red-100 !border-red-500',
+  },
+};

--- a/apps/website-25/src/components/courses/Callout.stories.tsx
+++ b/apps/website-25/src/components/courses/Callout.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Callout from './Callout';
+import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
 
 const meta = {
   title: 'website/Callout',
@@ -29,17 +30,17 @@ export const MdxCallout: Story = {
     title: 'Markdown Example',
     children: `## Formatted Content
 
-Any content passed to the callout is automatically handled as **MDX** so you can use:
+If you use a Callout within a \`MarkdownExtendedRenderer\`, content passed to the callout is automatically handled as **MDX** so you can use:
 
 - Bullet points
 - *Italic text*
 - [Links](https://example.com)
 
-And other components from \`MarkdownExtendedRenderer\`!
+And even other components!
 
-<Embed url="https://www.youtube.com/embed/dQw4w9WgXcQ" />
-    `,
+<Embed url="https://www.youtube.com/embed/dQw4w9WgXcQ" />`,
   },
+  render: (args) => <MarkdownExtendedRenderer>{`<Callout title="${args.title}" className="${args.className ?? ''}">\n${args.children}\n</Callout>`}</MarkdownExtendedRenderer>,
 };
 
 export const CustomStylesCallout: Story = {

--- a/apps/website-25/src/components/courses/Callout.tsx
+++ b/apps/website-25/src/components/courses/Callout.tsx
@@ -1,0 +1,24 @@
+import { Collapsible } from '@bluedot/ui';
+import clsx from 'clsx';
+import React from 'react';
+import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
+
+type CalloutProps = {
+  title: string;
+  children?: string;
+  className?: string;
+};
+
+const Callout: React.FC<CalloutProps> = ({
+  title,
+  children,
+  className,
+}) => {
+  return (
+    <Collapsible title={title} className={clsx('callout bg-stone-200 border-l-8 px-8', className)}>
+      <MarkdownExtendedRenderer>{children}</MarkdownExtendedRenderer>
+    </Collapsible>
+  );
+};
+
+export default Callout;

--- a/apps/website-25/src/components/courses/Callout.tsx
+++ b/apps/website-25/src/components/courses/Callout.tsx
@@ -1,14 +1,11 @@
 import { Collapsible } from '@bluedot/ui';
 import clsx from 'clsx';
 import React from 'react';
-// eslint-disable-next-line import/no-cycle
-import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
 
-type CalloutProps = {
+type CalloutProps = React.PropsWithChildren<{
   title: string;
-  children?: string;
   className?: string;
-};
+}>;
 
 const Callout: React.FC<CalloutProps> = ({
   title,
@@ -17,7 +14,7 @@ const Callout: React.FC<CalloutProps> = ({
 }) => {
   return (
     <Collapsible title={title} className={clsx('callout bg-stone-200 border-l-8 px-8', className)}>
-      <MarkdownExtendedRenderer>{children}</MarkdownExtendedRenderer>
+      {children}
     </Collapsible>
   );
 };

--- a/apps/website-25/src/components/courses/Callout.tsx
+++ b/apps/website-25/src/components/courses/Callout.tsx
@@ -1,6 +1,7 @@
 import { Collapsible } from '@bluedot/ui';
 import clsx from 'clsx';
 import React from 'react';
+// eslint-disable-next-line import/no-cycle
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
 
 type CalloutProps = {

--- a/apps/website-25/src/components/courses/Embed.stories.tsx
+++ b/apps/website-25/src/components/courses/Embed.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Embed from './Embed';
+
+const meta = {
+  title: 'website/Embed',
+  component: Embed,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
+    layout: 'fullscreen',
+  },
+  args: {},
+} satisfies Meta<typeof Embed>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const YouTubeEmbed: Story = {
+  name: 'YouTube Embed',
+  args: {
+    url: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
+  },
+};
+
+export const DemoEmbed: Story = {
+  args: {
+    url: 'https://course-demos.k8s.bluedot.org/generate-react-component',
+  },
+};
+
+export const SunoEmbed: Story = {
+  args: {
+    url: 'https://suno.com/embed/e02aebab-1fe8-4b64-b849-7393e01eeafd',
+    className: '!h-40',
+  },
+};
+
+export const WebsiteEmbed: Story = {
+  args: {
+    url: 'https://example.com',
+  },
+};
+
+export const CustomStyleEmbed: Story = {
+  args: {
+    url: 'https://example.com',
+    className: 'invert !w-1/2 my-24 mx-auto rotate-30',
+  },
+};

--- a/apps/website-25/src/components/courses/Embed.tsx
+++ b/apps/website-25/src/components/courses/Embed.tsx
@@ -3,15 +3,13 @@ import React from 'react';
 
 type EmbedProps = {
   url: string;
-  width?: string;
-  height?: string;
   className?: string;
 };
 
 const Embed: React.FC<EmbedProps> = ({
   url,
-  width = '100%',
-  height = '600px',
+  // width = '100%',
+  // height = '600px',
   className,
 }) => {
   const isYouTube = url.startsWith('https://www.youtube.com/') || url.startsWith('https://www.youtube-nocookie.com/');
@@ -20,12 +18,13 @@ const Embed: React.FC<EmbedProps> = ({
     // eslint-disable-next-line jsx-a11y/iframe-has-title
     <iframe
       src={isYouTube ? url.replace('https://www.youtube.com/', 'https://www.youtube-nocookie.com/') : url}
-      width={width}
-      height={isYouTube ? '100%' : height}
+      // These should be overriden in css
+      width="100%"
+      height="100%"
       frameBorder="0"
       allowFullScreen
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-      className={clsx('embed w-full', isYouTube && 'aspect-video', className)}
+      className={clsx('embed rounded-lg', isYouTube && 'aspect-video', !isYouTube && 'h-150', className)}
     />
   );
 };

--- a/apps/website-25/src/components/courses/Embed.tsx
+++ b/apps/website-25/src/components/courses/Embed.tsx
@@ -1,0 +1,33 @@
+import clsx from 'clsx';
+import React from 'react';
+
+type EmbedProps = {
+  url: string;
+  width?: string;
+  height?: string;
+  className?: string;
+};
+
+const Embed: React.FC<EmbedProps> = ({
+  url,
+  width = '100%',
+  height = '600px',
+  className,
+}) => {
+  const isYouTube = url.startsWith('https://www.youtube.com/') || url.startsWith('https://www.youtube-nocookie.com/');
+
+  return (
+    // eslint-disable-next-line jsx-a11y/iframe-has-title
+    <iframe
+      src={isYouTube ? url.replace('https://www.youtube.com/', 'https://www.youtube-nocookie.com/') : url}
+      width={width}
+      height={isYouTube ? '100%' : height}
+      frameBorder="0"
+      allowFullScreen
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      className={clsx('embed w-full', isYouTube && 'aspect-video', className)}
+    />
+  );
+};
+
+export default Embed;

--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
@@ -112,16 +112,26 @@ export const WithGreetingComponent: Story = {
   args: {
     children: `# Using Components
 
-## Example
+Below is an example of using the Callout and Embed components:
 
-Below is an example of using the Greeting component:
+<Callout title="Want to see something cool?">
+  This is some markdown extended content, using _components_!
 
-<Greeting>Storybook User</Greeting>
+  And you can nest components as you like too:
+
+  <Embed url="https://www.youtube.com/embed/dQw4w9WgXcQ" />
+</Callout>
 
 Code:
 
 \`\`\`mdx
-<Greeting>Storybook User</Greeting>
+<Callout title="Want to see something cool?">
+  This is some markdown extended content, using _components_!
+
+  And you can nest components as you like too:
+
+  <Embed url="https://www.youtube.com/embed/dQw4w9WgXcQ" />
+</Callout>
 \`\`\`
 
 ## Supported components

--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import MarkdownExtendedRenderer, { SUPPORTED_COMPONENTS } from './MarkdownExtendedRenderer';
+import MarkdownExtendedRenderer, { getSupportedComponents } from './MarkdownExtendedRenderer';
 
 const meta = {
   title: 'website/MarkdownExtendedRenderer',
@@ -19,8 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 export const BasicMarkdown: Story = {
   args: {
-    children: `
-# Standard markdown formatting
+    children: `# Standard markdown formatting
 
 This component supports standard markdown formatting
 
@@ -111,8 +110,7 @@ function greet(name) {
 
 export const WithGreetingComponent: Story = {
   args: {
-    children: `
-# Using Components
+    children: `# Using Components
 
 ## Example
 
@@ -130,11 +128,11 @@ Code:
 
 The following components are supported within your markdown content:
 
-${Object.keys(SUPPORTED_COMPONENTS).map((componentName) => `- \`${componentName}\``).join('\n')}
+${Object.keys(getSupportedComponents()).map((componentName) => `- \`${componentName}\``).join('\n')}
 
 See their Storybook pages for usage details.
 
-(to add to this list, add to \`SUPPORTED_COMPONENTS\` in \`MarkdownExtendedRenderer.tsx\`)
+(to add to this list, add to \`getSupportedComponents\` in \`MarkdownExtendedRenderer.tsx\`)
     `,
   },
 };

--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
@@ -108,7 +108,7 @@ function greet(name) {
   },
 };
 
-export const WithGreetingComponent: Story = {
+export const WithComponents: Story = {
   args: {
     children: `# Using Components
 

--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -3,17 +3,19 @@ import { evaluate } from '@mdx-js/mdx';
 import { MDXContent } from 'mdx/types';
 import Greeting from './Greeting';
 import Embed from './Embed';
+// eslint-disable-next-line import/no-cycle
 import Callout from './Callout';
 
 export interface MarkdownRendererProps {
   children?: string;
 }
 
-export const SUPPORTED_COMPONENTS = {
+// This must be a function, rather than a constant, to avoid dependency cycles
+export const getSupportedComponents = () => ({
   Greeting,
   Embed,
   Callout,
-};
+});
 
 const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children }) => {
   const [Component, setComponent] = React.useState<MDXContent | null>(null);
@@ -34,7 +36,7 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children })
 
   return (
     <div className="markdown-extended-renderer flex flex-col gap-4">
-      {Component && <Component components={SUPPORTED_COMPONENTS} />}
+      {Component && <Component components={getSupportedComponents()} />}
     </div>
   );
 };

--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -2,12 +2,18 @@ import React, { useEffect } from 'react';
 import { evaluate } from '@mdx-js/mdx';
 import { MDXContent } from 'mdx/types';
 import Greeting from './Greeting';
+import Embed from './Embed';
+import Callout from './Callout';
 
 export interface MarkdownRendererProps {
   children?: string;
 }
 
-export const SUPPORTED_COMPONENTS = { Greeting };
+export const SUPPORTED_COMPONENTS = {
+  Greeting,
+  Embed,
+  Callout,
+};
 
 const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children }) => {
   const [Component, setComponent] = React.useState<MDXContent | null>(null);
@@ -27,7 +33,7 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children })
   }, [children, setComponent]);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="markdown-extended-renderer flex flex-col gap-4">
       {Component && <Component components={SUPPORTED_COMPONENTS} />}
     </div>
   );

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -167,7 +167,7 @@ exports[`UnitLayout > renders default as expected 1`] = `
             class="unit__content flex flex-col flex-1 max-w-[728px] gap-4"
           >
             <div
-              class="flex flex-col gap-4"
+              class="markdown-extended-renderer flex flex-col gap-4"
             />
             <a
               class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link self-end mt-6"

--- a/apps/website-25/src/components/homepage/__snapshots__/FAQSection.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/FAQSection.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`FAQSection > renders default as expected 1`] = `
       class="section__body"
     >
       <details
-        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
       >
         <summary
           class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"
@@ -74,7 +74,7 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
       >
         <summary
           class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"
@@ -122,7 +122,7 @@ exports[`FAQSection > renders default as expected 1`] = `
         </div>
       </details>
       <details
-        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
+        class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden faq-section__item"
       >
         <summary
           class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"

--- a/libraries/ui/src/Collapsible.tsx
+++ b/libraries/ui/src/Collapsible.tsx
@@ -13,7 +13,7 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
   children, className, title,
 }) => {
   return (
-    <details className={clsx('collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden', className)}>
+    <details className={clsx('collapsible max-w-max-width border-b border-color-divider py-4 last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden', className)}>
       <summary className="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left">
         <span className="collapsible__title subtitle-sm">{title}</span>
         <span className="collapsible__button flex items-center">

--- a/libraries/ui/src/__snapshots__/Collapsible.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Collapsible.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Collapsible > renders to snapshot 1`] = `
 <div>
   <details
-    class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-none group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+    class="collapsible max-w-max-width border-b border-color-divider py-4 last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
   >
     <summary
       class="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left"


### PR DESCRIPTION
# Summary

Add components:
- `Embed` for iframe content, like YouTube videos, demos, etc.
- `Callout` for bonus content

## Issue

Part of #616, may also help with #585

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

<img width="818" alt="image" src="https://github.com/user-attachments/assets/e645fa5f-6563-4eaf-8d19-740f497681ff" />
