### PR TITLE
Add image URL handling to Embed

### DIFF
--- a/apps/website-25/src/components/courses/Embed.tsx
+++ b/apps/website-25/src/components/courses/Embed.tsx
@@ -11,19 +11,24 @@ const Embed: React.FC<EmbedProps> = ({
   className,
 }) => {
   const isYouTube = url.startsWith('https://www.youtube.com/') || url.startsWith('https://www.youtube-nocookie.com/');
+  const isImage = url.endsWith('.png') || url.endsWith('.jpg') || url.endsWith('.jpeg') || url.endsWith('.gif');
 
   return (
-    // eslint-disable-next-line jsx-a11y/iframe-has-title
-    <iframe
-      src={isYouTube ? url.replace('https://www.youtube.com/', 'https://www.youtube-nocookie.com/') : url}
-      // Width and height should be overriden in css
-      width="100%"
-      height="100%"
-      frameBorder="0"
-      allowFullScreen
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-      className={clsx('embed rounded-lg', isYouTube ? 'aspect-video h-auto' : 'h-[450px]', className)}
-    />
+    isImage ? (
+      <img src={url} alt="" className={clsx('embed rounded-lg', className)} />
+    ) : (
+      // eslint-disable-next-line jsx-a11y/iframe-has-title
+      <iframe
+        src={isYouTube ? url.replace('https://www.youtube.com/', 'https://www.youtube-nocookie.com/') : url}
+        // Width and height should be overriden in css
+        width="100%"
+        height="100%"
+        frameBorder="0"
+        allowFullScreen
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        className={clsx('embed rounded-lg', isYouTube ? 'aspect-video h-auto' : 'h-[450px]', className)}
+      />
+    )
   );
 };
 


### PR DESCRIPTION
# Summary

Add image URL handling to Embed

## Description

- If img URL path is recognized, we should embed within native `<img/>` tag rather than ifram

<img width="829" alt="Screenshot 2025-04-23 at 16 42 33" src="https://github.com/user-attachments/assets/73f1b717-7888-4ce1-be1f-7bdb4cdc7aa9" />

<img width="1512" alt="Screenshot 2025-04-23 at 16 42 11" src="https://github.com/user-attachments/assets/bfaecb85-00bd-417b-b3a9-c91a9fff62b5" />