### PR TITLE
website-25: Clean up PostHog setup

### DIFF
--- a/apps/website-25/.env.local.template
+++ b/apps/website-25/.env.local.template
@@ -9,7 +9,7 @@
 NEXT_PUBLIC_POSTHOG_KEY=phc_6lpcdfa5r3lWXPLqYExFejWNjLXcKv0HULDZwnK5cdF
 # When set, PostHog debug mode will be enabled. Comment out to disable.
 # See https://posthog.com/docs/advanced/debugging
-NEXT_PUBLIC_DEBUG_POSTHOG=true
+NEXT_PUBLIC_DEBUG_POSTHOG=false
 
 # Airtable: https://support.airtable.com/docs/creating-and-using-api-keys-and-access-tokens
 AIRTABLE_PERSONAL_ACCESS_TOKEN=


### PR DESCRIPTION
# Summary

- Init posthog in a useEffect hook, in line with PostHog docs to prevent random extra re-inits that cause errors
- Fix persistence setting so we are ePrivacy regs compliant - default to storing in memory (rather than a cookie) until acceptance
- Fix debug mode loading, but disable it by default to reduce log noise
- Remove unnecessary logs