### PR TITLE
Basic profile page UI

### DIFF
--- a/apps/website-25/src/components/courses/Congratulations.tsx
+++ b/apps/website-25/src/components/courses/Congratulations.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import SocialShare from './SocialShare';
 
 type CongratulationsProps = {
@@ -6,6 +7,7 @@ type CongratulationsProps = {
   coursePath: string;
   referralCode?: string;
   text?: string;
+  className?: string;
 };
 
 const Congratulations: React.FC<CongratulationsProps> = ({
@@ -13,11 +15,12 @@ const Congratulations: React.FC<CongratulationsProps> = ({
   coursePath,
   referralCode,
   text,
+  className,
 }) => {
   const socialShareText = text || `🎉 I just completed the ${courseTitle} course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:`;
 
   return (
-    <div className="congratulations flex flex-col gap-4 container-lined p-4 bg-white items-center">
+    <div className={clsx('congratulations flex flex-col gap-4 container-lined p-4 bg-white items-center', className)}>
       <h3 className="congratulations__title text-center">Congratulations on completing {courseTitle}!</h3>
       <p className="congratulations__description text-center">
         Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.

--- a/apps/website-25/src/pages/profile.tsx
+++ b/apps/website-25/src/pages/profile.tsx
@@ -38,12 +38,12 @@ const ProfilePage = withAuth(({ auth }) => {
         <Section
           className="profile max-w-[728px]"
         >
-          <div className="flex flex-col gap-4 container-lined bg-white p-8 mb-4">
+          <div className="profile__account-details flex flex-col gap-4 container-lined bg-white p-8 mb-4">
             <h3>Account details</h3>
             <p>Name: {data.user.name}</p>
             <p>Email: {data.user.email}</p>
           </div>
-          <div className="flex flex-row justify-between items-center gap-4 container-lined bg-white p-8 mb-4">
+          <div className="profile__course-progress flex flex-row justify-between items-center gap-4 container-lined bg-white p-8 mb-4">
             {data.user.courseSitesVisited.length > 0 ? (
               <>
                 <h3>{data.user.courseSitesVisited}</h3>
@@ -55,7 +55,7 @@ const ProfilePage = withAuth(({ auth }) => {
           </div>
           {data.user.completedMoocAt && (
             <Congratulations
-              className="!container-active"
+              className="profile__course-completion !container-active"
               courseTitle={data.user.courseSitesVisited}
               coursePath={data.user.courseSitesVisited}
               referralCode={data.user.referralId}
@@ -63,8 +63,8 @@ const ProfilePage = withAuth(({ auth }) => {
           )}
         </Section>
         {/* TODO #644: Move to Nav */}
-        <Section className="flex flex-row justify-center">
-          <CTALinkOrButton url="/login/clear" variant="secondary">
+        <Section className="profile__cta-container flex flex-row justify-center">
+          <CTALinkOrButton className="profile__logout" url="/login/clear" variant="secondary">
             Logout
           </CTALinkOrButton>
         </Section>

--- a/apps/website-25/src/pages/profile.tsx
+++ b/apps/website-25/src/pages/profile.tsx
@@ -1,6 +1,7 @@
 import {
   HeroSection,
   HeroH1,
+  HeroH2,
   ProgressDots,
   Section,
   withAuth,
@@ -9,6 +10,7 @@ import {
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import { GetUserResponse } from './api/users/me';
+import Congratulations from '../components/courses/Congratulations';
 
 // withAuth will redirect the user to login before viewing the page
 // If you want to get the user's token without redirecting them, use useAuthStore (which will be null if they're not logged in)
@@ -31,14 +33,38 @@ const ProfilePage = withAuth(({ auth }) => {
       <>
         <HeroSection>
           <HeroH1>Your profile</HeroH1>
+          <HeroH2>See your progress and share your learnings</HeroH2>
         </HeroSection>
         <Section
-          className="profile"
+          className="profile max-w-[728px]"
         >
-          <pre className="profile__content flex flex-col gap-4">
-            {JSON.stringify(data.user, null, 2)}
-          </pre>
-          <CTALinkOrButton url="/login/clear">
+          <div className="flex flex-col gap-4 container-lined bg-white p-8 mb-4">
+            <h3>Account details</h3>
+            <p>Name: {data.user.name}</p>
+            <p>Email: {data.user.email}</p>
+          </div>
+          <div className="flex flex-row justify-between items-center gap-4 container-lined bg-white p-8 mb-4">
+            {data.user.courseSitesVisited.length > 0 ? (
+              <>
+                <h3>{data.user.courseSitesVisited}</h3>
+                <p>{data.user.completedMoocAt ? 'Completed 🎉' : 'In progress'}</p>
+              </>
+            ) : (
+              <p>You have not enrolled in any courses yet.</p>
+            )}
+          </div>
+          {data.user.completedMoocAt && (
+            <Congratulations
+              className="!container-active"
+              courseTitle={data.user.courseSitesVisited}
+              coursePath={data.user.courseSitesVisited}
+              referralCode={data.user.referralId}
+            />
+          )}
+        </Section>
+        {/* TODO #644: Move to Nav */}
+        <Section className="flex flex-row justify-center">
+          <CTALinkOrButton url="/login/clear" variant="secondary">
             Logout
           </CTALinkOrButton>
         </Section>


### PR DESCRIPTION
# Summary

Basic profile page UI

Resolves #575 

## Description

- Simple course UI for account details and course progress
- Very bare-bones for an initial MVP

### To do
- Should update to include links to continue course, course progression, and maybe a more personalized social share to profile page.
- More robust testing, e.g. on SocialShare links w/ referral code working
- We will also need to update Nav bar, likely for a dropdown to take someone to Profile, Help, or Logout

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

<img width="1512" alt="Screenshot 2025-04-11 at 12 42 13" src="https://github.com/user-attachments/assets/6e82fc6c-abf3-4c6a-8f06-2bd49058a12d" />
<img width="403" alt="Screenshot 2025-04-11 at 12 42 29" src="https://github.com/user-attachments/assets/92fd71e8-8c2e-46a5-a34a-686b35355459" />

<img width="1512" alt="Screenshot 2025-04-11 at 12 50 18" src="https://github.com/user-attachments/assets/c86d34c9-e081-49aa-b346-fa1806b73d46" />
<img width="1512" alt="Screenshot 2025-04-11 at 12 50 13" src="https://github.com/user-attachments/assets/c074762b-6b3a-4eb1-b1e5-99ebe640f6fd" />

## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```