### PR TITLE
website-25: Fix heading link font weight

### DIFF
--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -40,7 +40,7 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, c
 
   return (
     // See @utility prose in globals.css for advanced styles
-    <div className={clsx('markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal max-w-none', className)}>
+    <div className={clsx('markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal max-w-none prose-a:in-prose-headings:font-bold', className)}>
       {Component && <Component components={getSupportedComponents()} />}
     </div>
   );

--- a/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website-25/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -325,7 +325,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             class="unit__content flex flex-col flex-1 max-w-[728px] gap-4"
           >
             <div
-              class="markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal max-w-none"
+              class="markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal max-w-none prose-a:in-prose-headings:font-bold"
             />
             <div
               class="unit__cta-container flex flex-row justify-between mt-6 mx-1"


### PR DESCRIPTION
https://bluedotimpact.slack.com/archives/C08LQKWBX9B/p1745426786571269

Before:

<img width="569" alt="image" src="https://github.com/user-attachments/assets/22fe5739-e4ec-48ad-8b9f-60c6933137d0" />

After:

<img width="569" alt="image" src="https://github.com/user-attachments/assets/f8c4ca3f-dd9c-4f0a-ad20-d1b48a3746d7" />

Also raised upstream: https://github.com/tailwindlabs/tailwindcss-typography/issues/391