### PR TITLE
website: Fix exercise API returning invalid response rather than error when exercise does not exist

### DIFF
--- a/apps/website/src/pages/api/courses/exercises/[exerciseId]/index.ts
+++ b/apps/website/src/pages/api/courses/exercises/[exerciseId]/index.ts
@@ -16,7 +16,7 @@ export default makeApiRoute({
   requireAuth: false,
   responseBody: z.object({
     type: z.literal('success'),
-    exercise: z.any().optional(),
+    exercise: z.any(),
   }),
 }, async (body, { raw }) => {
   const { exerciseId } = raw.req.query;
@@ -26,6 +26,10 @@ export default makeApiRoute({
       const exercise = (await db.scan(exerciseTable, {
         filterByFormula: `{[*] Record ID} = "${exerciseId}"`,
       }))[0];
+
+      if (!exercise) {
+        throw new createHttpError.NotFound('Exercise not found');
+      }
 
       return {
         type: 'success' as const,

--- a/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
+++ b/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
@@ -9,7 +9,7 @@ import {
 
 export type GetExerciseResponseResponse = {
   type: 'success',
-  exerciseResponse: ExerciseResponse,
+  exerciseResponse?: ExerciseResponse,
 };
 
 export type PutExerciseResponseRequest = {

--- a/libraries/ui/src/ErrorView.tsx
+++ b/libraries/ui/src/ErrorView.tsx
@@ -16,7 +16,7 @@ export const ErrorView: React.FC<ErrorViewProps> = ({ error: input }) => {
   const primaryErrorText = isRichAxiosError ? error.response!.data.error : truncate(error.message, 200);
 
   return (
-    <div className="border-l-4 border-red-500 bg-red-100 text-black p-8 flex flex-col gap-4">
+    <div className="border-l-4 border-red-500 bg-red-100 text-black p-8 flex flex-col gap-4 not-prose">
       <h3 className="bluedot-h3 whitespace-pre-line">Error: {primaryErrorText}
       </h3>
       <p>If the above message doesn't help, try again later or <A href={contactUsUrl}>contact us</A> for support.</p>


### PR DESCRIPTION
Either, the exercise should be:
- marked as optional everywhere, including in the `GetExercise` type; or
- marked as mandatory everywhere, including in the Zod types (which then requires fixing the API function)

Here it makes more sense to do the latter, and throw a 404 if someone tries to request an exercise that doesn't exist.

This was breaking unit 3 from rendering at all, because someone added an Exercise that didn't exist. With this change, just the exercise shows an error message.
 
## Issue

Fixes #791