### PR TITLE
ui(Login): Fix refresh token rehydration after session expiry

### DIFF
--- a/libraries/ui/src/legacy/Login.tsx
+++ b/libraries/ui/src/legacy/Login.tsx
@@ -97,6 +97,7 @@ export const loginPresets = {
       authority: 'https://login.bluedot.org/realms/customers/',
       client_id: 'bluedot-web-apps',
       redirect_uri: `${typeof window === 'undefined' ? '' : window.location.origin}/login/oauth-callback`,
+      scope: 'openid email offline_access',
     },
     verifyAndDecodeToken: async (token: string) => {
       return verifyJwt(token, {
@@ -118,7 +119,7 @@ export const loginPresets = {
       // It's okay for this to be public because we always use PKCE
       // eslint-disable-next-line no-useless-concat
       client_secret: 'GOCSPX-gM' + 'FRMUkLGIJG0wyWj09BPH6H8aSM',
-      scope: 'email',
+      scope: 'openid email',
       redirect_uri: `${typeof window === 'undefined' ? '' : window.location.origin}/login/oauth-callback`,
       extraQueryParams: { hd: 'bluedot.org' },
     },


### PR DESCRIPTION
This PR adds th "offline_access" scope parameter to the Keycloak OIDC settings, which is required to obtain refresh tokens that persist beyond user sessions and can be used when the access token expires.

According to the [OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess), the "offline_access" scope explicitly requests refresh tokens that remain valid even when the user is not present, allowing authentication to be maintained through token expiration.

Without this scope parameter, Keycloak would issue refresh tokens that become invalid once the access token expires, preventing automatic re-authentication on rehydration and forcing users to log in again.

## Issue

Fixes #751 