### PR TITLE
auth: Temporary fix for refresh tokens missing audience claim

### DIFF
--- a/libraries/ui/src/Login.tsx
+++ b/libraries/ui/src/Login.tsx
@@ -97,7 +97,8 @@ export const loginPresets = {
       authority: 'https://login.bluedot.org/realms/customers/',
       client_id: 'bluedot-web-apps',
       redirect_uri: `${typeof window === 'undefined' ? '' : window.location.origin}/login/oauth-callback`,
-      scope: 'openid email offline_access',
+      // 2025-04-27: offline_access temporarily disabled - see https://github.com/bluedotimpact/bluedot/issues/761
+      // scope: 'openid email offline_access',
     },
     verifyAndDecodeToken: async (token: string) => {
       return verifyJwt(token, {

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -99,7 +99,7 @@ export const useAuthStore = create<{
   internal_refreshTimer: null,
 }), {
   name: 'bluedot_auth',
-  version: 20250423,
+  version: 20250427,
 
   // On rehydration, set the state again
   // This starts the refresh and expiry logic


### PR DESCRIPTION
Temporary fix for #761

Trade-off: This will cause users to be logged out more frequently than we intend. This is because without the offline_access scope, if the user is away from the page when the access token expires they are logged out.

Related:
- https://github.com/keycloak/keycloak/issues/20517