### PR TITLE
ui,website: Fix link-on-dark class portability

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/404.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/404.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Error404Page > should render correctly 1`] = `
           </div>
         </div>
         <h2
-          class="hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2"
+          class="hero-section__subtitle text-color-text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2"
         >
           Sorry, this page does not exist.
         </h2>

--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -10,12 +10,12 @@ exports[`AboutPage > should render correctly 1`] = `
         class="hero-section__content max-w-[865px] py-12"
       >
         <div
-          class="hero-section__mini-title text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"
+          class="hero-section__mini-title text-color-text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"
         >
           About us
         </div>
         <h1
-          class="hero-section__title text-on-dark text-center bluedot-h1"
+          class="hero-section__title text-color-text-on-dark text-center bluedot-h1"
         >
           Our mission is to ensure humanity safely navigates the transition to transformative AI.
         </h1>
@@ -421,7 +421,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 class="history-section__year-container w-full flex gap-2"
               >
                 <p
-                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
                 >
                   2021
                 </p>
@@ -450,7 +450,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 class="history-section__year-container w-full flex gap-2"
               >
                 <p
-                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
                 >
                   2022
                 </p>
@@ -486,7 +486,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 class="history-section__year-container w-full flex gap-2"
               >
                 <p
-                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
                 >
                   2023
                 </p>
@@ -515,7 +515,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 class="history-section__year-container w-full flex gap-2"
               >
                 <p
-                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
                 >
                   2024
                 </p>
@@ -548,7 +548,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 class="history-section__year-container w-full flex gap-2"
               >
                 <p
-                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                  class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
                 >
                   2025
                 </p>

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -10,12 +10,12 @@ exports[`JoinUsPage > should render correctly 1`] = `
         class="hero-section__content max-w-[865px] py-12"
       >
         <div
-          class="hero-section__mini-title text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"
+          class="hero-section__mini-title text-color-text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"
         >
           Join Us
         </div>
         <h1
-          class="hero-section__title text-on-dark text-center bluedot-h1"
+          class="hero-section__title text-color-text-on-dark text-center bluedot-h1"
         >
           Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
         </h1>

--- a/apps/website/src/components/about/HistorySection.tsx
+++ b/apps/website/src/components/about/HistorySection.tsx
@@ -31,7 +31,7 @@ const HistoryEvent = ({ year, now, children }: { year: string, now?: boolean, ch
       ) : (
         <div className="history-section__event-container--desktop flex flex-col gap-space-between">
           <div className="history-section__year-container w-full flex gap-2">
-            <P className="history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min">{year}</P>
+            <P className="history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min">{year}</P>
             <div className="history-section__year-decoration relative w-full after:content-[''] after:absolute after:top-1/2 after:w-full after:h-[2px] after:bg-bluedot-normal after:right-0" />
           </div>
           <P className="history-section__event-details mr-12">{children}</P>

--- a/apps/website/src/components/about/__snapshots__/HistorySection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/HistorySection.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`HistorySection > renders desktop as expected 1`] = `
               class="history-section__year-container w-full flex gap-2"
             >
               <p
-                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
               >
                 2021
               </p>
@@ -63,7 +63,7 @@ exports[`HistorySection > renders desktop as expected 1`] = `
               class="history-section__year-container w-full flex gap-2"
             >
               <p
-                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
               >
                 2022
               </p>
@@ -99,7 +99,7 @@ exports[`HistorySection > renders desktop as expected 1`] = `
               class="history-section__year-container w-full flex gap-2"
             >
               <p
-                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
               >
                 2023
               </p>
@@ -128,7 +128,7 @@ exports[`HistorySection > renders desktop as expected 1`] = `
               class="history-section__year-container w-full flex gap-2"
             >
               <p
-                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
               >
                 2024
               </p>
@@ -161,7 +161,7 @@ exports[`HistorySection > renders desktop as expected 1`] = `
               class="history-section__year-container w-full flex gap-2"
             >
               <p
-                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-on-dark text-[16px] font-bold w-min"
+                class="bluedot-p history-section__year bg-bluedot-normal rounded-full px-4 py-2 text-color-text-on-dark text-[16px] font-bold w-min"
               >
                 2025
               </p>

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -10,12 +10,12 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
         class="hero-section__content max-w-[865px] py-12"
       >
         <div
-          class="hero-section__mini-title text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"
+          class="hero-section__mini-title text-color-text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4"
         >
           What the fish [Test Course]
         </div>
         <h1
-          class="hero-section__title text-on-dark text-center bluedot-h1"
+          class="hero-section__title text-color-text-on-dark text-center bluedot-h1"
         >
           Basic Principles of Fish
         </h1>

--- a/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
@@ -18,12 +18,12 @@ exports[`HomeHeroContent > renders as expected 1`] = `
       </div>
     </div>
     <h1
-      class="hero-section__title text-on-dark text-center bluedot-h1 home-hero-content__heading slide-up-fade-in"
+      class="hero-section__title text-color-text-on-dark text-center bluedot-h1 home-hero-content__heading slide-up-fade-in"
     >
       The expertise you need to shape safe AI
     </h1>
     <h2
-      class="hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2 home-hero-content__subheading slide-up-fade-in"
+      class="hero-section__subtitle text-color-text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2 home-hero-content__subheading slide-up-fade-in"
       style="animation-delay: 100ms;"
     >
       Learn alongside thousands of professionals through comprehensive courses designed with leading AI safety experts.

--- a/apps/website/src/globals.css
+++ b/apps/website/src/globals.css
@@ -57,16 +57,6 @@
   }
 }
 
-@utility link-on-dark {
-  @apply text-color-text-on-dark hover:text-color-secondary-accent cursor-pointer;
-}
-
-@layer base {
-  .text-on-dark {
-    @apply text-color-text-on-dark;
-  }
-}
-
 .slide-up-fade-in {
   opacity: 0;
   transform: translateY(50px);

--- a/libraries/ui/src/Footer.tsx
+++ b/libraries/ui/src/Footer.tsx
@@ -20,7 +20,7 @@ type FooterSectionProps = {
 
 const FooterLinksSection: React.FC<FooterSectionProps> = ({ title, links, className }) => (
   <div className={clsx('footer__section', className)}>
-    {title && <h3 className="footer__heading font-[650] text-on-dark mb-4 text-size-md bluedot-h3">{title}</h3>}
+    {title && <h3 className="footer__heading font-[650] text-color-text-on-dark mb-4 text-size-md bluedot-h3">{title}</h3>}
     {links && (
       <ul className="footer__list space-y-4 mb-auto list-none p-0">
         {links.map((link) => (

--- a/libraries/ui/src/HeroSection.tsx
+++ b/libraries/ui/src/HeroSection.tsx
@@ -9,7 +9,7 @@ export const HeroMiniTitle: React.FC<HeroMiniTitleProps> = ({
   children, className,
 }) => {
   return (
-    <div className={clsx('hero-section__mini-title text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4', className)}>{children}</div>
+    <div className={clsx('hero-section__mini-title text-color-text-on-dark text-center uppercase tracking-wider text-sm font-semibold mb-4', className)}>{children}</div>
   );
 };
 
@@ -17,7 +17,7 @@ export const HeroH1: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = ({
   children, className, ...otherProps
 }) => {
   return (
-    <h1 className={clsx('hero-section__title text-on-dark text-center bluedot-h1', className)} {...otherProps}>{children}</h1>
+    <h1 className={clsx('hero-section__title text-color-text-on-dark text-center bluedot-h1', className)} {...otherProps}>{children}</h1>
   );
 };
 
@@ -26,7 +26,7 @@ export const HeroH2: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = ({
 }) => {
   return (
     <h2
-      className={clsx('hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2', className)}
+      className={clsx('hero-section__subtitle text-color-text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2', className)}
       {...otherProps}
     >
       {children}

--- a/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`Footer > renders default as expected 1`] = `
             class="footer__section min-w-0 whitespace-nowrap"
           >
             <h3
-              class="footer__heading font-[650] text-on-dark mb-4 text-size-md bluedot-h3"
+              class="footer__heading font-[650] text-color-text-on-dark mb-4 text-size-md bluedot-h3"
             >
               BlueDot Impact
             </h3>
@@ -165,7 +165,7 @@ exports[`Footer > renders default as expected 1`] = `
             class="footer__section min-w-0 flex-1"
           >
             <h3
-              class="footer__heading font-[650] text-on-dark mb-4 text-size-md bluedot-h3"
+              class="footer__heading font-[650] text-color-text-on-dark mb-4 text-size-md bluedot-h3"
             >
               Explore
             </h3>
@@ -425,7 +425,7 @@ exports[`Footer > renders with optional args 1`] = `
             class="footer__section min-w-0 whitespace-nowrap"
           >
             <h3
-              class="footer__heading font-[650] text-on-dark mb-4 text-size-md bluedot-h3"
+              class="footer__heading font-[650] text-color-text-on-dark mb-4 text-size-md bluedot-h3"
             >
               BlueDot Impact
             </h3>
@@ -488,7 +488,7 @@ exports[`Footer > renders with optional args 1`] = `
             class="footer__section min-w-0 flex-1"
           >
             <h3
-              class="footer__heading font-[650] text-on-dark mb-4 text-size-md bluedot-h3"
+              class="footer__heading font-[650] text-color-text-on-dark mb-4 text-size-md bluedot-h3"
             >
               Explore
             </h3>

--- a/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
@@ -21,12 +21,12 @@ exports[`HeroSection > renders with buttons 1`] = `
       class="hero-section__content max-w-[865px] py-12"
     >
       <h1
-        class="hero-section__title text-on-dark text-center bluedot-h1"
+        class="hero-section__title text-color-text-on-dark text-center bluedot-h1"
       >
         This is the title
       </h1>
       <h2
-        class="hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2"
+        class="hero-section__subtitle text-color-text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2"
       >
         This is the subtitle
       </h2>
@@ -75,12 +75,12 @@ exports[`HeroSection > renders with titles 1`] = `
       class="hero-section__content max-w-[865px] py-12"
     >
       <h1
-        class="hero-section__title text-on-dark text-center bluedot-h1"
+        class="hero-section__title text-color-text-on-dark text-center bluedot-h1"
       >
         This is the title
       </h1>
       <h2
-        class="hero-section__subtitle text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2"
+        class="hero-section__subtitle text-color-text-on-dark text-2xl font-[400] text-center mt-4 bluedot-h2"
       >
         This is the subtitle
       </h2>

--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -145,6 +145,10 @@
     @apply after:bg-bluedot-lighter;
 }
 
+@utility link-on-dark {
+    @apply text-color-text-on-dark hover:text-color-secondary-accent cursor-pointer;
+}
+
 :root {
     --bluedot-lightest: #F5F4F7;
     --bluedot-lighter: #CCD7FF;


### PR DESCRIPTION
This is used in some shared components e.g. CTALinkOrButton, but only defined in website, so the styles don't get applied properly in the other apps.

Also .text-on-dark is not necessary - people should just use the normal .text-color-text-on-dark.

Part of #749