### PR TITLE
website-25: Fix explore menu in Nav on desktop

### DIFF
--- a/apps/website-25/src/components/Nav.tsx
+++ b/apps/website-25/src/components/Nav.tsx
@@ -278,14 +278,14 @@ export const Nav: React.FC<NavProps> = ({
               )}
             </div>
           </div>
-          <div className={clsx('nav__links-drawer', drawerBaseClassName, expandedSections.explore ? drawerOpenClassName : drawerClosedClassName)}>
-            <ExploreSection
-              expanded={expandedSections.explore}
-              courses={courses}
-              className="nav__drawer-content--desktop"
-              innerClassName="pb-10 hidden lg:flex mx-auto"
-              isScrolled={isScrolled}
-            />
+          <ExploreSection
+            expanded={expandedSections.explore}
+            courses={courses}
+            className="nav__drawer-content--desktop"
+            innerClassName="pb-10 hidden lg:flex mx-auto"
+            isScrolled={isScrolled}
+          />
+          <div className={clsx('nav__links-drawer', drawerBaseClassName, expandedSections.mobileNav ? drawerOpenClassName : drawerClosedClassName)}>
             {/* Mobile & Tablet content (including Explore) */}
             <div className="nav__drawer-content--mobile-tablet flex flex-col grow font-medium pb-8 pt-2 lg:hidden">
               <NavLinks

--- a/apps/website-25/src/components/Nav.tsx
+++ b/apps/website-25/src/components/Nav.tsx
@@ -278,7 +278,7 @@ export const Nav: React.FC<NavProps> = ({
               )}
             </div>
           </div>
-          <div className={clsx('nav__links-drawer', drawerBaseClassName, expandedSections.mobileNav ? drawerOpenClassName : drawerClosedClassName)}>
+          <div className={clsx('nav__links-drawer', drawerBaseClassName, expandedSections.explore ? drawerOpenClassName : drawerClosedClassName)}>
             <ExploreSection
               expanded={expandedSections.explore}
               courses={courses}

--- a/apps/website-25/src/components/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website-25/src/components/__snapshots__/Nav.test.tsx.snap
@@ -143,38 +143,38 @@ exports[`Nav > renders with courses 1`] = `
         </div>
       </div>
       <div
-        class="nav__links-drawer transition-[max-height,opacity] relative overflow-hidden px-3 max-h-0 opacity-0 duration-300"
+        class="nav-explore-section__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 nav__drawer-content--desktop"
       >
         <div
-          class="nav-explore-section__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 nav__drawer-content--desktop"
+          class="nav-explore-section___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden text-pretty pb-10 hidden lg:flex mx-auto"
         >
-          <div
-            class="nav-explore-section___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden text-pretty pb-10 hidden lg:flex mx-auto"
+          <h3
+            class="nav-explore-section__dropdown-title font-bold"
           >
-            <h3
-              class="nav-explore-section__dropdown-title font-bold"
+            Our courses
+          </h3>
+          <a
+            class="nav-explore-section__dropdown-link"
+            href="/course1"
+          >
+            Course 1
+          </a>
+          <a
+            class="nav-explore-section__dropdown-link"
+            href="/course2"
+          >
+            <span
+              class="nav-explore-section__new-badge text-bluedot-normal font-black pr-2"
             >
-              Our courses
-            </h3>
-            <a
-              class="nav-explore-section__dropdown-link"
-              href="/course1"
-            >
-              Course 1
-            </a>
-            <a
-              class="nav-explore-section__dropdown-link"
-              href="/course2"
-            >
-              <span
-                class="nav-explore-section__new-badge text-bluedot-normal font-black pr-2"
-              >
-                New!
-              </span>
-              Course 2
-            </a>
-          </div>
+              New!
+            </span>
+            Course 2
+          </a>
         </div>
+      </div>
+      <div
+        class="nav__links-drawer transition-[max-height,opacity] relative overflow-hidden px-3 max-h-0 opacity-0 duration-300"
+      >
         <div
           class="nav__drawer-content--mobile-tablet flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
         >


### PR DESCRIPTION
# Summary

website-25: Fix explore menu in Nav on desktop

The desktop explore panel was incorrectly nested inside the mobile panel. This PR moves it out of the mobile panel, so it displays properly on desktop. The `hidden lg:flex` already stops it being shown on mobile.

## Issue

Fixes #673 