### PR TITLE
Update icons for Safari browsers

### DIFF
--- a/apps/website-25/src/components/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website-25/src/components/__snapshots__/Nav.test.tsx.snap
@@ -20,7 +20,9 @@ exports[`Nav > renders with courses 1`] = `
           >
             <svg
               fill="none"
-              viewBox="8 8 32 32"
+              height="48"
+              viewBox="0 0 48 48"
+              width="48"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/libraries/ui/src/IconButton.tsx
+++ b/libraries/ui/src/IconButton.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 
 export const HamburgerIcon: React.FC<{ className?: string }> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="8 8 32 32" fill="none" className={className}>
+  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none" className={className}>
     <path d="M16 18H32" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
     <path d="M16 24H32" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
     <path d="M16 30H32" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
@@ -10,7 +10,7 @@ export const HamburgerIcon: React.FC<{ className?: string }> = ({ className }) =
 );
 
 const CloseIcon: React.FC<{ className?: string }> = ({ className }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="8 8 32 32" fill="none" className={className}>
+  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none" className={className}>
     <path d="M18 29.3135L29.3137 17.9998" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
     <path d="M18 18.3135L29.3137 29.6272" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
   </svg>


### PR DESCRIPTION
# Summary

Update icons for Safari browsers

<img width="701" alt="Screenshot 2025-04-23 at 13 32 56" src="https://github.com/user-attachments/assets/251327f9-eb7b-4afb-b132-4a8ffa7dc623" />
<img width="673" alt="Screenshot 2025-04-23 at 13 32 53" src="https://github.com/user-attachments/assets/03c72a26-dbc9-4423-9068-ab3884703a14" />
