### PR TITLE
lint: Apply rules to make styles more consistent

### DIFF
--- a/apps/app-template/src/components/ExampleComponent.tsx
+++ b/apps/app-template/src/components/ExampleComponent.tsx
@@ -1,8 +1,8 @@
 import { LegacyText } from '@bluedot/ui';
 
-export interface ExampleComponentProps {
+export type ExampleComponentProps = {
   name?: string,
-}
+};
 
 export const ExampleComponent: React.FC<ExampleComponentProps> = ({ name }) => {
   return (

--- a/apps/availability/src/components/TimeAvailabilityInput.tsx
+++ b/apps/availability/src/components/TimeAvailabilityInput.tsx
@@ -34,7 +34,7 @@ const isWithin = (
   );
 };
 
-type TimeAvailabilityMap = { [weeklyTime: wa.WeeklyTime]: boolean };
+type TimeAvailabilityMap = Record<wa.WeeklyTime, boolean>;
 
 const TimeAvailabilityGrid: React.FC<{ show24: boolean, value: TimeAvailabilityMap, onChange: (v: TimeAvailabilityMap) => void }> = ({ show24, value, onChange }) => {
   const startUnit = show24 ? 0 : (8 * 60) / MINUTES_IN_UNIT;

--- a/apps/availability/src/lib/api/db/tables.ts
+++ b/apps/availability/src/lib/api/db/tables.ts
@@ -1,11 +1,11 @@
 import { Table, Item } from 'airtable-ts';
 
-export interface FormConfiguration extends Item {
+export type FormConfiguration = {
   'Slug': string,
   'Title': string,
   'Webhook': string,
   'Minimum length': number,
-}
+} & Item;
 
 export const formConfigurationTable: Table<FormConfiguration> = {
   name: 'form configuration',

--- a/apps/availability/src/pages/form/[slug].tsx
+++ b/apps/availability/src/pages/form/[slug].tsx
@@ -13,14 +13,14 @@ import { TimeOffsetSelector } from '../../components/TimeOffsetSelector';
 import { MINUTES_IN_UNIT, TimeAvailabilityInput } from '../../components/TimeAvailabilityInput';
 import { formatOffsetFromMinutesToString, parseOffsetFromStringToMinutes } from '../../lib/offset';
 
-interface FormFieldData {
+type FormFieldData = {
   email: string;
   timezone: string;
-  timeAv: { [weeklyTime: wa.WeeklyTime]: boolean };
+  timeAv: Record<wa.WeeklyTime, boolean>;
   comment: string;
-}
+};
 
-const toIntervals = (timeAv: { [weeklyTime: wa.WeeklyTime]: boolean }): wa.Interval[] => {
+const toIntervals = (timeAv: Record<wa.WeeklyTime, boolean>): wa.Interval[] => {
   return wa.unionSchedules(Object.entries(timeAv)
     .filter(([, available]) => available)
     .map(([weeklyTime]) => [

--- a/apps/backend/src/lib/authPlugin.ts
+++ b/apps/backend/src/lib/authPlugin.ts
@@ -61,7 +61,7 @@ export const authPlugin: FastifyPluginAsync = fp(async (instance) => {
 });
 
 declare module 'fastify' {
-  interface FastifyRequest {
+  type FastifyRequest = {
     user: Zod.TypeOf<typeof IdTokenPayloadSchema>
-  }
+  };
 }

--- a/apps/backend/src/lib/authPlugin.ts
+++ b/apps/backend/src/lib/authPlugin.ts
@@ -61,7 +61,8 @@ export const authPlugin: FastifyPluginAsync = fp(async (instance) => {
 });
 
 declare module 'fastify' {
-  type FastifyRequest = {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface FastifyRequest {
     user: Zod.TypeOf<typeof IdTokenPayloadSchema>
-  };
+  }
 }

--- a/apps/course-demos/src/components/CodeRenderer.tsx
+++ b/apps/course-demos/src/components/CodeRenderer.tsx
@@ -4,11 +4,11 @@ import {
 } from '@codesandbox/sandpack-react';
 import { LegacyText, Button } from '@bluedot/ui';
 
-interface CodeRendererProps {
+type CodeRendererProps = {
   code: string;
   height?: string;
   hidePreview?: boolean;
-}
+};
 
 export const CodeRenderer: React.FC<CodeRendererProps> = ({ code, height, hidePreview = false }) => {
   const files = {

--- a/apps/course-demos/src/components/MarkdownRenderer.tsx
+++ b/apps/course-demos/src/components/MarkdownRenderer.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-interface MarkdownRendererProps {
+type MarkdownRendererProps = {
   children?: string;
-}
+};
 
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ children }) => {
   return (

--- a/apps/course-demos/src/components/ShareSavedDemoButton.tsx
+++ b/apps/course-demos/src/components/ShareSavedDemoButton.tsx
@@ -2,11 +2,11 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import { ShareButton } from '@bluedot/ui';
 
-interface ShareSavedDemoButtonProps {
+type ShareSavedDemoButtonProps = {
   type: string;
   data: string;
   text: string;
-}
+};
 
 export const ShareSavedDemoButton: React.FC<ShareSavedDemoButtonProps> = ({
   type,

--- a/apps/course-demos/src/lib/api/db.ts
+++ b/apps/course-demos/src/lib/api/db.ts
@@ -8,12 +8,12 @@ export default new AirtableTs({
 
 export const demoTypes = z.literal('generate-react-component');
 
-export interface SharedDemoOutput extends Item {
+export type SharedDemoOutput = {
   id: string,
   type: z.infer<typeof demoTypes>,
   data: string,
   createdAt: number,
-}
+} & Item;
 
 export const sharedDemoOutputTable: Table<SharedDemoOutput> = {
   name: 'SharedComponents',

--- a/apps/frontend-example/src/components/ErrorPage.tsx
+++ b/apps/frontend-example/src/components/ErrorPage.tsx
@@ -1,8 +1,8 @@
 import { asError, LegacyText } from '@bluedot/ui';
 
-export interface ErrorPageProps {
+export type ErrorPageProps = {
   error: unknown,
-}
+};
 
 export const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
   return (

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -229,7 +229,7 @@ export const services: ServiceDefinition[] = [
   },
 ];
 
-interface ServiceDefinition {
+type ServiceDefinition = {
   /**
    * A name for the service. It should be unique and kebab case.
    * This gets used in the names of Pulumi and Kubernetes resources.
@@ -269,4 +269,4 @@ interface ServiceDefinition {
    * @default 8080
    * */
   targetPort?: number,
-}
+};

--- a/apps/meet/src/components/Text.tsx
+++ b/apps/meet/src/components/Text.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 
-export interface TextProps {
+export type TextProps = {
   className?: string;
-}
+};
 
 export const H1: React.FC<React.PropsWithChildren<TextProps>> = ({ children, className }) => {
   return <h1 className={clsx('text-3xl font-bold mb-6', className)}>{children}</h1>;

--- a/apps/meet/src/lib/api/db/tables.ts
+++ b/apps/meet/src/lib/api/db/tables.ts
@@ -2,10 +2,10 @@ import { Table, Item } from 'airtable-ts';
 
 const airtableBaseId = 'appPs3sb9BrYZN69z';
 
-export interface Group extends Item {
+export type Group = {
   'groupDiscussions': string[],
   'round': string,
-}
+} & Item;
 
 export const groupTable: Table<Group> = {
   name: 'group',
@@ -21,7 +21,7 @@ export const groupTable: Table<Group> = {
   },
 };
 
-export interface GroupDiscussion extends Item {
+export type GroupDiscussion = {
   'Facilitators': string[],
   'Participants (Expected)': string[],
   'Attendees': string[],
@@ -29,7 +29,7 @@ export interface GroupDiscussion extends Item {
   'End date/time': number | null,
   'Group': string,
   'Zoom account': string | null,
-}
+} & Item;
 
 export const groupDiscussionTable: Table<GroupDiscussion> = {
   name: 'group discussion',
@@ -55,9 +55,9 @@ export const groupDiscussionTable: Table<GroupDiscussion> = {
   },
 };
 
-export interface Person extends Item {
+export type Person = {
   'name': string,
-}
+} & Item;
 
 export const personTable: Table<Person> = {
   name: 'person',
@@ -71,10 +71,10 @@ export const personTable: Table<Person> = {
   },
 };
 
-export interface ZoomAccount extends Item {
+export type ZoomAccount = {
   'Meeting link': string,
   'Host key': string,
-}
+} & Item;
 
 export const zoomAccountTable: Table<ZoomAccount> = {
   name: 'zoom account',
@@ -90,9 +90,9 @@ export const zoomAccountTable: Table<ZoomAccount> = {
   },
 };
 
-export interface Round extends Item {
+export type Round = {
   'Course': string,
-}
+} & Item;
 
 export const roundTable: Table<Round> = {
   name: 'round',
@@ -106,9 +106,9 @@ export const roundTable: Table<Round> = {
   },
 };
 
-export interface Course extends Item {
+export type Course = {
   '[*] Course Site': string,
-}
+} & Item;
 
 export const courseTable: Table<Course> = {
   name: 'course',

--- a/apps/website/src/components/Nav.tsx
+++ b/apps/website/src/components/Nav.tsx
@@ -14,11 +14,11 @@ export type NavProps = React.PropsWithChildren<{
   logo?: string;
   primaryCtaText?: string;
   primaryCtaUrl?: string;
-  courses: Array<{
+  courses: {
     title: string;
     url: string;
     isNew?: boolean;
-  }>;
+  }[];
 }>;
 
 const TRANSITION_DURATION_CLASS = 'duration-300';
@@ -38,7 +38,7 @@ const ExploreSection: React.FC<{
   expanded: boolean;
   innerClassName?: string;
   className?: string;
-  courses: Array<{ title: string; url: string; isNew?: boolean }>;
+  courses: { title: string; url: string; isNew?: boolean }[];
   isScrolled?: boolean;
 }> = ({
   expanded, innerClassName, className, courses, isScrolled,
@@ -74,7 +74,7 @@ const ExploreSection: React.FC<{
 
 const NavLinks: React.FC<{
   exploreSectionInline?: boolean;
-  courses: Array<{ title: string; url: string; isNew?: boolean }>;
+  courses: { title: string; url: string; isNew?: boolean }[];
   exploreExpanded: boolean;
   onToggleExplore: () => void;
   className?: string;
@@ -163,11 +163,11 @@ const CTAButtons: React.FC<{
   );
 };
 
-interface ExpandedSectionsState {
+type ExpandedSectionsState = {
   mobileNav: boolean;
   explore: boolean;
   profile: boolean;
-}
+};
 
 export const isCurrentPath = (url: string): boolean => {
   if (typeof window === 'undefined') return false;

--- a/apps/website/src/components/courses/CertificateLinkCard.tsx
+++ b/apps/website/src/components/courses/CertificateLinkCard.tsx
@@ -11,9 +11,9 @@ import { GetCourseRegistrationResponse } from '../../pages/api/course-registrati
 import { ROUTES } from '../../lib/routes';
 import { RequestCertificateRequest, RequestCertificateResponse } from '../../pages/api/certificates/request';
 
-interface CertificateLinkCardProps {
+type CertificateLinkCardProps = {
   courseId: string;
-}
+};
 
 const CertificateLinkCard: React.FC<CertificateLinkCardProps> = ({
   courseId,

--- a/apps/website/src/components/courses/MarkdownEditor.tsx
+++ b/apps/website/src/components/courses/MarkdownEditor.tsx
@@ -32,12 +32,12 @@ import {
   FaCode,
 } from 'react-icons/fa6';
 
-interface ToolbarButtonProps {
+type ToolbarButtonProps = {
   onPress: () => void;
   isActive: boolean;
   icon: React.ReactNode;
   'aria-label'?: string;
-}
+};
 
 const ToolbarButton: React.FC<ToolbarButtonProps> = ({
   onPress,
@@ -58,9 +58,9 @@ const ToolbarButton: React.FC<ToolbarButtonProps> = ({
   );
 };
 
-interface ToolbarProps {
+type ToolbarProps = {
   editor: Editor;
-}
+};
 
 const ToolbarDivider: React.FC = () => {
   return <div className="h-4 w-px bg-gray-300 mx-1" />;
@@ -120,10 +120,10 @@ const Toolbar: React.FC<ToolbarProps> = ({ editor }) => {
   );
 };
 
-interface MarkdownEditorProps {
+type MarkdownEditorProps = {
   children?: string;
   onChange?: (markdown: string) => void;
-}
+};
 
 const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ children, onChange }) => {
   const editor = useEditor({

--- a/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -39,10 +39,10 @@ const remarkUnescapeMdxAttributes: Plugin = () => {
   };
 };
 
-export interface MarkdownRendererProps {
+export type MarkdownRendererProps = {
   children?: string;
   className?: string;
-}
+};
 
 // This must be a function, rather than a constant, to avoid dependency cycles
 export const getSupportedComponents = () => ({

--- a/apps/website/src/components/homepage/CommunitySection/ProjectsSubSection.tsx
+++ b/apps/website/src/components/homepage/CommunitySection/ProjectsSubSection.tsx
@@ -2,13 +2,13 @@ import {
   Card, CTALinkOrButton, SectionHeading, SlideList,
 } from '@bluedot/ui';
 
-interface Project {
+type Project = {
   id: number;
   title: string;
   authorName: string;
   imageSrc: string;
   ctaUrl: string;
-}
+};
 
 const projects: Project[] = [
   {

--- a/apps/website/src/components/lander/ClassicHero.tsx
+++ b/apps/website/src/components/lander/ClassicHero.tsx
@@ -10,10 +10,10 @@ import { ReactNode } from 'react';
 import { getCtaUrl } from './getCtaUrl';
 
 // Feature item component
-interface FeatureProps {
+type FeatureProps = {
   icon: IconType;
   children: ReactNode;
-}
+};
 
 const Feature = ({ icon: Icon, children }: FeatureProps) => (
   <div className="flex items-center gap-2">
@@ -23,10 +23,10 @@ const Feature = ({ icon: Icon, children }: FeatureProps) => (
 );
 
 // Title component
-interface TitleProps {
+type TitleProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 const Title = ({ children, className = '' }: TitleProps) => (
   <HeroH1 className={`font-serif text-5xl sm:text-7xl font-normal ${className}`}>
@@ -35,10 +35,10 @@ const Title = ({ children, className = '' }: TitleProps) => (
 );
 
 // Subtitle component
-interface SubtitleProps {
+type SubtitleProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 const Subtitle = ({ children, className = '' }: SubtitleProps) => (
   <HeroH2 className={`text-size-md sm:text-size-lg font-light max-w-2xl mx-auto mt-10 ${className}`}>
@@ -47,11 +47,11 @@ const Subtitle = ({ children, className = '' }: SubtitleProps) => (
 );
 
 // CTA component
-interface CTAProps {
+type CTAProps = {
   variant: string;
   children: ReactNode;
   className?: string;
-}
+};
 
 const CTA = ({ variant, children, className = '' }: CTAProps) => (
   <HeroCTAContainer className={className}>
@@ -60,10 +60,10 @@ const CTA = ({ variant, children, className = '' }: CTAProps) => (
 );
 
 // Features container component
-interface FeaturesProps {
+type FeaturesProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 const Features = ({ children, className = '' }: FeaturesProps) => (
   <div className={`flex flex-wrap justify-center gap-6 sm:gap-20 mt-10 uppercase font-bold ${className}`}>
@@ -72,10 +72,10 @@ const Features = ({ children, className = '' }: FeaturesProps) => (
 );
 
 // Main ClassicHero component
-interface ClassicHeroProps {
+type ClassicHeroProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 const ClassicHero = ({ children, className = '' }: ClassicHeroProps) => {
   return (

--- a/apps/website/src/components/lander/Container.tsx
+++ b/apps/website/src/components/lander/Container.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import clsx from 'clsx';
 
-interface ContainerProps {
+type ContainerProps = {
   children: React.ReactNode;
   className?: string;
   bgClassname?: string;
-}
+};
 
 /**
  * Provides consistent max-width and padding

--- a/apps/website/src/components/lander/CourseUnits.tsx
+++ b/apps/website/src/components/lander/CourseUnits.tsx
@@ -2,12 +2,12 @@ import { ReactNode } from 'react';
 import clsx from 'clsx';
 import { H3, P } from '../Text';
 
-interface UnitProps {
+type UnitProps = {
   unitNumber: string;
   id?: string;
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * Unit component - container for a single course unit
@@ -24,10 +24,10 @@ const Unit = ({
   </div>
 );
 
-interface TitleProps {
+type TitleProps = {
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * Title component - title for a course unit
@@ -39,10 +39,10 @@ const Title = ({
   <H3 className={`text-size-lg font-semibold my-2 ${className}`}>{children}</H3>
 );
 
-interface DescriptionProps {
+type DescriptionProps = {
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * Description component - description for a course unit
@@ -54,10 +54,10 @@ const Description = ({
   <P className={`text-gray-600 ${className}`}>{children}</P>
 );
 
-interface CourseUnitsProps {
+type CourseUnitsProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 /**
  * Component for displaying course units using compound component pattern

--- a/apps/website/src/components/lander/CourseUnitsSection.tsx
+++ b/apps/website/src/components/lander/CourseUnitsSection.tsx
@@ -2,12 +2,12 @@ import React, { ReactNode } from 'react';
 import clsx from 'clsx';
 import { H3, P } from '../Text';
 
-interface CourseUnitProps {
+type CourseUnitProps = {
   unitNumber: string;
   id?: string;
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * CourseUnit component - container for a single course unit
@@ -24,10 +24,10 @@ export const CourseUnit: React.FC<CourseUnitProps> = ({
   </div>
 );
 
-interface CourseUnitTitleProps {
+type CourseUnitTitleProps = {
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * CourseUnitTitle component - title for a course unit
@@ -39,10 +39,10 @@ export const CourseUnitTitle: React.FC<CourseUnitTitleProps> = ({
   <H3 className={`text-size-lg font-semibold my-2 ${className}`}>{children}</H3>
 );
 
-interface CourseUnitDescriptionProps {
+type CourseUnitDescriptionProps = {
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * CourseUnitDescription component - description for a course unit
@@ -54,10 +54,10 @@ export const CourseUnitDescription: React.FC<CourseUnitDescriptionProps> = ({
   <P className={`text-gray-600 ${className}`}>{children}</P>
 );
 
-interface CourseUnitsSectionProps {
+type CourseUnitsSectionProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 /**
  * Section component for displaying course units using compound component pattern

--- a/apps/website/src/components/lander/Features.tsx
+++ b/apps/website/src/components/lander/Features.tsx
@@ -2,13 +2,13 @@ import clsx from 'clsx';
 import { ReactNode } from 'react';
 import { H3, P } from '../Text';
 
-interface FeatureProps {
+type FeatureProps = {
   iconSrc?: string;
   id?: string;
   className?: string;
   iconClassName?: string;
   children: ReactNode;
-}
+};
 
 /**
  * Feature component - container for a single feature
@@ -30,10 +30,10 @@ const Feature = ({
   </div>
 );
 
-interface TitleProps {
+type TitleProps = {
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * Title component - title for a feature
@@ -45,10 +45,10 @@ const Title = ({
   <H3 className={`font-semibold mb-2 ${className}`}>{children}</H3>
 );
 
-interface SubtitleProps {
+type SubtitleProps = {
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * Subtitle component - subtitle/description for a feature
@@ -60,9 +60,9 @@ const Subtitle = ({
   <P className={`text-gray-600 text-size-md mx-4 ${className}`}>{children}</P>
 );
 
-interface FeaturesProps {
+type FeaturesProps = {
   children: ReactNode;
-}
+};
 
 /**
  * Component for displaying course features using compound component pattern

--- a/apps/website/src/components/lander/FeaturesSection.tsx
+++ b/apps/website/src/components/lander/FeaturesSection.tsx
@@ -2,13 +2,13 @@ import clsx from 'clsx';
 import React, { ReactNode } from 'react';
 import { H3, P } from '../Text';
 
-interface FeatureProps {
+type FeatureProps = {
   iconSrc?: string;
   id?: string;
   className?: string;
   iconClassName?: string;
   children: ReactNode;
-}
+};
 
 /**
  * Feature component - container for a single feature
@@ -30,10 +30,10 @@ export const Feature: React.FC<FeatureProps> = ({
   </div>
 );
 
-interface FeatureTitleProps {
+type FeatureTitleProps = {
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * FeatureTitle component - title for a feature
@@ -45,10 +45,10 @@ export const FeatureTitle: React.FC<FeatureTitleProps> = ({
   <H3 className={`font-semibold mb-2 ${className}`}>{children}</H3>
 );
 
-interface FeatureSubtitleProps {
+type FeatureSubtitleProps = {
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * FeatureSubtitle component - subtitle/description for a feature
@@ -60,9 +60,9 @@ export const FeatureSubtitle: React.FC<FeatureSubtitleProps> = ({
   <P className={`text-gray-600 text-size-md mx-4 ${className}`}>{children}</P>
 );
 
-interface FeaturesSectionProps {
+type FeaturesSectionProps = {
   children: ReactNode;
-}
+};
 
 /**
  * Section component for displaying course features

--- a/apps/website/src/components/lander/LandingPageBase.tsx
+++ b/apps/website/src/components/lander/LandingPageBase.tsx
@@ -15,12 +15,12 @@ import { Nav } from '../Nav';
 import GraduateSection from '../homepage/GraduateSection';
 import { H2, P } from '../Text';
 
-export interface LandingPageBaseProps {
+export type LandingPageBaseProps = {
   /** Hero component to render */
   hero: React.ReactNode;
   /** Variant name, used for analytics */
   variant: string;
-}
+};
 
 const LandingPageBase = ({ hero, variant }: LandingPageBaseProps) => {
   const ctaUrl = getCtaUrl(variant);

--- a/apps/website/src/components/lander/SingleTestimonial.tsx
+++ b/apps/website/src/components/lander/SingleTestimonial.tsx
@@ -3,10 +3,10 @@ import { CTALinkOrButton } from '@bluedot/ui';
 import clsx from 'clsx';
 import { P } from '../Text';
 
-interface QuoteProps {
+type QuoteProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 /**
  * Quote component - displays the testimonial quote text
@@ -20,10 +20,10 @@ const Quote = ({
   </P>
 );
 
-interface AttributionProps {
+type AttributionProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 /**
  * Attribution component - displays the testimonial attribution
@@ -37,11 +37,11 @@ const Attribution = ({
   </P>
 );
 
-interface CTAProps {
+type CTAProps = {
   url: string;
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * CTA component - displays the call-to-action button
@@ -61,11 +61,11 @@ const CTA = ({
   </>
 );
 
-interface SingleTestimonialProps {
+type SingleTestimonialProps = {
   imgSrc: string;
   children: ReactNode;
   className?: string;
-}
+};
 
 /**
  * Displays a single testimonial with a CTA button using compound component pattern

--- a/apps/website/src/components/lander/SingleTestimonialSection.tsx
+++ b/apps/website/src/components/lander/SingleTestimonialSection.tsx
@@ -3,10 +3,10 @@ import { CTALinkOrButton } from '@bluedot/ui';
 import clsx from 'clsx';
 import { P } from '../Text';
 
-interface TestimonialQuoteProps {
+type TestimonialQuoteProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 /**
  * TestimonialQuote component - displays the testimonial quote text
@@ -20,10 +20,10 @@ export const TestimonialQuote: React.FC<TestimonialQuoteProps> = ({
   </P>
 );
 
-interface TestimonialAttributionProps {
+type TestimonialAttributionProps = {
   children: ReactNode;
   className?: string;
-}
+};
 
 /**
  * TestimonialAttribution component - displays the testimonial attribution
@@ -37,11 +37,11 @@ export const TestimonialAttribution: React.FC<TestimonialAttributionProps> = ({
   </P>
 );
 
-interface TestimonialCTAProps {
+type TestimonialCTAProps = {
   url: string;
   className?: string;
   children: ReactNode;
-}
+};
 
 /**
  * TestimonialCTA component - displays the call-to-action button
@@ -61,11 +61,11 @@ export const TestimonialCTA: React.FC<TestimonialCTAProps> = ({
   </>
 );
 
-interface SingleTestimonialSectionProps {
+type SingleTestimonialSectionProps = {
   imgSrc: string;
   children: ReactNode;
   className?: string;
-}
+};
 
 /**
  * Displays a single testimonial with a CTA button using compound component pattern

--- a/apps/website/src/lib/api/db/tables.ts
+++ b/apps/website/src/lib/api/db/tables.ts
@@ -1,6 +1,6 @@
 import { Item, Table } from 'airtable-ts';
 
-export interface Course extends Item {
+export type Course = {
   certificationBadgeImage: string,
   certificatonDescription: string,
   description: string,
@@ -13,7 +13,7 @@ export interface Course extends Item {
   shortDescription: string,
   title: string,
   units: string[],
-}
+} & Item;
 
 export const courseTable: Table<Course> = {
   name: 'Course',
@@ -47,10 +47,10 @@ export const courseTable: Table<Course> = {
   },
 };
 
-export interface ApplicationsCourse extends Item {
+export type ApplicationsCourse = {
   id: string, // Applications base record id
   courseBuilderId: string,
-}
+} & Item;
 
 export const applicationsCourseTable: Table<ApplicationsCourse> = {
   name: 'Course',
@@ -64,7 +64,7 @@ export const applicationsCourseTable: Table<ApplicationsCourse> = {
   },
 };
 
-export interface UnitFeedback extends Item {
+export type UnitFeedback = {
   unitId: string,
   overallRating: number,
   anythingElse: string,
@@ -72,7 +72,7 @@ export interface UnitFeedback extends Item {
   userFullName: string,
   createdAt: string | null,
   lastModified: string | null,
-}
+} & Item;
 
 export const unitFeedbackTable: Table<UnitFeedback> = {
   name: 'UnitFeedback',
@@ -98,7 +98,7 @@ export const unitFeedbackTable: Table<UnitFeedback> = {
   },
 };
 
-export interface Unit extends Item {
+export type Unit = {
   id: string,
   courseId: string,
   courseTitle: string,
@@ -110,7 +110,7 @@ export interface Unit extends Item {
   unitNumber: string,
   duration: number,
   description: string,
-}
+} & Item;
 
 export const unitTable: Table<Unit> = {
   name: 'Unit',
@@ -142,7 +142,7 @@ export const unitTable: Table<Unit> = {
   },
 };
 
-export interface Exercise extends Item {
+export type Exercise = {
   id: string,
   answer: string,
   courseId: string,
@@ -154,7 +154,7 @@ export interface Exercise extends Item {
   unitId: string,
   unitNumber: string,
   status: string,
-}
+} & Item;
 
 export const exerciseTable: Table<Exercise> = {
   name: 'Exercise',
@@ -186,13 +186,13 @@ export const exerciseTable: Table<Exercise> = {
   },
 };
 
-export interface ExerciseResponse extends Item {
+export type ExerciseResponse = {
   id: string,
   email: string,
   exerciseId: string,
   response: string,
   completed: boolean,
-}
+} & Item;
 
 export const exerciseResponseTable: Table<ExerciseResponse> = {
   name: 'Exercise response',
@@ -212,7 +212,7 @@ export const exerciseResponseTable: Table<ExerciseResponse> = {
   },
 };
 
-export interface CourseRegistration extends Item {
+export type CourseRegistration = {
   id: string,
   userId: string | null,
   email: string,
@@ -227,7 +227,7 @@ export interface CourseRegistration extends Item {
   role: string,
   certificateId: string | null,
   certificateCreatedAt: number | null,
-}
+} & Item;
 
 export const courseRegistrationTable: Table<CourseRegistration> = {
   name: 'Course registration',
@@ -261,7 +261,7 @@ export const courseRegistrationTable: Table<CourseRegistration> = {
   },
 };
 
-export interface User extends Item {
+export type User = {
   id: string,
   email: string,
   createdAt: string,
@@ -274,7 +274,7 @@ export interface User extends Item {
   utmContent: string,
   courseSitesVisitedCsv: string,
   completedMoocAt: number | null,
-}
+} & Item;
 
 export const userTable: Table<User> = {
   name: 'User',

--- a/apps/website/src/lib/withClickTracking.test.tsx
+++ b/apps/website/src/lib/withClickTracking.test.tsx
@@ -62,9 +62,9 @@ describe('withClickTracking', () => {
   });
 
   it('renders the wrapped component with its original props', () => {
-    interface TestProps {
+    type TestProps = {
       testProp: string;
-    }
+    };
     const TestComponent = ({ testProp }: TestProps) => <div>{testProp}</div>;
 
     const WrappedComponent = withClickTracking(TestComponent);

--- a/apps/website/src/lib/withClickTracking.tsx
+++ b/apps/website/src/lib/withClickTracking.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import { sendGAEvent } from '@next/third-parties/google';
 
 // Base tracking configuration type
-interface TrackingConfig {
+type TrackingConfig = {
   eventName: string;
   eventParams?: Record<string, string>;
-}
+};
 
 // Props that will be available on the wrapped component
-interface TrackingProps {
+type TrackingProps = {
   trackingEventName?: string;
   trackingEventParams?: Record<string, string>;
-}
+};
 
 // Type helper to ensure wrapped component has onClick
 type WithClick<P> = P & { onClick?: (e: React.MouseEvent) => void };

--- a/apps/website/src/pages/profile.tsx
+++ b/apps/website/src/pages/profile.tsx
@@ -115,11 +115,11 @@ const ProfilePage = withAuth(({ auth }) => {
   );
 });
 
-interface ProfileCourseCardProps {
+type ProfileCourseCardProps = {
   course: Course;
   courseRegistration: CourseRegistration;
   user: User;
-}
+};
 
 const ProfileCourseCard: React.FC<ProfileCourseCardProps> = ({ course, courseRegistration, user }) => {
   const isCompleted = !!courseRegistration.certificateId;

--- a/libraries/affected-packages/package.json
+++ b/libraries/affected-packages/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "lint": "eslint . --report-unused-disable-directives --max-warnings=0",
     "lint:fix": "npm run lint -- --fix",
-    "test": "vitest run",
+    "test": "vitest --run",
     "test:watch": "vitest"
   },
   "devDependencies": {

--- a/libraries/affected-packages/src/lib/getPackagesWithChanges.ts
+++ b/libraries/affected-packages/src/lib/getPackagesWithChanges.ts
@@ -63,19 +63,19 @@ const getSuccessfulParentCommits = async (
   }))).flat();
 };
 
-interface NPMPackage {
+type NPMPackage = {
   name: string;
   location: string;
   scripts: { 'deploy:cd'?: string };
-  dependencies?: { [key: string]: string };
-  devDependencies?: { [key: string]: string };
-}
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
 
-interface PackageInfo {
+type PackageInfo = {
   name: string;
   isDeployableByCd: boolean;
   fileGlobs: string[];
-}
+};
 
 /**
  * @returns Array of package information for all packages in the monorepo

--- a/libraries/eslint-config/src/index.js
+++ b/libraries/eslint-config/src/index.js
@@ -54,9 +54,29 @@ const rules = {
   }],
   // Almost always a false positive on the <Link> component
   'jsx-a11y/anchor-is-valid': ['off'],
+
+  // Tailwind rules
   'tailwindcss/no-contradicting-classname': ['error'],
   'tailwindcss/no-unnecessary-arbitrary-value': ['error'],
   'tailwindcss/enforces-shorthand': ['error'],
+
+  // Overrides airbnb config to remove banning ForOfStatement
+  // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L338-L358
+  'no-restricted-syntax': [
+    'error',
+    {
+      selector: 'ForInStatement',
+      message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+    },
+    {
+      selector: 'LabeledStatement',
+      message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+    },
+    {
+      selector: 'WithStatement',
+      message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+    },
+  ],
 
   // Custom rules
   '@bluedot/custom/no-default-tailwind-tokens': ['error'],
@@ -86,6 +106,16 @@ const tsOnlyRules = {
       leadingUnderscore: 'allow',
     },
   ],
+
+  // Mainly based on https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/eslintrc/stylistic.ts
+  '@typescript-eslint/array-type': ['error'],
+  '@typescript-eslint/consistent-generic-constructors': ['error'],
+  '@typescript-eslint/consistent-indexed-object-style': ['error'],
+  '@typescript-eslint/consistent-type-assertions': ['error'],
+  '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+  '@typescript-eslint/no-inferrable-types': ['error'],
+  '@typescript-eslint/prefer-for-of': ['error'],
+  '@typescript-eslint/prefer-function-type': ['error'],
 };
 
 /** @type {import("eslint").Linter.Config} */

--- a/libraries/ui/src/Banner.tsx
+++ b/libraries/ui/src/Banner.tsx
@@ -2,14 +2,14 @@ import React, { useState } from 'react';
 import clsx from 'clsx';
 import { CTALinkOrButton } from './CTALinkOrButton';
 
-export interface BannerProps {
+export type BannerProps = {
   title: string;
   className?: string;
   inputPlaceholder?: string;
   buttonText?: string;
   showInput?: boolean;
   showButton?: boolean;
-}
+};
 
 export const Banner: React.FC<BannerProps> = ({
   title, className, inputPlaceholder = 'you@example.com', // Default placeholder

--- a/libraries/ui/src/ErrorSection.tsx
+++ b/libraries/ui/src/ErrorSection.tsx
@@ -1,8 +1,8 @@
 import { ErrorView } from './ErrorView';
 
-export interface ErrorSectionProps {
+export type ErrorSectionProps = {
   error: unknown,
-}
+};
 
 export const ErrorSection: React.FC<ErrorSectionProps> = ({ error }) => {
   return (

--- a/libraries/ui/src/ErrorView.tsx
+++ b/libraries/ui/src/ErrorView.tsx
@@ -3,9 +3,9 @@ import { asError } from './utils/asError';
 import { Collapsible } from './Collapsible';
 import { contactUsUrl } from './constants';
 
-export interface ErrorViewProps {
+export type ErrorViewProps = {
   error: unknown,
-}
+};
 
 const truncate = (str: string, n: number) => (str.length > n ? `${str.slice(0, n)}...` : str);
 
@@ -36,10 +36,10 @@ export const ErrorView: React.FC<ErrorViewProps> = ({ error: input }) => {
   );
 };
 
-interface ErrorDetailsProps {
+type ErrorDetailsProps = {
   error: Error,
   prefix?: string,
-}
+};
 
 const ErrorDetails: React.FC<ErrorDetailsProps> = ({ error, prefix = '' }) => {
   const prefixSpace = `${prefix} `;

--- a/libraries/ui/src/FaceTiles.tsx
+++ b/libraries/ui/src/FaceTiles.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
-export interface FaceTilesProps {
-  faces: Array<{
+export type FaceTilesProps = {
+  faces: {
     src: string;
     alt: string;
-  }>;
+  }[];
   maxDisplay?: number;
   size?: number;
   className?: string;
-}
+};
 
 export const FaceTiles: React.FC<FaceTilesProps> = ({
   faces,

--- a/libraries/ui/src/Modal.stories.tsx
+++ b/libraries/ui/src/Modal.stories.tsx
@@ -4,11 +4,11 @@ import { Button } from './legacy/Button';
 import { Modal } from './Modal';
 
 // Wrapper component to handle the modal state
-interface ModalDemoProps {
+type ModalDemoProps = {
   title?: string;
   children?: React.ReactNode;
   initialOpen?: boolean;
-}
+};
 
 const ModalDemo: React.FC<ModalDemoProps> = ({
   title = 'Modal Title',

--- a/libraries/ui/src/Modal.tsx
+++ b/libraries/ui/src/Modal.tsx
@@ -7,12 +7,12 @@ import {
   Heading,
 } from 'react-aria-components';
 
-export interface ModalProps {
+export type ModalProps = {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
   title: string;
   children: ReactNode;
-}
+};
 
 export const Modal: React.FC<ModalProps> = ({
   isOpen,

--- a/libraries/ui/src/ShareButton.tsx
+++ b/libraries/ui/src/ShareButton.tsx
@@ -9,12 +9,12 @@ import { Modal } from './Modal';
 import { LinkOrButton } from './legacy/LinkOrButton';
 import { ErrorView } from './ErrorView';
 
-interface SocialButtonProps {
+type SocialButtonProps = {
   icon: ReactNode;
   color: string;
   onPress: () => void;
   children: ReactNode;
-}
+};
 
 const SocialButton: React.FC<SocialButtonProps> = ({
   icon, color, onPress, children,

--- a/libraries/ui/src/UnitCard.tsx
+++ b/libraries/ui/src/UnitCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { Tag } from './Tag';
 
-export interface UnitCardProps {
+export type UnitCardProps = {
   // Required
   title: string,
   unitNumber: string,
@@ -12,7 +12,7 @@ export interface UnitCardProps {
   description?: string,
   duration?: number,
   isCurrentUnit?: boolean,
-}
+};
 
 export const UnitCard: React.FC<UnitCardProps> = ({
   className,

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -32,13 +32,13 @@ const oidcRefresh = async (auth: Auth): Promise<Auth> => {
   };
 };
 
-export interface Auth {
+export type Auth = {
   token: string,
   /** ms unix timestamp */
   expiresAt: number,
   refreshToken?: string,
   oidcSettings?: OidcClientSettings,
-}
+};
 
 export const useAuthStore = create<{
   auth: Auth | null,

--- a/libraries/ui/src/utils/index.ts
+++ b/libraries/ui/src/utils/index.ts
@@ -1,3 +1,3 @@
-export const maybePlural = (count: number, base: string, pluralEnding: string = 's'): string => {
+export const maybePlural = (count: number, base: string, pluralEnding = 's'): string => {
   return `${count} ${base}${count === 1 ? '' : pluralEnding}`;
 };

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,9 @@
       "inputs": ["$TURBO_DEFAULT$"],
       "outputs": ["dist/**", "!dist/cache/**"]
     },
-    "lint": {},
+    "lint": {
+      "dependsOn": ["@bluedot/eslint-config#build"]
+    },
     "lint:fix": {
       "cache": false
     },


### PR DESCRIPTION
- Added some stylistic rules to libraries/eslint-config/src/index.js
- Ran `npm run lint:fix`

## Issue

Related to #749: while I was moving around components I wanted more consistency in how they were defined (and to think less about which option I should pick).

## Testing

Checked website and availability still look happy