### PR TITLE
ui: Fix CTALinkOrButton chevron portability by using FA icons

### DIFF
--- a/apps/website/public/icons/chevron_blue.svg
+++ b/apps/website/public/icons/chevron_blue.svg
@@ -1,3 +1,0 @@
-<svg width="10" height="12" viewBox="0 0 10 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M4.75729 1.75736L8.99993 6L4.75729 10.2426" stroke="#0037FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/apps/website/public/icons/chevron_white.svg
+++ b/apps/website/public/icons/chevron_white.svg
@@ -1,3 +1,0 @@
-<svg width="7" height="12" viewBox="0 0 7 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.24264 1.75736L5.48528 6L1.24264 10.2426" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -35,11 +35,20 @@ exports[`AboutPage > should render correctly 1`] = `
             <span
               class="cta-button__chevron ml-3"
             >
-              <img
-                alt="→"
+              <svg
                 class="cta-button__chevron-icon size-2"
-                src="/icons/chevron_white.svg"
-              />
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 320 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                />
+              </svg>
             </span>
           </a>
         </div>
@@ -1013,11 +1022,20 @@ exports[`AboutPage > should render correctly 1`] = `
           <span
             class="cta-button__chevron ml-3"
           >
-            <img
-              alt="→"
+            <svg
               class="cta-button__chevron-icon size-2"
-              src="/icons/chevron_white.svg"
-            />
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
           </span>
         </a>
       </div>
@@ -1059,11 +1077,20 @@ exports[`AboutPage > should render correctly 1`] = `
           <span
             class="cta-button__chevron ml-3"
           >
-            <img
-              alt="→"
+            <svg
               class="cta-button__chevron-icon size-2"
-              src="/icons/chevron_blue.svg"
-            />
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
           </span>
         </a>
       </div>

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -35,11 +35,20 @@ exports[`JoinUsPage > should render correctly 1`] = `
             <span
               class="cta-button__chevron ml-3"
             >
-              <img
-                alt="→"
+              <svg
                 class="cta-button__chevron-icon size-2"
-                src="/icons/chevron_white.svg"
-              />
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 320 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                />
+              </svg>
             </span>
           </a>
         </div>
@@ -427,11 +436,20 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 <span
                   class="cta-button__chevron ml-3"
                 >
-                  <img
-                    alt="→"
+                  <svg
                     class="cta-button__chevron-icon size-2"
-                    src="/icons/chevron_blue.svg"
-                  />
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                    />
+                  </svg>
                 </span>
               </a>
             </div>
@@ -470,11 +488,20 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 <span
                   class="cta-button__chevron ml-3"
                 >
-                  <img
-                    alt="→"
+                  <svg
                     class="cta-button__chevron-icon size-2"
-                    src="/icons/chevron_blue.svg"
-                  />
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                    />
+                  </svg>
                 </span>
               </a>
             </div>

--- a/apps/website/src/components/about/__snapshots__/JoinUsCta.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/JoinUsCta.test.tsx.snap
@@ -26,11 +26,20 @@ exports[`JoinUsCta > renders default as expected 1`] = `
         <span
           class="cta-button__chevron ml-3"
         >
-          <img
-            alt="→"
+          <svg
             class="cta-button__chevron-icon size-2"
-            src="/icons/chevron_white.svg"
-          />
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 320 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+            />
+          </svg>
         </span>
       </a>
     </div>

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -238,11 +238,20 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 <span
                   class="cta-button__chevron ml-3"
                 >
-                  <img
-                    alt="→"
+                  <svg
                     class="cta-button__chevron-icon size-2"
-                    src="/icons/chevron_white.svg"
-                  />
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                    />
+                  </svg>
                 </span>
               </a>
             </div>
@@ -263,11 +272,20 @@ exports[`UnitLayout > renders previous and next unit buttons for middle unit 1`]
   <span
     class="cta-button__chevron mr-3"
   >
-    <img
-      alt="←"
-      class="cta-button__chevron-icon size-2 rotate-180"
-      src="/icons/chevron_blue.svg"
-    />
+    <svg
+      class="cta-button__chevron-icon size-2"
+      fill="currentColor"
+      height="1em"
+      stroke="currentColor"
+      stroke-width="0"
+      viewBox="0 0 320 512"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 246.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z"
+      />
+    </svg>
   </span>
   <span
     class="cta-button__text"

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -53,11 +53,20 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
       <span
         class="cta-button__chevron ml-3"
       >
-        <img
-          alt="→"
+        <svg
           class="cta-button__chevron-icon size-2"
-          src="/icons/chevron_white.svg"
-        />
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 320 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+          />
+        </svg>
       </span>
     </a>
   </form>

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -121,11 +121,20 @@ exports[`MultipleChoice > renders default as expected 1`] = `
       <span
         class="cta-button__chevron ml-3"
       >
-        <img
-          alt="→"
+        <svg
           class="cta-button__chevron-icon size-2"
-          src="/icons/chevron_white.svg"
-        />
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 320 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+          />
+        </svg>
       </span>
     </a>
   </form>

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
@@ -265,11 +265,20 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
         <span
           class="cta-button__chevron ml-3"
         >
-          <img
-            alt="→"
+          <svg
             class="cta-button__chevron-icon size-2"
-            src="/icons/chevron_blue.svg"
-          />
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 320 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+            />
+          </svg>
         </span>
       </a>
     </div>

--- a/apps/website/src/components/homepage/__snapshots__/BlogSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/BlogSection.test.tsx.snap
@@ -131,11 +131,20 @@ exports[`BlogSection > renders default as expected 1`] = `
         <span
           class="cta-button__chevron ml-3"
         >
-          <img
-            alt="→"
+          <svg
             class="cta-button__chevron-icon size-2"
-            src="/icons/chevron_blue.svg"
-          />
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 320 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+            />
+          </svg>
         </span>
       </a>
     </div>

--- a/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -60,11 +60,20 @@ exports[`StorySection > renders default as expected 1`] = `
             <span
               class="cta-button__chevron ml-3"
             >
-              <img
-                alt="→"
+              <svg
                 class="cta-button__chevron-icon size-2"
-                src="/icons/chevron_blue.svg"
-              />
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 320 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                />
+              </svg>
             </span>
           </a>
         </div>

--- a/apps/website/src/components/join-us/__snapshots__/CareersSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/CareersSection.test.tsx.snap
@@ -62,11 +62,20 @@ exports[`CareersSection > renders default as expected 1`] = `
               <span
                 class="cta-button__chevron ml-3"
               >
-                <img
-                  alt="→"
+                <svg
                   class="cta-button__chevron-icon size-2"
-                  src="/icons/chevron_blue.svg"
-                />
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                  />
+                </svg>
               </span>
             </a>
           </div>
@@ -105,11 +114,20 @@ exports[`CareersSection > renders default as expected 1`] = `
               <span
                 class="cta-button__chevron ml-3"
               >
-                <img
-                  alt="→"
+                <svg
                   class="cta-button__chevron-icon size-2"
-                  src="/icons/chevron_blue.svg"
-                />
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                  />
+                </svg>
               </span>
             </a>
           </div>

--- a/libraries/ui/src/CTALinkOrButton.tsx
+++ b/libraries/ui/src/CTALinkOrButton.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import React from 'react';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 import { EXTERNAL_LINK_PROPS } from './utils/externalLinkProps';
 
 export type CTALinkOrButtonProps = {
@@ -45,21 +46,13 @@ export const CTALinkOrButton: React.FC<CTALinkOrButtonProps> = ({
       >
         {withBackChevron && (
           <span className="cta-button__chevron mr-3">
-            <img
-              src={variant === 'primary' ? '/icons/chevron_white.svg' : '/icons/chevron_blue.svg'}
-              alt="←"
-              className="cta-button__chevron-icon size-2 rotate-180"
-            />
+            <FaChevronLeft className="cta-button__chevron-icon size-2" />
           </span>
         )}
         <span className="cta-button__text">{children}</span>
         {withChevron && (
           <span className="cta-button__chevron ml-3">
-            <img
-              src={variant === 'primary' ? '/icons/chevron_white.svg' : '/icons/chevron_blue.svg'}
-              alt="→"
-              className="cta-button__chevron-icon size-2"
-            />
+            <FaChevronRight className="cta-button__chevron-icon size-2" />
           </span>
         )}
       </a>

--- a/libraries/ui/src/CTALinkOrButton.tsx
+++ b/libraries/ui/src/CTALinkOrButton.tsx
@@ -66,15 +66,16 @@ export const CTALinkOrButton: React.FC<CTALinkOrButtonProps> = ({
       className={commonClassNames}
       {...rest}
     >
+      {withBackChevron && (
+      <span className="cta-button__chevron mr-3">
+        <FaChevronLeft className="cta-button__chevron-icon size-2" />
+      </span>
+      )}
       <span className="cta-button__text">{children}</span>
       {withChevron && (
-        <span className="cta-button__chevron ml-3">
-          <img
-            src={variant === 'primary' ? '/icons/chevron_white.svg' : '/icons/chevron_blue.svg'}
-            alt="→"
-            className="cta-button__chevron-icon size-2"
-          />
-        </span>
+      <span className="cta-button__chevron ml-3">
+        <FaChevronRight className="cta-button__chevron-icon size-2" />
+      </span>
       )}
     </button>
   );

--- a/libraries/ui/src/__snapshots__/CTALinkOrButton.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CTALinkOrButton.test.tsx.snap
@@ -1,16 +1,44 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CTALinkOrButton > renders back chevron when withBackChevron is true 1`] = `null`;
+exports[`CTALinkOrButton > renders back chevron when withBackChevron is true 1`] = `
+<span
+  class="cta-button__chevron mr-3"
+>
+  <svg
+    class="cta-button__chevron-icon size-2"
+    fill="currentColor"
+    height="1em"
+    stroke="currentColor"
+    stroke-width="0"
+    viewBox="0 0 320 512"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 246.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z"
+    />
+  </svg>
+</span>
+`;
 
 exports[`CTALinkOrButton > renders chevron when withChevron is true 1`] = `
 <span
   class="cta-button__chevron ml-3"
 >
-  <img
-    alt="→"
+  <svg
     class="cta-button__chevron-icon size-2"
-    src="/icons/chevron_white.svg"
-  />
+    fill="currentColor"
+    height="1em"
+    stroke="currentColor"
+    stroke-width="0"
+    viewBox="0 0 320 512"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+    />
+  </svg>
 </span>
 `;
 


### PR DESCRIPTION
Previously this assumed all the apps had the icons installed, which is not the case - meaning it couldn't be used across apps easily.

The font awesome icon looks near-identical to the previous icon.

Also withBackChevron was broken on buttons, so I've fixed that.

Part of #749

## Screenshots

Before:

<img width="126" alt="image" src="https://github.com/user-attachments/assets/258722cd-83e5-4ec5-a496-f2f9a0038ad9" />

After:

<img width="126" alt="image" src="https://github.com/user-attachments/assets/737056e8-a51d-4964-8d96-fd8e81efa606" />
