### PR TITLE
website: Make ClickTarget compatible with withClickTracking

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/404.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/404.test.tsx.snap
@@ -43,7 +43,6 @@ exports[`Error404Page > should render correctly 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/"
               tabindex="0"
             >
@@ -60,7 +59,6 @@ exports[`Error404Page > should render correctly 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/an-invalid-path"
               tabindex="0"
             >

--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`AboutPage > should render correctly 1`] = `
         >
           <a
             class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark"
-            data-rac=""
             href="/join-us"
             tabindex="0"
           >
@@ -70,7 +69,6 @@ exports[`AboutPage > should render correctly 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/"
               tabindex="0"
             >
@@ -87,7 +85,6 @@ exports[`AboutPage > should render correctly 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/about"
               tabindex="0"
             >
@@ -659,7 +656,6 @@ exports[`AboutPage > should render correctly 1`] = `
                     >
                       <a
                         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                        data-rac=""
                         href="https://www.linkedin.com/in/dewierwan/"
                         tabindex="0"
                       >
@@ -712,7 +708,6 @@ exports[`AboutPage > should render correctly 1`] = `
                     >
                       <a
                         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                        data-rac=""
                         href="https://linkedin.com/in/will-saunter"
                         tabindex="0"
                       >
@@ -765,7 +760,6 @@ exports[`AboutPage > should render correctly 1`] = `
                     >
                       <a
                         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                        data-rac=""
                         href="https://linkedin.com/in/anglilian"
                         tabindex="0"
                       >
@@ -818,7 +812,6 @@ exports[`AboutPage > should render correctly 1`] = `
                     >
                       <a
                         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                        data-rac=""
                         href="https://www.linkedin.com/in/domdomegg/"
                         tabindex="0"
                       >
@@ -871,7 +864,6 @@ exports[`AboutPage > should render correctly 1`] = `
                     >
                       <a
                         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                        data-rac=""
                         href="https://linkedin.com/in/josh-landes12"
                         tabindex="0"
                       >
@@ -924,7 +916,6 @@ exports[`AboutPage > should render correctly 1`] = `
                     >
                       <a
                         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                        data-rac=""
                         href="https://linkedin.com/in/tarinrickett/"
                         tabindex="0"
                       >
@@ -1010,7 +1001,6 @@ exports[`AboutPage > should render correctly 1`] = `
         </h3>
         <a
           class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
-          data-rac=""
           href="/careers"
           tabindex="0"
         >
@@ -1066,7 +1056,6 @@ exports[`AboutPage > should render correctly 1`] = `
         </p>
         <a
           class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter mt-5"
-          data-rac=""
           href="/contact"
           tabindex="0"
         >

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`JoinUsPage > should render correctly 1`] = `
         >
           <a
             class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark"
-            data-rac=""
             href="#open-roles-anchor"
             tabindex="0"
           >
@@ -70,7 +69,6 @@ exports[`JoinUsPage > should render correctly 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/"
               tabindex="0"
             >
@@ -87,7 +85,6 @@ exports[`JoinUsPage > should render correctly 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/join-us"
               tabindex="0"
             >
@@ -430,7 +427,6 @@ exports[`JoinUsPage > should render correctly 1`] = `
               </p>
               <a
                 class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-                data-rac=""
                 href="/join-us/swe-contractor"
                 tabindex="0"
               >
@@ -483,7 +479,6 @@ exports[`JoinUsPage > should render correctly 1`] = `
               </p>
               <a
                 class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-                data-rac=""
                 href="/join-us/ai-safety-teaching-fellow"
                 tabindex="0"
               >

--- a/apps/website/src/components/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/__snapshots__/Nav.test.tsx.snap
@@ -47,7 +47,6 @@ exports[`Nav > renders with courses 1`] = `
           </button>
           <a
             class="bluedot-a nav__logo-link shrink-0 w-[200px] no-underline"
-            data-rac=""
             href="/"
             tabindex="0"
           >
@@ -84,7 +83,6 @@ exports[`Nav > renders with courses 1`] = `
           </div>
           <a
             class="bluedot-a nav-links__link nav-link-animation no-underline"
-            data-rac=""
             href="/about"
             tabindex="0"
           >
@@ -92,7 +90,6 @@ exports[`Nav > renders with courses 1`] = `
           </a>
           <a
             class="bluedot-a nav-links__link nav-link-animation no-underline"
-            data-rac=""
             href="/join-us"
             tabindex="0"
           >
@@ -100,7 +97,6 @@ exports[`Nav > renders with courses 1`] = `
           </a>
           <a
             class="bluedot-a nav-links__link nav-link-animation no-underline"
-            data-rac=""
             href="https://bluedot.org/blog/"
             tabindex="0"
           >
@@ -108,7 +104,6 @@ exports[`Nav > renders with courses 1`] = `
           </a>
           <a
             class="bluedot-a nav-links__link nav-link-animation no-underline"
-            data-rac=""
             href="https://lu.ma/aisafetycommunityevents?utm_source=website&utm_campaign=nav"
             tabindex="0"
           >
@@ -123,7 +118,6 @@ exports[`Nav > renders with courses 1`] = `
           >
             <a
               class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter nav__secondary-cta"
-              data-rac=""
               href="http://localhost:3000/login?redirect_to=%2F"
               tabindex="0"
             >
@@ -135,7 +129,6 @@ exports[`Nav > renders with courses 1`] = `
             </a>
             <a
               class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark nav__primary-cta"
-              data-rac=""
               href="https://donate.stripe.com/5kA3fpgjpdJv6o89AA"
               tabindex="0"
             >
@@ -161,7 +154,6 @@ exports[`Nav > renders with courses 1`] = `
           </h3>
           <a
             class="bluedot-a nav-explore-section__dropdown-link no-underline"
-            data-rac=""
             href="/course1"
             tabindex="0"
           >
@@ -169,7 +161,6 @@ exports[`Nav > renders with courses 1`] = `
           </a>
           <a
             class="bluedot-a nav-explore-section__dropdown-link no-underline"
-            data-rac=""
             href="/course2"
             tabindex="0"
           >
@@ -224,7 +215,6 @@ exports[`Nav > renders with courses 1`] = `
                   </h3>
                   <a
                     class="bluedot-a nav-explore-section__dropdown-link no-underline"
-                    data-rac=""
                     href="/course1"
                     tabindex="0"
                   >
@@ -232,7 +222,6 @@ exports[`Nav > renders with courses 1`] = `
                   </a>
                   <a
                     class="bluedot-a nav-explore-section__dropdown-link no-underline"
-                    data-rac=""
                     href="/course2"
                     tabindex="0"
                   >
@@ -248,7 +237,6 @@ exports[`Nav > renders with courses 1`] = `
             </div>
             <a
               class="bluedot-a nav-links__link nav-link-animation no-underline"
-              data-rac=""
               href="/about"
               tabindex="0"
             >
@@ -256,7 +244,6 @@ exports[`Nav > renders with courses 1`] = `
             </a>
             <a
               class="bluedot-a nav-links__link nav-link-animation no-underline"
-              data-rac=""
               href="/join-us"
               tabindex="0"
             >
@@ -264,7 +251,6 @@ exports[`Nav > renders with courses 1`] = `
             </a>
             <a
               class="bluedot-a nav-links__link nav-link-animation no-underline"
-              data-rac=""
               href="https://bluedot.org/blog/"
               tabindex="0"
             >
@@ -272,7 +258,6 @@ exports[`Nav > renders with courses 1`] = `
             </a>
             <a
               class="bluedot-a nav-links__link nav-link-animation no-underline"
-              data-rac=""
               href="https://lu.ma/aisafetycommunityevents?utm_source=website&utm_campaign=nav"
               tabindex="0"
             >
@@ -284,7 +269,6 @@ exports[`Nav > renders with courses 1`] = `
           >
             <a
               class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter nav__secondary-cta"
-              data-rac=""
               href="http://localhost:3000/login?redirect_to=%2F"
               tabindex="0"
             >
@@ -296,7 +280,6 @@ exports[`Nav > renders with courses 1`] = `
             </a>
             <a
               class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark nav__primary-cta"
-              data-rac=""
               href="https://donate.stripe.com/5kA3fpgjpdJv6o89AA"
               tabindex="0"
             >
@@ -317,7 +300,6 @@ exports[`Nav > renders with courses 1`] = `
         >
           <a
             class="bluedot-a nav__profile-link nav-link-animation w-fit no-underline"
-            data-rac=""
             href="/profile"
             tabindex="0"
           >
@@ -325,7 +307,6 @@ exports[`Nav > renders with courses 1`] = `
           </a>
           <a
             class="bluedot-a nav__profile-link nav-link-animation w-fit no-underline"
-            data-rac=""
             href="/contact"
             tabindex="0"
           >
@@ -333,7 +314,6 @@ exports[`Nav > renders with courses 1`] = `
           </a>
           <a
             class="bluedot-a nav__profile-link nav-link-animation w-fit no-underline"
-            data-rac=""
             href="/login/clear"
             tabindex="0"
           >

--- a/apps/website/src/components/about/__snapshots__/JoinUsCta.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/JoinUsCta.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`JoinUsCta > renders default as expected 1`] = `
       </h3>
       <a
         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
-        data-rac=""
         href="/careers"
         tabindex="0"
       >

--- a/apps/website/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -77,7 +77,6 @@ exports[`TeamSection > renders as expected 1`] = `
                   >
                     <a
                       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                      data-rac=""
                       href="https://www.linkedin.com/in/dewierwan/"
                       tabindex="0"
                     >
@@ -130,7 +129,6 @@ exports[`TeamSection > renders as expected 1`] = `
                   >
                     <a
                       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                      data-rac=""
                       href="https://linkedin.com/in/will-saunter"
                       tabindex="0"
                     >
@@ -183,7 +181,6 @@ exports[`TeamSection > renders as expected 1`] = `
                   >
                     <a
                       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                      data-rac=""
                       href="https://linkedin.com/in/anglilian"
                       tabindex="0"
                     >
@@ -236,7 +233,6 @@ exports[`TeamSection > renders as expected 1`] = `
                   >
                     <a
                       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                      data-rac=""
                       href="https://www.linkedin.com/in/domdomegg/"
                       tabindex="0"
                     >
@@ -289,7 +285,6 @@ exports[`TeamSection > renders as expected 1`] = `
                   >
                     <a
                       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                      data-rac=""
                       href="https://linkedin.com/in/josh-landes12"
                       tabindex="0"
                     >
@@ -342,7 +337,6 @@ exports[`TeamSection > renders as expected 1`] = `
                   >
                     <a
                       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                      data-rac=""
                       href="https://linkedin.com/in/tarinrickett/"
                       tabindex="0"
                     >

--- a/apps/website/src/components/courses/SocialShare.tsx
+++ b/apps/website/src/components/courses/SocialShare.tsx
@@ -1,3 +1,4 @@
+import { ClickTarget } from '@bluedot/ui';
 import React from 'react';
 import { FaFacebook, FaLinkedin, FaTwitter } from 'react-icons/fa6';
 
@@ -16,30 +17,27 @@ const SocialShare: React.FC<SocialShareProps> = ({ coursePath, referralCode, tex
 
   return (
     <div className="social-share flex flex-row gap-4">
-      <a
+      <ClickTarget
         className="social-share__link size-6"
-        href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(constructFullCourseUrl('linkedin'))}${text ? `&text=${text}` : ''}`}
+        url={`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(constructFullCourseUrl('linkedin'))}${text ? `&text=${text}` : ''}`}
         target="_blank"
-        rel="noopener noreferrer"
       >
         <FaLinkedin className="social-share__link-icon size-6" />
-      </a>
-      <a
+      </ClickTarget>
+      <ClickTarget
         className="social-share__link size-6"
-        href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(constructFullCourseUrl('twitter'))}${text ? `&text=${text}` : ''}`}
+        url={`https://twitter.com/intent/tweet?url=${encodeURIComponent(constructFullCourseUrl('twitter'))}${text ? `&text=${text}` : ''}`}
         target="_blank"
-        rel="noopener noreferrer"
       >
         <FaTwitter className="social-share__link-icon size-6" />
-      </a>
-      <a
+      </ClickTarget>
+      <ClickTarget
         className="social-share__link size-6"
-        href="https://www.facebook.com/sharer/sharer.php"
+        url="https://www.facebook.com/sharer/sharer.php"
         target="_blank"
-        rel="noopener noreferrer"
       >
         <FaFacebook className="social-share__link-icon size-6" />
-      </a>
+      </ClickTarget>
     </div>
   );
 };

--- a/apps/website/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Congratulations > renders default as expected 1`] = `
       <a
         class="social-share__link size-6"
         href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dlinkedin&text=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
-        rel="noopener noreferrer"
+        tabindex="0"
         target="_blank"
       >
         <svg
@@ -44,7 +44,7 @@ exports[`Congratulations > renders default as expected 1`] = `
       <a
         class="social-share__link size-6"
         href="https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dtwitter&text=🎉 I just completed the Future of AI course from BlueDot Impact! It’s free, self-paced, and packed with insights. Check it out and sign up with my referral link below:"
-        rel="noopener noreferrer"
+        tabindex="0"
         target="_blank"
       >
         <svg
@@ -65,7 +65,7 @@ exports[`Congratulations > renders default as expected 1`] = `
       <a
         class="social-share__link size-6"
         href="https://www.facebook.com/sharer/sharer.php"
-        rel="noopener noreferrer"
+        tabindex="0"
         target="_blank"
       >
         <svg
@@ -111,7 +111,7 @@ exports[`Congratulations > renders with custom args 1`] = `
       <a
         class="social-share__link size-6"
         href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dlinkedin%26r%3DABCDEF&text=This is a custom text I've written for this course!"
-        rel="noopener noreferrer"
+        tabindex="0"
         target="_blank"
       >
         <svg
@@ -132,7 +132,7 @@ exports[`Congratulations > renders with custom args 1`] = `
       <a
         class="social-share__link size-6"
         href="https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dtwitter%26r%3DABCDEF&text=This is a custom text I've written for this course!"
-        rel="noopener noreferrer"
+        tabindex="0"
         target="_blank"
       >
         <svg
@@ -153,7 +153,7 @@ exports[`Congratulations > renders with custom args 1`] = `
       <a
         class="social-share__link size-6"
         href="https://www.facebook.com/sharer/sharer.php"
-        rel="noopener noreferrer"
+        tabindex="0"
         target="_blank"
       >
         <svg

--- a/apps/website/src/components/courses/__snapshots__/CourseSearchCard.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/CourseSearchCard.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`CourseSearchCard > renders default as expected 1`] = `
 <div>
   <a
     class="course-search-card flex sm:flex-row flex-col gap-6 container-lined p-6 max-w-[828px] size-full transition-transform duration-200 hover:scale-[1.01] hover:container-elevated"
-    data-rac=""
     href="https://bluedot.org/courses/what-the-fish"
     tabindex="0"
   >
@@ -45,7 +44,6 @@ exports[`CourseSearchCard > renders with optional args 1`] = `
 <div>
   <a
     class="course-search-card flex sm:flex-row flex-col gap-6 container-lined p-6 max-w-[828px] size-full transition-transform duration-200 hover:scale-[1.01] hover:container-elevated"
-    data-rac=""
     href="https://bluedot.org/courses/what-the-fish"
     tabindex="0"
   >

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`SideBar > renders default as expected 1`] = `
     >
       <a
         class="unit-card p-4 flex flex-col gap-2 justify-between unit-card--active border-color-primary border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-        data-rac=""
         href="/courses/test-course/1"
         tabindex="0"
       >
@@ -37,7 +36,6 @@ exports[`SideBar > renders default as expected 1`] = `
       </a>
       <a
         class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-        data-rac=""
         href="/courses/test-course/2"
         tabindex="0"
       >
@@ -64,7 +62,6 @@ exports[`SideBar > renders default as expected 1`] = `
       </a>
       <a
         class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-        data-rac=""
         href="/courses/test-course/3"
         tabindex="0"
       >
@@ -91,7 +88,6 @@ exports[`SideBar > renders default as expected 1`] = `
       </a>
       <a
         class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-        data-rac=""
         href="/courses/test-course/4"
         tabindex="0"
       >
@@ -118,7 +114,6 @@ exports[`SideBar > renders default as expected 1`] = `
       </a>
       <a
         class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-        data-rac=""
         href="/courses/test-course/5"
         tabindex="0"
       >

--- a/apps/website/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SocialShare.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`SocialShare > renders default as expected 1`] = `
     <a
       class="social-share__link size-6"
       href="https://www.linkedin.com/shareArticle?mini=true&url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dlinkedin%26r%3D5SR7C4&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
-      rel="noopener noreferrer"
+      tabindex="0"
       target="_blank"
     >
       <svg
@@ -29,7 +29,7 @@ exports[`SocialShare > renders default as expected 1`] = `
     <a
       class="social-share__link size-6"
       href="https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost%3A3000%2Fcourses%2Ffuture-of-ai%3Futm_source%3Dreferral%26utm_campaign%3Dtwitter%26r%3D5SR7C4&text=I've just completed a free, 2-hour course on the future of AI and its impacts on society. Here are my takeaways:"
-      rel="noopener noreferrer"
+      tabindex="0"
       target="_blank"
     >
       <svg
@@ -50,7 +50,7 @@ exports[`SocialShare > renders default as expected 1`] = `
     <a
       class="social-share__link size-6"
       href="https://www.facebook.com/sharer/sharer.php"
-      rel="noopener noreferrer"
+      tabindex="0"
       target="_blank"
     >
       <svg

--- a/apps/website/src/components/courses/__snapshots__/UnitFeedback.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitFeedback.test.tsx.snap
@@ -161,9 +161,6 @@ exports[`UnitFeedback > should render correctly 1`] = `
     </div>
     <button
       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark unit-feedback__submit self-start"
-      data-rac=""
-      id="react-aria-:r0:"
-      tabindex="0"
       type="button"
     >
       <span

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -36,7 +36,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/"
               tabindex="0"
             >
@@ -53,7 +52,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/courses"
               tabindex="0"
             >
@@ -70,7 +68,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           >
             <a
               class="bluedot-a breadcrumbs__link no-underline"
-              data-rac=""
               href="/courses/test-course"
               tabindex="0"
             >
@@ -97,7 +94,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             >
               <a
                 class="unit-card p-4 flex flex-col gap-2 justify-between unit-card--active border-color-primary border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-                data-rac=""
                 href="/courses/test-course/1"
                 tabindex="0"
               >
@@ -124,7 +120,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               </a>
               <a
                 class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-                data-rac=""
                 href="/courses/test-course/2"
                 tabindex="0"
               >
@@ -151,7 +146,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               </a>
               <a
                 class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-                data-rac=""
                 href="/courses/test-course/3"
                 tabindex="0"
               >
@@ -178,7 +172,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               </a>
               <a
                 class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-                data-rac=""
                 href="/courses/test-course/4"
                 tabindex="0"
               >
@@ -205,7 +198,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               </a>
               <a
                 class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-                data-rac=""
                 href="/courses/test-course/5"
                 tabindex="0"
               >
@@ -243,7 +235,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             >
               <a
                 class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
-                data-rac=""
                 href="/courses/test-course/2"
                 tabindex="0"
               >
@@ -283,7 +274,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
 exports[`UnitLayout > renders previous and next unit buttons for middle unit 1`] = `
 <a
   class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter unit__cta-link mr-auto"
-  data-rac=""
   href="/courses/test-course/1"
   tabindex="0"
 >

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
     </div>
     <a
       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark free-text-response__login-cta"
-      data-rac=""
       href="http://localhost:3000/login?redirect_to=http%3A%2F%2Flocalhost%3A3000%2F"
       tabindex="0"
     >
@@ -115,9 +114,6 @@ exports[`FreeTextResponse > renders logged in as expected 1`] = `
     </div>
     <button
       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark free-text-response__submit"
-      data-rac=""
-      id="react-aria-:r0:"
-      tabindex="0"
       type="button"
     >
       <span
@@ -171,9 +167,6 @@ exports[`FreeTextResponse > renders with saved exercise response 1`] = `
     </div>
     <button
       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark free-text-response__submit"
-      data-rac=""
-      id="react-aria-:r2:"
-      tabindex="0"
       type="button"
     >
       <span

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -110,7 +110,6 @@ exports[`MultipleChoice > renders default as expected 1`] = `
     </div>
     <a
       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark multiple-choice__login-cta"
-      data-rac=""
       href="http://localhost:3000/login?redirect_to=http%3A%2F%2Flocalhost%3A3000%2F"
       tabindex="0"
     >
@@ -248,9 +247,6 @@ exports[`MultipleChoice > renders logged in as expected 1`] = `
     </div>
     <button
       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark multiple-choice__submit"
-      data-rac=""
-      id="react-aria-:r0:"
-      tabindex="0"
       type="button"
     >
       <span

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
@@ -254,7 +254,6 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
       </div>
       <a
         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter projects__link h-fit py-3"
-        data-rac=""
         href="https://aisafetyfundamentals.com/projects/"
         tabindex="0"
       >

--- a/apps/website/src/components/homepage/__snapshots__/BlogSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/BlogSection.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`BlogSection > renders default as expected 1`] = `
       >
         <a
           class="blog-section__blog-post-container w-full flex flex-col sm:flex-row items-start align-top justify-between py-6 last:border-b-0 border-b border-color-divider sm:gap-6"
-          data-rac=""
           href="https://bluedot.org/blog/teach-swap-explain-activity/"
           tabindex="0"
         >
@@ -57,7 +56,6 @@ exports[`BlogSection > renders default as expected 1`] = `
         </a>
         <a
           class="blog-section__blog-post-container w-full flex flex-col sm:flex-row items-start align-top justify-between py-6 last:border-b-0 border-b border-color-divider sm:gap-6"
-          data-rac=""
           href="https://bluedot.org/blog/why-we-run-our-ai-safety-courses/"
           tabindex="0"
         >
@@ -88,7 +86,6 @@ exports[`BlogSection > renders default as expected 1`] = `
         </a>
         <a
           class="blog-section__blog-post-container w-full flex flex-col sm:flex-row items-start align-top justify-between py-6 last:border-b-0 border-b border-color-divider sm:gap-6"
-          data-rac=""
           href="https://bluedot.org/blog/ai-alignment-june-2024-retro/"
           tabindex="0"
         >
@@ -126,7 +123,6 @@ exports[`BlogSection > renders default as expected 1`] = `
       </div>
       <a
         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
-        data-rac=""
         href="https://bluedot.org/blog/"
         tabindex="0"
       >

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -32,7 +32,8 @@ exports[`CourseSection > renders as expected 1`] = `
         <span>
           <a
             class="course-card course-card--featured card flex flex-col items-start justify-between m-[3px] container-lined p-6 max-w-[700px] transition-transform duration-200 hover:scale-[1.01] hover:container-elevated course-section__featured"
-            href="/courses/future-of-ai/"
+            href="/courses/future-of-ai"
+            tabindex="0"
           >
             <div
               class="course-card__content block md:flex gap-space-between w-full"
@@ -52,9 +53,6 @@ exports[`CourseSection > renders as expected 1`] = `
                 </h3>
                 <button
                   class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
-                  data-rac=""
-                  id="react-aria-:r0:"
-                  tabindex="0"
                   type="button"
                 >
                   <span

--- a/apps/website/src/components/homepage/__snapshots__/FAQSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/FAQSection.test.tsx.snap
@@ -64,7 +64,6 @@ exports[`FAQSection > renders default as expected 1`] = `
             You can read more about these 
             <a
               class="bluedot-a"
-              data-rac=""
               href="https://aisafetyfundamentals.com/blog/what-is-ai-alignment/"
               tabindex="0"
             >
@@ -73,7 +72,6 @@ exports[`FAQSection > renders default as expected 1`] = `
              and the 
             <a
               class="bluedot-a"
-              data-rac=""
               href="https://aisafetyfundamentals.com/blog/ai-risks/"
               tabindex="0"
             >
@@ -121,7 +119,6 @@ exports[`FAQSection > renders default as expected 1`] = `
             Check you are the 
             <a
               class="bluedot-a"
-              data-rac=""
               href="https://bluedot.org/blog/am-i-the-right-fit-for-bluedots-courses/"
               tabindex="0"
             >
@@ -130,7 +127,6 @@ exports[`FAQSection > renders default as expected 1`] = `
              and read our tips for making a 
             <a
               class="bluedot-a"
-              data-rac=""
               href="https://aisafetyfundamentals.com/blog/avoid-governance-application-mistakes/"
               tabindex="0"
             >
@@ -177,7 +173,6 @@ exports[`FAQSection > renders default as expected 1`] = `
             We’d love for you to do this! All our reading and discussion materials are freely available online. You are welcome to run a local version of our course so long as you 
             <a
               class="bluedot-a"
-              data-rac=""
               href="https://bluedot.org/running-versions-of-our-courses/"
               tabindex="0"
             >
@@ -191,7 +186,6 @@ exports[`FAQSection > renders default as expected 1`] = `
             If you want tips for your discussion facilitation, we recommend taking a look through our 
             <a
               class="bluedot-a"
-              data-rac=""
               href="https://course.bluedot.org/home/facilitator-training"
               tabindex="0"
             >

--- a/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -49,7 +49,6 @@ exports[`StorySection > renders default as expected 1`] = `
           </p>
           <a
             class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
-            data-rac=""
             href="/about"
             tabindex="0"
           >

--- a/apps/website/src/components/join-us/__snapshots__/CareersSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/CareersSection.test.tsx.snap
@@ -51,7 +51,6 @@ exports[`CareersSection > renders default as expected 1`] = `
             </p>
             <a
               class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-              data-rac=""
               href="/join-us/swe-contractor"
               tabindex="0"
             >
@@ -104,7 +103,6 @@ exports[`CareersSection > renders default as expected 1`] = `
             </p>
             <a
               class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter careers-section__cta-button"
-              data-rac=""
               href="/join-us/ai-safety-teaching-fellow"
               tabindex="0"
             >
@@ -196,7 +194,6 @@ exports[`CareersSection > renders mobile as expected 1`] = `
               >
                 <a
                   class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                  data-rac=""
                   href="/join-us/swe-contractor"
                   tabindex="0"
                 >
@@ -238,7 +235,6 @@ exports[`CareersSection > renders mobile as expected 1`] = `
               >
                 <a
                   class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                  data-rac=""
                   href="/join-us/ai-safety-teaching-fellow"
                   tabindex="0"
                 >

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { Card } from './Card';
 import { CTALinkOrButton } from './CTALinkOrButton';
 import { Tag } from './Tag';
+import { ClickTarget } from './ClickTarget';
 
 export type CourseCardProps = React.PropsWithChildren<{
   title: string,
@@ -44,8 +45,8 @@ const FeaturedCourseCard: React.FC<CourseCardProps> = ({
   );
 
   return (
-    <a
-      href={url}
+    <ClickTarget
+      url={url}
       className={wrapperClassName}
     >
       <div className="course-card__content block md:flex gap-space-between w-full">
@@ -80,7 +81,7 @@ const FeaturedCourseCard: React.FC<CourseCardProps> = ({
         )}
       </div>
       {children}
-    </a>
+    </ClickTarget>
   );
 };
 

--- a/libraries/ui/src/__snapshots__/Banner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Banner.test.tsx.snap
@@ -38,9 +38,6 @@ exports[`Banner > renders with input and button 1`] = `
       />
       <button
         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark banner__submit-btn"
-        data-rac=""
-        id="react-aria-:r0:"
-        tabindex="0"
         type="button"
       >
         <span

--- a/libraries/ui/src/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Breadcrumbs > renders all urls and titles in the document 1`] = `
         >
           <a
             class="bluedot-a breadcrumbs__link no-underline"
-            data-rac=""
             href="/"
             tabindex="0"
           >
@@ -34,7 +33,6 @@ exports[`Breadcrumbs > renders all urls and titles in the document 1`] = `
         >
           <a
             class="bluedot-a breadcrumbs__link no-underline"
-            data-rac=""
             href="/about"
             tabindex="0"
           >

--- a/libraries/ui/src/__snapshots__/CTALinkOrButton.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CTALinkOrButton.test.tsx.snap
@@ -45,9 +45,6 @@ exports[`CTALinkOrButton > renders chevron when withChevron is true 1`] = `
 exports[`CTALinkOrButton > renders with primary variant by default as a button 1`] = `
 <button
   class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark"
-  data-rac=""
-  id="react-aria-:r0:"
-  tabindex="0"
   type="button"
 >
   <span

--- a/libraries/ui/src/__snapshots__/Card.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Card.test.tsx.snap
@@ -36,7 +36,6 @@ exports[`Card > renders default as expected 1`] = `
       >
         <a
           class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-          data-rac=""
           href="https://linkedin.com/in/johndoe"
           tabindex="0"
         >

--- a/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CookieBanner.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`CookieBanner > renders as expected 1`] = `
        
       <a
         class="bluedot-a"
-        data-rac=""
         href="https://bluedot.org/privacy-policy"
         tabindex="0"
       >
@@ -25,9 +24,6 @@ exports[`CookieBanner > renders as expected 1`] = `
     >
       <button
         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--reject"
-        data-rac=""
-        id="react-aria-:r0:"
-        tabindex="0"
         type="button"
       >
         <span
@@ -38,9 +34,6 @@ exports[`CookieBanner > renders as expected 1`] = `
       </button>
       <button
         class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--accept"
-        data-rac=""
-        id="react-aria-:r2:"
-        tabindex="0"
         type="button"
       >
         <span

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`CourseCard > renders Featured as expected 1`] = `
   <a
     class="course-card course-card--featured card flex flex-col items-start justify-between m-[3px] container-lined p-6 max-w-[700px] transition-transform duration-200 hover:scale-[1.01] hover:container-elevated"
     href="https://bluedot.org/courses/what-the-fish"
+    tabindex="0"
   >
     <div
       class="course-card__content block md:flex gap-space-between w-full"
@@ -24,9 +25,6 @@ exports[`CourseCard > renders Featured as expected 1`] = `
         </h3>
         <button
           class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
-          data-rac=""
-          id="react-aria-:r0:"
-          tabindex="0"
           type="button"
         >
           <span

--- a/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`Footer > renders default as expected 1`] = `
         >
           <a
             class="footer__logo"
-            data-rac=""
             href="/"
             tabindex="0"
           >
@@ -32,7 +31,6 @@ exports[`Footer > renders default as expected 1`] = `
             <a
               aria-label="Twitter"
               class="bluedot-a footer__social-link link-on-dark"
-              data-rac=""
               href="https://twitter.com/BlueDotImpact"
               tabindex="0"
             >
@@ -54,7 +52,6 @@ exports[`Footer > renders default as expected 1`] = `
             <a
               aria-label="YouTube"
               class="bluedot-a footer__social-link link-on-dark"
-              data-rac=""
               href="https://youtube.com/@bluedotimpact"
               tabindex="0"
             >
@@ -76,7 +73,6 @@ exports[`Footer > renders default as expected 1`] = `
             <a
               aria-label="LinkedIn"
               class="bluedot-a footer__social-link link-on-dark"
-              data-rac=""
               href="https://www.linkedin.com/company/bluedotimpact/"
               tabindex="0"
             >
@@ -116,7 +112,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/about"
                   tabindex="0"
                 >
@@ -128,7 +123,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="https://donate.stripe.com/5kA3fpgjpdJv6o89AA"
                   tabindex="0"
                 >
@@ -140,7 +134,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/careers"
                   tabindex="0"
                 >
@@ -152,7 +145,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/contact"
                   tabindex="0"
                 >
@@ -164,7 +156,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/privacy-policy"
                   tabindex="0"
                 >
@@ -189,7 +180,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/courses/future-of-ai"
                   tabindex="0"
                 >
@@ -201,7 +191,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="https://aisafetyfundamentals.com/economics-of-tai/"
                   tabindex="0"
                 >
@@ -213,7 +202,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="https://aisafetyfundamentals.com/alignment/"
                   tabindex="0"
                 >
@@ -225,7 +213,6 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="https://aisafetyfundamentals.com/governance/"
                   tabindex="0"
                 >
@@ -241,7 +228,6 @@ exports[`Footer > renders default as expected 1`] = `
           <a
             aria-label="Twitter"
             class="bluedot-a footer__social-link link-on-dark"
-            data-rac=""
             href="https://twitter.com/BlueDotImpact"
             tabindex="0"
           >
@@ -263,7 +249,6 @@ exports[`Footer > renders default as expected 1`] = `
           <a
             aria-label="YouTube"
             class="bluedot-a footer__social-link link-on-dark"
-            data-rac=""
             href="https://youtube.com/@bluedotimpact"
             tabindex="0"
           >
@@ -285,7 +270,6 @@ exports[`Footer > renders default as expected 1`] = `
           <a
             aria-label="LinkedIn"
             class="bluedot-a footer__social-link link-on-dark"
-            data-rac=""
             href="https://www.linkedin.com/company/bluedotimpact/"
             tabindex="0"
           >
@@ -314,7 +298,6 @@ exports[`Footer > renders default as expected 1`] = `
          
         <a
           class="bluedot-a footer__link text-bluedot-lighter hover:text-white"
-          data-rac=""
           href="https://bluedot.org/"
           tabindex="0"
         >
@@ -323,7 +306,6 @@ exports[`Footer > renders default as expected 1`] = `
          is primarily funded by 
         <a
           class="bluedot-a footer__link text-bluedot-lighter hover:text-white"
-          data-rac=""
           href="https://www.openphilanthropy.org/"
           tabindex="0"
         >
@@ -332,7 +314,6 @@ exports[`Footer > renders default as expected 1`] = `
         , and is a non-profit based in the UK (company number 
         <a
           class="bluedot-a footer__link text-bluedot-lighter hover:text-white"
-          data-rac=""
           href="https://find-and-update.company-information.service.gov.uk/company/14964572"
           tabindex="0"
         >
@@ -361,7 +342,6 @@ exports[`Footer > renders with optional args 1`] = `
         >
           <a
             class="footer__logo"
-            data-rac=""
             href="/"
             tabindex="0"
           >
@@ -377,7 +357,6 @@ exports[`Footer > renders with optional args 1`] = `
             <a
               aria-label="Twitter"
               class="bluedot-a footer__social-link link-on-dark"
-              data-rac=""
               href="https://twitter.com/BlueDotImpact"
               tabindex="0"
             >
@@ -399,7 +378,6 @@ exports[`Footer > renders with optional args 1`] = `
             <a
               aria-label="YouTube"
               class="bluedot-a footer__social-link link-on-dark"
-              data-rac=""
               href="https://youtube.com/@bluedotimpact"
               tabindex="0"
             >
@@ -421,7 +399,6 @@ exports[`Footer > renders with optional args 1`] = `
             <a
               aria-label="LinkedIn"
               class="bluedot-a footer__social-link link-on-dark"
-              data-rac=""
               href="https://www.linkedin.com/company/bluedotimpact/"
               tabindex="0"
             >
@@ -461,7 +438,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/about"
                   tabindex="0"
                 >
@@ -473,7 +449,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="https://donate.stripe.com/5kA3fpgjpdJv6o89AA"
                   tabindex="0"
                 >
@@ -485,7 +460,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/careers"
                   tabindex="0"
                 >
@@ -497,7 +471,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/contact"
                   tabindex="0"
                 >
@@ -509,7 +482,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/privacy-policy"
                   tabindex="0"
                 >
@@ -534,7 +506,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="/courses/future-of-ai"
                   tabindex="0"
                 >
@@ -546,7 +517,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="https://aisafetyfundamentals.com/economics-of-tai/"
                   tabindex="0"
                 >
@@ -558,7 +528,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="https://aisafetyfundamentals.com/alignment/"
                   tabindex="0"
                 >
@@ -570,7 +539,6 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a footer__link text-bluedot-lighter hover:text-white no-underline"
-                  data-rac=""
                   href="https://aisafetyfundamentals.com/governance/"
                   tabindex="0"
                 >
@@ -586,7 +554,6 @@ exports[`Footer > renders with optional args 1`] = `
           <a
             aria-label="Twitter"
             class="bluedot-a footer__social-link link-on-dark"
-            data-rac=""
             href="https://twitter.com/BlueDotImpact"
             tabindex="0"
           >
@@ -608,7 +575,6 @@ exports[`Footer > renders with optional args 1`] = `
           <a
             aria-label="YouTube"
             class="bluedot-a footer__social-link link-on-dark"
-            data-rac=""
             href="https://youtube.com/@bluedotimpact"
             tabindex="0"
           >
@@ -630,7 +596,6 @@ exports[`Footer > renders with optional args 1`] = `
           <a
             aria-label="LinkedIn"
             class="bluedot-a footer__social-link link-on-dark"
-            data-rac=""
             href="https://www.linkedin.com/company/bluedotimpact/"
             tabindex="0"
           >
@@ -659,7 +624,6 @@ exports[`Footer > renders with optional args 1`] = `
          
         <a
           class="bluedot-a footer__link text-bluedot-lighter hover:text-white"
-          data-rac=""
           href="https://bluedot.org/"
           tabindex="0"
         >
@@ -668,7 +632,6 @@ exports[`Footer > renders with optional args 1`] = `
          is primarily funded by 
         <a
           class="bluedot-a footer__link text-bluedot-lighter hover:text-white"
-          data-rac=""
           href="https://www.openphilanthropy.org/"
           tabindex="0"
         >
@@ -677,7 +640,6 @@ exports[`Footer > renders with optional args 1`] = `
         , and is a non-profit based in the UK (company number 
         <a
           class="bluedot-a footer__link text-bluedot-lighter hover:text-white"
-          data-rac=""
           href="https://find-and-update.company-information.service.gov.uk/company/14964572"
           tabindex="0"
         >

--- a/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`HeroSection > renders with buttons 1`] = `
       >
         <a
           class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer cta-button--primary bg-bluedot-normal link-on-dark"
-          data-rac=""
           href="https://example.com"
           tabindex="0"
         >

--- a/libraries/ui/src/__snapshots__/UnitCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/UnitCard.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`UnitCard > renders default as expected 1`] = `
 <div>
   <a
     class="unit-card p-4 flex flex-col gap-2 justify-between border-color-divider border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-    data-rac=""
     href="https://bluedot.org/courses/what-the-fish/1"
     tabindex="0"
   >
@@ -36,7 +35,6 @@ exports[`UnitCard > renders with optional args 1`] = `
 <div>
   <a
     class="unit-card p-4 flex flex-col gap-2 justify-between unit-card--active border-color-primary border rounded-lg hover:bg-bluedot-lightest hover:border-color-primary"
-    data-rac=""
     href="https://bluedot.org/courses/what-the-fish/1"
     tabindex="0"
   >


### PR DESCRIPTION
React Aria's links and buttons emit non-standard `PressEvent`s. This makes it incompatible with `withClickTracking`.

Given we only use a small subset of behaviour anyway, I've swapped this out for some `handleInteraction` logic, which I've made sure is still ARIA compliant. This allows us to continue emitting `React.SyntheticBaseEvent`s so that `withClickTracking` works.

I've also now used it on the CourseCards, as previously we were blocked from doing this because of this incompatibility.