### PR TITLE
website-25: Fix unit page indexing

### DIFF
--- a/apps/website-25/src/__tests__/pages/courses/[courseSlug]/units/[unitId].test.tsx
+++ b/apps/website-25/src/__tests__/pages/courses/[courseSlug]/units/[unitId].test.tsx
@@ -1,0 +1,104 @@
+import { render, waitFor } from '@testing-library/react';
+import {
+  describe, expect, test, vi,
+} from 'vitest';
+import { useRouter } from 'next/router';
+import type { NextRouter } from 'next/router';
+import CourseUnitPage from '../../../../../pages/courses/[courseSlug]/units/[unitId]';
+// Mock next/router
+vi.mock('next/router', () => ({
+  useRouter: vi.fn(() => ({
+    query: { courseSlug: 'test-course', unitId: '3' },
+  })),
+}));
+
+// Mock axios-hooks
+const mockUseAxios = vi.fn();
+vi.mock('axios-hooks', () => ({
+  default: (...args: unknown[]) => mockUseAxios(...args),
+}));
+
+describe('CourseUnitPage', () => {
+  test('renders unit 0 correctly with 0-indexed units', async () => {
+    vi.mocked(useRouter).mockReturnValueOnce({
+      query: { courseSlug: 'test-course', unitId: '0' },
+    } as unknown as NextRouter);
+
+    const mockUnits = [
+      { unitNumber: '0', title: 'Icebreaker', content: 'Welcome to the course' },
+      { unitNumber: '1', title: 'Unit 1', content: 'First unit content' },
+      { unitNumber: '2', title: 'Unit 2', content: 'Second unit content' },
+      { unitNumber: '3', title: 'Unit 3', content: 'Third unit content' },
+    ];
+
+    mockUseAxios.mockReturnValue([{
+      data: { units: mockUnits },
+      loading: false,
+    }]);
+
+    const { getByRole, getByText } = render(<CourseUnitPage />);
+
+    expect(getByRole('heading', { level: 1 }).textContent).toBe('Icebreaker');
+    // Markdown renders async
+    waitFor(() => expect(getByText('Welcome to the course')).toBeTruthy());
+  });
+
+  test('renders unit 3 correctly with 0-indexed units', () => {
+    const mockUnits = [
+      { unitNumber: '0', title: 'Icebreaker', content: 'Welcome to the course' },
+      { unitNumber: '1', title: 'Unit 1', content: 'First unit content' },
+      { unitNumber: '2', title: 'Unit 2', content: 'Second unit content' },
+      { unitNumber: '3', title: 'Unit 3', content: 'Third unit content' },
+    ];
+
+    mockUseAxios.mockReturnValue([{
+      data: { units: mockUnits },
+      loading: false,
+    }]);
+
+    const { getByRole, getByText } = render(<CourseUnitPage />);
+
+    expect(getByRole('heading', { level: 1 }).textContent).toBe('Unit 3');
+    // Markdown renders async
+    waitFor(() => expect(getByText('Third unit content')).toBeTruthy());
+  });
+
+  test('renders unit 3 correctly with 1-indexed units', () => {
+    const mockUnits = [
+      { unitNumber: '1', title: 'Unit 1', content: 'First unit content' },
+      { unitNumber: '2', title: 'Unit 2', content: 'Second unit content' },
+      { unitNumber: '3', title: 'Unit 3', content: 'Third unit content' },
+      { unitNumber: '4', title: 'Unit 4', content: 'Fourth unit content' },
+    ];
+
+    mockUseAxios.mockReturnValue([{
+      data: { units: mockUnits },
+      loading: false,
+    }]);
+
+    const { getByRole, getByText } = render(<CourseUnitPage />);
+
+    expect(getByRole('heading', { level: 1 }).textContent).toBe('Unit 3');
+    // Markdown renders async
+    waitFor(() => expect(getByText('Third unit content')).toBeTruthy());
+  });
+
+  test('renders unit 3 correctly when unit 2 is missing', () => {
+    const mockUnits = [
+      { unitNumber: '1', title: 'Unit 1', content: 'First unit content' },
+      { unitNumber: '3', title: 'Unit 3', content: 'Third unit content' },
+      { unitNumber: '4', title: 'Unit 4', content: 'Fourth unit content' },
+    ];
+
+    mockUseAxios.mockReturnValue([{
+      data: { units: mockUnits },
+      loading: false,
+    }]);
+
+    const { getByRole, getByText } = render(<CourseUnitPage />);
+
+    expect(getByRole('heading', { level: 1 }).textContent).toBe('Unit 3');
+    // Markdown renders async
+    waitFor(() => expect(getByText('Third unit content')).toBeTruthy());
+  });
+});

--- a/apps/website-25/src/pages/courses/[courseSlug]/units/[unitId].tsx
+++ b/apps/website-25/src/pages/courses/[courseSlug]/units/[unitId].tsx
@@ -12,9 +12,9 @@ const CourseUnitPage = () => {
     url: `/api/courses/${courseSlug}/${unitId}`,
   });
 
-  const unitNumber = unitId ? parseInt(unitId as string) : 0;
+  const unitNumber = typeof unitId === 'string' ? parseInt(unitId) : 0;
   const units = data?.units;
-  const unit = units?.[unitNumber - 1];
+  const unit = units?.find((u) => u.unitNumber === unitId);
 
   return (
     (units && unit) ? (


### PR DESCRIPTION
# Summary

website-25: Fix unit page indexing

Previously this broke if units were not 1-indexed, or not continuous. This could be seen on some of the existing courses where unit 0 is an icebreaker session. e.g.:
- unit 0 doesn't render properly at all
- unit 1 renders the content for unit 0
- unit 2 renders the content for unit 1
- ...

This PR improves the unit number handling logic to be more robust.

## Issue

Fixes #676

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

Unit 0 renders properly now 🎉:

<img width="1624" alt="Screenshot 2025-04-23 at 02 41 52" src="https://github.com/user-attachments/assets/dcdd54df-9e37-4bfc-9b72-289c974809f9" />