### PR TITLE
website-25: Add more usable course landing pages

### DIFF
--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { evaluate } from '@mdx-js/mdx';
 import { MDXContent } from 'mdx/types';
+import clsx from 'clsx';
 import Greeting from './Greeting';
 import Embed from './Embed';
 // eslint-disable-next-line import/no-cycle
@@ -9,6 +10,7 @@ import Exercise from './exercises/Exercise';
 
 export interface MarkdownRendererProps {
   children?: string;
+  className?: string;
 }
 
 // This must be a function, rather than a constant, to avoid dependency cycles
@@ -19,7 +21,7 @@ export const getSupportedComponents = () => ({
   Exercise,
 });
 
-const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children }) => {
+const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, className }) => {
   const [Component, setComponent] = React.useState<MDXContent | null>(null);
   useEffect(() => {
     if (!children) {
@@ -38,7 +40,7 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children })
 
   return (
     // See globals.css for advanced prose styles
-    <div className="markdown-extended-renderer prose">
+    <div className={clsx('markdown-extended-renderer prose', className)}>
       {Component && <Component components={getSupportedComponents()} />}
     </div>
   );

--- a/apps/website-25/src/components/lander/ClassicHero.tsx
+++ b/apps/website-25/src/components/lander/ClassicHero.tsx
@@ -80,7 +80,7 @@ interface ClassicHeroProps {
 
 const ClassicHero = ({ children, className = '' }: ClassicHeroProps) => {
   return (
-    <HeroSection className={`-mt-20 text-white bg-[url('/images/logo/logo_hero_background.svg')] bg-cover ${className}`}>
+    <HeroSection className={`text-white bg-[url('/images/logo/logo_hero_background.svg')] bg-cover ${className}`}>
       {children}
     </HeroSection>
   );

--- a/apps/website-25/src/components/lander/LandingPageBase.tsx
+++ b/apps/website-25/src/components/lander/LandingPageBase.tsx
@@ -35,6 +35,17 @@ const LandingPageBase = ({ hero, variant }: LandingPageBaseProps) => {
       </NewNav>
       {hero}
 
+      <LandingPageContent ctaUrl={ctaUrl} />
+
+      {/* Footer */}
+      <Footer />
+    </div>
+  );
+};
+
+export const LandingPageContent = ({ ctaUrl }: { ctaUrl: string }) => {
+  return (
+    <>
       <Container>
         <GraduateSection />
       </Container>
@@ -90,24 +101,24 @@ const LandingPageBase = ({ hero, variant }: LandingPageBaseProps) => {
         <BlueH2>What's covered?</BlueH2>
         <CourseUnits>
           <CourseUnits.Unit unitNumber="1">
-            <CourseUnits.Title>AI Agents & What They Can Do</CourseUnits.Title>
-            <CourseUnits.Description>See how smart AI assistants are making work-optional futures possible for the first time and how they're already changing everyday tasks.</CourseUnits.Description>
+            <CourseUnits.Title>Beyond chatbots: the expanding frontier of AI capabilities</CourseUnits.Title>
+            <CourseUnits.Description>Explore how AI capabilities now extend far beyond chatbots, including creating art, writing code, and acting independently as 'agents'.</CourseUnits.Description>
           </CourseUnits.Unit>
           <CourseUnits.Unit unitNumber="2">
-            <CourseUnits.Title>Getting Your Time Back</CourseUnits.Title>
-            <CourseUnits.Description>Try practical AI tools that can save you 10+ hours every week by handling your most boring tasks, freeing you to do what really matters.</CourseUnits.Description>
+            <CourseUnits.Title>Artificial general intelligence: on the horizon?</CourseUnits.Title>
+            <CourseUnits.Description>Learn what AGI means—AI outperforming humans at most cognitive tasks—and why current progress suggests it might arrive within years.</CourseUnits.Description>
           </CourseUnits.Unit>
           <CourseUnits.Unit unitNumber="3">
-            <CourseUnits.Title>Two Possible Futures</CourseUnits.Title>
-            <CourseUnits.Description>Learn about the key choices that will decide whether technology makes life better for everyone or just benefits a few powerful groups.</CourseUnits.Description>
+            <CourseUnits.Title>AGI will drastically change how we live</CourseUnits.Title>
+            <CourseUnits.Description>Grasp the immense potential benefits of AGI, like tackling disease, alongside the severe risks, including misuse, authoritarianism, and losing control.</CourseUnits.Description>
           </CourseUnits.Unit>
           <CourseUnits.Unit unitNumber="4">
-            <CourseUnits.Title>Be Part of the Change</CourseUnits.Title>
-            <CourseUnits.Description>Discover how you can help shape these technologies in your community and workplace, and join others working toward a better future.</CourseUnits.Description>
+            <CourseUnits.Title>What can be done?</CourseUnits.Title>
+            <CourseUnits.Description>Learn about key strategies for safely managing AGI development amid global competition, and discover how we can work towards ensuring its benefits for humanity.</CourseUnits.Description>
           </CourseUnits.Unit>
         </CourseUnits>
         <div className="flex justify-center mt-8">
-          <CTALinkOrButton url={ctaUrl}>Sign up for free</CTALinkOrButton>
+          <CTALinkOrButton url={ctaUrl}>Start learning for free</CTALinkOrButton>
         </div>
       </Container>
 
@@ -120,7 +131,7 @@ const LandingPageBase = ({ hero, variant }: LandingPageBaseProps) => {
           <p className="mb-8 text-size-md">
             Since 2021, we've designed our courses with some of the world's leading experts and helped thousands of talented people build the skills to make a real difference.
           </p>
-          <CTALinkOrButton variant="secondary" url={ROUTES.about.url}>Read about us</CTALinkOrButton>
+          <CTALinkOrButton variant="secondary" url={ROUTES.about.url}>Get to know us</CTALinkOrButton>
         </div>
         <div className="flex justify-end -mt-8 sm:-mt-16 pointer-events-none">
           <img src="/images/lander/signed_dewi_and_will.svg" alt="Dewi and Will, BlueDot Co-Founders" className="sm:w-2/3" />
@@ -136,10 +147,7 @@ const LandingPageBase = ({ hero, variant }: LandingPageBaseProps) => {
           <CTALinkOrButton url={ctaUrl}>Start learning for free</CTALinkOrButton>
         </div>
       </Container>
-
-      {/* Footer */}
-      <Footer />
-    </div>
+    </>
   );
 };
 

--- a/apps/website-25/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website-25/src/pages/courses/[courseSlug]/index.tsx
@@ -2,21 +2,61 @@ import {
   HeroSection,
   HeroCTAContainer,
   HeroH1,
-  HeroH2,
   CTALinkOrButton,
   ProgressDots,
   Section,
   CourseCard,
+  Breadcrumbs,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import useAxios from 'axios-hooks';
 import { useRouter } from 'next/router';
+import { FaAward, FaStar, FaStopwatch } from 'react-icons/fa6';
 import { ROUTES } from '../../../lib/routes';
 import { GetCourseResponse } from '../../api/courses/[courseSlug]';
+import { LandingPageContent } from '../../../components/lander/LandingPageBase';
+import ClassicHero from '../../../components/lander/ClassicHero';
+import MarkdownExtendedRenderer from '../../../components/courses/MarkdownExtendedRenderer';
 
 const CoursePage = () => {
   const { query: { courseSlug } } = useRouter();
 
+  if (typeof courseSlug !== 'string') {
+    return 'Invalid course slug';
+  }
+
+  if (courseSlug === 'future-of-ai') {
+    return <FutureOfAILander />;
+  }
+
+  return <StandardCoursePage courseSlug={courseSlug} />;
+};
+
+const FutureOfAILander = () => {
+  const ctaUrl = `${ROUTES.courses.url}/future-of-ai/1`;
+
+  return (
+    <>
+      <ClassicHero>
+        <ClassicHero.Title>Future-proof your career</ClassicHero.Title>
+        <ClassicHero.Subtitle>
+          No jargon, no coding, no pre-requisites – just bring your curiosity for how AI will reshape your world.
+        </ClassicHero.Subtitle>
+        <HeroCTAContainer>
+          <CTALinkOrButton url={ctaUrl}>Start learning for free</CTALinkOrButton>
+        </HeroCTAContainer>
+        <ClassicHero.Features>
+          <ClassicHero.Feature icon={FaStar}>4.7/5 rating</ClassicHero.Feature>
+          <ClassicHero.Feature icon={FaStopwatch}>2 hours</ClassicHero.Feature>
+          <ClassicHero.Feature icon={FaAward}>Get certified</ClassicHero.Feature>
+        </ClassicHero.Features>
+      </ClassicHero>
+      <LandingPageContent ctaUrl={ctaUrl} />
+    </>
+  );
+};
+
+const StandardCoursePage = ({ courseSlug }: { courseSlug: string }) => {
   const [{ data, loading }] = useAxios<GetCourseResponse>({
     method: 'get',
     url: `/api/courses/${courseSlug}`,
@@ -34,11 +74,21 @@ const CoursePage = () => {
           </Head>
           <HeroSection>
             <HeroH1>{data.course.title}</HeroH1>
-            <HeroH2>{data.course.description}</HeroH2>
+            <MarkdownExtendedRenderer className="invert my-8">{data.course.description}</MarkdownExtendedRenderer>
+            {data.units?.[0]?.path && (
             <HeroCTAContainer>
-              <CTALinkOrButton url={ROUTES.joinUs.url}>Start learning for free</CTALinkOrButton>
+              <CTALinkOrButton url={data.units[0].path}>Browse the curriculum for free</CTALinkOrButton>
             </HeroCTAContainer>
+            )}
           </HeroSection>
+          <Breadcrumbs
+            className="course-serp__breadcrumbs"
+            route={{
+              title: data.course.title,
+              url: data.course.path,
+              parentPages: [ROUTES.home, ROUTES.courses],
+            }}
+          />
           <Section
             className="course-serp"
           >


### PR DESCRIPTION
# Summary

Add more usable course landing pages

For future of AI, this reuses our classic landing page (which performed best at converting users in our most recent tests).

For other courses, this renders the description as markdown and lists the units. This was 80% done already, and I'm not going to bother polishing this right now because (1) it doesn't look too bad, (2) it's not planned to go live soon - we're going to redirect to the old course hub for the resource-list courses for now.

## Issue

Fixes #654

## Developer checklist
- [x] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

https://github.com/user-attachments/assets/3e6f730a-2f43-4048-9699-e41a0522d4a4

| Mobile: FOAI | Mobile: Other |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/64e9abd2-be85-4164-8494-b09fac2e254b) | ![image](https://github.com/user-attachments/assets/89fe05c9-688f-4fda-a6c9-cf063e98b965) |

