### PR TITLE
Restore "Rive on homepage"

### DIFF
--- a/apps/website-25/src/components/homepage/HomeHeroContent.tsx
+++ b/apps/website-25/src/components/homepage/HomeHeroContent.tsx
@@ -2,12 +2,16 @@ import {
   HeroH1,
   HeroH2,
 } from '@bluedot/ui';
+import Rive, { Fit, Layout } from '@rive-app/react-canvas';
 import clsx from 'clsx';
 
 const HomeHeroContent: React.FC<{ className?: string }> = ({ className }) => (
   <div className={clsx('home-hero-content pb-5 bg-bluedot-darker', className)}>
-    <div className="home-hero-content__logo-container flex flex-col items-center gap-7 mb-8 slide-up-fade-in">
-      <img className="home-hero-content__logo-icon w-20" src="/images/logo/BlueDot_Impact_Icon_White.svg" alt="BlueDot Impact" />
+    <div className="home-hero-content__animation-container w-[350px] max-w-[80vw] aspect-4/3 mx-auto">
+      <Rive
+        src="/animations/herobluedot_hero.riv"
+        layout={new Layout({ fit: Fit.Cover })}
+      />
     </div>
     <HeroH1 className="home-hero-content__heading slide-up-fade-in">
       The expertise you need to shape safe AI

--- a/apps/website-25/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
+++ b/apps/website-25/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
@@ -6,13 +6,16 @@ exports[`HomeHeroContent > renders as expected 1`] = `
     class="home-hero-content pb-5 bg-bluedot-darker"
   >
     <div
-      class="home-hero-content__logo-container flex flex-col items-center gap-7 mb-8 slide-up-fade-in"
+      class="home-hero-content__animation-container w-[350px] max-w-[80vw] aspect-4/3 mx-auto"
     >
-      <img
-        alt="BlueDot Impact"
-        class="home-hero-content__logo-icon w-20"
-        src="/images/logo/BlueDot_Impact_Icon_White.svg"
-      />
+      <div
+        class=""
+        style="width: 100%; height: 100%;"
+      >
+        <canvas
+          style="vertical-align: top; width: 0px; height: 0px;"
+        />
+      </div>
     </div>
     <h1
       class="hero-section__title text-on-dark text-center bluedot-h1 home-hero-content__heading slide-up-fade-in"


### PR DESCRIPTION
Reverts bluedotimpact/bluedot#610, to restore the homepage hero animation

Fixes #738 
Fixes #611
Fixes #395

We think this works now after #736