### PR TITLE
ui: Add tests and handling for search param edge cases

### DIFF
--- a/libraries/ui/src/utils/addQueryParam.test.ts
+++ b/libraries/ui/src/utils/addQueryParam.test.ts
@@ -14,16 +14,22 @@ describe('addQueryParam', () => {
     expect(result).toBe('https://example.com/?existing=param&key=value');
   });
 
+  test('overwrites existing query parameter when setting it again', () => {
+    const url = 'https://example.com?existing=old';
+    const result = addQueryParam(url, 'existing', 'new');
+    expect(result).toBe('https://example.com/?existing=new');
+  });
+
   test('adds query parameter to relative path URL', () => {
     const url = '/login';
     const result = addQueryParam(url, 'key', 'value');
     expect(result).toBe('http://localhost:3000/login?key=value');
   });
 
-  test('handles empty key by returning original URL', () => {
+  test('can set param with empty string key', () => {
     const url = 'https://example.com/';
     const result = addQueryParam(url, '', 'value');
-    expect(result).toBe(url);
+    expect(result).toBe('https://example.com/?=value');
   });
 
   test('handles empty value', () => {

--- a/libraries/ui/src/utils/addQueryParam.ts
+++ b/libraries/ui/src/utils/addQueryParam.ts
@@ -1,11 +1,8 @@
 export const addQueryParam = (url: string, key: string, value: string) => {
   if (!url) {
-    throw new Error('URL is required');
+    throw new Error('addQueryParam: URL is required');
   }
   const urlObj = new URL(url, window.location.origin);
-  if (!key) {
-    return urlObj.toString();
-  }
   urlObj.searchParams.set(key, value);
   return urlObj.toString();
 };

--- a/libraries/ui/src/utils/getQueryParam.test.ts
+++ b/libraries/ui/src/utils/getQueryParam.test.ts
@@ -14,6 +14,18 @@ describe('getQueryParam', () => {
     expect(result).toBe(null);
   });
 
+  test('handles URL with duplicated parameters by returning first value', () => {
+    const url = 'https://example.com/?myQueryParam=first&myQueryParam=middle&myQueryParam=last';
+    const result = getQueryParam(url, 'myQueryParam');
+    expect(result).toBe('first');
+  });
+
+  test('gets query parameter from URL with empty string key', () => {
+    const url = 'https://example.com?=data';
+    const result = getQueryParam(url, '');
+    expect(result).toBe('data');
+  });
+
   test('handles URL without target parameter', () => {
     const url = 'https://example.com?myQueryParam=data';
     const result = getQueryParam(url, 'key');

--- a/libraries/ui/src/utils/getQueryParam.ts
+++ b/libraries/ui/src/utils/getQueryParam.ts
@@ -1,6 +1,6 @@
 export const getQueryParam = (url: string, key: string) => {
   if (!url) {
-    throw new Error('URL is required');
+    throw new Error('getQueryParam: URL is required');
   }
   const urlObj = new URL(url, window.location.origin);
   return urlObj.searchParams.get(key);


### PR DESCRIPTION
- Add handling for empty string keys, which are supported by the search params spec
- Add tests for adding existing keys
- Add tests for getting when there are duplicate keys