### PR TITLE
infra: Increase memory available to Keycloak

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -220,7 +220,7 @@ export const services: ServiceDefinition[] = [
         },
         resources: {
           limits: {
-            memory: '500Mi',
+            memory: '1000Mi',
           },
         },
       }],


### PR DESCRIPTION
Keycloak occasionally OOMs during periods of high load. We have plenty of memory headroom after #692, so we should give Keycloak more memory.