### PR TITLE
website-25: [test only] refactor CourseSection.test.tsx to be independent of course names

### DIFF
--- a/apps/website-25/src/components/homepage/CourseSection.test.tsx
+++ b/apps/website-25/src/components/homepage/CourseSection.test.tsx
@@ -5,6 +5,10 @@ import {
 import { sendGAEvent } from '@next/third-parties/google';
 import { constants } from '@bluedot/ui';
 import CourseSection from './CourseSection';
+
+const EVENT_NAME = 'course_card_click' as const;
+const featuredCourse = constants.COURSES.find((course) => course.isFeatured)!;
+const nonFeaturedCourses = constants.COURSES.filter((course) => course !== featuredCourse);
 // Mock the GA event tracking
 vi.mock('@next/third-parties/google', () => ({
   sendGAEvent: vi.fn(),
@@ -20,32 +24,32 @@ describe('CourseSection', () => {
     expect(container).toMatchSnapshot();
 
     // Verify featured course is present
-    expect(screen.getByText('The Future of AI Course')).toBeDefined();
-    // Verify the first of the other courses is present
-    expect(screen.getByText('Economics of Transformative AI')).toBeDefined();
+    expect(screen.getByText(featuredCourse.title)).toBeDefined();
+    // Verify one of the other courses is present
+    expect(screen.getByText(nonFeaturedCourses[0]!.title)).toBeDefined();
   });
 
   test('tracks clicks on course cards', () => {
     render(<CourseSection />);
 
     // Click the featured course card
-    const featuredCard = screen.getByText('The Future of AI Course');
+    const featuredCard = screen.getByText(featuredCourse.title);
     fireEvent.click(featuredCard);
 
     // Verify GA event was sent with correct parameters
-    expect(sendGAEvent).toHaveBeenCalledWith('event', 'course_card_click', {
-      course_title: 'The Future of AI Course',
-      course_url: constants.COURSES[0]?.url,
+    expect(sendGAEvent).toHaveBeenCalledWith('event', EVENT_NAME, {
+      course_title: featuredCourse.title,
+      course_url: featuredCourse.url,
     });
 
     // Click another course card
-    const other = screen.getByText('AI Alignment');
+    const other = screen.getByText(nonFeaturedCourses[0]!.title);
     fireEvent.click(other);
 
     // Verify GA event was sent with correct parameters
-    expect(sendGAEvent).toHaveBeenCalledWith('event', 'course_card_click', {
-      course_title: 'AI Alignment',
-      course_url: 'https://aisafetyfundamentals.com/alignment/',
+    expect(sendGAEvent).toHaveBeenCalledWith('event', EVENT_NAME, {
+      course_title: nonFeaturedCourses[0]!.title,
+      course_url: nonFeaturedCourses[0]!.url,
     });
   });
 });


### PR DESCRIPTION
# Summary

website-25: [test only] refactor CourseSection.test.tsx to be independent of course names

Follow up from https://github.com/bluedotimpact/bluedot/pull/691#discussion_r2055957207

## Issue

Fixes #695