### PR TITLE
website-25: Improve not-prose custom style handling

### DIFF
--- a/apps/website-25/src/globals.css
+++ b/apps/website-25/src/globals.css
@@ -15,12 +15,14 @@
 @utility prose {
   :not(:where([class~="not-prose"],[class~="not-prose"] *)) {
     /* Bullets should inherit text color */
-    li::marker {
-      @apply text-inherit
+    &:where(li) {
+      &::marker {
+        @apply text-inherit
+      }
     }
 
     /* https://bluedotimpact.slack.com/archives/C08LQKWBX9B/p1745428606815279 */
-    blockquote {
+    &:where(blockquote) {
       /* Disable quote marks */
       p:first-of-type::before,
       p:last-of-type::after {
@@ -33,7 +35,7 @@
     }
 
     /* Disable code backticks */
-    code {
+    &:where(code) {
       &::before,
       &::after {
         content: none;
@@ -41,13 +43,13 @@
     }
 
     /* Hovering link color */
-    a {
+    &:where(a) {
       @apply hover:text-color-primary-accent
     }
 
     /* Links in headings should be the same font weight
     * See https://github.com/tailwindlabs/tailwindcss-typography/issues/391 */
-    h1, h2, h3, h4, h5, h6 {
+    &:where(h1, h2, h3, h4, h5, h6) {
       a {
         font-weight: inherit;
       }


### PR DESCRIPTION
Bug: If you had an overridden style that was a direct descendant of prose it wouldn't get rendered properly, because there is no parent element that isn't set to `not-prose`. (i.e. it required `<prose class="prose"><subcontainer><overridenelement /></subcontainer></prose>`)

This PR fixes the behaviour by allowing the element itself to be a direct descendant of prose, so long as it isn't a .not-prose. (so you can do `<prose class="prose"><overridenelement /</prose>`)