### PR TITLE
website-25: Fix exercise heading formatting

### DIFF
--- a/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website-25/src/components/courses/exercises/FreeTextResponse.tsx
@@ -61,7 +61,7 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
           <img src="/icons/lightning_bolt.svg" className="w-15 h-15" alt="" />
         </div>
         <div className="free-text-response__header-content flex flex-col gap-2">
-          <P className="free-text-response__title bluedot-h4">{title}</P>
+          <p className="free-text-response__title bluedot-h4">{title}</p>
           <ReactMarkdown>{description}</ReactMarkdown>
         </div>
       </div>

--- a/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website-25/src/components/courses/exercises/MultipleChoice.tsx
@@ -88,7 +88,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
           <img src="/icons/lightning_bolt.svg" className="w-15 h-15" alt="" />
         </div>
         <div className="multiple-choice__header-content flex flex-col gap-2">
-          <P className="multiple-choice__title bluedot-h4">{title}</P>
+          <p className="multiple-choice__title bluedot-h4">{title}</p>
           <P className="multiple-choice__description">{description}</P>
         </div>
       </div>

--- a/apps/website-25/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website-25/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
         class="free-text-response__header-content flex flex-col gap-2"
       >
         <p
-          class="bluedot-p free-text-response__title bluedot-h4"
+          class="free-text-response__title bluedot-h4"
         >
           Understanding LLMs
         </p>
@@ -85,7 +85,7 @@ exports[`FreeTextResponse > renders logged in as expected 1`] = `
         class="free-text-response__header-content flex flex-col gap-2"
       >
         <p
-          class="bluedot-p free-text-response__title bluedot-h4"
+          class="free-text-response__title bluedot-h4"
         >
           Understanding LLMs
         </p>
@@ -139,7 +139,7 @@ exports[`FreeTextResponse > renders with saved exercise response 1`] = `
         class="free-text-response__header-content flex flex-col gap-2"
       >
         <p
-          class="bluedot-p free-text-response__title bluedot-h4"
+          class="free-text-response__title bluedot-h4"
         >
           Understanding LLMs
         </p>

--- a/apps/website-25/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website-25/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
         class="multiple-choice__header-content flex flex-col gap-2"
       >
         <p
-          class="bluedot-p multiple-choice__title bluedot-h4"
+          class="multiple-choice__title bluedot-h4"
         >
           Understanding LLMs
         </p>
@@ -153,7 +153,7 @@ exports[`MultipleChoice > renders logged in as expected 1`] = `
         class="multiple-choice__header-content flex flex-col gap-2"
       >
         <p
-          class="bluedot-p multiple-choice__title bluedot-h4"
+          class="multiple-choice__title bluedot-h4"
         >
           Understanding LLMs
         </p>


### PR DESCRIPTION
Before:

<img width="569" alt="image" src="https://github.com/user-attachments/assets/2710884b-9087-4fbc-b45d-d84342c765a3" />

After:

<img width="569" alt="image" src="https://github.com/user-attachments/assets/17ad0bba-4b82-4b90-bdbd-cd7362ca785f" />
