### PR TITLE
Exercise API get and put handling

### DIFF
--- a/apps/website-25/package.json
+++ b/apps/website-25/package.json
@@ -36,6 +36,7 @@
     "react-click-away-listener": "^2.3.0",
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.56.0",
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "zod": "^3.24.2",

--- a/apps/website-25/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website-25/src/components/courses/exercises/Exercise.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import useAxios from 'axios-hooks';
+import { useAuthStore } from '@bluedot/ui';
 import FreeTextResponse from './FreeTextResponse';
 import MultipleChoice from './MultipleChoice';
-import { GetExerciseResponse } from '../../../pages/api/courses/exercises/[exerciseId]';
+import { GetExercise } from '../../../pages/api/courses/exercises/[exerciseId]';
+import { GetExerciseResponse } from '../../../pages/api/courses/exercises/[exerciseId]/response';
 
 type ExerciseProps = {
   // Required
@@ -12,23 +14,56 @@ type ExerciseProps = {
 const Exercise: React.FC<ExerciseProps> = ({
   exerciseId,
 }) => {
-  const [{ data }] = useAxios<GetExerciseResponse>({
+  const [{ data: exerciseData }] = useAxios<GetExercise>({
     method: 'get',
     url: `/api/courses/exercises/${exerciseId}`,
   });
 
-  if (!data || !data.exercise) {
+  if (!exerciseData || !exerciseData.exercise) {
     console.error('Exercise not found');
     return null;
   }
 
+  const auth = useAuthStore((s) => s.auth);
+
+  const [{ data: responseData }, executeResponse] = useAxios<GetExerciseResponse>({
+    method: 'get',
+    url: `/api/courses/exercises/${exerciseId}/response`,
+    headers: auth ? {
+      Authorization: `Bearer ${auth.token}`,
+    } : undefined,
+  }, { manual: true });
+
+  // If the user is authenticated, fetch their response
+  // This is needed as React always expects the same number of hooks to be returned
+  // so we need to return an empty array for the second hook if the user is not authenticated
+  React.useEffect(() => {
+    if (auth) {
+      executeResponse();
+    }
+  }, [auth, executeResponse]);
+
   const exerciseClassNames = 'exercise not-prose my-6';
 
-  switch (data.exercise.type) {
+  switch (exerciseData.exercise.type) {
     case 'Free text':
-      return <FreeTextResponse className={exerciseClassNames} {...data.exercise} exerciseId={exerciseId} />;
+      return (
+        <FreeTextResponse
+          className={exerciseClassNames}
+          {...exerciseData.exercise}
+          exerciseId={exerciseId}
+          exerciseResponse={responseData?.exerciseResponse?.response}
+        />
+      );
     case 'Multiple choice':
-      return <MultipleChoice className={exerciseClassNames} {...data.exercise} exerciseId={exerciseId} />;
+      return (
+        <MultipleChoice
+          className={exerciseClassNames}
+          {...exerciseData.exercise}
+          exerciseId={exerciseId}
+          exerciseResponse={responseData?.exerciseResponse?.response}
+        />
+      );
     default:
       return null;
   }

--- a/apps/website-25/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website-25/src/components/courses/exercises/Exercise.tsx
@@ -26,9 +26,9 @@ const Exercise: React.FC<ExerciseProps> = ({
 
   switch (data.exercise.type) {
     case 'Free text':
-      return <FreeTextResponse className={exerciseClassNames} {...data.exercise} />;
+      return <FreeTextResponse className={exerciseClassNames} {...data.exercise} exerciseId={exerciseId} />;
     case 'Multiple choice':
-      return <MultipleChoice className={exerciseClassNames} {...data.exercise} />;
+      return <MultipleChoice className={exerciseClassNames} {...data.exercise} exerciseId={exerciseId} />;
     default:
       return null;
   }

--- a/apps/website-25/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website-25/src/components/courses/exercises/Exercise.tsx
@@ -6,7 +6,6 @@ import FreeTextResponse from './FreeTextResponse';
 import MultipleChoice from './MultipleChoice';
 import { GetExercise } from '../../../pages/api/courses/exercises/[exerciseId]';
 import { GetExerciseResponseResponse, PutExerciseResponseRequest } from '../../../pages/api/courses/exercises/[exerciseId]/response';
-import { error } from 'console';
 
 type ExerciseProps = {
   // Required
@@ -33,11 +32,12 @@ const Exercise: React.FC<ExerciseProps> = ({
     } : undefined,
   });
 
-  const handleExerciseSubmit = useCallback(async (exerciseResponse: string) => {
+  const handleExerciseSubmit = useCallback(async (exerciseResponse: string, completed?: boolean) => {
     await axios.put<unknown, unknown, PutExerciseResponseRequest>(
       `/api/courses/exercises/${exerciseId}/response`,
       {
         response: exerciseResponse,
+        completed,
       },
       {
         headers: {

--- a/apps/website-25/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website-25/src/components/courses/exercises/Exercise.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import useAxios from 'axios-hooks';
+import axios from 'axios';
 import { useAuthStore } from '@bluedot/ui';
 import FreeTextResponse from './FreeTextResponse';
 import MultipleChoice from './MultipleChoice';
 import { GetExercise } from '../../../pages/api/courses/exercises/[exerciseId]';
-import { GetExerciseResponse } from '../../../pages/api/courses/exercises/[exerciseId]/response';
+import { GetExerciseResponseResponse, PutExerciseResponseRequest } from '../../../pages/api/courses/exercises/[exerciseId]/response';
+import { error } from 'console';
 
 type ExerciseProps = {
   // Required
@@ -14,36 +16,43 @@ type ExerciseProps = {
 const Exercise: React.FC<ExerciseProps> = ({
   exerciseId,
 }) => {
+  const exerciseClassNames = 'exercise not-prose my-6';
+
+  const auth = useAuthStore((s) => s.auth);
+  
   const [{ data: exerciseData }] = useAxios<GetExercise>({
     method: 'get',
     url: `/api/courses/exercises/${exerciseId}`,
   });
 
-  if (!exerciseData || !exerciseData.exercise) {
-    console.error('Exercise not found');
-    return null;
-  }
-
-  const auth = useAuthStore((s) => s.auth);
-
-  const [{ data: responseData }, executeResponse] = useAxios<GetExerciseResponse>({
+  const [{ data: responseData }, refetch] = useAxios<GetExerciseResponseResponse>({
     method: 'get',
     url: `/api/courses/exercises/${exerciseId}/response`,
     headers: auth ? {
       Authorization: `Bearer ${auth.token}`,
     } : undefined,
-  }, { manual: true });
+  });
 
-  // If the user is authenticated, fetch their response
-  // This is needed as React always expects the same number of hooks to be returned
-  // so we need to return an empty array for the second hook if the user is not authenticated
-  React.useEffect(() => {
-    if (auth) {
-      executeResponse();
-    }
-  }, [auth, executeResponse]);
+  const handleExerciseSubmit = useCallback(async (exerciseResponse: string) => {
+    await axios.put<unknown, unknown, PutExerciseResponseRequest>(
+      `/api/courses/exercises/${exerciseId}/response`,
+      {
+        response: exerciseResponse,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${auth?.token}`,
+        },
+      },
+    );
+    
+    await refetch();
+  }, [exerciseId, auth, refetch]);
 
-  const exerciseClassNames = 'exercise not-prose my-6';
+  if (!exerciseData || !exerciseData.exercise) {
+    console.error('Exercise not found');
+    return null;
+  }
 
   switch (exerciseData.exercise.type) {
     case 'Free text':
@@ -51,8 +60,8 @@ const Exercise: React.FC<ExerciseProps> = ({
         <FreeTextResponse
           className={exerciseClassNames}
           {...exerciseData.exercise}
-          exerciseId={exerciseId}
           exerciseResponse={responseData?.exerciseResponse?.response}
+          onExerciseSubmit={handleExerciseSubmit}
         />
       );
     case 'Multiple choice':
@@ -60,8 +69,8 @@ const Exercise: React.FC<ExerciseProps> = ({
         <MultipleChoice
           className={exerciseClassNames}
           {...exerciseData.exercise}
-          exerciseId={exerciseId}
           exerciseResponse={responseData?.exerciseResponse?.response}
+          onExerciseSubmit={handleExerciseSubmit}
         />
       );
     default:

--- a/apps/website-25/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website-25/src/components/courses/exercises/Exercise.tsx
@@ -18,7 +18,7 @@ const Exercise: React.FC<ExerciseProps> = ({
   const exerciseClassNames = 'exercise not-prose my-6';
 
   const auth = useAuthStore((s) => s.auth);
-  
+
   const [{ data: exerciseData }] = useAxios<GetExercise>({
     method: 'get',
     url: `/api/courses/exercises/${exerciseId}`,
@@ -45,7 +45,7 @@ const Exercise: React.FC<ExerciseProps> = ({
         },
       },
     );
-    
+
     await refetch();
   }, [exerciseId, auth, refetch]);
 

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.stories.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.stories.tsx
@@ -21,5 +21,6 @@ export const Default: Story = {
   args: {
     title: 'Understanding LLMs',
     description: 'Why is a language model\'s ability to predict \'the next word\' capable of producing complex behaviors like solving maths problems?',
+    exerciseId: 'rec1234567890',
   },
 };

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.stories.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.stories.tsx
@@ -21,6 +21,13 @@ export const Default: Story = {
   args: {
     title: 'Understanding LLMs',
     description: 'Why is a language model\'s ability to predict \'the next word\' capable of producing complex behaviors like solving maths problems?',
-    exerciseId: 'rec1234567890',
+    onExerciseSubmit: () => {},
+  },
+};
+
+export const Saved: Story = {
+  args: {
+    ...Default.args,
+    exerciseResponse: 'This is my saved answer.',
   },
 };

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.test.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import {
   describe,
   expect,
@@ -38,30 +38,7 @@ describe('FreeTextResponse', () => {
     const textareaEl = container.querySelector('.free-text-response__textarea') as HTMLTextAreaElement;
 
     expect(container).toMatchSnapshot();
-    expect(container.querySelector('.free-text-response__saved-msg')).toBeTruthy();
     expect(textareaEl.classList.contains('free-text-response__textarea--saved')).toBeTruthy();
     expect(textareaEl.value).toBe('This is my saved answer.');
-  });
-
-  test('calls onExerciseSubmit when answer is saved', async () => {
-    const { container } = render(
-      <FreeTextResponse {...mockArgs} />,
-    );
-
-    const textareaEl = container.querySelector('.free-text-response__textarea') as HTMLTextAreaElement;
-
-    // Set the answer in the free text response field
-    // Set as an event to trigger the change event for react-hook-form
-    const testAnswer = 'My test answer';
-    fireEvent.change(textareaEl, { target: { value: testAnswer } });
-
-    // Submit an answer
-    const submitEl = container.querySelector('.free-text-response__submit') as HTMLElement;
-    fireEvent.click(submitEl);
-
-    // Verify submit callback was called with correct arguments
-    await waitFor(() => {
-      expect(mockArgs.onExerciseSubmit).toHaveBeenCalledWith(testAnswer);
-    });
   });
 });

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.test.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.test.tsx
@@ -1,5 +1,10 @@
 import { render, waitFor } from '@testing-library/react';
-import { describe, expect, test, vi } from 'vitest';
+import {
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
 import axios from 'axios';
 import FreeTextResponse from './FreeTextResponse';
 
@@ -29,13 +34,13 @@ describe('FreeTextResponse', () => {
     const { container } = render(
       <FreeTextResponse {...mockArgs} />,
     );
-    
+
     const textareaEl = container.querySelector('.free-text-response__textarea') as HTMLElement;
-    
+
     // Add some text to the textarea
     const testAnswer = 'My test answer';
     textareaEl.textContent = testAnswer;
-    
+
     // Submit an answer
     const submitEl = container.querySelector('.free-text-response__submit') as HTMLElement;
     submitEl?.click();
@@ -43,9 +48,9 @@ describe('FreeTextResponse', () => {
     // Verify axios was called with correct arguments
     expect(axios.put).toHaveBeenCalledWith(
       `/api/courses/exercises/${mockArgs.exerciseId}`,
-      { response: testAnswer }
+      { response: testAnswer },
     );
-    
+
     // Expect 'saved' state change after axios resolves
     await waitFor(() => {
       expect(textareaEl.classList.contains('free-text-response__textarea--saved')).toBeTruthy();

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.test.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.test.tsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react';
 import {
   describe,
   expect,
+  Mock,
   test,
   vi,
 } from 'vitest';
@@ -10,6 +11,8 @@ import FreeTextResponse from './FreeTextResponse';
 
 // Mock axios
 vi.mock('axios');
+// Setup axios mock to resolve successfully
+(axios.put as Mock).mockResolvedValue({ data: {} });
 
 const mockArgs = {
   title: 'Understanding LLMs',
@@ -28,9 +31,6 @@ describe('FreeTextResponse', () => {
   });
 
   test('updates styles when answer is saved', async () => {
-    // Setup axios mock to resolve successfully
-    (axios.put as vi.Mock).mockResolvedValue({ data: {} });
-
     const { container } = render(
       <FreeTextResponse {...mockArgs} />,
     );
@@ -47,7 +47,7 @@ describe('FreeTextResponse', () => {
 
     // Verify axios was called with correct arguments
     expect(axios.put).toHaveBeenCalledWith(
-      `/api/courses/exercises/${mockArgs.exerciseId}`,
+      `/api/courses/exercises/${mockArgs.exerciseId}/response`,
       { response: testAnswer },
     );
 

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.test.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import {
   describe,
   expect,
@@ -18,6 +18,7 @@ const mockArgs = {
   title: 'Understanding LLMs',
   description: 'Why is a language model\'s ability to predict \'the next word\' capable of producing complex behaviors like solving maths problems?',
   exerciseId: 'rec1234567890',
+  onExerciseSubmit: vi.fn(),
 };
 
 describe('FreeTextResponse', () => {
@@ -30,31 +31,37 @@ describe('FreeTextResponse', () => {
     expect(container.querySelector('.free-text-response__saved-msg')).toBeFalsy();
   });
 
-  test('updates styles when answer is saved', async () => {
+  test('renders with saved exercise response', () => {
+    const { container } = render(
+      <FreeTextResponse {...mockArgs} exerciseResponse="This is my saved answer." />,
+    );
+    const textareaEl = container.querySelector('.free-text-response__textarea') as HTMLTextAreaElement;
+
+    expect(container).toMatchSnapshot();
+    expect(container.querySelector('.free-text-response__saved-msg')).toBeTruthy();
+    expect(textareaEl.classList.contains('free-text-response__textarea--saved')).toBeTruthy();
+    expect(textareaEl.value).toBe('This is my saved answer.');
+  });
+
+  test('calls onExerciseSubmit when answer is saved', async () => {
     const { container } = render(
       <FreeTextResponse {...mockArgs} />,
     );
 
-    const textareaEl = container.querySelector('.free-text-response__textarea') as HTMLElement;
+    const textareaEl = container.querySelector('.free-text-response__textarea') as HTMLTextAreaElement;
 
-    // Add some text to the textarea
+    // Set the answer in the free text response field
+    // Set as an event to trigger the change event for react-hook-form
     const testAnswer = 'My test answer';
-    textareaEl.textContent = testAnswer;
+    fireEvent.change(textareaEl, { target: { value: testAnswer } });
 
     // Submit an answer
     const submitEl = container.querySelector('.free-text-response__submit') as HTMLElement;
-    submitEl?.click();
+    fireEvent.click(submitEl);
 
-    // Verify axios was called with correct arguments
-    expect(axios.put).toHaveBeenCalledWith(
-      `/api/courses/exercises/${mockArgs.exerciseId}/response`,
-      { response: testAnswer },
-    );
-
-    // Expect 'saved' state change after axios resolves
+    // Verify submit callback was called with correct arguments
     await waitFor(() => {
-      expect(textareaEl.classList.contains('free-text-response__textarea--saved')).toBeTruthy();
-      expect(container.querySelector('.free-text-response__saved-msg')).toMatchSnapshot();
+      expect(mockArgs.onExerciseSubmit).toHaveBeenCalledWith(testAnswer);
     });
   });
 });

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import CTALinkOrButton from '@bluedot/ui/src/CTALinkOrButton';
+import { CTALinkOrButton } from '@bluedot/ui';
 import axios from 'axios';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -10,19 +10,22 @@ type FreeTextResponseProps = {
   description: string;
   exerciseId: string;
   title: string;
+  // Optional
+  exerciseResponse?: string;
 };
 
 const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
   className,
   description,
   exerciseId,
+  exerciseResponse,
   title,
 }) => {
   const [isSaved, setIsSaved] = React.useState<boolean>(false);
 
   const handleAnswerSubmit = () => {
     const textArea = document.querySelector('.free-text-response__textarea') as HTMLTextAreaElement;
-    axios.put(`/api/courses/exercises/${exerciseId}`, {
+    axios.put(`/api/courses/exercises/${exerciseId}/response`, {
       response: textArea?.value,
     }).then(() => {
       setIsSaved(true);
@@ -53,6 +56,7 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
           }`}
           placeholder="Enter your answer here"
           onChange={handleAnswerChange}
+          value={exerciseResponse}
         />
       </div>
       <CTALinkOrButton

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { CTALinkOrButton } from '@bluedot/ui';
 import React, { useCallback, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { useForm } from "react-hook-form";
+import { useForm } from 'react-hook-form';
 
 type FreeTextResponseProps = {
   // Required
@@ -28,8 +28,8 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
   const [isEditing, setIsEditing] = React.useState<boolean>(false);
   const { register, handleSubmit, setValue } = useForm<FormData>({
     defaultValues: {
-      answer: exerciseResponse || ''
-    }
+      answer: exerciseResponse || '',
+    },
   });
 
   useEffect(() => {

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
@@ -1,45 +1,55 @@
 import clsx from 'clsx';
 import { CTALinkOrButton } from '@bluedot/ui';
-import axios from 'axios';
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { useForm } from "react-hook-form";
 
 type FreeTextResponseProps = {
   // Required
   className?: string;
   description: string;
-  exerciseId: string;
+  onExerciseSubmit: (exerciseResponse: string) => void;
   title: string;
   // Optional
   exerciseResponse?: string;
 };
 
+type FormData = {
+  answer: string;
+};
+
 const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
   className,
   description,
-  exerciseId,
   exerciseResponse,
+  onExerciseSubmit,
   title,
 }) => {
-  const [isSaved, setIsSaved] = React.useState<boolean>(false);
-
-  const handleAnswerSubmit = () => {
-    const textArea = document.querySelector('.free-text-response__textarea') as HTMLTextAreaElement;
-    axios.put(`/api/courses/exercises/${exerciseId}/response`, {
-      response: textArea?.value,
-    }).then(() => {
-      setIsSaved(true);
-    });
-  };
-
-  const handleAnswerChange = () => {
-    if (isSaved) {
-      setIsSaved(false);
+  const [isEditing, setIsEditing] = React.useState<boolean>(false);
+  const { register, handleSubmit, setValue } = useForm<FormData>({
+    defaultValues: {
+      answer: exerciseResponse || ''
     }
-  };
+  });
+
+  useEffect(() => {
+    if (exerciseResponse) {
+      setValue('answer', exerciseResponse);
+    }
+  }, [exerciseResponse, setValue]);
+
+  const onSubmit = useCallback(async (data: FormData) => {
+    try {
+      await onExerciseSubmit(data.answer);
+      setIsEditing(false);
+    } catch (e) {
+      console.log('error', e);
+      // Set some state for the error and render it
+    }
+  }, [onExerciseSubmit]);
 
   return (
-    <div className={clsx('free-text-response container-lined bg-white p-8 flex flex-col gap-6', className)}>
+    <form onSubmit={handleSubmit(onSubmit)} className={clsx('free-text-response container-lined bg-white p-8 flex flex-col gap-6', className)}>
       <div className="free-text-response__header flex flex-col gap-4">
         <div className="free-text-response__header-icon">
           <img src="/icons/lightning_bolt.svg" className="w-15 h-15" alt="" />
@@ -51,24 +61,23 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
       </div>
       <div className="free-text-response__options flex flex-col gap-2">
         <textarea
+          {...register('answer')}
           className={`free-text-response__textarea p-4${
-            isSaved ? ' free-text-response__textarea--saved container-active bg-[#63C96533] border-[#63C965] text-[#2A5D2A]' : ' container-lined'
+            (!isEditing && exerciseResponse) ? ' free-text-response__textarea--saved container-active bg-[#63C96533] border-[#63C965] text-[#2A5D2A]' : ' container-lined'
           }`}
           placeholder="Enter your answer here"
-          onChange={handleAnswerChange}
-          value={exerciseResponse}
+          onChange={() => setIsEditing(true)}
         />
       </div>
       <CTALinkOrButton
         className="free-text-response__submit"
         variant="primary"
-        onClick={handleAnswerSubmit}
-        type="button"
+        type="submit"
       >
         Save
       </CTALinkOrButton>
-      {isSaved && <p className="free-text-response__saved-msg">Saved! 🎉</p>}
-    </div>
+      {(!isEditing && exerciseResponse) && <p className="free-text-response__saved-msg">Saved! 🎉</p>}
+    </form>
   );
 };
 

--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
@@ -1,30 +1,36 @@
 import clsx from 'clsx';
 import CTALinkOrButton from '@bluedot/ui/src/CTALinkOrButton';
+import axios from 'axios';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
 type FreeTextResponseProps = {
   // Required
-  title: string;
-  description: string;
   className?: string;
+  description: string;
+  exerciseId: string;
+  title: string;
 };
 
 const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
-  title,
-  description,
   className,
+  description,
+  exerciseId,
+  title,
 }) => {
-  const [submittedOption, setSubmittedOption] = React.useState<string | null>(null);
   const [isSaved, setIsSaved] = React.useState<boolean>(false);
 
   const handleAnswerSubmit = () => {
-    setSubmittedOption('test');
-    setIsSaved(true);
+    const textArea = document.querySelector('.free-text-response__textarea') as HTMLTextAreaElement;
+    axios.put(`/api/courses/exercises/${exerciseId}`, {
+      response: textArea?.value,
+    }).then(() => {
+      setIsSaved(true);
+    });
   };
 
   const handleAnswerChange = () => {
-    if (submittedOption && isSaved) {
+    if (isSaved) {
       setIsSaved(false);
     }
   };

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.stories.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.stories.tsx
@@ -23,5 +23,6 @@ export const Default: Story = {
     description: 'Why is a language model\'s ability to predict \'the next word\' capable of producing complex behaviors like solving maths problems?',
     options: 'The community\'s preference for low-tech fishing traditions\nRising consumer demand for fish with more Omega-3s\nEnvironmental regulations and declining cod stocks\nA cultural shift toward vegetarianism in the region\n',
     answer: 'The community\'s preference for low-tech fishing traditions',
+    exerciseId: 'rec1234567890',
   },
 };

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.stories.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.stories.tsx
@@ -22,7 +22,21 @@ export const Default: Story = {
     title: 'Understanding LLMs',
     description: 'Why is a language model\'s ability to predict \'the next word\' capable of producing complex behaviors like solving maths problems?',
     options: 'The community\'s preference for low-tech fishing traditions\nRising consumer demand for fish with more Omega-3s\nEnvironmental regulations and declining cod stocks\nA cultural shift toward vegetarianism in the region\n',
-    answer: 'The community\'s preference for low-tech fishing traditions',
-    exerciseId: 'rec1234567890',
+    answer: 'The community\'s preference for low-tech fishing traditions\n',
+    onExerciseSubmit: () => {},
+  },
+};
+
+export const SavedCorrectResponse: Story = {
+  args: {
+    ...Default.args,
+    exerciseResponse: Default.args.answer,
+  },
+};
+
+export const SavedIncorrectResponse: Story = {
+  args: {
+    ...Default.args,
+    exerciseResponse: 'A cultural shift toward vegetarianism in the region\n',
   },
 };

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.test.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.test.tsx
@@ -1,5 +1,10 @@
 import { render, waitFor } from '@testing-library/react';
-import { describe, expect, test, vi } from 'vitest';
+import {
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
 import axios from 'axios';
 import MultipleChoice from './MultipleChoice';
 
@@ -72,7 +77,7 @@ describe('MultipleChoice', () => {
     // Verify axios was called with correct arguments
     expect(axios.put).toHaveBeenCalledWith(
       `/api/courses/exercises/${mockArgs.exerciseId}`,
-      { response: mockArgs.options[0] }
+      { response: mockArgs.options[0] },
     );
   });
 
@@ -105,7 +110,7 @@ describe('MultipleChoice', () => {
     // Verify axios was called with correct arguments
     expect(axios.put).toHaveBeenCalledWith(
       `/api/courses/exercises/${mockArgs.exerciseId}`,
-      { response: mockArgs.options[1] }
+      { response: mockArgs.options[1] },
     );
   });
 });

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.test.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.test.tsx
@@ -20,13 +20,13 @@ const mockArgs = {
   description: 'Why is a language model\'s ability to predict \'the next word\' capable of producing complex behaviors like solving maths problems?',
   options: mockOptions,
   answer: 'The community\'s preference for low-tech fishing traditions\n',
-  exerciseId: 'rec1234567890',
+  onExerciseSubmit: () => {},
 };
 
 describe('MultipleChoice', () => {
   test('renders default as expected', () => {
     const { container } = render(
-      <MultipleChoice {...mockArgs} exerciseId="rec1234567890" />,
+      <MultipleChoice {...mockArgs} />,
     );
 
     expect(container).toMatchSnapshot();
@@ -50,76 +50,30 @@ describe('MultipleChoice', () => {
     });
   });
 
-  test('updates styles for correct option', async () => {
+  test('updates styles for correct option', () => {
     const { container } = render(
-      <MultipleChoice
-        {...mockArgs}
-      />,
+      <MultipleChoice {...mockArgs} exerciseResponse={mockArgs.answer} />,
     );
-    // Select the correct option
-    const optionEls = container.querySelectorAll('.multiple-choice__input');
-    const optionEl = optionEls[0] as HTMLInputElement;
-    const optionLabelEl = optionEl.closest('label') as HTMLElement;
-    optionEl?.click();
-    // Submit the answer
-    const submitEl = container.querySelector('.multiple-choice__submit') as HTMLElement;
-    expect(submitEl).toBeTruthy();
-    submitEl?.click();
-    // Expect 'correct' state change
-    await waitFor(() => {
-      const correctOption = container.querySelectorAll('.multiple-choice__option--correct');
-      expect(correctOption.length).toBe(1);
-      expect(correctOption[0]).toBe(optionLabelEl);
-      expect(container.querySelector('.multiple-choice__correct-msg')).toMatchSnapshot();
-    });
-
-    // Verify axios was called with correct arguments
-    expect(axios.put).toHaveBeenCalledWith(
-      `/api/courses/exercises/${mockArgs.exerciseId}/response`,
-      { response: mockArgs.answer.trim() },
-    );
+    // Expect only one correct option
+    expect(container.querySelectorAll('.multiple-choice__option--correct').length).toBe(1);
+    // Expect 'correct' UI
+    const correctOption = container.querySelector('.multiple-choice__option--correct') as HTMLInputElement;
+    expect(correctOption.textContent).toBe(mockArgs.answer.trim());
+    expect(correctOption).toMatchSnapshot();
+    expect(container.querySelector('.multiple-choice__correct-msg')).toMatchSnapshot();
   });
 
-  test('updates styles for incorrect option', async () => {
+  test('updates styles for correct option', () => {
+    const incorrectAnswer = 'Rising consumer demand for fish with more Omega-3s\n';
     const { container } = render(
-      <MultipleChoice
-        {...mockArgs}
-      />,
+      <MultipleChoice {...mockArgs} exerciseResponse={incorrectAnswer} />,
     );
-    // Select the second option
-    const optionEls = container.querySelectorAll('.multiple-choice__input');
-    const optionEl = optionEls[1] as HTMLInputElement;
-    const optionLabelEl = optionEl.closest('label') as HTMLElement;
-    optionEl?.click();
-    // Submit the answer
-    const submitEl = container.querySelector('.multiple-choice__submit') as HTMLElement;
-    expect(submitEl).toBeTruthy();
-    submitEl?.click();
-    // Expect 'incorrect' state change for the selected option
-    await waitFor(() => {
-      const incorrectOption = container.querySelectorAll('.multiple-choice__option--incorrect');
-      expect(incorrectOption.length).toBe(1);
-      expect(incorrectOption[0]).toBe(optionLabelEl);
-      expect(container.querySelector('.multiple-choice__incorrect-msg')).toMatchSnapshot();
-    });
-
-    // Verify axios was called with correct arguments
-    expect(axios.put).toHaveBeenCalledWith(
-      `/api/courses/exercises/${mockArgs.exerciseId}/response`,
-      { response: 'Rising consumer demand for fish with more Omega-3s' },
-    );
+    // Expect only one incorrect option
+    expect(container.querySelectorAll('.multiple-choice__option--incorrect').length).toBe(1);
+    // Expect 'incorrect' UI
+    const incorrectOption = container.querySelector('.multiple-choice__option--incorrect') as HTMLInputElement;
+    expect(incorrectOption.textContent).toBe(incorrectAnswer.trim());
+    expect(incorrectOption).toMatchSnapshot();
+    expect(container.querySelector('.multiple-choice__incorrect-msg')).toMatchSnapshot();
   });
-
-  // test('renders with existing exercise response as expected', async () => {
-  //   const { container } = render(
-  //     <MultipleChoice {...mockArgs} exerciseId="rec1234567890" exerciseResponse={mockArgs.answer} />,
-  //   );
-
-  //   // Expect 'selected' state change
-  //   await waitFor(() => {
-  //     const selectedOption = container.querySelectorAll('.multiple-choice__option--selected');
-  //     expect(selectedOption.length).toBe(1);
-  //     expect(selectedOption[0]?.textContent).toBe(mockArgs.answer.trim());
-  //   });
-  // });
 });

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.test.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.test.tsx
@@ -1,6 +1,10 @@
 import { render, waitFor } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import axios from 'axios';
 import MultipleChoice from './MultipleChoice';
+
+// Mock axios
+vi.mock('axios');
 
 const mockOptions = 'The community\'s preference for low-tech fishing traditions\nRising consumer demand for fish with more Omega-3s\nEnvironmental regulations and declining cod stocks\nA cultural shift toward vegetarianism in the region\n';
 
@@ -9,12 +13,13 @@ const mockArgs = {
   description: 'Why is a language model\'s ability to predict \'the next word\' capable of producing complex behaviors like solving maths problems?',
   options: mockOptions,
   answer: 'The community\'s preference for low-tech fishing traditions\n',
+  exerciseId: 'rec1234567890',
 };
 
 describe('MultipleChoice', () => {
   test('renders default as expected', () => {
     const { container } = render(
-      <MultipleChoice {...mockArgs} />,
+      <MultipleChoice {...mockArgs} exerciseId="rec1234567890" />,
     );
 
     expect(container).toMatchSnapshot();
@@ -39,6 +44,9 @@ describe('MultipleChoice', () => {
   });
 
   test('updates styles for correct option', async () => {
+    // Setup axios mock to resolve successfully
+    (axios.put as vi.Mock).mockResolvedValue({ data: {} });
+
     const { container } = render(
       <MultipleChoice
         {...mockArgs}
@@ -60,9 +68,18 @@ describe('MultipleChoice', () => {
       expect(correctOption[0]).toBe(optionLabelEl);
       expect(container.querySelector('.multiple-choice__correct-msg')).toMatchSnapshot();
     });
+
+    // Verify axios was called with correct arguments
+    expect(axios.put).toHaveBeenCalledWith(
+      `/api/courses/exercises/${mockArgs.exerciseId}`,
+      { response: mockArgs.options[0] }
+    );
   });
 
   test('updates styles for incorrect option', async () => {
+    // Setup axios mock to resolve successfully
+    (axios.put as vi.Mock).mockResolvedValue({ data: {} });
+
     const { container } = render(
       <MultipleChoice
         {...mockArgs}
@@ -84,5 +101,11 @@ describe('MultipleChoice', () => {
       expect(incorrectOption[0]).toBe(optionLabelEl);
       expect(container.querySelector('.multiple-choice__incorrect-msg')).toMatchSnapshot();
     });
+
+    // Verify axios was called with correct arguments
+    expect(axios.put).toHaveBeenCalledWith(
+      `/api/courses/exercises/${mockArgs.exerciseId}`,
+      { response: mockArgs.options[1] }
+    );
   });
 });

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.test.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.test.tsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react';
 import {
   describe,
   expect,
+  Mock,
   test,
   vi,
 } from 'vitest';
@@ -10,6 +11,7 @@ import MultipleChoice from './MultipleChoice';
 
 // Mock axios
 vi.mock('axios');
+(axios.put as Mock).mockResolvedValue({ data: {} });
 
 const mockOptions = 'The community\'s preference for low-tech fishing traditions\nRising consumer demand for fish with more Omega-3s\nEnvironmental regulations and declining cod stocks\nA cultural shift toward vegetarianism in the region\n';
 
@@ -49,9 +51,6 @@ describe('MultipleChoice', () => {
   });
 
   test('updates styles for correct option', async () => {
-    // Setup axios mock to resolve successfully
-    (axios.put as vi.Mock).mockResolvedValue({ data: {} });
-
     const { container } = render(
       <MultipleChoice
         {...mockArgs}
@@ -76,15 +75,12 @@ describe('MultipleChoice', () => {
 
     // Verify axios was called with correct arguments
     expect(axios.put).toHaveBeenCalledWith(
-      `/api/courses/exercises/${mockArgs.exerciseId}`,
-      { response: mockArgs.options[0] },
+      `/api/courses/exercises/${mockArgs.exerciseId}/response`,
+      { response: mockArgs.answer.trim() },
     );
   });
 
   test('updates styles for incorrect option', async () => {
-    // Setup axios mock to resolve successfully
-    (axios.put as vi.Mock).mockResolvedValue({ data: {} });
-
     const { container } = render(
       <MultipleChoice
         {...mockArgs}
@@ -109,8 +105,21 @@ describe('MultipleChoice', () => {
 
     // Verify axios was called with correct arguments
     expect(axios.put).toHaveBeenCalledWith(
-      `/api/courses/exercises/${mockArgs.exerciseId}`,
-      { response: mockArgs.options[1] },
+      `/api/courses/exercises/${mockArgs.exerciseId}/response`,
+      { response: 'Rising consumer demand for fish with more Omega-3s' },
     );
   });
+
+  // test('renders with existing exercise response as expected', async () => {
+  //   const { container } = render(
+  //     <MultipleChoice {...mockArgs} exerciseId="rec1234567890" exerciseResponse={mockArgs.answer} />,
+  //   );
+
+  //   // Expect 'selected' state change
+  //   await waitFor(() => {
+  //     const selectedOption = container.querySelectorAll('.multiple-choice__option--selected');
+  //     expect(selectedOption.length).toBe(1);
+  //     expect(selectedOption[0]?.textContent).toBe(mockArgs.answer.trim());
+  //   });
+  // });
 });

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
@@ -12,6 +12,7 @@ type MultipleChoiceProps = {
   title: string;
   // Optional
   className?: string;
+  exerciseResponse?: string;
 };
 
 const MultipleChoice: React.FC<MultipleChoiceProps> = ({
@@ -19,6 +20,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   className,
   description,
   exerciseId,
+  exerciseResponse,
   options,
   title,
 }) => {
@@ -29,7 +31,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   const formattedOptions = (options.split('\n').map((o) => o.trim()).filter((o) => o !== ''));
   const formattedAnswer = answer.trim();
 
-  const [selectedOption, setSelectedOption] = React.useState<string | null>(null);
+  const [selectedOption, setSelectedOption] = React.useState<string | null>(exerciseResponse ?? null);
   const [submittedOption, setSubmittedOption] = React.useState<string | null>(null);
 
   const handleOptionSelect = (option: string) => {
@@ -42,7 +44,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   };
 
   const handleAnswerSubmit = () => {
-    axios.put(`/api/courses/exercises/${exerciseId}`, {
+    axios.put(`/api/courses/exercises/${exerciseId}/response`, {
       response: selectedOption,
     }).then(() => {
       setSubmittedOption(selectedOption);

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
@@ -1,13 +1,13 @@
 import CTALinkOrButton from '@bluedot/ui/src/CTALinkOrButton';
-import axios from 'axios';
 import clsx from 'clsx';
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
 
 type MultipleChoiceProps = {
   // Required
   answer: string;
   description: string;
-  exerciseId: string;
+  onExerciseSubmit: (savedExerciseResponse: string, completed?: boolean) => void;
   options: string;
   title: string;
   // Optional
@@ -15,12 +15,16 @@ type MultipleChoiceProps = {
   exerciseResponse?: string;
 };
 
+type FormData = {
+  answer: string;
+};
+
 const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   answer,
   className,
   description,
-  exerciseId,
   exerciseResponse,
+  onExerciseSubmit,
   options,
   title,
 }) => {
@@ -30,32 +34,52 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
    */
   const formattedOptions = (options.split('\n').map((o) => o.trim()).filter((o) => o !== ''));
   const formattedAnswer = answer.trim();
+  const formattedExerciseResponse = exerciseResponse?.trim();
 
-  const [selectedOption, setSelectedOption] = React.useState<string | null>(exerciseResponse ?? null);
-  const [submittedOption, setSubmittedOption] = React.useState<string | null>(null);
+  const [selectedOption, setSelectedOption] = React.useState<string | null>();
+  const [isEditing, setIsEditing] = React.useState<boolean>(false);
+  const { register, handleSubmit, setValue } = useForm<FormData>({
+    defaultValues: {
+      answer: formattedExerciseResponse || ''
+    }
+  });
 
   const handleOptionSelect = (option: string) => {
     setSelectedOption(option);
-    setSubmittedOption(null); // Reset the submitted option when a new option is selected
+    setIsEditing(true);
   };
 
   const isSelected = (option: string): boolean => {
-    return selectedOption === option;
+    if (!isEditing && formattedExerciseResponse) {
+      return formattedExerciseResponse === option;
+    } else {
+      return selectedOption === option;
+    }
   };
 
-  const handleAnswerSubmit = () => {
-    axios.put(`/api/courses/exercises/${exerciseId}/response`, {
-      response: selectedOption,
-    }).then(() => {
-      setSubmittedOption(selectedOption);
-    });
-  };
+  useEffect(() => {
+    if (formattedExerciseResponse) {
+      setValue('answer', formattedExerciseResponse);
+    }
+  }, [formattedExerciseResponse, setValue]);
 
-  const isCorrect = submittedOption && submittedOption === formattedAnswer;
-  const isIncorrect = submittedOption && submittedOption !== formattedAnswer;
+  const onSubmit = useCallback(async (data: FormData) => {
+    try {
+      const isAnswerCorrect = data.answer === formattedAnswer;
+      console.log('submitted this answer: ', data.answer, ' and is it correct? ', isAnswerCorrect);
+      await onExerciseSubmit(data.answer, isAnswerCorrect);
+      setIsEditing(false);
+    } catch (e) {
+      console.log('error', e);
+      // Set some state for the error and render it
+    }
+  }, [onExerciseSubmit]);
+
+  const isCorrect = formattedExerciseResponse && formattedExerciseResponse === formattedAnswer;
+  const isIncorrect = formattedExerciseResponse && formattedExerciseResponse !== formattedAnswer;
 
   return (
-    <div className={clsx('multiple-choice container-lined bg-white p-8 flex flex-col gap-6', className)}>
+    <form onSubmit={handleSubmit(onSubmit)} className={clsx('multiple-choice container-lined bg-white p-8 flex flex-col gap-6', className)}>
       <div className="multiple-choice__header flex flex-col gap-4">
         <div className="multiple-choice__header-icon">
           <img src="/icons/lightning_bolt.svg" className="w-15 h-15" alt="" />
@@ -68,17 +92,19 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
       <div className="multiple-choice__options flex flex-col gap-2">
         {formattedOptions.map((option) => (
           <label
+            key={option}
             className={`
               multiple-choice__option flex items-center gap-2 p-4 hover:cursor-pointer
-              ${isSelected(option) ? `multiple-choice__option--selected container-active
-                ${isCorrect && 'multiple-choice__option--correct bg-[#63C96533] border-[#63C965]'}
-                ${isIncorrect && 'multiple-choice__option--incorrect bg-[#FF636333] border-[#FF6363]'}`
+              ${(isSelected(option)) ? `multiple-choice__option--selected container-active
+                ${(!isEditing && isCorrect) && 'multiple-choice__option--correct bg-[#63C96533] border-[#63C965]'}
+                ${(!isEditing && isIncorrect) && 'multiple-choice__option--incorrect bg-[#FF636333] border-[#FF6363]'}`
               : 'container-lined'}`}
           >
             <input
+              {...register('answer')}
+              defaultChecked={formattedExerciseResponse === option}
               className="multiple-choice__input"
               type="radio"
-              name="multiple-choice"
               value={option}
               onChange={() => handleOptionSelect(option)}
             />
@@ -89,13 +115,13 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
       <CTALinkOrButton
         className="multiple-choice__submit"
         variant="primary"
-        onClick={handleAnswerSubmit}
+        type="submit"
       >
         Check
       </CTALinkOrButton>
-      {isCorrect && <p className="multiple-choice__correct-msg">Correct! Quiz completed. 🎉</p>}
-      {isIncorrect && <p className="multiple-choice__incorrect-msg">Try again. 🤔</p>}
-    </div>
+      {(!isEditing && isCorrect) && <p className="multiple-choice__correct-msg">Correct! Quiz completed. 🎉</p>}
+      {(!isEditing && isIncorrect) && <p className="multiple-choice__incorrect-msg">Try again. 🤔</p>}
+    </form>
   );
 };
 

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
@@ -1,22 +1,26 @@
 import CTALinkOrButton from '@bluedot/ui/src/CTALinkOrButton';
+import axios from 'axios';
 import clsx from 'clsx';
 import React from 'react';
 
 type MultipleChoiceProps = {
   // Required
-  title: string;
-  description: string;
-  options: string;
   answer: string;
+  description: string;
+  exerciseId: string;
+  options: string;
+  title: string;
+  // Optional
   className?: string;
 };
 
 const MultipleChoice: React.FC<MultipleChoiceProps> = ({
-  title,
-  description,
-  options,
   answer,
   className,
+  description,
+  exerciseId,
+  options,
+  title,
 }) => {
   /**
    * Options are stored as a string with newlines
@@ -38,7 +42,11 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   };
 
   const handleAnswerSubmit = () => {
-    setSubmittedOption(selectedOption);
+    axios.put(`/api/courses/exercises/${exerciseId}`, {
+      response: selectedOption,
+    }).then(() => {
+      setSubmittedOption(selectedOption);
+    });
   };
 
   const isCorrect = submittedOption && submittedOption === formattedAnswer;

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
@@ -40,8 +40,8 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   const [isEditing, setIsEditing] = React.useState<boolean>(false);
   const { register, handleSubmit, setValue } = useForm<FormData>({
     defaultValues: {
-      answer: formattedExerciseResponse || ''
-    }
+      answer: formattedExerciseResponse || '',
+    },
   });
 
   const handleOptionSelect = (option: string) => {
@@ -52,9 +52,8 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   const isSelected = (option: string): boolean => {
     if (!isEditing && formattedExerciseResponse) {
       return formattedExerciseResponse === option;
-    } else {
-      return selectedOption === option;
     }
+    return selectedOption === option;
   };
 
   useEffect(() => {

--- a/apps/website-25/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website-25/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FreeTextResponse > renders default as expected 1`] = `
 <div>
-  <div
+  <form
     class="free-text-response container-lined bg-white p-8 flex flex-col gap-6"
   >
     <div
@@ -35,13 +35,14 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
     >
       <textarea
         class="free-text-response__textarea p-4 container-lined"
+        name="answer"
         placeholder="Enter your answer here"
       />
     </div>
     <button
       class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark free-text-response__submit"
       data-testid="cta-button"
-      type="button"
+      type="submit"
     >
       <span
         class="cta-button__text"
@@ -49,14 +50,65 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
         Save
       </span>
     </button>
-  </div>
+  </form>
 </div>
 `;
 
-exports[`FreeTextResponse > updates styles when answer is saved 1`] = `
-<p
-  class="free-text-response__saved-msg"
->
-  Saved! 🎉
-</p>
+exports[`FreeTextResponse > renders with saved exercise response 1`] = `
+<div>
+  <form
+    class="free-text-response container-lined bg-white p-8 flex flex-col gap-6"
+  >
+    <div
+      class="free-text-response__header flex flex-col gap-4"
+    >
+      <div
+        class="free-text-response__header-icon"
+      >
+        <img
+          alt=""
+          class="w-15 h-15"
+          src="/icons/lightning_bolt.svg"
+        />
+      </div>
+      <div
+        class="free-text-response__header-content flex flex-col gap-2"
+      >
+        <p
+          class="free-text-response__title subtitle-sm"
+        >
+          Understanding LLMs
+        </p>
+        <p>
+          Why is a language model's ability to predict 'the next word' capable of producing complex behaviors like solving maths problems?
+        </p>
+      </div>
+    </div>
+    <div
+      class="free-text-response__options flex flex-col gap-2"
+    >
+      <textarea
+        class="free-text-response__textarea p-4 free-text-response__textarea--saved container-active bg-[#63C96533] border-[#63C965] text-[#2A5D2A]"
+        name="answer"
+        placeholder="Enter your answer here"
+      />
+    </div>
+    <button
+      class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark free-text-response__submit"
+      data-testid="cta-button"
+      type="submit"
+    >
+      <span
+        class="cta-button__text"
+      >
+        Save
+      </span>
+    </button>
+    <p
+      class="free-text-response__saved-msg"
+    >
+      Saved! 🎉
+    </p>
+  </form>
+</div>
 `;

--- a/apps/website-25/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website-25/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MultipleChoice > renders default as expected 1`] = `
 <div>
-  <div
+  <form
     class="multiple-choice container-lined bg-white p-8 flex flex-col gap-6"
   >
     <div
@@ -42,7 +42,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
       >
         <input
           class="multiple-choice__input"
-          name="multiple-choice"
+          name="answer"
           type="radio"
           value="The community's preference for low-tech fishing traditions"
         />
@@ -59,7 +59,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
       >
         <input
           class="multiple-choice__input"
-          name="multiple-choice"
+          name="answer"
           type="radio"
           value="Rising consumer demand for fish with more Omega-3s"
         />
@@ -76,7 +76,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
       >
         <input
           class="multiple-choice__input"
-          name="multiple-choice"
+          name="answer"
           type="radio"
           value="Environmental regulations and declining cod stocks"
         />
@@ -93,7 +93,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
       >
         <input
           class="multiple-choice__input"
-          name="multiple-choice"
+          name="answer"
           type="radio"
           value="A cultural shift toward vegetarianism in the region"
         />
@@ -107,7 +107,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
     <button
       class="cta-button flex items-center justify-center rounded-radius-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cta-button--primary bg-bluedot-normal link-on-dark multiple-choice__submit"
       data-testid="cta-button"
-      type="button"
+      type="submit"
     >
       <span
         class="cta-button__text"
@@ -115,11 +115,33 @@ exports[`MultipleChoice > renders default as expected 1`] = `
         Check
       </span>
     </button>
-  </div>
+  </form>
 </div>
 `;
 
 exports[`MultipleChoice > updates styles for correct option 1`] = `
+<label
+  class="
+              multiple-choice__option flex items-center gap-2 p-4 hover:cursor-pointer
+              multiple-choice__option--selected container-active
+                multiple-choice__option--correct bg-[#63C96533] border-[#63C965]
+                false"
+>
+  <input
+    class="multiple-choice__input"
+    name="answer"
+    type="radio"
+    value="The community's preference for low-tech fishing traditions"
+  />
+  <span
+    class="multiple-choice__label"
+  >
+    The community's preference for low-tech fishing traditions
+  </span>
+</label>
+`;
+
+exports[`MultipleChoice > updates styles for correct option 2`] = `
 <p
   class="multiple-choice__correct-msg"
 >
@@ -127,7 +149,29 @@ exports[`MultipleChoice > updates styles for correct option 1`] = `
 </p>
 `;
 
-exports[`MultipleChoice > updates styles for incorrect option 1`] = `
+exports[`MultipleChoice > updates styles for correct option 3`] = `
+<label
+  class="
+              multiple-choice__option flex items-center gap-2 p-4 hover:cursor-pointer
+              multiple-choice__option--selected container-active
+                false
+                multiple-choice__option--incorrect bg-[#FF636333] border-[#FF6363]"
+>
+  <input
+    class="multiple-choice__input"
+    name="answer"
+    type="radio"
+    value="Rising consumer demand for fish with more Omega-3s"
+  />
+  <span
+    class="multiple-choice__label"
+  >
+    Rising consumer demand for fish with more Omega-3s
+  </span>
+</label>
+`;
+
+exports[`MultipleChoice > updates styles for correct option 4`] = `
 <p
   class="multiple-choice__incorrect-msg"
 >

--- a/apps/website-25/src/lib/api/db/tables.ts
+++ b/apps/website-25/src/lib/api/db/tables.ts
@@ -159,8 +159,10 @@ export const exerciseTable: Table<Exercise> = {
 
 export interface ExerciseResponse extends Item {
   id: string,
+  email: string,
   exerciseId: string,
   response: string,
+  completed: boolean,
 }
 
 export const exerciseResponseTable: Table<ExerciseResponse> = {
@@ -168,12 +170,16 @@ export const exerciseResponseTable: Table<ExerciseResponse> = {
   baseId: 'appnJbsG1eWbAdEvf',
   tableId: 'tblLNijbqwoLtkd3O',
   mappings: {
+    email: 'fldI5oHurlbNjQJmM',
     exerciseId: 'fldSKltln4l3yYdi2',
     response: 'fld7Qa3JDnRNwCTlH',
+    completed: 'fldz8rocQd7Ws9s2q',
   },
   schema: {
+    email: 'string',
     exerciseId: 'string',
     response: 'string',
+    completed: 'boolean',
   },
 };
 

--- a/apps/website-25/src/lib/api/db/tables.ts
+++ b/apps/website-25/src/lib/api/db/tables.ts
@@ -157,6 +157,26 @@ export const exerciseTable: Table<Exercise> = {
   },
 };
 
+export interface ExerciseResponse extends Item {
+  id: string,
+  exerciseId: string,
+  response: string,
+}
+
+export const exerciseResponseTable: Table<ExerciseResponse> = {
+  name: 'Exercise response',
+  baseId: 'appnJbsG1eWbAdEvf',
+  tableId: 'tblLNijbqwoLtkd3O',
+  mappings: {
+    exerciseId: 'fldSKltln4l3yYdi2',
+    response: 'fld7Qa3JDnRNwCTlH',
+  },
+  schema: {
+    exerciseId: 'string',
+    response: 'string',
+  },
+};
+
 export interface CourseRegistration extends Item {
   id: string,
   userId: string,

--- a/apps/website-25/src/pages/api/courses/exercises/[exerciseId]/index.ts
+++ b/apps/website-25/src/pages/api/courses/exercises/[exerciseId]/index.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import createHttpError from 'http-errors';
+import db from '../../../../../lib/api/db';
+import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
+import {
+  Exercise,
+  exerciseTable,
+} from '../../../../../lib/api/db/tables';
+
+export type GetExercise = {
+  type: 'success',
+  exercise: Exercise,
+};
+
+export default makeApiRoute({
+  requireAuth: false,
+  responseBody: z.object({
+    type: z.literal('success'),
+    exercise: z.any().optional(),
+  }),
+}, async (body, { raw }) => {
+  const { exerciseId } = raw.req.query;
+
+  switch (raw.req.method) {
+    case 'GET': {
+      const exercise = (await db.scan(exerciseTable, {
+        filterByFormula: `{[*] Record ID} = "${exerciseId}"`,
+      }))[0];
+
+      return {
+        type: 'success' as const,
+        exercise,
+      };
+    }
+
+    default: {
+      throw new createHttpError.MethodNotAllowed();
+    }
+  }
+});

--- a/apps/website-25/src/pages/api/courses/exercises/[exerciseId]/response.ts
+++ b/apps/website-25/src/pages/api/courses/exercises/[exerciseId]/response.ts
@@ -7,14 +7,13 @@ import {
   exerciseResponseTable,
 } from '../../../../../lib/api/db/tables';
 
-export type GetExerciseResponse = {
+export type GetExerciseResponseResponse = {
   type: 'success',
   exerciseResponse: ExerciseResponse,
 };
 
-export type PutExerciseResponse = {
-  type: 'success',
-  exerciseResponse: ExerciseResponse,
+export type PutExerciseResponseRequest = {
+  response: string,
 };
 
 export default makeApiRoute({
@@ -60,12 +59,16 @@ export default makeApiRoute({
       if (exerciseResponse) {
         updatedExerciseResponse = await db.update(exerciseResponseTable, {
           id: exerciseResponse.id,
+          exerciseId,
           response: body.response,
         });
       } else {
         // If the exercise response does NOT exist, create it
         updatedExerciseResponse = await db.insert(exerciseResponseTable, {
+          email: auth.email,
+          exerciseId,
           response: body.response,
+          completed: true,
         });
       }
 

--- a/apps/website-25/src/pages/api/courses/exercises/[exerciseId]/response.ts
+++ b/apps/website-25/src/pages/api/courses/exercises/[exerciseId]/response.ts
@@ -14,6 +14,7 @@ export type GetExerciseResponseResponse = {
 
 export type PutExerciseResponseRequest = {
   response: string,
+  completed?: boolean,
 };
 
 export default makeApiRoute({
@@ -21,6 +22,7 @@ export default makeApiRoute({
   requestBody: z.optional(
     z.object({
       response: z.string(),
+      completed: z.boolean().optional(),
     }),
   ),
   responseBody: z.object({
@@ -61,6 +63,7 @@ export default makeApiRoute({
           id: exerciseResponse.id,
           exerciseId,
           response: body.response,
+          completed: body.completed ?? false,
         });
       } else {
         // If the exercise response does NOT exist, create it
@@ -68,7 +71,7 @@ export default makeApiRoute({
           email: auth.email,
           exerciseId,
           response: body.response,
-          completed: true,
+          completed: body.completed ?? false,
         });
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -586,6 +586,7 @@
         "react-click-away-listener": "^2.3.0",
         "react-device-detect": "^2.2.3",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.56.0",
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "zod": "^3.24.2",
@@ -23803,9 +23804,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.53.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
-      "integrity": "sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==",
+      "version": "7.56.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.0.tgz",
+      "integrity": "sha512-U2QQgx5z2Y8Z0qlXv3W19hWHJgfKdWMz0O/osuY+o+CYq568V2R/JhzC6OAXfR8k24rIN0Muan2Qliaq9eKs/g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"


### PR DESCRIPTION
# Summary

Updating Exercise, FreeTextResponse, and MultipleChoice to handle saving, updating, and rendering saved user responses

## Issue
Fixes #562 

## Description
- New APIs:
  - GET /api/courses/exercises/${exerciseId} – does not require auth, returns exercise details
  - GET /api/courses/exercises/${exerciseId}/response – requires auth, returns saved exercise responses
  - PUT /api/courses/exercises/${exerciseId}/response – requires auth, upsert exercise with new submitted state
- Exercise handles API methods and passes a callback to FreeTextResponse and MultipleChoice
- Use react-hook-form to help handle form updates in FreeTextResponse and MultipleChoice

## Screen Recordings

https://github.com/user-attachments/assets/5d3748d7-ddb5-4fc7-a408-0e54357ae378

<img width="686" alt="Screenshot 2025-04-22 at 18 15 30" src="https://github.com/user-attachments/assets/38f25d68-c3e7-4edf-8941-009ac673270d" />

<img width="686" alt="Screenshot 2025-04-22 at 18 15 26" src="https://github.com/user-attachments/assets/86d4523c-13f2-4d29-aedb-de3ec7318329" />

<img width="685" alt="Screenshot 2025-04-22 at 18 15 37" src="https://github.com/user-attachments/assets/0b12b755-04a9-42ca-b68d-0e7b7fbdb664" />

https://github.com/user-attachments/assets/041ef8a3-0e75-49e7-ab74-dd79424d77aa

<img width="693" alt="Screenshot 2025-04-22 at 18 14 54" src="https://github.com/user-attachments/assets/7d6aa5e8-f85d-47ad-90a0-56dd75238609" />

<img width="696" alt="Screenshot 2025-04-22 at 18 15 04" src="https://github.com/user-attachments/assets/92f708f9-836f-4df9-9154-6d8bd8c117d1" />
