### PR TITLE
website-25: Embed: Fix YouTube video sizing

### DIFF
--- a/apps/website-25/src/components/courses/Embed.tsx
+++ b/apps/website-25/src/components/courses/Embed.tsx
@@ -8,8 +8,6 @@ type EmbedProps = {
 
 const Embed: React.FC<EmbedProps> = ({
   url,
-  // width = '100%',
-  // height = '600px',
   className,
 }) => {
   const isYouTube = url.startsWith('https://www.youtube.com/') || url.startsWith('https://www.youtube-nocookie.com/');
@@ -18,13 +16,13 @@ const Embed: React.FC<EmbedProps> = ({
     // eslint-disable-next-line jsx-a11y/iframe-has-title
     <iframe
       src={isYouTube ? url.replace('https://www.youtube.com/', 'https://www.youtube-nocookie.com/') : url}
-      // These should be overriden in css
+      // Width and height should be overriden in css
       width="100%"
       height="100%"
       frameBorder="0"
       allowFullScreen
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-      className={clsx('embed rounded-lg h-[450px]', isYouTube && 'aspect-video', className)}
+      className={clsx('embed rounded-lg', isYouTube ? 'aspect-video h-auto' : 'h-[450px]', className)}
     />
   );
 };


### PR DESCRIPTION
# Summary

For YouTube videos, we want a 16:9 aspect ratio to reduce [letterboxing](https://en.wikipedia.org/wiki/Letterboxing_(filming)).

In #643 I think we tweaked the embed styles to change the height, but moved the height tag from the !isYoutube condition so it also applied to YouTube videos. This PR fixes the behaviour by setting the height (rather than aspect ratio) only when it's not YouTube.

## Screenshot

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/f7dbee66-4038-43ef-bea4-41dc392ed691) | ![image](https://github.com/user-attachments/assets/55411a73-6837-40d2-b3a9-77524f7689c4) |