### PR TITLE
Add utils for mocking login state in stories

### DIFF
--- a/apps/website-25/src/components/Nav.stories.tsx
+++ b/apps/website-25/src/components/Nav.stories.tsx
@@ -16,12 +16,11 @@ const NavWrapper: React.FC<React.ComponentProps<typeof Nav>> = (props) => (
 const meta = {
   title: 'ui/Nav',
   component: NavWrapper,
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: 'fullscreen',
   },
+  // Note: autodocs removed because it doesn't work with the global logged in/out
   args: {
     courses: [
       { title: 'Course 1', url: '#1' },

--- a/apps/website-25/src/components/Nav.stories.tsx
+++ b/apps/website-25/src/components/Nav.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { loggedInStory, loggedOutStory } from '@bluedot/ui';
 
 import imgSrc from '../../public/images/logo/BlueDot_Impact_Logo.svg';
 import { Nav } from './Nav';
@@ -27,16 +28,22 @@ const meta = {
       { title: 'Course 2', url: '#2' },
     ],
   },
+  ...loggedOutStory(),
 } satisfies Meta<typeof NavWrapper>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const LoggedIn: Story = {
+  args: {},
+  ...loggedInStory(),
+};
+
 export const Default: Story = {
   args: {},
 };
 
-export const Customized: Story = {
+export const CustomizedExploreLinks: Story = {
   args: {
     logo: imgSrc,
     primaryCtaText: 'Start learning',

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -51,6 +51,8 @@ export * as constants from './constants';
 export { Navigate } from './legacy/Navigate';
 export type { NavigateProps } from './legacy/Navigate';
 
+export { loggedOutStory, loggedInStory } from './utils/storybook';
+
 // Legacy Components
 
 export { Box } from './legacy/Box';

--- a/libraries/ui/src/utils/storybook.ts
+++ b/libraries/ui/src/utils/storybook.ts
@@ -1,0 +1,61 @@
+import { useAuthStore } from './auth';
+
+/**
+ * Spread into the props of a Story to render it as logged out, like so:
+ * ```typescript
+ * export const LoggedOut: Story = {
+ *    args: {},
+ *    ...loggedOutStory(),
+ *  };
+ * ```
+ *
+ * Since stories are logged out by default, this his is most useful in the `meta`
+ * story definition when you have some logged in stories to ensure it resets to
+ * logged out between rendering:
+ * ```typescript
+ * const meta = {
+ *   title: 'ui/MyComponent',
+ *   component: MyComponent,
+ *   tags: ['autodocs'],
+ *   parameters: {
+ *     layout: 'fullscreen',
+ *   },
+ *   args: {
+ *   },
+ *   ...loggedOutStory(),
+ * } satisfies Meta<typeof MyComponent>;
+ * ```
+ */
+export const loggedOutStory = () => ({
+  beforeEach() {
+    const { setAuth } = useAuthStore.getState();
+    setAuth(null);
+    // Clear any potentially lingering timers from previous stories
+    // eslint-disable-next-line no-underscore-dangle
+    const timer = useAuthStore.getState()._authClearTimer;
+    if (timer) {
+      clearTimeout(timer);
+      useAuthStore.setState({ _authClearTimer: null });
+    }
+  },
+});
+
+/**
+ * Spread into the props of a Story to render it as logged in, like so:
+ * ```typescript
+ * export const LoggedIn: Story = {
+ *    args: {},
+ *    ...loggedInStory(),
+ *  };
+ * ```
+ */
+export const loggedInStory = () => ({
+  beforeEach() {
+    const { setAuth } = useAuthStore.getState();
+    // Call the *real* setAuth function to set the state
+    setAuth({
+      token: 'mockToken',
+      expiresAt: Math.floor(Date.now() / 1000) + 3_600, // Expires in 1 hour
+    });
+  },
+});


### PR DESCRIPTION
# Summary

Adds `loggedOutStory()` and `loggedInStory()` utils which can be spread into the story params.

I have applied this to the `Nav` stories, all the others require additional mocking of API calls which is more involved to fix. I have made another followup ticket for that (#687) (which I will claim and start on, seeing as getting all the stories working was the intent of this ticket)

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #650
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [X] [N/A] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [X] [N/A] Added or updated Jest tests
- [X] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | ![Screenshot 2025-04-23 at 12 48 34](https://github.com/user-attachments/assets/7ecc7f50-ed00-4176-afbe-9c987017a0b2) |
| | ![Screenshot 2025-04-23 at 12 48 41](https://github.com/user-attachments/assets/a1e99d56-ecd7-48f7-9a68-169066b906d7) |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |

## Testing
```
$ npm run test:update
 Tasks:    13 successful, 13 total
Cached:    9 cached, 13 total
  Time:    19.086s
```