### PR TITLE
Bug fix Congratulations and SocialShare

### DIFF
--- a/apps/website-25/src/components/courses/Congratulations.stories.tsx
+++ b/apps/website-25/src/components/courses/Congratulations.stories.tsx
@@ -20,8 +20,8 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     courseTitle: 'Future of AI',
-    courseUrl: 'https://course.bluedot.org/future-of-ai',
-    referralCode: '5SR7C4',
-    text: 'I\'ve just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:',
+    coursePath: '/courses/future-of-ai',
+    referralCode: '',
+    text: '',
   },
 };

--- a/apps/website-25/src/components/courses/Congratulations.test.tsx
+++ b/apps/website-25/src/components/courses/Congratulations.test.tsx
@@ -7,9 +7,19 @@ describe('Congratulations', () => {
     const { container } = render(
       <Congratulations
         courseTitle="Future of AI"
-        courseUrl="https://course.bluedot.org/future-of-ai"
-        referralCode="5SR7C4"
-        text="I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+        coursePath="/courses/future-of-ai"
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders with custom args', () => {
+    const { container } = render(
+      <Congratulations
+        courseTitle="Future of AI"
+        coursePath="/courses/future-of-ai"
+        referralCode="ABCDEF"
+        text="This is a custom text I've written for this course!"
       />,
     );
     expect(container).toMatchSnapshot();

--- a/apps/website-25/src/components/courses/Congratulations.tsx
+++ b/apps/website-25/src/components/courses/Congratulations.tsx
@@ -3,17 +3,20 @@ import SocialShare from './SocialShare';
 
 type CongratulationsProps = {
   courseTitle: string;
-  courseUrl: string;
+  coursePath: string;
   referralCode?: string;
   text?: string;
 };
 
 const Congratulations: React.FC<CongratulationsProps> = ({
   courseTitle,
-  courseUrl,
+  coursePath,
   referralCode,
   text,
 }) => {
+  const socialShareText = text || 
+    `🎉 I just completed the ${courseTitle} course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:`;
+
   return (
     <div className="congratulations flex flex-col gap-4 container-lined p-4 bg-white items-center">
       <h3 className="congratulations__title text-center">Congratulations on completing {courseTitle}!</h3>
@@ -21,9 +24,9 @@ const Congratulations: React.FC<CongratulationsProps> = ({
         Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.
       </p>
       <SocialShare
-        courseUrl={courseUrl}
+        coursePath={coursePath}
         referralCode={referralCode}
-        text={text}
+        text={socialShareText}
       />
     </div>
   );

--- a/apps/website-25/src/components/courses/Congratulations.tsx
+++ b/apps/website-25/src/components/courses/Congratulations.tsx
@@ -14,8 +14,7 @@ const Congratulations: React.FC<CongratulationsProps> = ({
   referralCode,
   text,
 }) => {
-  const socialShareText = text || 
-    `🎉 I just completed the ${courseTitle} course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:`;
+  const socialShareText = text || `🎉 I just completed the ${courseTitle} course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:`;
 
   return (
     <div className="congratulations flex flex-col gap-4 container-lined p-4 bg-white items-center">

--- a/apps/website-25/src/components/courses/SocialShare.stories.tsx
+++ b/apps/website-25/src/components/courses/SocialShare.stories.tsx
@@ -19,8 +19,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    courseUrl: 'https://course.bluedot.org/future-of-ai',
+    coursePath: '/courses/future-of-ai',
     referralCode: '5SR7C4',
-    text: 'I\'ve just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:',
+    text: 'This is my custom text for this course!',
   },
 };

--- a/apps/website-25/src/components/courses/SocialShare.test.tsx
+++ b/apps/website-25/src/components/courses/SocialShare.test.tsx
@@ -6,11 +6,23 @@ describe('SocialShare', () => {
   test('renders default as expected', () => {
     const { container } = render(
       <SocialShare
-        courseUrl="https://course.bluedot.org/future-of-ai"
+        coursePath="/courses/future-of-ai"
         referralCode="5SR7C4"
         text="I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
       />,
     );
     expect(container).toMatchSnapshot();
+  });
+
+  test('renders without optional args', () => {
+    const { container } = render(
+      <SocialShare
+        coursePath="/future-of-ai"
+      />,
+    );
+    const socialShareLinks = container.querySelectorAll('.social-share__link');
+    socialShareLinks.forEach((link) => {
+      expect(link.getAttribute('href')).toMatchSnapshot();
+    });
   });
 });

--- a/apps/website-25/src/components/courses/SocialShare.tsx
+++ b/apps/website-25/src/components/courses/SocialShare.tsx
@@ -11,7 +11,7 @@ const SocialShare: React.FC<SocialShareProps> = ({ coursePath, referralCode, tex
   const constructFullCourseUrl = (campaign: string) => {
     const url = `bluedot.org${coursePath}?utm_source=referral&utm_campaign=${campaign}`;
     return referralCode ? `${url}&r=${referralCode}` : url;
-  }
+  };
 
   return (
     <div className="social-share flex flex-row gap-4">

--- a/apps/website-25/src/components/courses/SocialShare.tsx
+++ b/apps/website-25/src/components/courses/SocialShare.tsx
@@ -2,17 +2,22 @@ import React from 'react';
 import { FaFacebook, FaLinkedin, FaTwitter } from 'react-icons/fa6';
 
 type SocialShareProps = {
-  courseUrl: string;
+  coursePath: string;
   referralCode?: string;
   text?: string;
 };
 
-const SocialShare: React.FC<SocialShareProps> = ({ courseUrl, referralCode, text }) => {
+const SocialShare: React.FC<SocialShareProps> = ({ coursePath, referralCode, text }) => {
+  const constructFullCourseUrl = (campaign: string) => {
+    const url = `bluedot.org${coursePath}?utm_source=referral&utm_campaign=${campaign}`;
+    return referralCode ? `${url}&r=${referralCode}` : url;
+  }
+
   return (
     <div className="social-share flex flex-row gap-4">
       <a
         className="social-share__link size-6"
-        href={`https://www.linkedin.com/shareArticle?mini=true&url=${courseUrl}?r=${referralCode}&utm_source=referral&utm_campaign=linkedin&text=${text}`}
+        href={`https://www.linkedin.com/shareArticle?mini=true&url=${constructFullCourseUrl('linkedin')}${text && `&text=${text}`}`}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -20,7 +25,7 @@ const SocialShare: React.FC<SocialShareProps> = ({ courseUrl, referralCode, text
       </a>
       <a
         className="social-share__link size-6"
-        href={`https://twitter.com/intent/tweet?text=${text}&url=${courseUrl}?r=${referralCode}`}
+        href={`https://twitter.com/intent/tweet?url=${constructFullCourseUrl('twitter')}${text && `&text=${text}`}`}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -28,7 +33,7 @@ const SocialShare: React.FC<SocialShareProps> = ({ courseUrl, referralCode, text
       </a>
       <a
         className="social-share__link size-6"
-        href={`https://www.facebook.com/sharer/sharer.php?u=${courseUrl}?r=${referralCode}&utm_source=referral&utm_campaign=fb&quote=${text}`}
+        href={`https://www.facebook.com/sharer/sharer.php?u=${constructFullCourseUrl('facebook')}${text && `&quote=${text}`}`}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/apps/website-25/src/components/courses/UnitLayout.tsx
+++ b/apps/website-25/src/components/courses/UnitLayout.tsx
@@ -67,7 +67,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
                 Next unit
               </CTALinkOrButton>
             ) : (
-              <Congratulations courseTitle={unit.courseTitle} courseUrl={unit.coursePath} />
+              <Congratulations courseTitle={unit.courseTitle} coursePath={unit.coursePath} />
             )}
           </div>
         </div>

--- a/apps/website-25/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Congratulations > renders default as expected 1`] = `
     >
       <a
         class="social-share__link size-6"
-        href="https://www.linkedin.com/shareArticle?mini=true&url=https://course.bluedot.org/future-of-ai?r=5SR7C4&utm_source=referral&utm_campaign=linkedin&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+        href="https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=linkedin&text=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -43,7 +43,7 @@ exports[`Congratulations > renders default as expected 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://twitter.com/intent/tweet?text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:&url=https://course.bluedot.org/future-of-ai?r=5SR7C4"
+        href="https://twitter.com/intent/tweet?url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=twitter&text=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -64,7 +64,95 @@ exports[`Congratulations > renders default as expected 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://www.facebook.com/sharer/sharer.php?u=https://course.bluedot.org/future-of-ai?r=5SR7C4&utm_source=referral&utm_campaign=fb&quote=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+        href="https://www.facebook.com/sharer/sharer.php?u=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=facebook&quote=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <svg
+          class="social-share__link-icon size-6"
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 512 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M512 256C512 114.6 397.4 0 256 0S0 114.6 0 256C0 376 82.7 476.8 194.2 504.5V334.2H141.4V256h52.8V222.3c0-87.1 39.4-127.5 125-127.5c16.2 0 44.2 3.2 55.7 6.4V172c-6-.6-16.5-1-29.6-1c-42 0-58.2 15.9-58.2 57.2V256h83.6l-14.4 78.2H287V510.1C413.8 494.8 512 386.9 512 256h0z"
+          />
+        </svg>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Congratulations > renders with custom args 1`] = `
+<div>
+  <div
+    class="congratulations flex flex-col gap-4 container-lined p-4 bg-white items-center"
+  >
+    <h3
+      class="congratulations__title text-center"
+    >
+      Congratulations on completing 
+      Future of AI
+      !
+    </h3>
+    <p
+      class="congratulations__description text-center"
+    >
+      Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.
+    </p>
+    <div
+      class="social-share flex flex-row gap-4"
+    >
+      <a
+        class="social-share__link size-6"
+        href="https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=linkedin&r=ABCDEF&text=This is a custom text I've written for this course!"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <svg
+          class="social-share__link-icon size-6"
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 448 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"
+          />
+        </svg>
+      </a>
+      <a
+        class="social-share__link size-6"
+        href="https://twitter.com/intent/tweet?url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=twitter&r=ABCDEF&text=This is a custom text I've written for this course!"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <svg
+          class="social-share__link-icon size-6"
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 512 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"
+          />
+        </svg>
+      </a>
+      <a
+        class="social-share__link size-6"
+        href="https://www.facebook.com/sharer/sharer.php?u=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=facebook&r=ABCDEF&quote=This is a custom text I've written for this course!"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/apps/website-25/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`SocialShare > renders default as expected 1`] = `
   >
     <a
       class="social-share__link size-6"
-      href="https://www.linkedin.com/shareArticle?mini=true&url=https://course.bluedot.org/future-of-ai?r=5SR7C4&utm_source=referral&utm_campaign=linkedin&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+      href="https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=linkedin&r=5SR7C4&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -28,7 +28,7 @@ exports[`SocialShare > renders default as expected 1`] = `
     </a>
     <a
       class="social-share__link size-6"
-      href="https://twitter.com/intent/tweet?text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:&url=https://course.bluedot.org/future-of-ai?r=5SR7C4"
+      href="https://twitter.com/intent/tweet?url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=twitter&r=5SR7C4&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -49,7 +49,7 @@ exports[`SocialShare > renders default as expected 1`] = `
     </a>
     <a
       class="social-share__link size-6"
-      href="https://www.facebook.com/sharer/sharer.php?u=https://course.bluedot.org/future-of-ai?r=5SR7C4&utm_source=referral&utm_campaign=fb&quote=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+      href="https://www.facebook.com/sharer/sharer.php?u=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=facebook&r=5SR7C4&quote=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -71,3 +71,9 @@ exports[`SocialShare > renders default as expected 1`] = `
   </div>
 </div>
 `;
+
+exports[`SocialShare > renders without optional args 1`] = `"https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/future-of-ai?utm_source=referral&utm_campaign=linkedinundefined"`;
+
+exports[`SocialShare > renders without optional args 2`] = `"https://twitter.com/intent/tweet?url=bluedot.org/future-of-ai?utm_source=referral&utm_campaign=twitterundefined"`;
+
+exports[`SocialShare > renders without optional args 3`] = `"https://www.facebook.com/sharer/sharer.php?u=bluedot.org/future-of-ai?utm_source=referral&utm_campaign=facebookundefined"`;

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`UnitLayout > renders Congratulations on final unit 1`] = `
   >
     <a
       class="social-share__link size-6"
-      href="https://www.linkedin.com/shareArticle?mini=true&url=/courses/test-course?r=undefined&utm_source=referral&utm_campaign=linkedin&text=undefined"
+      href="https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/courses/test-course?utm_source=referral&utm_campaign=linkedin&text=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -42,7 +42,7 @@ exports[`UnitLayout > renders Congratulations on final unit 1`] = `
     </a>
     <a
       class="social-share__link size-6"
-      href="https://twitter.com/intent/tweet?text=undefined&url=/courses/test-course?r=undefined"
+      href="https://twitter.com/intent/tweet?url=bluedot.org/courses/test-course?utm_source=referral&utm_campaign=twitter&text=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -63,7 +63,7 @@ exports[`UnitLayout > renders Congratulations on final unit 1`] = `
     </a>
     <a
       class="social-share__link size-6"
-      href="https://www.facebook.com/sharer/sharer.php?u=/courses/test-course?r=undefined&utm_source=referral&utm_campaign=fb&quote=undefined"
+      href="https://www.facebook.com/sharer/sharer.php?u=bluedot.org/courses/test-course?utm_source=referral&utm_campaign=facebook&quote=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
       rel="noopener noreferrer"
       target="_blank"
     >


### PR DESCRIPTION
# Summary

Bug fix Congratulations and SocialShare

## Description

- Fix SocialShare URL construction to include base off of dynamic coursePath slugs
- Update a default text copy

### To do
- Will need to QA this once the URLs are actually available

## Screenshot
<img width="1432" alt="image" src="https://github.com/user-attachments/assets/bb50f2a1-efc1-4077-ac0e-f9d765fb7761" />

<img width="580" alt="Screenshot 2025-04-10 at 13 06 54" src="https://github.com/user-attachments/assets/28cd61c9-c185-4cda-a820-7b04541c5429" />
<img width="837" alt="Screenshot 2025-04-10 at 13 06 51" src="https://github.com/user-attachments/assets/7022d823-f3ff-48d2-8448-50581d509d54" />
<img width="783" alt="Screenshot 2025-04-10 at 13 06 42" src="https://github.com/user-attachments/assets/be2f0316-b8dd-47d0-8516-a5356532b68d" />

<img width="1512" alt="Screenshot 2025-04-10 at 13 25 00" src="https://github.com/user-attachments/assets/fbee9377-00bd-4557-b128-603aa19a66da" />

<img width="1512" alt="Screenshot 2025-04-10 at 13 25 06" src="https://github.com/user-attachments/assets/9076ef31-4572-417a-af26-2dfa25d8c32c" />


## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```