### PR TITLE
Add new container-active to design system documentation

### DIFF
--- a/apps/storybook/src/GettingStarted.mdx
+++ b/apps/storybook/src/GettingStarted.mdx
@@ -169,7 +169,7 @@ You can use `rounded-` Tailwind CSS utility classes to create rounded corners on
 
 ### Elevation
 
-Use `container-lined`, `container-elevated`, `container-dialog` classes to create containers with different elevations.
+Use `container-lined`, `container-elevated`, `container-dialog`, `container-active` classes to create containers with different elevations.
 
 <Unstyled>
   <div className="bg-color-canvas m-10 min-h-24 container-lined flex justify-center items-center max-w-64">
@@ -180,6 +180,9 @@ Use `container-lined`, `container-elevated`, `container-dialog` classes to creat
   </div>
   <div className="bg-color-canvas m-10 min-h-24 container-dialog flex justify-center items-center max-w-64">
     <p className="text-color-text">container-dialog</p>
+  </div>
+  <div className="bg-color-canvas m-10 min-h-24 container-active flex justify-center items-center max-w-64">
+    <p className="text-color-text">container-active</p>
   </div>
 </Unstyled>
 


### PR DESCRIPTION
# Summary

Add new container-active to design system documentation

<img width="1404" alt="Screenshot 2025-04-24 at 14 29 26" src="https://github.com/user-attachments/assets/b2a11039-66a9-4d02-825b-34b7fa1ecb91" />
