### PR TITLE
Move new design system text components into ui

### DIFF
--- a/apps/app-template/src/components/ExampleComponent.tsx
+++ b/apps/app-template/src/components/ExampleComponent.tsx
@@ -1,4 +1,4 @@
-import { P } from '@bluedot/ui';
+import { LegacyText } from '@bluedot/ui';
 
 export interface ExampleComponentProps {
   name?: string,
@@ -6,6 +6,6 @@ export interface ExampleComponentProps {
 
 export const ExampleComponent: React.FC<ExampleComponentProps> = ({ name }) => {
   return (
-    <P>Hello {name ?? 'world'}!</P>
+    <LegacyText.P>Hello {name ?? 'world'}!</LegacyText.P>
   );
 };

--- a/apps/app-template/src/pages/authed.tsx
+++ b/apps/app-template/src/pages/authed.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import {
-  Box, Button, ErrorSection, H1, H2, Link, P, withAuth,
+  Box, Button, ErrorSection, LegacyText, Link, withAuth,
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import { Person, personTable } from '../lib/api/db/tables';
@@ -12,15 +12,15 @@ const AuthedPage = withAuth(({ auth, setAuth }) => {
 
   return (
     <div className="mx-8">
-      <H1>Authed page</H1>
-      <P>Here's the token we got: <code className="select-all">{auth.token}</code> (view on <Link url={`https://jwt.io/#debugger-io?token=${auth.token}`}>jwt.io</Link>)</P>
-      <P>It expires at: {new Date(auth.expiresAt * 1000).toISOString()}</P>
+      <LegacyText.H1>Authed page</LegacyText.H1>
+      <LegacyText.P>Here's the token we got: <code className="select-all">{auth.token}</code> (view on <Link url={`https://jwt.io/#debugger-io?token=${auth.token}`}>jwt.io</Link>)</LegacyText.P>
+      <LegacyText.P>It expires at: {new Date(auth.expiresAt * 1000).toISOString()}</LegacyText.P>
       <Button onPress={() => setCount((c) => c + 1)}>
         count is {count}
       </Button>
-      <H2>People</H2>
+      <LegacyText.H2>People</LegacyText.H2>
       <PeopleListView />
-      <H2>Logout</H2>
+      <LegacyText.H2>Logout</LegacyText.H2>
       <Button onPress={() => {
         // This is a little jank: if we immediately setAuth to false the withAuth HOC will redirect us to login first
         router.push('/');
@@ -45,7 +45,7 @@ const PeopleListView: React.FC = withAuth(({ auth }) => {
   });
 
   if (loading) {
-    return <P>Loading...</P>;
+    return <LegacyText.P>Loading...</LegacyText.P>;
   }
 
   if (error) {
@@ -56,7 +56,7 @@ const PeopleListView: React.FC = withAuth(({ auth }) => {
     <div className="grid md:grid-cols-4 gap-4">
       {data?.map((person) => (
         <Box key={person.id} className="px-4 py-2">
-          <P>{person.firstName} {person.lastName} (<Link url={`https://airtable.com/${personTable.baseId}/${personTable.tableId}/${person.id}`}>view in Airtable</Link>)</P>
+          <LegacyText.P>{person.firstName} {person.lastName} (<Link url={`https://airtable.com/${personTable.baseId}/${personTable.tableId}/${person.id}`}>view in Airtable</Link>)</LegacyText.P>
         </Box>
       ))}
     </div>

--- a/apps/app-template/src/pages/index.tsx
+++ b/apps/app-template/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import {
-  Button, H1, P,
+  Button, LegacyText,
 } from '@bluedot/ui';
 import { ExampleComponent } from '../components/ExampleComponent';
 
@@ -9,13 +9,13 @@ const HomePage = () => {
 
   return (
     <div className="mx-8">
-      <H1>app-template</H1>
-      <P>This is some example text</P>
+      <LegacyText.H1>app-template</LegacyText.H1>
+      <LegacyText.P>This is some example text</LegacyText.P>
       <ExampleComponent />
       <Button onPress={() => setCount((c) => c + 1)}>
         count is {count}
       </Button>
-      <P>You can test logging in below</P>
+      <LegacyText.P>You can test logging in below</LegacyText.P>
       <Button url="/authed">View page requiring auth</Button>
     </div>
   );

--- a/apps/availability/src/pages/form/[slug].tsx
+++ b/apps/availability/src/pages/form/[slug].tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import {
-  Box, Button, ErrorSection, H1, Input, Textarea,
+  Box, Button, ErrorSection, Input, LegacyText, Textarea,
 } from '@bluedot/ui';
 import * as wa from 'weekly-availabilities';
 import { SpinnerIcon } from '../../components/SpinnerIcon';
@@ -129,7 +129,7 @@ const Form: React.FC<{
     <div className="py-16 px-4">
       <Box className="max-w-3xl mx-auto">
         <div className="m-12">
-          <H1 className="!text-5xl">{title}</H1>
+          <LegacyText.H1 className="!text-5xl">{title}</LegacyText.H1>
           <div className="space-y-2 mt-4">
             <p>Submit your availability so we can schedule your discussions at times that suit you.</p>
           </div>

--- a/apps/course-demos/src/components/CodeRenderer.tsx
+++ b/apps/course-demos/src/components/CodeRenderer.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   SandpackCodeEditor, SandpackLayout, SandpackPreview, SandpackProvider,
 } from '@codesandbox/sandpack-react';
-import { P, Button } from '@bluedot/ui';
+import { LegacyText, Button } from '@bluedot/ui';
 
 interface CodeRendererProps {
   code: string;
@@ -55,7 +55,7 @@ export default function App() {
       {view === 'load_preview' && <div style={{ height, margin: '0 1px' }} />}
       {!hidePreview && (
       <nav className="justify-end items-center flex gap-2">
-        <P className="!my-0">Show:</P>
+        <LegacyText.P className="!my-0">Show:</LegacyText.P>
         <Button className={view === 'code' ? 'bg-bluedot-lighter' : ''} onPress={() => setView('code')}>Code</Button>
         <Button className={view === 'preview' ? 'bg-bluedot-lighter' : ''} onPress={() => setView('load_preview')}>Preview</Button>
       </nav>

--- a/apps/course-demos/src/pages/2018-to-present/index.tsx
+++ b/apps/course-demos/src/pages/2018-to-present/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { P } from '@bluedot/ui';
+import { LegacyText } from '@bluedot/ui';
 import { LinkOrButton } from '@bluedot/ui/src/legacy/LinkOrButton';
 import prompts from './responses.json';
 import MarkdownRenderer from '../../components/MarkdownRenderer';
@@ -92,7 +92,7 @@ const DemoPage: React.FC = () => {
   return (
     <main className="mx-auto px-4">
       <div className="mb-8">
-        <P className="font-medium mb-2">Examples:</P>
+        <LegacyText.P className="font-medium mb-2">Examples:</LegacyText.P>
         <div className="flex flex-wrap gap-2">
           {prompts.map((prompt, index) => (
             <LinkOrButton

--- a/apps/course-demos/src/pages/generate-react-component.tsx
+++ b/apps/course-demos/src/pages/generate-react-component.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-  Button, H2, Link, P, ProgressDots,
+  Button, LegacyText, Link, ProgressDots,
 } from '@bluedot/ui';
 import { useCompletion } from '@ai-sdk/react';
 import { LinkOrButton } from '@bluedot/ui/src/legacy/LinkOrButton';
@@ -46,7 +46,7 @@ const DemoPage: React.FC = () => {
     return (
       <main className="mx-auto px-4">
         <div className="mb-4">
-          <H2 className="!mt-4">What do you want to build?</H2>
+          <LegacyText.H2 className="!mt-4">What do you want to build?</LegacyText.H2>
           <textarea
             placeholder="A website about..."
             value={userPrompt}
@@ -84,13 +84,13 @@ const DemoPage: React.FC = () => {
 
         {error && (
         <>
-          <H2 className="text-red-500">Something went wrong</H2>
-          <P>
+          <LegacyText.H2 className="text-red-500">Something went wrong</LegacyText.H2>
+          <LegacyText.P>
             Sorry, we couldn't generate your app. Error: {error?.message ?? 'Unknown'}
-          </P>
-          <P>
+          </LegacyText.P>
+          <LegacyText.P>
             Errors sometime happen when too many people are taking our course at once. You can try again later, or try <LinkOrButton url="https://web.lmarena.ai/" className="underline cursor-pointer">WebDev Arena</LinkOrButton> to see a similar demo.
-          </P>
+          </LegacyText.P>
           <Button onPress={() => handleSubmit()}>Try again</Button>
         </>
         )}
@@ -102,8 +102,8 @@ const DemoPage: React.FC = () => {
     return (
       <main className="mx-auto px-4">
         <div className="text-center">
-          <P className="text-xl font-medium mt-4 mb-2">AI is creating your webpage...</P>
-          <P className="mb-6">Prompt: {userPrompt}</P>
+          <LegacyText.P className="text-xl font-medium mt-4 mb-2">AI is creating your webpage...</LegacyText.P>
+          <LegacyText.P className="mb-6">Prompt: {userPrompt}</LegacyText.P>
           <ProgressDots />
         </div>
         <CodeRenderer code={generatedCode} height="calc(100vh - 150px)" hidePreview />
@@ -135,7 +135,7 @@ export const GenerateReactComponentSavedDemoOutputViewer = ({ savedDemoOutput, c
   return (
     <div className="flex flex-col gap-4 mt-2">
       <div className="bg-gray-100 p-4 rounded-md">
-        <P className="font-medium"><Link url={courseLink}>The Future of AI Course</Link> is a free 2-hour online experience to help you prepare for what might be humanity's biggest transition yet. It's packed with up-to-date interactive content - and in this demo, a student got AI to create this app based on the prompt "{prompt}".</P>
+        <LegacyText.P className="font-medium"><Link url={courseLink}>The Future of AI Course</Link> is a free 2-hour online experience to help you prepare for what might be humanity's biggest transition yet. It's packed with up-to-date interactive content - and in this demo, a student got AI to create this app based on the prompt "{prompt}".</LegacyText.P>
       </div>
       <CodeRenderer code={code} height="calc(100vh - 250px)" />
       <div className="flex gap-2 w-fit relative bottom-12.5 mt-1 -mb-10">

--- a/apps/course-demos/src/pages/index.tsx
+++ b/apps/course-demos/src/pages/index.tsx
@@ -1,12 +1,12 @@
 import {
-  Button, H1, P,
+  Button, LegacyText,
 } from '@bluedot/ui';
 
 const HomePage = () => {
   return (
     <div className="mx-8">
-      <H1>course-demos</H1>
-      <P>This site contains demos we use on our courses</P>
+      <LegacyText.H1>course-demos</LegacyText.H1>
+      <LegacyText.P>This site contains demos we use on our courses</LegacyText.P>
       <Button url="https://bluedot.org">Learn more about our courses</Button>
     </div>
   );

--- a/apps/course-demos/src/pages/s/[savedDemoOutputId].tsx
+++ b/apps/course-demos/src/pages/s/[savedDemoOutputId].tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import {
-  H2, P, Link, ProgressDots, asError,
+  LegacyText, Link, ProgressDots, asError,
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import { SavedDemoOutput } from '../api/saved-output/[savedDemoOutputId]';
@@ -30,10 +30,10 @@ const ContentViewer: React.FC<{ savedDemoOutput: SavedDemoOutput, courseLink: st
 
     return (
       <>
-        <H2 className="text-red-500">Couldn't interpret your demo</H2>
-        <P>This can sometimes happen if the link is invalid or the content has been deleted.</P>
-        <P>Using the demos yourself is often more fun anyway - you can find them all in our free <Link url={courseLink}>Future of AI Course</Link>.</P>
-        <P>Details: {asError(error).message}</P>
+        <LegacyText.H2 className="text-red-500">Couldn't interpret your demo</LegacyText.H2>
+        <LegacyText.P>This can sometimes happen if the link is invalid or the content has been deleted.</LegacyText.P>
+        <LegacyText.P>Using the demos yourself is often more fun anyway - you can find them all in our free <Link url={courseLink}>Future of AI Course</Link>.</LegacyText.P>
+        <LegacyText.P>Details: {asError(error).message}</LegacyText.P>
       </>
     );
   }
@@ -54,7 +54,7 @@ const SharePage: React.FC = () => {
   if (loading || !savedDemoOutputId) {
     return (
       <main className="mx-auto px-4 py-8">
-        <P className="text-center">Loading shared content...</P>
+        <LegacyText.P className="text-center">Loading shared content...</LegacyText.P>
         <ProgressDots />
       </main>
     );
@@ -63,10 +63,10 @@ const SharePage: React.FC = () => {
   if (error || !savedDemoOutput) {
     return (
       <main className="mx-auto px-4 py-8">
-        <H2 className="text-red-500">Couldn't find your demo</H2>
-        <P>This can sometimes happen if the link is invalid or the content has been deleted.</P>
-        <P>Using the demos yourself is often more fun anyway - you can find them all in our free <Link url={courseLink}>Future of AI Course</Link>.</P>
-        <P>Details: {error?.message || 'Failed to load shared content'}</P>
+        <LegacyText.H2 className="text-red-500">Couldn't find your demo</LegacyText.H2>
+        <LegacyText.P>This can sometimes happen if the link is invalid or the content has been deleted.</LegacyText.P>
+        <LegacyText.P>Using the demos yourself is often more fun anyway - you can find them all in our free <Link url={courseLink}>Future of AI Course</Link>.</LegacyText.P>
+        <LegacyText.P>Details: {error?.message || 'Failed to load shared content'}</LegacyText.P>
       </main>
     );
   }

--- a/apps/frontend-example/src/components/ErrorPage.tsx
+++ b/apps/frontend-example/src/components/ErrorPage.tsx
@@ -1,4 +1,4 @@
-import { asError, H1, P } from '@bluedot/ui';
+import { asError, LegacyText } from '@bluedot/ui';
 
 export interface ErrorPageProps {
   error: unknown,
@@ -7,11 +7,11 @@ export interface ErrorPageProps {
 export const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
   return (
     <div className="m-8">
-      <H1>Error</H1>
-      <P>Sorry, an unexpected error has occurred.</P>
-      <P>
+      <LegacyText.H1>Error</LegacyText.H1>
+      <LegacyText.P>Sorry, an unexpected error has occurred.</LegacyText.P>
+      <LegacyText.P>
         Error message: <span className="italic">{asError(error).message}</span>
-      </P>
+      </LegacyText.P>
     </div>
   );
 };

--- a/apps/frontend-example/src/pages/adam.tsx
+++ b/apps/frontend-example/src/pages/adam.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import {
-  Box, Button, H1, H2, Input, Link, P,
+  Box, Button, LegacyText, Input, Link,
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import { GetPeopleResponse } from './api/public/people';
@@ -18,22 +18,22 @@ const HomePage = () => {
 
   return (
     <div className="mx-8">
-      <H1>Adam's page!</H1>
-      <P>Increment by:</P>
+      <LegacyText.H1>Adam's page!</LegacyText.H1>
+      <LegacyText.P>Increment by:</LegacyText.P>
       <Input type="number" value={incrementBy} onChange={(e) => setIncrementBy(e.target.valueAsNumber)} />
 
-      <P className="mt-8">Value is {value}</P>
+      <LegacyText.P className="mt-8">Value is {value}</LegacyText.P>
       <Button onPress={() => setValue((c) => c + incrementBy)}>+</Button>
       <Button onPress={() => setValue((c) => c - incrementBy)} className="ml-2">-</Button>
 
-      <H2>People</H2>
+      <LegacyText.H2>People</LegacyText.H2>
       {loading
-        ? <P className="animate-pulse">Loading...</P>
+        ? <LegacyText.P className="animate-pulse">Loading...</LegacyText.P>
         : (
           <div className="grid grid-cols-2 gap-2">
             {data?.persons.map((person) => (
               <Box className="px-4 py-2">
-                <P>{person.firstName} {person.lastName} (<Link url={`https://airtable.com/${personTable.baseId}/${personTable.tableId}/${person.id}`}>view in Airtable</Link>)</P>
+                <LegacyText.P>{person.firstName} {person.lastName} (<Link url={`https://airtable.com/${personTable.baseId}/${personTable.tableId}/${person.id}`}>view in Airtable</Link>)</LegacyText.P>
               </Box>
             ))}
           </div>

--- a/apps/frontend-example/src/pages/authed.tsx
+++ b/apps/frontend-example/src/pages/authed.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import {
-  Button, CardButton, ErrorSection, H1, H2, Link, P, ProgressDots, withAuth,
+  Button, CardButton, ErrorSection, LegacyText, Link, ProgressDots, withAuth,
 } from '@bluedot/ui';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { useQueryClient } from '@tanstack/react-query';
@@ -17,9 +17,9 @@ const AuthedPage = withAuth(({ auth, setAuth }) => {
 
   return (
     <div className="mx-8">
-      <H1>Authed page</H1>
-      <P>Here's the token we got: <code className="select-all">{auth.token}</code> (view on <Link url={`https://jwt.io/#debugger-io?token=${auth.token}`}>jwt.io</Link>)</P>
-      <P>It expires at: {new Date(auth.expiresAt * 1000).toISOString()}</P>
+      <LegacyText.H1>Authed page</LegacyText.H1>
+      <LegacyText.P>Here's the token we got: <code className="select-all">{auth.token}</code> (view on <Link url={`https://jwt.io/#debugger-io?token=${auth.token}`}>jwt.io</Link>)</LegacyText.P>
+      <LegacyText.P>It expires at: {new Date(auth.expiresAt * 1000).toISOString()}</LegacyText.P>
       <Button onPress={() => setCount((c) => c + 1)}>
         count is {count}
       </Button>
@@ -27,7 +27,7 @@ const AuthedPage = withAuth(({ auth, setAuth }) => {
       <CourseListView />
       <H2>Create course</H2>
       <Button onPress={() => { mutate({ body: {}, headers: { authorization: '' } }); }}>Create</Button> */}
-      <H2>Logout</H2>
+      <LegacyText.H2>Logout</LegacyText.H2>
       <Button onPress={() => setAuth(null)}>Logout</Button>
     </div>
   );
@@ -51,7 +51,7 @@ const CourseListView: React.FC = () => {
       {data?.body.map((course) => (
         // eslint-disable-next-line no-alert
         <CardButton key={course.courseId} onPress={() => alert('test')}>
-          <H2>{course.name}</H2>
+          <LegacyText.H2>{course.name}</LegacyText.H2>
         </CardButton>
       ))}
     </div>

--- a/apps/frontend-example/src/pages/dewi.tsx
+++ b/apps/frontend-example/src/pages/dewi.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from 'react';
-import {
-  H1, P,
-} from '@bluedot/ui';
+import { LegacyText } from '@bluedot/ui';
 
 const Dewi = () => {
   const [value, setValue] = useState(0);
@@ -29,8 +27,8 @@ const Dewi = () => {
 
   return (
     <div className="mx-8">
-      <H1>Dewi's magic page</H1>
-      <P className="mt-8">Value is {value}</P>
+      <LegacyText.H1>Dewi's magic page</LegacyText.H1>
+      <LegacyText.P className="mt-8">Value is {value}</LegacyText.P>
       <img src={getCurrentImage()} alt="" style={{ width: '300px' }} />
     </div>
   );

--- a/apps/frontend-example/src/pages/index.tsx
+++ b/apps/frontend-example/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import {
-  Button, H1, P,
+  Button, LegacyText,
 } from '@bluedot/ui';
 
 const HomePage = () => {
@@ -8,14 +8,14 @@ const HomePage = () => {
 
   return (
     <div className="mx-8">
-      <H1>frontend-example</H1>
-      <P>This is some example text</P>
+      <LegacyText.H1>frontend-example</LegacyText.H1>
+      <LegacyText.P>This is some example text</LegacyText.P>
       <Button onPress={() => setCount((c) => c + 1)}>
         count is {count}
       </Button>
-      <P>
-        Edit <code>src/App.tsx</code> and save to test HMR
-      </P>
+      <LegacyText.P>
+        Edit <code>src/pages/index.tsx</code> and save to test HMR
+      </LegacyText.P>
       <Button url="/authed">View page requiring auth</Button>
     </div>
   );

--- a/apps/room/src/pages/[roomId].tsx
+++ b/apps/room/src/pages/[roomId].tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import {
-  asError, Button, H1, H2, Input, P, withAuth, Link,
+  asError, Button, LegacyText, Input, withAuth, Link,
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import axios from 'axios';
@@ -50,8 +50,8 @@ const RoomControlPage = withAuth(({ auth }) => {
     return (
       <div className="p-8">
         <div className="max-w-2xl mx-auto">
-          <H1 className="text-red-600">Error</H1>
-          <P className="text-red-700">{asError(error || 'Missing room data').message}</P>
+          <LegacyText.H1 className="text-red-600">Error</LegacyText.H1>
+          <LegacyText.P className="text-red-700">{asError(error || 'Missing room data').message}</LegacyText.P>
         </div>
       </div>
     );
@@ -103,7 +103,7 @@ const RoomControlPage = withAuth(({ auth }) => {
       <div className="max-w-2xl mx-auto">
         <div className="container-lined p-8 my-4 space-y-4">
           <div className="flex items-center justify-between">
-            <H2 className="!mt-0">{room.name}</H2>
+            <LegacyText.H2 className="!mt-0">{room.name}</LegacyText.H2>
             <div className="hidden sm:block">
               <RoomHealthIndicator status={room.status} />
             </div>
@@ -144,7 +144,7 @@ const RoomControlPage = withAuth(({ auth }) => {
               </div>
             ) : (
               <div className="flex flex-col gap-2">
-                <P>Currently viewing <Link url={room.status.currentUrl} className="underline">{room.status.currentUrl}</Link></P>
+                <LegacyText.P>Currently viewing <Link url={room.status.currentUrl} className="underline">{room.status.currentUrl}</Link></LegacyText.P>
                 <Button onPress={() => setPiCurrentUrl(defaultDisplayUrl)}>
                   Leave {room.status.currentUrl.includes('meet') ? 'meeting' : 'page'}
                 </Button>
@@ -154,8 +154,8 @@ const RoomControlPage = withAuth(({ auth }) => {
 
           {!isRoomHealthy(room.status) && (
             <div>
-              <P>This room is offline. {room.status.lastHeartbeatAt ? `It was last seen at ${new Date(room.status.lastHeartbeatAt * 1000).toLocaleString()}` : 'We have not seen it online recently'}.</P>
-              <P>Make sure the meeting room device is turned on and has an internet connection.</P>
+              <LegacyText.P>This room is offline. {room.status.lastHeartbeatAt ? `It was last seen at ${new Date(room.status.lastHeartbeatAt * 1000).toLocaleString()}` : 'We have not seen it online recently'}.</LegacyText.P>
+              <LegacyText.P>Make sure the meeting room device is turned on and has an internet connection.</LegacyText.P>
             </div>
           )}
         </div>

--- a/apps/room/src/pages/display/[roomId].tsx
+++ b/apps/room/src/pages/display/[roomId].tsx
@@ -1,4 +1,4 @@
-import { P } from '@bluedot/ui';
+import { LegacyText } from '@bluedot/ui';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
@@ -27,8 +27,8 @@ const DisplayPage = () => {
           <p className="text-xl mt-20 mb-6">
             This room is ready for your meeting.
           </p>
-          <P>Control it at <span className="font-mono bg-stone-200 px-2 py-1 rounded select-all">{window.location.host}/{roomId}</span></P>
-          <P>Or hit <kbd className="font-mono bg-stone-50 border shadow px-2 mx-1 py-1 rounded">Enter</kbd> to start an instant meeting</P>
+          <LegacyText.P>Control it at <span className="font-mono bg-stone-200 px-2 py-1 rounded select-all">{window.location.host}/{roomId}</span></LegacyText.P>
+          <LegacyText.P>Or hit <kbd className="font-mono bg-stone-50 border shadow px-2 mx-1 py-1 rounded">Enter</kbd> to start an instant meeting</LegacyText.P>
         </div>
 
         <div className="text-sm text-gray-500 flex gap-2 justify-center">

--- a/apps/room/src/pages/index.tsx
+++ b/apps/room/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import {
-  asError, CardButton, H1, P, withAuth,
+  asError, CardButton, LegacyText, withAuth,
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import { Room } from '../lib/types';
@@ -37,7 +37,7 @@ const DashboardPage = withAuth(({ auth }) => {
     return (
       <div className="p-8">
         <div className="max-w-4xl mx-auto">
-          <H1>Rooms</H1>
+          <LegacyText.H1>Rooms</LegacyText.H1>
           <div className="animate-pulse grid gap-6 md:grid-cols-2">
             <div className="h-20 bg-stone-200 rounded" />
             <div className="h-20 bg-stone-200 rounded" />
@@ -52,8 +52,8 @@ const DashboardPage = withAuth(({ auth }) => {
     return (
       <div className="p-8">
         <div className="max-w-2xl mx-auto">
-          <H1 className="text-red-600">Error</H1>
-          <P className="text-red-700">{asError(error || 'Missing room data').message}</P>
+          <LegacyText.H1 className="text-red-600">Error</LegacyText.H1>
+          <LegacyText.P className="text-red-700">{asError(error || 'Missing room data').message}</LegacyText.P>
         </div>
       </div>
     );
@@ -62,7 +62,7 @@ const DashboardPage = withAuth(({ auth }) => {
   return (
     <div className="p-8">
       <div className="max-w-4xl mx-auto">
-        <H1>Rooms</H1>
+        <LegacyText.H1>Rooms</LegacyText.H1>
 
         <div className="grid gap-6 md:grid-cols-2">
           {rooms.map((room) => (

--- a/apps/website/src/components/Text.tsx
+++ b/apps/website/src/components/Text.tsx
@@ -1,47 +1,6 @@
-import clsx from 'clsx';
+import { NewText } from '@bluedot/ui';
 
-export type TextProps = React.PropsWithChildren<{
-  className?: string;
-}>;
-
-export const H1 = ({
-  children, className,
-}: TextProps) => {
-  return <h1 className={clsx('bluedot-h1', className)}>{children}</h1>;
-};
-
-export const H2 = ({
-  children, className,
-}: TextProps) => {
-  return <h2 className={clsx('bluedot-h2', className)}>{children}</h2>;
-};
-
-export const H3 = ({
-  children, className,
-}: TextProps) => {
-  return <h3 className={clsx('bluedot-h3', className)}>{children}</h3>;
-};
-
-export const H4 = ({
-  children, className,
-}: TextProps) => {
-  return <h4 className={clsx('bluedot-h4', className)}>{children}</h4>;
-};
-
-export const P = ({
-  children, className,
-}: TextProps) => {
-  return <p className={clsx('bluedot-p', className)}>{children}</p>;
-};
-
-export const A = ({
-  children, className, ...aProps
-}: TextProps & React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>) => {
-  return <a className={clsx('bluedot-a', className)} {...aProps}>{children}</a>;
-};
-
-export const Blockquote = ({
-  children, className,
-}: TextProps) => {
-  return <blockquote className={clsx('bluedot-blockquote', className)}>{children}</blockquote>;
-};
+// TODO: this file will be removed shortly, after the migration to @bluedot/ui
+export const {
+  H1, H2, H3, H4, P, A,
+} = NewText;

--- a/apps/website/src/globals.css
+++ b/apps/website/src/globals.css
@@ -62,27 +62,6 @@
 }
 
 @layer base {
-  .bluedot-h1 {
-    @apply text-color-secondary-text font-sans text-size-xl font-bold;
-  }
-  .bluedot-h2 {
-    @apply text-color-secondary-text font-sans text-size-xl font-bold;
-  }
-  .bluedot-h3 {
-    @apply text-color-secondary-text font-sans text-size-lg font-[650];
-  }
-  .bluedot-h4 {
-    @apply text-color-secondary-text font-sans text-size-md font-[650];
-  }
-  .bluedot-p {
-    @apply text-color-text font-sans text-size-sm font-normal;
-  }
-  .bluedot-a {
-    @apply text-color-secondary-text hover:text-color-primary-accent cursor-pointer underline;
-  }
-  .bluedot-blockquote {
-    @apply text-color-text font-sans text-size-md font-normal font-[650] mb-4 last:mb-0;
-  }
   .text-on-dark {
     @apply text-color-text-on-dark;
   }

--- a/apps/website/src/pages/certification.tsx
+++ b/apps/website/src/pages/certification.tsx
@@ -1,7 +1,6 @@
 import {
   CTALinkOrButton,
-  H1 as LegacyH1,
-  P as LegacyP,
+  LegacyText,
   ProgressDots,
   Section,
   Footer,
@@ -23,8 +22,8 @@ const CertificatePage = () => {
   if (!certificateId) {
     return (
       <Section>
-        <LegacyH1>Invalid certificate</LegacyH1>
-        <LegacyP>Check the link you were sent and try again.</LegacyP>
+        <LegacyText.H1>Invalid certificate</LegacyText.H1>
+        <LegacyText.P>Check the link you were sent and try again.</LegacyText.P>
         <div className="flex flex-row gap-4 mt-4">
           <CTALinkOrButton url={ROUTES.courses.url}>Back to Courses</CTALinkOrButton>
           <CTALinkOrButton url={ROUTES.contact.url} variant="secondary">Contact us</CTALinkOrButton>
@@ -50,8 +49,8 @@ const CertificatePage = () => {
     return (
       <main className="bluedot-base">
         <Section>
-          <LegacyH1>Certificate not found</LegacyH1>
-          <LegacyP>We couldn't find the certificate you're looking for.</LegacyP>
+          <LegacyText.H1>Certificate not found</LegacyText.H1>
+          <LegacyText.P>We couldn't find the certificate you're looking for.</LegacyText.P>
           <div className="flex flex-row gap-4 mt-4">
             <CTALinkOrButton url={ROUTES.courses.url}>Back to Courses</CTALinkOrButton>
             <CTALinkOrButton url={ROUTES.contact.url} variant="secondary">Contact us</CTALinkOrButton>

--- a/libraries/ui/src/Text.tsx
+++ b/libraries/ui/src/Text.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx';
+
+export type TextProps = React.PropsWithChildren<{
+  className?: string;
+}>;
+
+export const H1 = ({
+  children, className,
+}: TextProps) => {
+  return <h1 className={clsx('bluedot-h1', className)}>{children}</h1>;
+};
+
+export const H2 = ({
+  children, className,
+}: TextProps) => {
+  return <h2 className={clsx('bluedot-h2', className)}>{children}</h2>;
+};
+
+export const H3 = ({
+  children, className,
+}: TextProps) => {
+  return <h3 className={clsx('bluedot-h3', className)}>{children}</h3>;
+};
+
+export const H4 = ({
+  children, className,
+}: TextProps) => {
+  return <h4 className={clsx('bluedot-h4', className)}>{children}</h4>;
+};
+
+export const P = ({
+  children, className,
+}: TextProps) => {
+  return <p className={clsx('bluedot-p', className)}>{children}</p>;
+};
+
+export const A = ({
+  children, className, ...aProps
+}: TextProps & React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>) => {
+  return <a className={clsx('bluedot-a', className)} {...aProps}>{children}</a>;
+};

--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -72,6 +72,25 @@
     ::file-selector-button {
         border-color: var(--color-stone-200, currentColor);
     }
+
+    .bluedot-h1 {
+        @apply text-color-secondary-text font-sans text-size-xl font-bold;
+    }
+    .bluedot-h2 {
+        @apply text-color-secondary-text font-sans text-size-xl font-bold;
+    }
+    .bluedot-h3 {
+        @apply text-color-secondary-text font-sans text-size-lg font-[650];
+    }
+    .bluedot-h4 {
+        @apply text-color-secondary-text font-sans text-size-md font-[650];
+    }
+    .bluedot-p {
+        @apply text-color-text font-sans text-size-sm font-normal;
+    }
+    .bluedot-a {
+        @apply text-color-secondary-text hover:text-color-primary-accent cursor-pointer underline;
+    }
 }
 
 @utility bluedot-base {

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -37,6 +37,9 @@ export { SlideList } from './SlideList';
 
 export { Tag } from './Tag';
 
+// This will eventually be exported directly, but for now it's namespaced as NewText to avoid mistakes in the migration from LegacyText
+export * as NewText from './Text';
+
 export { UnitCard } from './UnitCard';
 
 // Utils

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -77,9 +77,7 @@ export type { LinkProps } from './legacy/Link';
 export { LoginRedirectPage, LoginOauthCallbackPage, loginPresets } from './legacy/Login';
 export type { LoginPageProps } from './legacy/Login';
 
-export {
-  H1, H2, HPrefix, P,
-} from './legacy/Text';
+export * as LegacyText from './legacy/Text';
 export type { TextProps } from './legacy/Text';
 
 export { Textarea } from './legacy/Textarea';


### PR DESCRIPTION
- Move legacy text components into their own namespace
- Move new text components to ui, also namespaced for now

This will help us in the journey to making sure everything can be migrated onto the new design system components, without missing things.

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Related to #749

## Testing

Confirmed availability and website render normally