### PR TITLE
website-25: Create new users in Airtable when logging in for the first time

### DIFF
--- a/apps/website-25/src/lib/api/db/tables.ts
+++ b/apps/website-25/src/lib/api/db/tables.ts
@@ -238,7 +238,7 @@ export interface User extends Item {
   utmSource: string,
   utmCampaign: string,
   utmContent: string,
-  courseSitesVisited: string,
+  courseSitesVisitedCsv: string,
   completedMoocAt: number | null,
 }
 
@@ -256,7 +256,7 @@ export const userTable: Table<User> = {
     utmSource: 'fldl1gTMXI44BvCUS',
     utmCampaign: 'fldcNcqMxSFpmiGWT',
     utmContent: 'fldlpjcdh7jpZhHhv',
-    courseSitesVisited: 'fldgbXANYvYCEw4OV',
+    courseSitesVisitedCsv: 'fldgbXANYvYCEw4OV',
     completedMoocAt: 'fldTCSAIKNs4nPfDn',
   },
   schema: {
@@ -269,7 +269,7 @@ export const userTable: Table<User> = {
     utmSource: 'string',
     utmCampaign: 'string',
     utmContent: 'string',
-    courseSitesVisited: 'string',
+    courseSitesVisitedCsv: 'string',
     completedMoocAt: 'number | null',
   },
 };

--- a/apps/website-25/src/pages/api/users/me.ts
+++ b/apps/website-25/src/pages/api/users/me.ts
@@ -23,6 +23,12 @@ export type PatchUserBody = {
 
 export default makeApiRoute({
   requireAuth: true,
+  requestBody: z.object({
+    name: z.string().optional(),
+    referredById: z.string().optional(),
+    courseSitesVisited: z.string().optional(),
+    completedMoocAt: z.number().optional(),
+  }).optional(),
   responseBody: z.object({
     type: z.literal('success'),
     user: z.any(),
@@ -30,12 +36,6 @@ export default makeApiRoute({
       title: z.string(),
       path: z.string(),
     })),
-  }).optional(),
-  requestBody: z.object({
-    name: z.string().optional(),
-    referredById: z.string().optional(),
-    courseSitesVisited: z.string().optional(),
-    completedMoocAt: z.number().optional(),
   }).optional(),
 }, async (body, { auth, raw }) => {
   // Handle GET request

--- a/apps/website-25/src/pages/api/users/me.ts
+++ b/apps/website-25/src/pages/api/users/me.ts
@@ -10,7 +10,15 @@ import {
 
 export type GetUserResponse = {
   type: 'success';
-  user: User & { coursePath: string };
+  user: User;
+  enrolledCourses: { id: string, title: string, path: string }[];
+};
+
+export type PatchUserBody = {
+  name?: string;
+  referredById?: string;
+  courseSitesVisitedCsv?: string;
+  completedMoocAt?: number;
 };
 
 export default makeApiRoute({
@@ -18,32 +26,74 @@ export default makeApiRoute({
   responseBody: z.object({
     type: z.literal('success'),
     user: z.any(),
-  }),
-}, async (body, { auth }) => {
-  const user = (await db.scan(userTable, {
+    enrolledCourses: z.array(z.object({
+      title: z.string(),
+      path: z.string(),
+    })),
+  }).optional(),
+  requestBody: z.object({
+    name: z.string().optional(),
+    referredById: z.string().optional(),
+    courseSitesVisited: z.string().optional(),
+    completedMoocAt: z.number().optional(),
+  }).optional(),
+}, async (body, { auth, raw }) => {
+  // Handle GET request
+  const [existingUser] = await db.scan(userTable, {
     filterByFormula: `{Email} = "${auth.email}"`,
-  }))[0];
+  });
 
-  const courseNames = user?.courseSitesVisited.split(',') ?? [];
+  switch (raw.req.method) {
+    case 'GET': {
+      let user: User;
+      if (!existingUser) {
+        // Create user if doesn't exist
+        user = await db.insert(userTable, {
+          email: auth.email,
+          lastSeenAt: new Date().toISOString(),
+        });
+      } else {
+        // Update last seen timestamp if does exist
+        user = await db.update(userTable, {
+          id: existingUser.id,
+          lastSeenAt: new Date().toISOString(),
+        });
+      }
 
-  if (courseNames.length > 1) {
-    // eslint-disable-next-line no-console
-    console.error('Users with multiple courses are not supported yet, only returning the first coursePath');
+      const courseNames = user.courseSitesVisitedCsv.split(',');
+      const courses = (await Promise.all(
+        courseNames.map((courseName) => db.scan(courseTable, {
+          filterByFormula: `{Course} = "${courseName}"`,
+        })),
+      )).flat();
+
+      return {
+        type: 'success' as const,
+        user,
+        enrolledCourses: courses.map((c) => ({ id: c.id, title: c.title, path: c.path })),
+      };
+    }
+
+    case 'PATCH': {
+      if (!existingUser) {
+        throw new createHttpError.NotFound('User not found');
+      }
+
+      if (!body) {
+        throw new createHttpError.BadRequest('PATCH request requires a body');
+      }
+
+      // Update user with provided fields
+      await db.update(userTable, {
+        id: existingUser.id,
+        ...body,
+      });
+
+      return undefined;
+    }
+
+    default: {
+      throw new createHttpError.MethodNotAllowed();
+    }
   }
-
-  const course = (await db.scan(courseTable, {
-    filterByFormula: `{Course} = "${courseNames[0]}"`,
-  }))[0];
-
-  if (!user) {
-    // In practice we might want to create a user for them if this is the case
-    throw new createHttpError.NotFound('User not found');
-  }
-
-  const res: GetUserResponse = {
-    type: 'success' as const,
-    user: { ...user, coursePath: course?.path ?? '' },
-  };
-
-  return res;
 });

--- a/apps/website-25/src/pages/login/oauth-callback.tsx
+++ b/apps/website-25/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,17 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
+import axios from 'axios';
+import { GetUserResponse } from '../api/users/me';
 
-export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => (
+  <LoginOauthCallbackPage
+    oidcSettings={loginPresets.keycloak.oidcSettings}
+    onLoginComplete={async (auth) => {
+      // This ensures the user is created
+      await axios.get<GetUserResponse>('/api/users/me', {
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+        },
+      });
+    }}
+  />
+);


### PR DESCRIPTION
# Summary

website-25: Create new users in Airtable when logging in for the first time

## Issue

Fixes #696

## Description

Mostly a backend change: when we try to get the current user, we create one in Airtable if one does not exist. Then we call this endpoint when logging in (as part of oauth callback) to ensure the user exists in Airtable if they go through the login flow.

Tested locally by creating a new user.

Also put in some groundwork for updating the user with a PATCH, which will be useful for the user to update their name etc. but not used yet.