### PR TITLE
Add util for splitting comma separated strings

### DIFF
--- a/apps/website/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website/src/components/courses/exercises/MultipleChoice.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { ROUTES } from '../../../lib/routes';
 import { P } from '../../Text';
+import { formatStringToArray } from '../../../lib/utils';
 
 type MultipleChoiceProps = {
   // Required
@@ -36,7 +37,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
    * Options are stored as a string with newlines
    * Format them to be an array of strings with no empty strings (i.e., removing trailing return statements)
    */
-  const formattedOptions = (options.split('\n').map((o) => o.trim()).filter((o) => o !== ''));
+  const formattedOptions = formatStringToArray(options, '\n');
   const formattedAnswer = answer.trim();
   const formattedExerciseResponse = exerciseResponse?.trim();
 

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -1,0 +1,11 @@
+export const formatStringToArray = (
+  input: string | null | undefined,
+  splitBy: string,
+): string[] => {
+  return input
+    ? input
+      .split(splitBy)
+      .map((o) => o.trim())
+      .filter((item) => item !== '')
+    : [];
+};


### PR DESCRIPTION
# Summary

I'm not actually convinced of the utility of this. Apart from the one here, the [other case we have](https://github.com/bluedotimpact/bluedot/pull/647#discussion_r2044317855) of a string that needs to be split coming from Airtable is too different to combine in the function, and it remains to be seen if the cases will tend to be that similar (e.g. if it makes sense to trim the strings always or not).

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #648
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

<!-- Description of the changes you've made -->

## Developer checklist
- [X] [N/A] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [X] [N/A] Added or updated Jest tests
- [X] [N/A] Added or updated Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |

## Testing
```
$ npm run test:update
 Tasks:    13 successful, 13 total
Cached:    11 cached, 13 total
  Time:    12.222s
```