### PR TITLE
devex: Make setup of .env.local easier

### DIFF
--- a/apps/app-template/.env.local.template
+++ b/apps/app-template/.env.local.template
@@ -8,4 +8,4 @@ ALERTS_SLACK_CHANNEL_ID=C04SFUECECU
 # For (local) BlueBot see https://airtable.com/appnNmNoNMB6crg6I/tbllthJ2YSPDsKWCt/viwfjWLvplq6Xw93D/recqurdJTPWzm5y4W
 # For (prod) BlueBot see https://api.slack.com/apps/A04PV2GAQRY/install-on-team
 # Starts 'xoxb-'
-ALERTS_SLACK_BOT_TOKEN=
+ALERTS_SLACK_BOT_TOKEN=IGNORE_SLACK_ALERTS

--- a/apps/app-template/package.json
+++ b/apps/app-template/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "shx cp -n .env.local.template .env.local",
     "start": "next dev -p 8000",
     "start:docker": "docker-scripts start",
     "build": "next build",
@@ -37,7 +38,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.14.1",
     "postcss": "^8.4.38",
-    "shx": "^0.3.4",
+    "shx": "^0.4.0",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.8.3",
     "vitest": "^1.5.0"

--- a/apps/availability/.env.local.template
+++ b/apps/availability/.env.local.template
@@ -8,4 +8,4 @@ ALERTS_SLACK_CHANNEL_ID=C04SFUECECU
 # For (local) BlueBot see 1Password Team Vault "(local) BlueBot Slack App key"
 # For (prod) BlueBot see 1Password Team Vault "(prod) BlueBot Slack App key"
 # Starts 'xoxb-'
-ALERTS_SLACK_BOT_TOKEN=
+ALERTS_SLACK_BOT_TOKEN=IGNORE_SLACK_ALERTS

--- a/apps/availability/package.json
+++ b/apps/availability/package.json
@@ -42,7 +42,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.14.1",
     "postcss": "^8.4.38",
-    "shx": "^0.3.4",
+    "shx": "^0.4.0",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.8.3",
     "vitest": "^1.5.0"

--- a/apps/course-demos/.env.local.template
+++ b/apps/course-demos/.env.local.template
@@ -12,4 +12,4 @@ ALERTS_SLACK_CHANNEL_ID=C04SFUECECU
 # For (local) BlueBot see https://airtable.com/appnNmNoNMB6crg6I/tbllthJ2YSPDsKWCt/viwfjWLvplq6Xw93D/recqurdJTPWzm5y4W
 # For (prod) BlueBot see https://api.slack.com/apps/A04PV2GAQRY/install-on-team
 # Starts 'xoxb-'
-ALERTS_SLACK_BOT_TOKEN=
+ALERTS_SLACK_BOT_TOKEN=IGNORE_SLACK_ALERTS

--- a/apps/course-demos/package.json
+++ b/apps/course-demos/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "shx cp -n .env.local.template .env.local",
     "start": "next dev -p 8000",
     "start:docker": "docker-scripts start",
     "build": "next build",
@@ -47,7 +48,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.14.1",
     "postcss": "^8.4.38",
-    "shx": "^0.3.4",
+    "shx": "^0.4.0",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.8.3",
     "vitest": "^1.5.0"

--- a/apps/frontend-example/.env.local.template
+++ b/apps/frontend-example/.env.local.template
@@ -8,4 +8,4 @@ ALERTS_SLACK_CHANNEL_ID=C04SFUECECU
 # For (local) BlueBot see https://airtable.com/appnNmNoNMB6crg6I/tbllthJ2YSPDsKWCt/viwfjWLvplq6Xw93D/recqurdJTPWzm5y4W
 # For (prod) BlueBot see https://api.slack.com/apps/A04PV2GAQRY/install-on-team
 # Starts 'xoxb-'
-ALERTS_SLACK_BOT_TOKEN=
+ALERTS_SLACK_BOT_TOKEN=IGNORE_SLACK_ALERTS

--- a/apps/frontend-example/package.json
+++ b/apps/frontend-example/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "shx cp -n .env.local.template .env.local",
     "start": "next dev -p 8000",
     "start:docker": "docker-scripts start",
     "build": "next build",
@@ -44,7 +45,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.14.1",
     "postcss": "^8.4.38",
-    "shx": "^0.3.4",
+    "shx": "^0.4.0",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.8.3",
     "vitest": "^1.5.0"

--- a/apps/login-account-proxy/.env.local.template
+++ b/apps/login-account-proxy/.env.local.template
@@ -11,4 +11,4 @@ ALERTS_SLACK_CHANNEL_ID=C04SFUECECU
 # For (local) BlueBot see https://airtable.com/appnNmNoNMB6crg6I/tbllthJ2YSPDsKWCt/viwfjWLvplq6Xw93D/recqurdJTPWzm5y4W
 # For (prod) BlueBot see https://api.slack.com/apps/A04PV2GAQRY/install-on-team
 # Starts 'xoxb-'
-ALERTS_SLACK_BOT_TOKEN=
+ALERTS_SLACK_BOT_TOKEN=IGNORE_SLACK_ALERTS

--- a/apps/login-account-proxy/package.json
+++ b/apps/login-account-proxy/package.json
@@ -37,7 +37,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.14.1",
     "postcss": "^8.4.38",
-    "shx": "^0.3.4",
+    "shx": "^0.4.0",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.8.3",
     "vitest": "^1.5.0"

--- a/apps/meet/.env.local.template
+++ b/apps/meet/.env.local.template
@@ -14,4 +14,4 @@ ALERTS_SLACK_CHANNEL_ID=C04SFUECECU
 # For (local) BlueBot see https://airtable.com/appnNmNoNMB6crg6I/tbllthJ2YSPDsKWCt/viwfjWLvplq6Xw93D/recqurdJTPWzm5y4W
 # For (prod) BlueBot, ask Adam for access and see https://api.slack.com/apps/A04PV2GAQRY/install-on-team
 # Starts 'xoxb-'
-ALERTS_SLACK_BOT_TOKEN=
+ALERTS_SLACK_BOT_TOKEN=IGNORE_SLACK_ALERTS

--- a/apps/meet/package.json
+++ b/apps/meet/package.json
@@ -43,7 +43,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.14.1",
     "postcss": "^8.4.38",
-    "shx": "^0.3.4",
+    "shx": "^0.4.0",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.8.3",
     "vitest": "^1.5.0"

--- a/apps/room/.env.local.template
+++ b/apps/room/.env.local.template
@@ -7,4 +7,4 @@ ALERTS_SLACK_CHANNEL_ID=C04SFUECECU
 # For (local) BlueBot see https://airtable.com/appnNmNoNMB6crg6I/tbllthJ2YSPDsKWCt/viwfjWLvplq6Xw93D/recqurdJTPWzm5y4W
 # For (prod) BlueBot see https://api.slack.com/apps/A04PV2GAQRY/install-on-team
 # Starts 'xoxb-'
-ALERTS_SLACK_BOT_TOKEN=
+ALERTS_SLACK_BOT_TOKEN=IGNORE_SLACK_ALERTS

--- a/apps/room/package.json
+++ b/apps/room/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "shx cp -n .env.local.template .env.local",
     "start": "next dev -p 8000",
     "start:docker": "docker-scripts start",
     "build": "next build",
@@ -40,6 +41,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.16.2",
     "postcss": "^8.4.38",
+    "shx": "^0.4.0",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.8.3",
     "vitest": "^1.5.0"

--- a/apps/website-25/.env.local.template
+++ b/apps/website-25/.env.local.template
@@ -19,6 +19,6 @@ ALERTS_SLACK_CHANNEL_ID=C04SFUECECU
 # For (local) BlueBot see https://airtable.com/appnNmNoNMB6crg6I/tbllthJ2YSPDsKWCt/viwfjWLvplq6Xw93D/recqurdJTPWzm5y4W
 # For (prod) BlueBot see https://api.slack.com/apps/A04PV2GAQRY/install-on-team
 # Starts 'xoxb-'
-ALERTS_SLACK_BOT_TOKEN=
+ALERTS_SLACK_BOT_TOKEN=IGNORE_SLACK_ALERTS
 
 APP_NAME=website-25

--- a/apps/website-25/package.json
+++ b/apps/website-25/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "shx cp -n .env.local.template .env.local",
     "start": "next dev -p 8000",
     "start:docker": "docker-scripts start",
     "build": "next build",
@@ -57,7 +58,7 @@
     "happy-dom": "^14.7.1",
     "node-mocks-http": "^1.14.1",
     "postcss": "^8.4.38",
-    "shx": "^0.3.4",
+    "shx": "^0.4.0",
     "tailwindcss": "^4.0.6",
     "typescript": "^5.8.3",
     "vitest": "^1.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
     "apps/app-template": {
       "name": "@bluedot/app-template",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@bluedot/ui": "*",
         "airtable-ts": "^1.4.0",
@@ -48,7 +49,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.14.1",
         "postcss": "^8.4.38",
-        "shx": "^0.3.4",
+        "shx": "^0.4.0",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.8.3",
         "vitest": "^1.5.0"
@@ -87,7 +88,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.14.1",
         "postcss": "^8.4.38",
-        "shx": "^0.3.4",
+        "shx": "^0.4.0",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.8.3",
         "vitest": "^1.5.0"
@@ -136,6 +137,7 @@
     "apps/course-demos": {
       "name": "@bluedot/course-demos",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "^1.1.15",
         "@ai-sdk/react": "^1.1.21",
@@ -171,7 +173,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.14.1",
         "postcss": "^8.4.38",
-        "shx": "^0.3.4",
+        "shx": "^0.4.0",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.8.3",
         "vitest": "^1.5.0"
@@ -180,6 +182,7 @@
     "apps/frontend-example": {
       "name": "@bluedot/frontend-example",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@bluedot/backend-contract": "*",
         "@bluedot/ui": "*",
@@ -212,7 +215,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.14.1",
         "postcss": "^8.4.38",
-        "shx": "^0.3.4",
+        "shx": "^0.4.0",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.8.3",
         "vitest": "^1.5.0"
@@ -279,7 +282,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.14.1",
         "postcss": "^8.4.38",
-        "shx": "^0.3.4",
+        "shx": "^0.4.0",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.8.3",
         "vitest": "^1.5.0"
@@ -319,7 +322,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.14.1",
         "postcss": "^8.4.38",
-        "shx": "^0.3.4",
+        "shx": "^0.4.0",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.8.3",
         "vitest": "^1.5.0"
@@ -342,6 +345,7 @@
     "apps/room": {
       "name": "@bluedot/room",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@bluedot/ui": "*",
         "airtable-ts": "^1.4.0",
@@ -370,6 +374,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.16.2",
         "postcss": "^8.4.38",
+        "shx": "^0.4.0",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.8.3",
         "vitest": "^1.5.0"
@@ -412,6 +417,7 @@
     "apps/website-25": {
       "name": "@bluedot/website-25",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@bluedot/docker-scripts": "*",
         "@bluedot/ui": "*",
@@ -454,7 +460,7 @@
         "happy-dom": "^14.7.1",
         "node-mocks-http": "^1.14.1",
         "postcss": "^8.4.38",
-        "shx": "^0.3.4",
+        "shx": "^0.4.0",
         "tailwindcss": "^4.0.6",
         "typescript": "^5.8.3",
         "vitest": "^1.5.0"
@@ -21310,6 +21316,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -21922,6 +21935,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -24929,13 +24952,14 @@
       }
     },
     "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
+      "integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "glob": "^7.0.0",
+        "execa": "^1.0.0",
+        "fast-glob": "^3.3.2",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
       },
@@ -24943,40 +24967,56 @@
         "shjs": "bin/shjs"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
     },
-    "node_modules/shelljs/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "node_modules/shelljs/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/shelljs/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       },
       "engines": {
-        "node": "*"
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/shelljs/node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/shelljs/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/shelljs/node_modules/interpret": {
@@ -24989,17 +25029,44 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/shelljs/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+    "node_modules/shelljs/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shelljs/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shelljs/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "path-key": "^2.0.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/shelljs/node_modules/rechoir": {
@@ -25014,6 +25081,52 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/shelljs/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/shelljs/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shelljs/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shelljs/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
@@ -25021,20 +25134,20 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.4.0.tgz",
+      "integrity": "sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
+        "minimist": "^1.2.8",
+        "shelljs": "^0.9.2"
       },
       "bin": {
         "shx": "lib/cli.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
       }
     },
     "node_modules/side-channel": {
@@ -25711,6 +25824,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {


### PR DESCRIPTION
Most apps create `.env.local` automatically if it doesn't exist on `postinstall`, but not all. This PR makes it consistent across all apps.

Also the Slack token isn't really required - shoving 'IGNORE_SLACK_ALERTS' as the API token will generally cause it to fail quietly which is fine locally. I've filled it in like this to make getting started easier.