### PR TITLE
ui(auth): add refresh token logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ generated/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+core
 
 # Misc
 .DS_Store

--- a/apps/app-template/src/pages/login/index.tsx
+++ b/apps/app-template/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginRedirectPage oidcSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/app-template/src/pages/login/index.tsx
+++ b/apps/app-template/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.userManagerSettings} />;
+export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/app-template/src/pages/login/oauth-callback.tsx
+++ b/apps/app-template/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/app-template/src/pages/login/oauth-callback.tsx
+++ b/apps/app-template/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.userManagerSettings} />;
+export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/frontend-example/package.json
+++ b/apps/frontend-example/package.json
@@ -23,7 +23,7 @@
     "axios-hooks": "^5.0.2",
     "http-errors": "^2.0.0",
     "next": "^15.1.7",
-    "oidc-client-ts": "^3.1.0",
+    "oidc-client-ts": "^3.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "zustand": "^4.5.2",

--- a/apps/frontend-example/src/pages/login/index.tsx
+++ b/apps/frontend-example/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginRedirectPage oidcSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/frontend-example/src/pages/login/index.tsx
+++ b/apps/frontend-example/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.userManagerSettings} />;
+export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/frontend-example/src/pages/login/oauth-callback.tsx
+++ b/apps/frontend-example/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/frontend-example/src/pages/login/oauth-callback.tsx
+++ b/apps/frontend-example/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.userManagerSettings} />;
+export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/room/src/pages/login/index.tsx
+++ b/apps/room/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.googleBlueDot.userManagerSettings} />;
+export default () => <LoginRedirectPage userManagerSettings={loginPresets.googleBlueDot.oidcSettings} />;

--- a/apps/room/src/pages/login/index.tsx
+++ b/apps/room/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.googleBlueDot.oidcSettings} />;
+export default () => <LoginRedirectPage oidcSettings={loginPresets.googleBlueDot.oidcSettings} />;

--- a/apps/room/src/pages/login/oauth-callback.tsx
+++ b/apps/room/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.googleBlueDot.oidcSettings} />;
+export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.googleBlueDot.oidcSettings} />;

--- a/apps/room/src/pages/login/oauth-callback.tsx
+++ b/apps/room/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.googleBlueDot.userManagerSettings} />;
+export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.googleBlueDot.oidcSettings} />;

--- a/apps/website-25/src/components/Nav.test.tsx
+++ b/apps/website-25/src/components/Nav.test.tsx
@@ -13,7 +13,8 @@ const mockLoggedInUser = () => {
       useAuthStore: vi.fn().mockImplementation(() => ({
         auth: { token: 'mockToken', expiresAt: Date.now() + 10000 },
         setAuth: vi.fn(),
-        _authClearTimer: null,
+        internal_clearTimer: null,
+        internal_refreshTimer: null,
       })),
     };
   });

--- a/apps/website-25/src/pages/login/index.tsx
+++ b/apps/website-25/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.userManagerSettings} />;
+export default () => <LoginRedirectPage oidcSettings={loginPresets.keycloak.oidcSettings} />;

--- a/apps/website-25/src/pages/login/oauth-callback.tsx
+++ b/apps/website-25/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.userManagerSettings} />;
+export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.keycloak.oidcSettings} />;

--- a/libraries/ui/README.md
+++ b/libraries/ui/README.md
@@ -141,14 +141,14 @@ For the above to work, you'll probably want to use the pre-built login flow page
 import { LoginRedirectPage, loginPresets } from '@bluedot/ui';
 
 // The login preset should match what you have on the backend
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.userManagerSettings} />;
+export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;
 ```
 
 ```typescript
 // In src/pages/login/oauth-callback.tsx
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.userManagerSettings} />;
+export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;
 ```
 
 ### Error Coercion

--- a/libraries/ui/README.md
+++ b/libraries/ui/README.md
@@ -141,14 +141,14 @@ For the above to work, you'll probably want to use the pre-built login flow page
 import { LoginRedirectPage, loginPresets } from '@bluedot/ui';
 
 // The login preset should match what you have on the backend
-export default () => <LoginRedirectPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginRedirectPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
 ```
 
 ```typescript
 // In src/pages/login/oauth-callback.tsx
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage userManagerSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
 ```
 
 ### Error Coercion

--- a/libraries/ui/package.json
+++ b/libraries/ui/package.json
@@ -16,7 +16,7 @@
     "clsx": "^2.0.0",
     "http-errors": "^2.0.0",
     "next": "^15.1.7",
-    "oidc-client-ts": "^3.1.0",
+    "oidc-client-ts": "^3.2.0",
     "posthog-js": "^1.217.4",
     "react": "^18.2.0",
     "react-aria-components": "^1.0.0-rc.0",

--- a/libraries/ui/src/legacy/Login.tsx
+++ b/libraries/ui/src/legacy/Login.tsx
@@ -185,7 +185,7 @@ export const LoginOauthCallbackPage: React.FC<LoginPageProps> = ({ oidcSettings 
         }
 
         setAuth({
-          expiresAt: user.expires_at,
+          expiresAt: user.expires_at * 1000,
           token: user.id_token,
           refreshToken: user.refresh_token,
           oidcSettings,

--- a/libraries/ui/src/legacy/Login.tsx
+++ b/libraries/ui/src/legacy/Login.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { UserManager, UserManagerSettings } from 'oidc-client-ts';
+import {
+  OidcClient, OidcClientSettings,
+} from 'oidc-client-ts';
 import { useRouter } from 'next/router';
 import axios from 'axios';
 import { createPublicKey, createVerify, JsonWebKey } from 'crypto';
@@ -10,7 +12,7 @@ import { useAuthStore } from '../utils/auth';
 import { asError } from '../utils/asError';
 
 export type LoginPageProps = {
-  userManagerSettings: UserManagerSettings
+  oidcSettings: OidcClientSettings
 };
 
 const verifyJwt = async (
@@ -89,7 +91,7 @@ const verifyJwt = async (
 export const loginPresets = {
   /** Any customer login.bluedot.org account can login */
   keycloak: {
-    userManagerSettings: {
+    oidcSettings: {
       authority: 'https://login.bluedot.org/realms/customers/',
       client_id: 'bluedot-web-apps',
       redirect_uri: `${typeof window === 'undefined' ? '' : window.location.origin}/login/oauth-callback`,
@@ -106,7 +108,7 @@ export const loginPresets = {
   // The useless concats are to avoid GitHub's secret scanner complaining
   // This is fine, because these are NOT secret
   googleBlueDot: {
-    userManagerSettings: {
+    oidcSettings: {
       authority: 'https://accounts.google.com/',
       // eslint-disable-next-line no-useless-concat
       client_id: '558012313311-ndfttio1u55baojf' + 'odrhiju4nvkakmqj.apps.googleusercontent.com',
@@ -134,19 +136,22 @@ export const loginPresets = {
     },
   },
 } satisfies Record<string, {
-  userManagerSettings: UserManagerSettings,
+  oidcSettings: OidcClientSettings,
   verifyAndDecodeToken: (token: string) => Promise<{ sub: string, email: string }>
 }>;
 
-export const LoginRedirectPage: React.FC<LoginPageProps> = ({ userManagerSettings }) => {
+export const LoginRedirectPage: React.FC<LoginPageProps> = ({ oidcSettings }) => {
   const searchParams = useSearchParams();
   const redirectTo = searchParams.get('redirect_to') || '/';
   const auth = useAuthStore((s) => s.auth);
 
   useEffect(() => {
     if (!auth) {
-      new UserManager(userManagerSettings)
-        .signinRedirect({ state: { redirectTo } });
+      new OidcClient(oidcSettings)
+        .createSigninRequest({ state: { redirectTo } })
+        .then((req) => {
+          window.location.href = req.url;
+        });
     }
   }, [auth]);
 
@@ -157,7 +162,7 @@ export const LoginRedirectPage: React.FC<LoginPageProps> = ({ userManagerSetting
   return <P className="m-8">Redirecting...</P>;
 };
 
-export const LoginOauthCallbackPage: React.FC<LoginPageProps> = ({ userManagerSettings }) => {
+export const LoginOauthCallbackPage: React.FC<LoginPageProps> = ({ oidcSettings }) => {
   const [error, setError] = useState<undefined | React.ReactNode | Error>();
   const setAuth = useAuthStore((s) => s.setAuth);
   const router = useRouter();
@@ -165,7 +170,7 @@ export const LoginOauthCallbackPage: React.FC<LoginPageProps> = ({ userManagerSe
   useEffect(() => {
     const signinUser = async () => {
       try {
-        const user = await new UserManager(userManagerSettings).signinCallback();
+        const user = await new OidcClient(oidcSettings).processSigninResponse(window.location.href);
         if (!user) {
           throw new Error('Bad login response: No user returned');
         }
@@ -175,7 +180,13 @@ export const LoginOauthCallbackPage: React.FC<LoginPageProps> = ({ userManagerSe
         if (typeof user.id_token !== 'string') {
           throw new Error('Bad login response: user.id_token is missing or not a string');
         }
-        setAuth({ expiresAt: user.expires_at, token: user.id_token });
+
+        setAuth({
+          expiresAt: user.expires_at,
+          token: user.id_token,
+          refreshToken: user.refresh_token,
+          oidcSettings: oidcSettings,
+        });
         router.push((user.state as { redirectTo?: string }).redirectTo || '/');
       } catch (err) {
         setError(err instanceof Error ? err : new Error(String(err)));

--- a/libraries/ui/src/utils/auth.test.tsx
+++ b/libraries/ui/src/utils/auth.test.tsx
@@ -1,0 +1,303 @@
+import {
+  describe, test, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import { OidcClient, OidcClientSettings } from 'oidc-client-ts';
+import { Auth, useAuthStore, withAuth } from './auth';
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+// Mock Next.js router
+const mockPush = vi.fn();
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+// Mock OIDC client
+vi.mock('oidc-client-ts', () => ({
+  OidcClient: vi.fn(),
+  OidcClientSettings: vi.fn(),
+}));
+
+// Helper to create auth object
+const createAuth = (overrides?: Partial<Auth>): Auth => ({
+  token: 'test-token',
+  expiresAt: Date.now() + 3600_000, // 1 hour from now
+  refreshToken: 'test-refresh-token',
+  oidcSettings: {
+    authority: 'https://auth.example.com',
+    client_id: 'test-client',
+    redirect_uri: 'http://localhost:3000/callback',
+  },
+  ...overrides,
+});
+
+// Helper to create mock OIDC response
+const createMockOidcResponse = (overrides?: Partial<any>) => ({
+  access_token: 'new-test-token',
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  refresh_token: 'new-refresh-token',
+  ...overrides,
+});
+
+// Helper to setup mocked OIDC client
+const setupMockOidcClient = (success = true, response?: any) => {
+  const mockUseRefreshToken = vi.fn().mockImplementation(() => {
+    if (!success) throw new Error('Refresh failed');
+    return response || createMockOidcResponse();
+  });
+
+  (OidcClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+    useRefreshToken: mockUseRefreshToken,
+  }));
+
+  return { mockUseRefreshToken };
+};
+
+describe('auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  describe('useAuthStore', () => {
+    test('should start with no authentication', () => {
+      const { auth } = useAuthStore.getState();
+      expect(auth).toBeNull();
+    });
+
+    test('should store authentication details', () => {
+      const auth = createAuth();
+      useAuthStore.getState().setAuth(auth);
+
+      const state = useAuthStore.getState();
+      expect(state.auth).toEqual(auth);
+    });
+
+    test('should keep new token when replacing soon-to-expire token', () => {
+      setupMockOidcClient(); // Set up OIDC client for potential refresh attempts
+      
+      // Set initial auth that expires in 30 seconds
+      const initialAuth = createAuth({
+        expiresAt: Date.now() + 30_000,
+        token: 'initial-token',
+      });
+      useAuthStore.getState().setAuth(initialAuth);
+
+      // Advance 20 seconds (10 seconds before initial token expires)
+      vi.advanceTimersByTime(20_000);
+
+      // Set new auth with fresh expiry
+      const newAuth = createAuth({
+        expiresAt: Date.now() + 3600_000, // 1 hour
+        token: 'new-token',
+      });
+      useAuthStore.getState().setAuth(newAuth);
+
+      // Advance 10 seconds (past when initial token would have expired)
+      vi.advanceTimersByTime(10_000);
+
+      // Should still have the new token (old expiry timer should have been cancelled)
+      const currentAuth = useAuthStore.getState().auth;
+      expect(currentAuth?.token).toBe('new-token');
+      expect(currentAuth?.expiresAt).toBe(newAuth.expiresAt)
+      expect(currentAuth?.expiresAt).toBeGreaterThan(Date.now()); // Should not be expired
+    });
+
+    test('should clear authentication when logging out', () => {
+      const auth = createAuth();
+      const { setAuth } = useAuthStore.getState();
+
+      setAuth(auth);
+      setAuth(null);
+
+      expect(useAuthStore.getState().auth).toBeNull();
+    });
+  });
+
+  describe('token lifecycle', () => {
+    test('should automatically refresh token before expiry', async () => {
+      const newToken = 'refreshed-token';
+      setupMockOidcClient(true, createMockOidcResponse({
+        access_token: newToken,
+      }));
+
+      const auth = createAuth({
+        expiresAt: Date.now() + 70_000,
+      });
+
+      useAuthStore.getState().setAuth(auth);
+
+      // Wait for automatic refresh
+      vi.advanceTimersByTime(10000);
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(useAuthStore.getState().auth?.token).toBe(newToken);
+    });
+
+    test('should log out when refresh fails', async () => {
+      setupMockOidcClient(false);
+      const auth = createAuth({
+        expiresAt: Date.now() + 70_000,
+      });
+
+      useAuthStore.getState().setAuth(auth);
+
+      // Wait for refresh attempt
+      vi.advanceTimersByTime(10000);
+      await vi.runAllTimersAsync();
+
+      expect(useAuthStore.getState().auth).toBeNull();
+    });
+
+    test('should log out when token expires without refresh token', () => {
+      const auth = createAuth({
+        expiresAt: Date.now() + 5_000,
+        refreshToken: undefined,
+      });
+
+      useAuthStore.getState().setAuth(auth);
+
+      // Wait for expiration
+      vi.advanceTimersByTime(5000);
+      expect(useAuthStore.getState().auth).toBeNull();
+    });
+  });
+
+  describe('session persistence', () => {
+    test('should restore valid session and refresh before expiry', async () => {
+      const newToken = 'refreshed-token';
+      const { mockUseRefreshToken } = setupMockOidcClient(true, createMockOidcResponse({
+        access_token: newToken,
+      }));
+
+      // Create auth that expires in 70 seconds
+      const auth = createAuth({
+        expiresAt: Date.now() + 70_000,
+        token: 'current-token',
+        refreshToken: 'valid-refresh-token',
+      });
+
+      // Reset store and restore session
+      useAuthStore.setState({ auth: null });
+      useAuthStore.getState().setAuth(auth);
+      
+      // Should restore immediately with current token
+      expect(useAuthStore.getState().auth?.token).toBe('current-token');
+      
+      // Advance to refresh time
+      vi.advanceTimersByTime(10000);
+      await vi.runOnlyPendingTimersAsync();
+      
+      // Should have refreshed to new token
+      expect(mockUseRefreshToken).toHaveBeenCalled();
+      expect(useAuthStore.getState().auth?.token).toBe(newToken);
+    });
+    
+    test('should refresh expired session on restore', async () => {
+      // Set up OIDC client to return new token
+      const newToken = 'refreshed-token';
+      const expiresAtSeconds = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+      const { mockUseRefreshToken } = setupMockOidcClient(true, createMockOidcResponse({
+        access_token: newToken,
+        expires_at: expiresAtSeconds,
+      }));
+
+      // Create expired auth with valid refresh token
+      const auth = createAuth({
+        expiresAt: Date.now() - 3600_000, // Expired 1 hour ago
+        token: 'expired-token',
+        refreshToken: 'valid-refresh-token',
+      });
+
+      // Reset store and set expired auth
+      useAuthStore.setState({ auth: null });
+      useAuthStore.getState().setAuth(auth);
+      
+      // Wait for next tick to allow refresh to be triggered
+      await vi.advanceTimersByTimeAsync(0);
+      
+      // Should have attempted refresh
+      expect(mockUseRefreshToken).toHaveBeenCalled();
+      
+      // Should have new token
+      const currentAuth = useAuthStore.getState().auth;
+      expect(currentAuth?.token).toBe(newToken);
+      expect(currentAuth?.expiresAt).toBe(expiresAtSeconds * 1000);
+    });
+
+    test('should not restore expired session when refresh fails', async () => {
+      setupMockOidcClient(false);
+
+      // Create expired auth with invalid refresh token
+      const auth = createAuth({
+        expiresAt: Date.now() - 3600_000, // Expired 1 hour ago
+        token: 'expired-token',
+        refreshToken: 'invalid-refresh-token',
+      });
+
+      // Reset store and attempt to restore session
+      useAuthStore.setState({ auth: null });
+      useAuthStore.getState().setAuth(auth);
+      
+      // Allow refresh attempt to complete
+      await vi.runAllTimersAsync();
+      
+      expect(useAuthStore.getState().auth).toBeNull();
+    });
+
+    test('should not restore expired session without refresh token', () => {
+      // Create expired auth with no refresh token
+      const auth = createAuth({
+        expiresAt: Date.now() - 3600_000, // Expired 1 hour ago
+        token: 'expired-token',
+        refreshToken: undefined,
+      });
+
+      // Reset store and attempt to restore session
+      useAuthStore.setState({ auth: null });
+      useAuthStore.getState().setAuth(auth);
+      vi.advanceTimersByTime(1000);
+      
+      expect(useAuthStore.getState().auth).toBeNull();
+    });
+  });
+
+  describe('protected routes', () => {
+    const ProtectedPage: React.FC<{ auth: Auth, setAuth: (s: Auth | null) => void }> = () => <div>Protected Content</div>;
+    
+    test('should show protected content when logged in', () => {
+      const auth = createAuth();
+      useAuthStore.getState().setAuth(auth);
+
+      const SecurePage = withAuth(ProtectedPage);
+      const { container } = render(<SecurePage />);
+
+      expect(container.innerHTML).toContain('Protected Content');
+    });
+
+    test('should redirect to login page when not logged in', () => {
+      useAuthStore.getState().setAuth(null);
+
+      const SecurePage = withAuth(ProtectedPage);
+      render(<SecurePage />);
+
+      expect(mockPush).toHaveBeenCalledWith('/login?redirect_to=%2F');
+    });
+
+    test('should support custom login pages', () => {
+      useAuthStore.getState().setAuth(null);
+
+      const SecurePage = withAuth(ProtectedPage, '/custom-login');
+      render(<SecurePage />);
+
+      expect(mockPush).toHaveBeenCalledWith('/custom-login?redirect_to=%2F');
+    });
+  });
+});

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -26,7 +26,7 @@ const oidcRefresh = async (auth: Auth): Promise<Auth> => {
 
   return {
     token: user.access_token,
-    expiresAt: user.expires_at,
+    expiresAt: user.expires_at * 1000,
     refreshToken: user.refresh_token ?? auth.refreshToken,
     oidcSettings: auth.oidcSettings,
   };
@@ -34,6 +34,7 @@ const oidcRefresh = async (auth: Auth): Promise<Auth> => {
 
 export interface Auth {
   token: string,
+  /** ms unix timestamp */ 
   expiresAt: number,
   refreshToken?: string,
   oidcSettings?: OidcClientSettings,
@@ -59,7 +60,7 @@ export const useAuthStore = create<{
     }
 
     const now = Date.now();
-    const expiresInMs = (auth.expiresAt * 1000) - now;
+    const expiresInMs = auth.expiresAt - now;
     const clearInMs = expiresInMs - 5_000;
     const refreshInMs = expiresInMs - 60_000;
 

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -34,7 +34,7 @@ const oidcRefresh = async (auth: Auth): Promise<Auth> => {
 
 export interface Auth {
   token: string,
-  /** ms unix timestamp */ 
+  /** ms unix timestamp */
   expiresAt: number,
   refreshToken?: string,
   oidcSettings?: OidcClientSettings,

--- a/libraries/ui/src/utils/storybook.ts
+++ b/libraries/ui/src/utils/storybook.ts
@@ -46,7 +46,7 @@ export const loggedInStory = () => ({
     // Call the *real* setAuth function to set the state
     useAuthStore.getState().setAuth({
       token: 'mockToken',
-      expiresAt: Math.floor(Date.now() / 1000) + 3_600, // Expires in 1 hour
+      expiresAt: Date.now() + 3600000, // Expires in 1 hour
     });
   },
 });

--- a/libraries/ui/src/utils/storybook.ts
+++ b/libraries/ui/src/utils/storybook.ts
@@ -28,15 +28,7 @@ import { useAuthStore } from './auth';
  */
 export const loggedOutStory = () => ({
   beforeEach() {
-    const { setAuth } = useAuthStore.getState();
-    setAuth(null);
-    // Clear any potentially lingering timers from previous stories
-    // eslint-disable-next-line no-underscore-dangle
-    const timer = useAuthStore.getState()._authClearTimer;
-    if (timer) {
-      clearTimeout(timer);
-      useAuthStore.setState({ _authClearTimer: null });
-    }
+    useAuthStore.getState().setAuth(null);
   },
 });
 
@@ -51,9 +43,8 @@ export const loggedOutStory = () => ({
  */
 export const loggedInStory = () => ({
   beforeEach() {
-    const { setAuth } = useAuthStore.getState();
     // Call the *real* setAuth function to set the state
-    setAuth({
+    useAuthStore.getState().setAuth({
       token: 'mockToken',
       expiresAt: Math.floor(Date.now() / 1000) + 3_600, // Expires in 1 hour
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -259,7 +259,7 @@
         "axios-hooks": "^5.0.2",
         "http-errors": "^2.0.0",
         "next": "^15.1.7",
-        "oidc-client-ts": "^3.1.0",
+        "oidc-client-ts": "^3.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "zod": "^3.24.2",
@@ -767,7 +767,7 @@
         "clsx": "^2.0.0",
         "http-errors": "^2.0.0",
         "next": "^15.1.7",
-        "oidc-client-ts": "^3.1.0",
+        "oidc-client-ts": "^3.2.0",
         "posthog-js": "^1.217.4",
         "react": "^18.2.0",
         "react-aria-components": "^1.0.0-rc.0",
@@ -22002,9 +22002,9 @@
       "license": "MIT"
     },
     "node_modules/oidc-client-ts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.1.0.tgz",
-      "integrity": "sha512-IDopEXjiwjkmJLYZo6BTlvwOtnlSniWZkKZoXforC/oLZHC9wkIxd25Kwtmo5yKFMMVcsp3JY6bhcNJqdYk8+g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.2.0.tgz",
+      "integrity": "sha512-wUvVcG3SXzZDKHxi/VGQGaTUk9qguMKfYh26Y1zOVrQsu1zp85JWx/SjZzKSXK5j3NA1RcasgMoaHe6gt1WNtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^4.0.0"


### PR DESCRIPTION
# Summary

Adds refresh token logic to auth.tsx, enabling long-lived and secure sessions.

## Issue

Fixes #694

## Description

Uses OidcClient instead of UserManager so we have more control over the refreshing logic - with the built-in refreshing of UserManager it's not clear how we get notified of changes to the token, and we can't hydrate the refresh token from localstorage AFAIK.