### PR TITLE
Link to course from profile page

### DIFF
--- a/apps/website-25/src/components/courses/SocialShare.tsx
+++ b/apps/website-25/src/components/courses/SocialShare.tsx
@@ -34,7 +34,7 @@ const SocialShare: React.FC<SocialShareProps> = ({ coursePath, referralCode, tex
       </a>
       <a
         className="social-share__link size-6"
-        href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(constructFullCourseUrl('facebook'))}${text && `&quote=${text}`}`}
+        href="https://www.facebook.com/sharer/sharer.php"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/apps/website-25/src/components/courses/SocialShare.tsx
+++ b/apps/website-25/src/components/courses/SocialShare.tsx
@@ -15,7 +15,7 @@ const SocialShare: React.FC<SocialShareProps> = ({ coursePath, referralCode, tex
   };
 
   return (
-    <div className="social-share flex flex-row gap-4 items-center">
+    <div className="social-share flex flex-row gap-4">
       <a
         className="social-share__link size-6"
         href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(constructFullCourseUrl('linkedin'))}${text && `&text=${text}`}`}

--- a/apps/website-25/src/components/courses/SocialShare.tsx
+++ b/apps/website-25/src/components/courses/SocialShare.tsx
@@ -9,15 +9,16 @@ type SocialShareProps = {
 
 const SocialShare: React.FC<SocialShareProps> = ({ coursePath, referralCode, text }) => {
   const constructFullCourseUrl = (campaign: string) => {
-    const url = `bluedot.org${coursePath}?utm_source=referral&utm_campaign=${campaign}`;
+    const baseUrl = window.location.origin;
+    const url = `${baseUrl}${coursePath}?utm_source=referral&utm_campaign=${campaign}`;
     return referralCode ? `${url}&r=${referralCode}` : url;
   };
 
   return (
-    <div className="social-share flex flex-row gap-4">
+    <div className="social-share flex flex-row gap-4 items-center">
       <a
         className="social-share__link size-6"
-        href={`https://www.linkedin.com/shareArticle?mini=true&url=${constructFullCourseUrl('linkedin')}${text && `&text=${text}`}`}
+        href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(constructFullCourseUrl('linkedin'))}${text && `&text=${text}`}`}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -25,7 +26,7 @@ const SocialShare: React.FC<SocialShareProps> = ({ coursePath, referralCode, tex
       </a>
       <a
         className="social-share__link size-6"
-        href={`https://twitter.com/intent/tweet?url=${constructFullCourseUrl('twitter')}${text && `&text=${text}`}`}
+        href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(constructFullCourseUrl('twitter'))}${text && `&text=${text}`}`}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -33,7 +34,7 @@ const SocialShare: React.FC<SocialShareProps> = ({ coursePath, referralCode, tex
       </a>
       <a
         className="social-share__link size-6"
-        href={`https://www.facebook.com/sharer/sharer.php?u=${constructFullCourseUrl('facebook')}${text && `&quote=${text}`}`}
+        href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(constructFullCourseUrl('facebook'))}${text && `&quote=${text}`}`}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/apps/website-25/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Congratulations > renders default as expected 1`] = `
       Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.
     </p>
     <div
-      class="social-share flex flex-row gap-4 items-center"
+      class="social-share flex flex-row gap-4"
     >
       <a
         class="social-share__link size-6"
@@ -106,7 +106,7 @@ exports[`Congratulations > renders with custom args 1`] = `
       Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.
     </p>
     <div
-      class="social-share flex flex-row gap-4 items-center"
+      class="social-share flex flex-row gap-4"
     >
       <a
         class="social-share__link size-6"

--- a/apps/website-25/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`Congratulations > renders default as expected 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dfacebook&quote=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        href="https://www.facebook.com/sharer/sharer.php"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -152,7 +152,7 @@ exports[`Congratulations > renders with custom args 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dfacebook%26r%3DABCDEF&quote=This is a custom text I've written for this course!"
+        href="https://www.facebook.com/sharer/sharer.php"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/apps/website-25/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
@@ -18,11 +18,11 @@ exports[`Congratulations > renders default as expected 1`] = `
       Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.
     </p>
     <div
-      class="social-share flex flex-row gap-4"
+      class="social-share flex flex-row gap-4 items-center"
     >
       <a
         class="social-share__link size-6"
-        href="https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=linkedin&text=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dlinkedin&text=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -43,7 +43,7 @@ exports[`Congratulations > renders default as expected 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://twitter.com/intent/tweet?url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=twitter&text=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        href="https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dtwitter&text=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -64,7 +64,7 @@ exports[`Congratulations > renders default as expected 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://www.facebook.com/sharer/sharer.php?u=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=facebook&quote=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dfacebook&quote=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -106,11 +106,11 @@ exports[`Congratulations > renders with custom args 1`] = `
       Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.
     </p>
     <div
-      class="social-share flex flex-row gap-4"
+      class="social-share flex flex-row gap-4 items-center"
     >
       <a
         class="social-share__link size-6"
-        href="https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=linkedin&r=ABCDEF&text=This is a custom text I've written for this course!"
+        href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dlinkedin%26r%3DABCDEF&text=This is a custom text I've written for this course!"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -131,7 +131,7 @@ exports[`Congratulations > renders with custom args 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://twitter.com/intent/tweet?url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=twitter&r=ABCDEF&text=This is a custom text I've written for this course!"
+        href="https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dtwitter%26r%3DABCDEF&text=This is a custom text I've written for this course!"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -152,7 +152,7 @@ exports[`Congratulations > renders with custom args 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://www.facebook.com/sharer/sharer.php?u=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=facebook&r=ABCDEF&quote=This is a custom text I've written for this course!"
+        href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dfacebook%26r%3DABCDEF&quote=This is a custom text I've written for this course!"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/apps/website-25/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SocialShare > renders default as expected 1`] = `
 <div>
   <div
-    class="social-share flex flex-row gap-4 items-center"
+    class="social-share flex flex-row gap-4"
   >
     <a
       class="social-share__link size-6"

--- a/apps/website-25/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`SocialShare > renders default as expected 1`] = `
 <div>
   <div
-    class="social-share flex flex-row gap-4"
+    class="social-share flex flex-row gap-4 items-center"
   >
     <a
       class="social-share__link size-6"
-      href="https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=linkedin&r=5SR7C4&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+      href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dlinkedin%26r%3D5SR7C4&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -28,7 +28,7 @@ exports[`SocialShare > renders default as expected 1`] = `
     </a>
     <a
       class="social-share__link size-6"
-      href="https://twitter.com/intent/tweet?url=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=twitter&r=5SR7C4&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+      href="https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dtwitter%26r%3D5SR7C4&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -49,7 +49,7 @@ exports[`SocialShare > renders default as expected 1`] = `
     </a>
     <a
       class="social-share__link size-6"
-      href="https://www.facebook.com/sharer/sharer.php?u=bluedot.org/courses/future-of-ai?utm_source=referral&utm_campaign=facebook&r=5SR7C4&quote=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+      href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dfacebook%26r%3D5SR7C4&quote=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -72,8 +72,8 @@ exports[`SocialShare > renders default as expected 1`] = `
 </div>
 `;
 
-exports[`SocialShare > renders without optional args 1`] = `"https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/future-of-ai?utm_source=referral&utm_campaign=linkedinundefined"`;
+exports[`SocialShare > renders without optional args 1`] = `"https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dlinkedinundefined"`;
 
-exports[`SocialShare > renders without optional args 2`] = `"https://twitter.com/intent/tweet?url=bluedot.org/future-of-ai?utm_source=referral&utm_campaign=twitterundefined"`;
+exports[`SocialShare > renders without optional args 2`] = `"https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dtwitterundefined"`;
 
-exports[`SocialShare > renders without optional args 3`] = `"https://www.facebook.com/sharer/sharer.php?u=bluedot.org/future-of-ai?utm_source=referral&utm_campaign=facebookundefined"`;
+exports[`SocialShare > renders without optional args 3`] = `"https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dfacebookundefined"`;

--- a/apps/website-25/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`SocialShare > renders default as expected 1`] = `
     </a>
     <a
       class="social-share__link size-6"
-      href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dfacebook%26r%3D5SR7C4&quote=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
+      href="https://www.facebook.com/sharer/sharer.php"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -76,4 +76,4 @@ exports[`SocialShare > renders without optional args 1`] = `"https://www.linkedi
 
 exports[`SocialShare > renders without optional args 2`] = `"https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dtwitterundefined"`;
 
-exports[`SocialShare > renders without optional args 3`] = `"https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dfacebookundefined"`;
+exports[`SocialShare > renders without optional args 3`] = `"https://www.facebook.com/sharer/sharer.php"`;

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`UnitLayout > renders Congratulations section on final unit 1`] = `
       Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.
     </p>
     <div
-      class="social-share flex flex-row gap-4 items-center"
+      class="social-share flex flex-row gap-4"
     >
       <a
         class="social-share__link size-6"

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`UnitLayout > renders Congratulations section on final unit 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ftest-course%3Futm_source%3Dreferral%26utm_campaign%3Dfacebook&quote=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        href="https://www.facebook.com/sharer/sharer.php"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -20,11 +20,11 @@ exports[`UnitLayout > renders Congratulations section on final unit 1`] = `
       Now share your perspective! Those reflections aren't going to achieve much sitting in an exercise box. Share them with your network to get the conversation going.
     </p>
     <div
-      class="social-share flex flex-row gap-4"
+      class="social-share flex flex-row gap-4 items-center"
     >
       <a
         class="social-share__link size-6"
-        href="https://www.linkedin.com/shareArticle?mini=true&url=bluedot.org/courses/test-course?utm_source=referral&utm_campaign=linkedin&text=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ftest-course%3Futm_source%3Dreferral%26utm_campaign%3Dlinkedin&text=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -45,7 +45,7 @@ exports[`UnitLayout > renders Congratulations section on final unit 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://twitter.com/intent/tweet?url=bluedot.org/courses/test-course?utm_source=referral&utm_campaign=twitter&text=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        href="https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ftest-course%3Futm_source%3Dreferral%26utm_campaign%3Dtwitter&text=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -66,7 +66,7 @@ exports[`UnitLayout > renders Congratulations section on final unit 1`] = `
       </a>
       <a
         class="social-share__link size-6"
-        href="https://www.facebook.com/sharer/sharer.php?u=bluedot.org/courses/test-course?utm_source=referral&utm_campaign=facebook&quote=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
+        href="https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ftest-course%3Futm_source%3Dreferral%26utm_campaign%3Dfacebook&quote=🎉 I just completed the What the fish [Test Course] course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/apps/website-25/src/pages/api/users/me.ts
+++ b/apps/website-25/src/pages/api/users/me.ts
@@ -27,6 +27,7 @@ export default makeApiRoute({
   const courseNames = user?.courseSitesVisited.split(',') ?? [];
 
   if (courseNames.length > 1) {
+    // eslint-disable-next-line no-console
     console.error('Users with multiple courses are not supported yet, only returning the first coursePath');
   }
 

--- a/apps/website-25/src/pages/api/users/me.ts
+++ b/apps/website-25/src/pages/api/users/me.ts
@@ -27,7 +27,7 @@ export default makeApiRoute({
   const courseNames = user?.courseSitesVisited.split(',') ?? [];
 
   if (courseNames.length > 1) {
-    throw new Error('Users with multiple courses are not supported yet');
+    console.error('Users with multiple courses are not supported yet, only returning the first coursePath');
   }
 
   const course = (await db.scan(courseTable, {

--- a/apps/website-25/src/pages/profile.tsx
+++ b/apps/website-25/src/pages/profile.tsx
@@ -25,6 +25,8 @@ const ProfilePage = withAuth(({ auth }) => {
     },
   });
 
+  const completedMooc = !!data?.user.completedMoocAt;
+
   return (
     <div>
       {loading && <ProgressDots />}
@@ -47,17 +49,23 @@ const ProfilePage = withAuth(({ auth }) => {
             {data.user.courseSitesVisited.length > 0 ? (
               <>
                 <h3>{data.user.courseSitesVisited}</h3>
-                <p>{data.user.completedMoocAt ? 'Completed 🎉' : 'In progress'}</p>
+                {completedMooc ? (
+                  <p>Completed 🎉</p>
+                ) : (
+                  <CTALinkOrButton url={data.user.coursePath} variant="primary">
+                    Continue
+                  </CTALinkOrButton>
+                )}
               </>
             ) : (
               <p>You have not enrolled in any courses yet.</p>
             )}
           </div>
-          {data.user.completedMoocAt && (
+          {completedMooc && (
             <Congratulations
               className="profile__course-completion !container-active"
               courseTitle={data.user.courseSitesVisited}
-              coursePath={data.user.courseSitesVisited}
+              coursePath={data.user.coursePath}
               referralCode={data.user.referralId}
             />
           )}


### PR DESCRIPTION
# Summary

Returns coursePath from the `/api/me` route, and uses it to link to course if it is in-progress.

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
#646 

This doesn't fully resolve the ticket, still to do:
- Making the referral flow work end to end (currently it doesn't) and adding a test for this

<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [X] [N/A] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot
The only visual change is adding the "Continue" button:

| 📸 |  |
|---------|---|
| 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
| 🖥️ | ![Screenshot 2025-04-15 at 11 25 06](https://github.com/user-attachments/assets/c106424a-edae-4b29-98c6-6f432e92eb65) |
| 📱  | ![Screenshot 2025-04-15 at 11 25 21](https://github.com/user-attachments/assets/694e456b-0bf4-42d0-aa12-33603d85bb7a) |

## Testing
```
$ npm run test:update
 Tasks:    13 successful, 13 total
Cached:    1 cached, 13 total
  Time:    24.451s
```