### PR TITLE
website-25: Unescape MDX attributes in MarkdownExtendedRenderer so that Embeds etc. work with underscores

### DIFF
--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
@@ -163,10 +163,10 @@ This is because by default most Markdown editors aren't aware of components, and
 If you do really want backslashes, escape them:
 
 \`\`\`mdx
-<Callout title="The backlash symbol (\\\\) is often used to escape other characters" />
+<Callout title="The backslash symbol (\\\\) is often used to escape other characters" />
 \`\`\`
 
-<Callout title="The backlash symbol (\\\\) is often used to escape other characters" />
+<Callout title="The backslash symbol (\\\\) is often used to escape other characters" />
 
 This only affects components, and not markdown text. So escaping works normally in markdown:
 

--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.stories.tsx
@@ -112,6 +112,16 @@ export const WithComponents: Story = {
   args: {
     children: `# Using Components
 
+The following components are supported within your markdown content:
+
+${Object.keys(getSupportedComponents()).map((componentName) => `- \`${componentName}\``).join('\n')}
+
+See their Storybook pages for usage details.
+
+(to add to this list, add to \`getSupportedComponents\` in \`MarkdownExtendedRenderer.tsx\`)
+
+## Example
+
 Below is an example of using the Callout and Embed components:
 
 <Callout title="Want to see something cool?">
@@ -134,15 +144,39 @@ Code:
 </Callout>
 \`\`\`
 
-## Supported components
+## Escaping
 
-The following components are supported within your markdown content:
+Component properties will be unescaped when rendered. For example the input:
 
-${Object.keys(getSupportedComponents()).map((componentName) => `- \`${componentName}\``).join('\n')}
+\`\`\`mdx
+<Embed url="https://example.com/some\\_underscored\\_path" />
+\`\`\`
 
-See their Storybook pages for usage details.
+Will actually render the following MDX:
 
-(to add to this list, add to \`getSupportedComponents\` in \`MarkdownExtendedRenderer.tsx\`)
-    `,
+\`\`\`mdx
+<Embed url="https://example.com/some_underscored_path" />
+\`\`\`
+
+This is because by default most Markdown editors aren't aware of components, and so will escape special markdown characters everywhere - including in component properties. This includes the Airtable markdown editor.
+
+If you do really want backslashes, escape them:
+
+\`\`\`mdx
+<Callout title="The backlash symbol (\\\\) is often used to escape other characters" />
+\`\`\`
+
+<Callout title="The backlash symbol (\\\\) is often used to escape other characters" />
+
+This only affects components, and not markdown text. So escaping works normally in markdown:
+
+\`\`\`mdx
+- _normal italics_
+- \\_escaped italics\\_
+\`\`\`
+
+- _normal italics_
+- \\_escaped italics\\_
+`,
   },
 };

--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.test.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.test.tsx
@@ -1,7 +1,5 @@
-import { render } from '@testing-library/react';
-import {
-  describe, expect, test, vi,
-} from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
 
 describe('MarkdownExtendedRenderer', () => {
@@ -25,16 +23,18 @@ describe('MarkdownExtendedRenderer', () => {
   test('renders basic markdown content', async () => {
     const { container } = render(
       <MarkdownExtendedRenderer>
-        # Hello
+        {'# Hello\n\nThis is some text with _italic content_'}
       </MarkdownExtendedRenderer>,
     );
 
     // Wait for the useEffect to run
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(container.querySelector('h1')).toBeTruthy();
+      expect(container.querySelector('em')).toBeTruthy();
     });
 
-    expect(container.querySelector('h1')?.textContent).toBe('Hello');
+    expect(container.querySelector('h1')!.textContent).toBe('Hello');
+    expect(container.querySelector('em')!.textContent).toBe('italic content');
   });
 
   test('renders content with Greeting component', async () => {
@@ -45,10 +45,80 @@ describe('MarkdownExtendedRenderer', () => {
     );
 
     // Wait for the useEffect to run
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(container.querySelector('p')).toBeTruthy();
     });
 
     expect(container.querySelector('p')?.textContent).toBe('Hello World');
+  });
+
+  describe('escaping logic', () => {
+    test('unescapes markdown characters in component attributes', async () => {
+      const { container } = render(
+        <MarkdownExtendedRenderer>
+          {'<Callout title="Characters \\_ \\* \\[ \\] \\( \\) \\# \\+ \\- \\. \\! \\` \\~ are unescaped">Content</Callout>'}
+        </MarkdownExtendedRenderer>,
+      );
+
+      // Wait for the useEffect to run
+      await waitFor(() => {
+        expect(container.querySelector('.callout')).toBeTruthy();
+      });
+
+      const titleElement = container.querySelector('.collapsible__title');
+      expect(titleElement?.textContent).toBe('Characters _ * [ ] ( ) # + - . ! ` ~ are unescaped');
+    });
+
+    test('preserves escaped characters in regular markdown text', async () => {
+      const { container } = render(
+        <MarkdownExtendedRenderer>
+          {'Regular markdown with \\_escaped\\_ characters'}
+        </MarkdownExtendedRenderer>,
+      );
+
+      // Wait for the useEffect to run
+      await waitFor(() => {
+        expect(container.querySelector('p')).toBeTruthy();
+      });
+
+      // The text should still have escaped underscores (not rendered as italics)
+      const paragraph = container.querySelector('p');
+      expect(paragraph?.textContent).toBe('Regular markdown with _escaped_ characters');
+      expect(paragraph?.querySelector('em')).toBeFalsy(); // No italics element should be present
+    });
+
+    test('handles multiple escaped characters in component attributes', async () => {
+      const { container } = render(
+        <MarkdownExtendedRenderer>
+          {'<Callout title="Multiple \\*escaped\\* \\[characters\\] with \\(different\\) \\`symbols\\`">Content</Callout>'}
+        </MarkdownExtendedRenderer>,
+      );
+
+      // Wait for the useEffect to run
+      await waitFor(() => {
+        expect(container.querySelector('.callout')).toBeTruthy();
+      });
+
+      // The title should have all unescaped characters
+      const titleElement = container.querySelector('.collapsible__title');
+      expect(titleElement?.textContent).toBe('Multiple *escaped* [characters] with (different) `symbols`');
+    });
+
+    test('handles double backslashes in component attributes to render actual backslashes', async () => {
+      const { container } = render(
+        <MarkdownExtendedRenderer>
+          {'<Callout title="The backslash symbol (\\\\) is used to escape">Content</Callout>'}
+        </MarkdownExtendedRenderer>,
+      );
+
+      // Wait for the useEffect to run
+      await waitFor(() => {
+        expect(container.querySelector('.callout')).toBeTruthy();
+      });
+
+      // The title should have an actual backslash
+      const titleElement = container.querySelector('.collapsible__title');
+      expect(titleElement?.textContent).toBe('The backslash symbol (\\) is used to escape');
+    });
   });
 });

--- a/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website-25/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -2,11 +2,42 @@ import React, { useEffect } from 'react';
 import { evaluate } from '@mdx-js/mdx';
 import { MDXContent } from 'mdx/types';
 import clsx from 'clsx';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { visit } from 'unist-util-visit';
+import type { Plugin } from 'unified';
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 import Greeting from './Greeting';
 import Embed from './Embed';
-// eslint-disable-next-line import/no-cycle
 import Callout from './Callout';
 import Exercise from './exercises/Exercise';
+
+/**
+ * A remark plugin that unescapes backslashed characters in MDX component attribute values.
+ * This fixes issues with escaped characters in MDX properties while preserving
+ * escaped characters in regular markdown text.
+ * This is useful for being able to use standard markdown editors, e.g. Airtable's markdown editor, for writing MDX.
+ */
+const remarkUnescapeMdxAttributes: Plugin = () => {
+  return (tree) => {
+    // Visit all MDX JSX elements in the syntax tree
+    visit(tree, 'mdxJsxFlowElement', (node: MdxJsxFlowElement) => {
+      // Process each attribute of the component
+      node.attributes.forEach((attr) => {
+        if (
+          attr.type === 'mdxJsxAttribute'
+            && typeof attr.value === 'string'
+        ) {
+          // Unescape common markdown characters in attribute values
+          // eslint-disable-next-line no-param-reassign
+          attr.value = attr.value.replace(
+            /\\([_*[\]()#+\-.!`~])/g,
+            '$1',
+          );
+        }
+      });
+    });
+  };
+};
 
 export interface MarkdownRendererProps {
   children?: string;
@@ -30,6 +61,7 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, c
 
     (async () => {
       const evalResult = await evaluate(children, {
+        remarkPlugins: [remarkUnescapeMdxAttributes],
         Fragment: React.Fragment,
         jsx: React.createElement,
         jsxs: React.createElement,


### PR DESCRIPTION
Unescape MDX attributes in MarkdownExtendedRenderer so that Embeds etc. work with underscores

Also see:
- https://bluedotimpact.slack.com/archives/C08LQKWBX9B/p1745490788274069?thread_ts=1745490689.842799&cid=C08LQKWBX9B
- https://bluedotimpact.slack.com/archives/C08LQKWBX9B/p1745501823046429?thread_ts=1745426786.571269&cid=C08LQKWBX9B

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #750
<!-- If you have no related issue, make sure to link this PR to the relevant project -->

## Description

Implemented a custom remark processor to handle this, so it works for all components without having to have weird logic within those components themselves.

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

https://github.com/user-attachments/assets/7604ff97-0f40-41ad-9f28-e7004da755bf