### PR TITLE
Fix Login redirect logic

### DIFF
--- a/libraries/ui/src/legacy/Login.test.tsx
+++ b/libraries/ui/src/legacy/Login.test.tsx
@@ -4,7 +4,7 @@ import {
   test,
   expect,
   beforeEach,
-  vi
+  vi,
 } from 'vitest';
 import { LoginRedirectPage, loginPresets } from './Login';
 import { Navigate } from './Navigate';

--- a/libraries/ui/src/legacy/Login.test.tsx
+++ b/libraries/ui/src/legacy/Login.test.tsx
@@ -1,0 +1,47 @@
+import { render } from '@testing-library/react';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { LoginRedirectPage, loginPresets } from './Login';
+import { Navigate } from './Navigate';
+import { useAuthStore } from '../utils/auth';
+import { getQueryParam } from '../utils/getQueryParam';
+
+vi.mock('../utils/auth', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+vi.mock('./Navigate', () => ({
+  Navigate: vi.fn(() => null),
+}));
+
+vi.mock('../utils/getQueryParam', () => ({
+  getQueryParam: vi.fn(),
+}));
+
+const CUSTOM_REDIRECT_PATH = '/custom-path';
+
+describe('LoginRedirectPage', () => {
+  const mockOidcSettings = loginPresets.keycloak.oidcSettings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('should navigate to the redirect_to value when auth is present', () => {
+    (useAuthStore as any).mockReturnValue({ auth: { token: 'test-token' } });
+    (getQueryParam as any).mockReturnValue(CUSTOM_REDIRECT_PATH);
+
+    render(<LoginRedirectPage oidcSettings={mockOidcSettings} />);
+
+    expect(Navigate).toHaveBeenCalledWith({
+      url: CUSTOM_REDIRECT_PATH
+    }, expect.anything());
+  });
+
+  test('if not authed, should createSigninRequest with with redirect_to query param', async () => {
+    // TODO #720
+  });
+
+  test('if not authed and no redirect_to, should createSigninRequest with default redirect path', async () => {
+    // TODO #720
+  });
+});

--- a/libraries/ui/src/legacy/Login.test.tsx
+++ b/libraries/ui/src/legacy/Login.test.tsx
@@ -1,5 +1,11 @@
 import { render } from '@testing-library/react';
-import { describe, test, expect, beforeEach, vi } from 'vitest';
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  vi
+} from 'vitest';
 import { LoginRedirectPage, loginPresets } from './Login';
 import { Navigate } from './Navigate';
 import { useAuthStore } from '../utils/auth';
@@ -27,13 +33,13 @@ describe('LoginRedirectPage', () => {
   });
 
   test('should navigate to the redirect_to value when auth is present', () => {
-    (useAuthStore as any).mockReturnValue({ auth: { token: 'test-token' } });
-    (getQueryParam as any).mockReturnValue(CUSTOM_REDIRECT_PATH);
+    vi.mocked(useAuthStore).mockReturnValue({ auth: { token: 'test-token' } });
+    vi.mocked(getQueryParam).mockReturnValue(CUSTOM_REDIRECT_PATH);
 
     render(<LoginRedirectPage oidcSettings={mockOidcSettings} />);
 
     expect(Navigate).toHaveBeenCalledWith({
-      url: CUSTOM_REDIRECT_PATH
+      url: CUSTOM_REDIRECT_PATH,
     }, expect.anything());
   });
 

--- a/libraries/ui/src/legacy/Login.tsx
+++ b/libraries/ui/src/legacy/Login.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { OidcClient, OidcClientSettings } from 'oidc-client-ts';
 import { useRouter } from 'next/router';
 import axios from 'axios';
@@ -8,6 +7,7 @@ import { P } from './Text';
 import { Navigate } from './Navigate';
 import { Auth, useAuthStore } from '../utils/auth';
 import { ErrorSection } from '../ErrorSection';
+import { getQueryParam } from '../utils/getQueryParam';
 
 export type LoginPageProps = {
   oidcSettings: OidcClientSettings
@@ -143,8 +143,7 @@ export const loginPresets = {
 }>;
 
 export const LoginRedirectPage: React.FC<LoginPageProps> = ({ oidcSettings }) => {
-  const searchParams = useSearchParams();
-  const redirectTo = searchParams.get('redirect_to') || '/';
+  const redirectTo = getQueryParam(window.location.href, 'redirect_to') || '/';
   const auth = useAuthStore((s) => s.auth);
 
   useEffect(() => {
@@ -198,7 +197,7 @@ export const LoginOauthCallbackPage: React.FC<LoginOauthCallbackPageProps> = ({ 
         if (onLoginComplete) {
           await onLoginComplete(auth);
         }
-        router.push((user.state as { redirectTo?: string }).redirectTo || '/');
+        router.push((user.userState as { redirectTo?: string }).redirectTo || '/');
       } catch (err) {
         setError(err instanceof Error ? err : new Error(String(err)));
       }


### PR DESCRIPTION
# Summary

Fix Login redirect logic

## Description

- Builds off of https://github.com/bluedotimpact/bluedot/pull/718 and https://github.com/bluedotimpact/bluedot/pull/724
- Started adding Login tests but had trouble with Oicd mocks so time boxed and am addressing this separately in [Add tests to Login.tsx](https://github.com/bluedotimpact/bluedot/issues/720) 

## Testing

### Redirect for login
https://github.com/user-attachments/assets/4918a0aa-0c6c-4d08-9313-424b60e1db1d

### Redirect for new user
https://github.com/user-attachments/assets/9cc1bdbb-1207-4e27-86a9-299825bee8c4

### Redirect for Google auth
https://github.com/user-attachments/assets/6df77d1d-f687-4797-abb0-996f103fbdad