### PR TITLE
Add traffic routing for certificates

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -81,7 +81,7 @@ http {
             proxy_pass https://website-production.k8s.bluedot.org;
         }
 
-        location = /contact {
+        location /certification {
             proxy_pass https://website-production.k8s.bluedot.org;
         }
 


### PR DESCRIPTION
# Summary

Add traffic routing for certificates

## Issue
https://bluedotimpact.slack.com/archives/C04CSNYF5QX/p1745615555418379

## Description

- Add traffic routing for anything in /certification route

## Testing
Wish we could mock out traffic changes somehow?

### Staging
https://website-staging.k8s.bluedot.org/certification/?id=recg3FUpPCHAxWge5

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/de6e43f1-aa73-4f44-b4d8-866c39d4bcef" />

Confirmed with other's certificates

https://website-staging.k8s.bluedot.org/certification?id=reckcH9U0KVA1jxMe

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3fe1ba71-90df-4859-991e-bb4c3d2365f3" />

### Prod
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/6c4bda96-8b77-4835-a71a-f60adca4e96a" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d82ef493-f327-46a7-b182-8d91b2e2713f" />
