### PR TITLE
website: Enable SSR

### DIFF
--- a/apps/website/src/components/Nav.tsx
+++ b/apps/website/src/components/Nav.tsx
@@ -141,13 +141,20 @@ const CTAButtons: React.FC<{
   primaryCtaUrl = 'https://donate.stripe.com/5kA3fpgjpdJv6o89AA',
   isLoggedIn,
 }) => {
+  const [loginUrl, setLoginUrl] = useState(ROUTES.login.url);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setLoginUrl(addQueryParam(ROUTES.login.url, 'redirect_to', window.location.pathname));
+    }
+  }, []);
+
   return (
     <div className={clsx('nav__cta-container', className)}>
       {!isLoggedIn && (
         <CTALinkOrButton
           className="nav__secondary-cta"
           variant="secondary"
-          url={typeof window === 'undefined' ? ROUTES.login.url : addQueryParam(ROUTES.login.url, 'redirect_to', window.location.pathname)}
+          url={loginUrl}
         >
           Login
         </CTALinkOrButton>

--- a/apps/website/src/components/lander/getCtaUrl.ts
+++ b/apps/website/src/components/lander/getCtaUrl.ts
@@ -1,5 +1,5 @@
 export const getCtaUrl = (variant: string) => {
-  const thisPageQueryParams = new URLSearchParams(window.location.search);
+  const thisPageQueryParams = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : undefined);
   const miniextensionsQueryParams = new URLSearchParams();
   thisPageQueryParams.forEach((value, key) => {
     miniextensionsQueryParams.append(`prefill_${key}`, value);

--- a/apps/website/src/pages/404.tsx
+++ b/apps/website/src/pages/404.tsx
@@ -20,7 +20,7 @@ const Error404Page = () => {
   return (
     <div>
       <Head>
-        <title>{currentRoute.title} | BlueDot Impact</title>
+        <title>{`${currentRoute.title} | BlueDot Impact`}</title>
       </Head>
       <HeroSection className="404-hero overflow-hidden">
         {/* The background on the Rive animation slightly mismatches the HeroSection

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import '../globals.css';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
-import dynamic from 'next/dynamic';
 import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
 import {
@@ -87,9 +86,4 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
   );
 };
 
-const AppWithNoSsr = dynamic(
-  () => Promise.resolve(App),
-  { ssr: false },
-);
-
-export default AppWithNoSsr;
+export default App;

--- a/apps/website/src/pages/about.tsx
+++ b/apps/website/src/pages/about.tsx
@@ -22,7 +22,7 @@ const AboutPage = () => {
   return (
     <div>
       <Head>
-        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
         <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
       </Head>
       <HeroSection>

--- a/apps/website/src/pages/certification.tsx
+++ b/apps/website/src/pages/certification.tsx
@@ -73,7 +73,7 @@ const CertificatePage = () => {
   return (
     <main className="bluedot-base flex flex-col">
       <Head>
-        <title>{certificate.recipientName}'s Certificate | BlueDot Impact</title>
+        <title>{`${certificate.recipientName}'s Certificate | BlueDot Impact`}</title>
         <meta name="description" content={`Certificate of completion for ${certificate.courseName}`} />
       </Head>
 

--- a/apps/website/src/pages/contact.tsx
+++ b/apps/website/src/pages/contact.tsx
@@ -14,7 +14,7 @@ const ContactPage = () => {
   return (
     <div>
       <Head>
-        <title>Contact us | BlueDot Impact</title>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
         <meta name="description" content="Contact BlueDot Impact, the team behind AI Safety Fundamentals." />
       </Head>
       <HeroSection>

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -70,7 +70,7 @@ const StandardCoursePage = ({ courseSlug }: { courseSlug: string }) => {
       {data?.course && (
         <>
           <Head>
-            <title>{data?.course.title} | BlueDot Impact</title>
+            <title>{`${data?.course.title} | BlueDot Impact`}</title>
             <meta name="description" content={data?.course.description} />
           </Head>
           <HeroSection>

--- a/apps/website/src/pages/join-us.tsx
+++ b/apps/website/src/pages/join-us.tsx
@@ -18,7 +18,7 @@ const JoinUsPage = () => {
   return (
     <div>
       <Head>
-        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
         <meta name="description" content="Join us in our mission to ensure humanity safely navigates the transition to transformative AI." />
       </Head>
       <HeroSection>

--- a/apps/website/src/pages/join-us/ai-safety-teaching-fellow.tsx
+++ b/apps/website/src/pages/join-us/ai-safety-teaching-fellow.tsx
@@ -21,7 +21,7 @@ const JobPostingPage = () => {
   return (
     <div>
       <Head>
-        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
       </Head>
       <HeroSection>
         <HeroH1>{CURRENT_ROUTE.title}</HeroH1>

--- a/apps/website/src/pages/join-us/swe-contractor.tsx
+++ b/apps/website/src/pages/join-us/swe-contractor.tsx
@@ -21,7 +21,7 @@ const JobPostingPage = () => {
   return (
     <div>
       <Head>
-        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
       </Head>
       <HeroSection>
         <HeroH1>{CURRENT_ROUTE.title}</HeroH1>

--- a/apps/website/src/pages/privacy-policy.tsx
+++ b/apps/website/src/pages/privacy-policy.tsx
@@ -15,7 +15,7 @@ const PrivacyPolicyPage = () => {
   return (
     <div>
       <Head>
-        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
       </Head>
       <HeroSection>
         <HeroH1>Privacy Policy</HeroH1>

--- a/apps/website/src/pages/profile.tsx
+++ b/apps/website/src/pages/profile.tsx
@@ -70,7 +70,7 @@ const ProfilePage = withAuth(({ auth }) => {
   return (
     <div>
       <Head>
-        <title>{CURRENT_ROUTE.title} | BlueDot Impact</title>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
       </Head>
       {loading && <ProgressDots />}
       {error && <ErrorSection error={error} />}

--- a/libraries/ui/src/Login.tsx
+++ b/libraries/ui/src/Login.tsx
@@ -144,7 +144,7 @@ export const loginPresets = {
 }>;
 
 export const LoginRedirectPage: React.FC<LoginPageProps> = ({ oidcSettings }) => {
-  const redirectTo = getQueryParam(window.location.href, 'redirect_to') || '/';
+  const redirectTo = (typeof window !== 'undefined' && getQueryParam(window.location.href, 'redirect_to')) || '/';
   const auth = useAuthStore((s) => s.auth);
 
   useEffect(() => {


### PR DESCRIPTION
# Summary

Enables SSR on the website

Almost everything seemed to work out of the box, except for:
- Dynamic page titles. This is because some of the page titles had nested components, which not actually allowed in Next.js, but we just didn't catch it because we had disabled SSR: https://github.com/vercel/next.js/discussions/38256. I've fixed this by ensuring any dynamic titles are just single strings.
- Getting and setting the query params from the URL in the login flow. This is because `window` is not defined on the server, so it throws an error when rendering. I've now gated the calls in a check for window or in a useEffect hook (which only runs client-side).

## Issue

Fixes #747

## Testing

- Checked the static pages (e.g. home, about us, join us)
- Checked the course listing, unit listing, FOAI lander, FOAI unit content (logged out + logged in)
- Checked login flow (including redirect_to)