### PR TITLE
website-25: Improve stars component

### DIFF
--- a/apps/website-25/src/components/courses/StarRating.tsx
+++ b/apps/website-25/src/components/courses/StarRating.tsx
@@ -10,6 +10,9 @@ const Star: React.FC<{ filled: boolean }> = ({ filled }) => (
       strokeLinecap="round"
       strokeLinejoin="round"
       fill={filled ? '#FFC16A' : 'transparent'}
+      style={{
+        transition: 'fill 0.1s ease-in-out',
+      }}
     />
   </svg>
 );
@@ -23,12 +26,12 @@ const StarRating: React.FC<StarRatingProps> = ({ rating, setRating }) => {
   const [hoverRating, setHoverRating] = useState<number>(0);
 
   return (
-    <div className="star-rating flex gap-3">
+    <div className="star-rating flex -mx-2">
       {[1, 2, 3, 4, 5].map((i) => (
         <button
           key={i}
           type="button"
-          className="star-rating__star cursor-pointer size-10"
+          className="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
           onMouseEnter={() => setHoverRating(i)}
           onMouseLeave={() => setHoverRating(0)}
           onClick={() => setRating(i)}

--- a/apps/website-25/src/components/courses/__snapshots__/StarRating.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/StarRating.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`StarRating Component > renders correctly 1`] = `
 <div>
   <div
-    class="star-rating flex gap-3"
+    class="star-rating flex -mx-2"
   >
     <button
       aria-label="Rate 1 star"
       aria-pressed="false"
-      class="star-rating__star cursor-pointer size-10"
+      class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
       type="button"
     >
       <svg
@@ -23,13 +23,14 @@ exports[`StarRating Component > renders correctly 1`] = `
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="2"
+          style="transition: fill 0.1s ease-in-out;"
         />
       </svg>
     </button>
     <button
       aria-label="Rate 2 stars"
       aria-pressed="false"
-      class="star-rating__star cursor-pointer size-10"
+      class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
       type="button"
     >
       <svg
@@ -44,13 +45,14 @@ exports[`StarRating Component > renders correctly 1`] = `
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="2"
+          style="transition: fill 0.1s ease-in-out;"
         />
       </svg>
     </button>
     <button
       aria-label="Rate 3 stars"
       aria-pressed="false"
-      class="star-rating__star cursor-pointer size-10"
+      class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
       type="button"
     >
       <svg
@@ -65,13 +67,14 @@ exports[`StarRating Component > renders correctly 1`] = `
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="2"
+          style="transition: fill 0.1s ease-in-out;"
         />
       </svg>
     </button>
     <button
       aria-label="Rate 4 stars"
       aria-pressed="false"
-      class="star-rating__star cursor-pointer size-10"
+      class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
       type="button"
     >
       <svg
@@ -86,13 +89,14 @@ exports[`StarRating Component > renders correctly 1`] = `
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="2"
+          style="transition: fill 0.1s ease-in-out;"
         />
       </svg>
     </button>
     <button
       aria-label="Rate 5 stars"
       aria-pressed="false"
-      class="star-rating__star cursor-pointer size-10"
+      class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
       type="button"
     >
       <svg
@@ -107,6 +111,7 @@ exports[`StarRating Component > renders correctly 1`] = `
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="2"
+          style="transition: fill 0.1s ease-in-out;"
         />
       </svg>
     </button>

--- a/apps/website-25/src/components/courses/__snapshots__/UnitFeedback.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitFeedback.test.tsx.snap
@@ -20,12 +20,12 @@ exports[`UnitFeedback > should render correctly 1`] = `
       </p>
     </div>
     <div
-      class="star-rating flex gap-3"
+      class="star-rating flex -mx-2"
     >
       <button
         aria-label="Rate 1 star"
         aria-pressed="false"
-        class="star-rating__star cursor-pointer size-10"
+        class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
         type="button"
       >
         <svg
@@ -40,13 +40,14 @@ exports[`UnitFeedback > should render correctly 1`] = `
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
+            style="transition: fill 0.1s ease-in-out;"
           />
         </svg>
       </button>
       <button
         aria-label="Rate 2 stars"
         aria-pressed="false"
-        class="star-rating__star cursor-pointer size-10"
+        class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
         type="button"
       >
         <svg
@@ -61,13 +62,14 @@ exports[`UnitFeedback > should render correctly 1`] = `
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
+            style="transition: fill 0.1s ease-in-out;"
           />
         </svg>
       </button>
       <button
         aria-label="Rate 3 stars"
         aria-pressed="false"
-        class="star-rating__star cursor-pointer size-10"
+        class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
         type="button"
       >
         <svg
@@ -82,13 +84,14 @@ exports[`UnitFeedback > should render correctly 1`] = `
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
+            style="transition: fill 0.1s ease-in-out;"
           />
         </svg>
       </button>
       <button
         aria-label="Rate 4 stars"
         aria-pressed="false"
-        class="star-rating__star cursor-pointer size-10"
+        class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
         type="button"
       >
         <svg
@@ -103,13 +106,14 @@ exports[`UnitFeedback > should render correctly 1`] = `
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
+            style="transition: fill 0.1s ease-in-out;"
           />
         </svg>
       </button>
       <button
         aria-label="Rate 5 stars"
         aria-pressed="false"
-        class="star-rating__star cursor-pointer size-10"
+        class="star-rating__star cursor-pointer h-10 w-14 px-2 hover:scale-125 active:scale-110 transition-all"
         type="button"
       >
         <svg
@@ -124,6 +128,7 @@ exports[`UnitFeedback > should render correctly 1`] = `
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
+            style="transition: fill 0.1s ease-in-out;"
           />
         </svg>
       </button>


### PR DESCRIPTION
# Summary

Make stars more delightful to use:
- fix padding so scrolling your mouse over them doesn't result in jumping between values
- add animations so they feel more 'springy' and fun to use

## Issue

Fixes #668 

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [x] Added or updated Jest tests
- [x] Added or updated Storybook stories

## Screenshot

These are really fun to use now

https://github.com/user-attachments/assets/f88261d5-3f94-4dc0-91b8-dffc79bc13b0