### PR TITLE
website-25: Address Slack feedback

### DIFF
--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -40,7 +40,7 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, c
 
   return (
     // See @utility prose in globals.css for advanced styles
-    <div className={clsx('markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal', className)}>
+    <div className={clsx('markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal max-w-none', className)}>
       {Component && <Component components={getSupportedComponents()} />}
     </div>
   );

--- a/apps/website-25/src/components/courses/UnitFeedback.tsx
+++ b/apps/website-25/src/components/courses/UnitFeedback.tsx
@@ -77,7 +77,7 @@ const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
         <H4>How did you like this unit?</H4>
         <P>
           We constantly try to get better and need your feedback to improve the
-          course. It only takes <u>1 min</u> to share your learning experience
+          course. It only takes <b>1 min</b> to share your learning experience
           with us.
         </P>
       </div>

--- a/apps/website-25/src/components/courses/UnitLayout.tsx
+++ b/apps/website-25/src/components/courses/UnitLayout.tsx
@@ -28,8 +28,9 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
   unitNumber,
   units,
 }) => {
-  const nextUnit = units[units.findIndex((u) => u === unit) + 1];
-  const prevUnit = units[units.findIndex((u) => u === unit) - 1];
+  const unitArrIndex = units.findIndex((u) => u.id === unit.id);
+  const nextUnit = units[unitArrIndex + 1];
+  const prevUnit = units[unitArrIndex - 1];
 
   if (!unit) {
     // Should never happen

--- a/apps/website-25/src/components/courses/UnitLayout.tsx
+++ b/apps/website-25/src/components/courses/UnitLayout.tsx
@@ -32,7 +32,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
   const nextUnit = units[unitArrIndex + 1];
   const prevUnit = units[unitArrIndex - 1];
 
-  if (!unit) {
+  if (!unit || unitArrIndex === -1) {
     // Should never happen
     throw new Error('Unit not found');
   }

--- a/apps/website-25/src/components/courses/__snapshots__/UnitFeedback.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitFeedback.test.tsx.snap
@@ -17,9 +17,9 @@ exports[`UnitFeedback > should render correctly 1`] = `
         class="bluedot-p"
       >
         We constantly try to get better and need your feedback to improve the course. It only takes 
-        <u>
+        <b>
           1 min
-        </u>
+        </b>
          to share your learning experience with us.
       </p>
     </div>

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -325,7 +325,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             class="unit__content flex flex-col flex-1 max-w-[728px] gap-4"
           >
             <div
-              class="markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal"
+              class="markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal max-w-none"
             />
             <div
               class="unit__cta-container flex flex-row justify-between mt-6 mx-1"


### PR DESCRIPTION
Fixes various issues tracked in Slack (have reacted ✅ on them):
- Make UnitFeedback '1 min' label not look like a link
- Fix content width being inconsistent with e.g. feedback / congratulations window
- Fix next/prev unit buttons

## Screenshot

https://github.com/user-attachments/assets/26a29ab9-9081-4ab3-9234-1589259f8bc5