### PR TITLE
SlideList should overflow to full width on mobile

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`AboutPage > should render correctly 1`] = `
         class="section__body"
       >
         <div
-          class="slide-list relative overflow-hidden flex flex-col gap-space-between beliefs-section__beliefs"
+          class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 beliefs-section__beliefs"
         >
           <div
             class="slide-list__gradient-wrapper relative flex-1"
@@ -190,11 +190,11 @@ exports[`AboutPage > should render correctly 1`] = `
               />
             </div>
             <div
-              class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+              class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
               style="scroll-padding-inline: 0px;"
             >
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -231,7 +231,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -268,7 +268,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -305,7 +305,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -601,7 +601,7 @@ exports[`AboutPage > should render correctly 1`] = `
         class="section__body"
       >
         <div
-          class="slide-list relative overflow-hidden flex flex-col gap-space-between team-section__team"
+          class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 team-section__team"
         >
           <div
             class="slide-list__gradient-wrapper relative flex-1"
@@ -614,11 +614,11 @@ exports[`AboutPage > should render correctly 1`] = `
               />
             </div>
             <div
-              class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+              class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
               style="scroll-padding-inline: 0px;"
             >
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -670,7 +670,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -722,7 +722,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -774,7 +774,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -826,7 +826,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -878,7 +878,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
         class="section__body"
       >
         <div
-          class="slide-list relative overflow-hidden flex flex-col gap-space-between values-section__values"
+          class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 values-section__values"
         >
           <div
             class="slide-list__gradient-wrapper relative flex-1"
@@ -205,11 +205,11 @@ exports[`JoinUsPage > should render correctly 1`] = `
               />
             </div>
             <div
-              class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+              class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
               style="scroll-padding-inline: 0px;"
             >
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -246,7 +246,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -283,7 +283,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >

--- a/apps/website/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
       class="section__body"
     >
       <div
-        class="slide-list relative overflow-hidden flex flex-col gap-space-between beliefs-section__beliefs"
+        class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 beliefs-section__beliefs"
       >
         <div
           class="slide-list__gradient-wrapper relative flex-1"
@@ -35,11 +35,11 @@ exports[`BeliefsSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+            class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
             style="scroll-padding-inline: 0px;"
           >
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -76,7 +76,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -113,7 +113,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -150,7 +150,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >

--- a/apps/website/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`TeamSection > renders as expected 1`] = `
       class="section__body"
     >
       <div
-        class="slide-list relative overflow-hidden flex flex-col gap-space-between team-section__team"
+        class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 team-section__team"
       >
         <div
           class="slide-list__gradient-wrapper relative flex-1"
@@ -35,11 +35,11 @@ exports[`TeamSection > renders as expected 1`] = `
             />
           </div>
           <div
-            class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+            class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
             style="scroll-padding-inline: 0px;"
           >
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -91,7 +91,7 @@ exports[`TeamSection > renders as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -143,7 +143,7 @@ exports[`TeamSection > renders as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -195,7 +195,7 @@ exports[`TeamSection > renders as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -247,7 +247,7 @@ exports[`TeamSection > renders as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -299,7 +299,7 @@ exports[`TeamSection > renders as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
       </div>
     </div>
     <div
-      class="slide-list relative overflow-hidden flex flex-col gap-space-between community-values-section__values"
+      class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 community-values-section__values"
     >
       <div
         class="slide-list__gradient-wrapper relative flex-1"
@@ -32,11 +32,11 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+          class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
           style="scroll-padding-inline: 0px;"
         >
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >
@@ -68,7 +68,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >
@@ -100,7 +100,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >
@@ -132,7 +132,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
       class="projects__body flex flex-col gap-spacing-y"
     >
       <div
-        class="slide-list relative overflow-hidden flex flex-col gap-space-between projects__projects"
+        class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 projects__projects"
       >
         <div
           class="slide-list__gradient-wrapper relative flex-1"
@@ -40,11 +40,11 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
             />
           </div>
           <div
-            class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+            class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
             style="scroll-padding-inline: 0px;"
           >
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -82,7 +82,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
               </a>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -120,7 +120,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
               </a>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -158,7 +158,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
               </a>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/TestimonialSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/TestimonialSection.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TestimonialSection > renders as expected 1`] = `
     class="testimonial-section pb-spacing-y"
   >
     <div
-      class="slide-list relative overflow-hidden flex flex-col gap-space-between testimonial-section__testimonials"
+      class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 testimonial-section__testimonials"
     >
       <div
         class="slide-list__gradient-wrapper relative flex-1"
@@ -19,11 +19,11 @@ exports[`TestimonialSection > renders as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+          class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
           style="scroll-padding-inline: 0px;"
         >
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >
@@ -67,7 +67,7 @@ exports[`TestimonialSection > renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
       </div>
     </div>
     <div
-      class="slide-list relative overflow-hidden flex flex-col gap-space-between community-values-section__values"
+      class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 community-values-section__values"
     >
       <div
         class="slide-list__gradient-wrapper relative flex-1"
@@ -32,11 +32,11 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
           />
         </div>
         <div
-          class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+          class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
           style="scroll-padding-inline: 0px;"
         >
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >
@@ -68,7 +68,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
             </div>
           </div>
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >
@@ -100,7 +100,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
             </div>
           </div>
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >
@@ -132,7 +132,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
             </div>
           </div>
           <div
-            class="slide-list__slide shrink-0 snap-start"
+            class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
             data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
             style="scroll-margin-left: -0px;"
           >

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`CourseSection > renders as expected 1`] = `
           </a>
         </span>
         <div
-          class="slide-list relative overflow-hidden flex flex-col gap-space-between course-section__carousel"
+          class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 course-section__carousel"
         >
           <div
             class="slide-list__gradient-wrapper relative flex-1"
@@ -110,11 +110,11 @@ exports[`CourseSection > renders as expected 1`] = `
               />
             </div>
             <div
-              class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+              class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
               style="scroll-padding-inline: 0px;"
             >
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -185,7 +185,7 @@ exports[`CourseSection > renders as expected 1`] = `
                 </span>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >
@@ -256,7 +256,7 @@ exports[`CourseSection > renders as expected 1`] = `
                 </span>
               </div>
               <div
-                class="slide-list__slide shrink-0 snap-start"
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
                 data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
                 style="scroll-margin-left: -0px;"
               >

--- a/apps/website/src/components/join-us/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/ValuesSection.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
       class="section__body"
     >
       <div
-        class="slide-list relative overflow-hidden flex flex-col gap-space-between values-section__values"
+        class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0 values-section__values"
       >
         <div
           class="slide-list__gradient-wrapper relative flex-1"
@@ -35,11 +35,11 @@ exports[`ValuesSection > renders default as expected 1`] = `
             />
           </div>
           <div
-            class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+            class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
             style="scroll-padding-inline: 0px;"
           >
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -76,7 +76,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >
@@ -113,7 +113,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
               </div>
             </div>
             <div
-              class="slide-list__slide shrink-0 snap-start"
+              class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
               style="scroll-margin-left: -0px;"
             >

--- a/libraries/ui/src/SlideList.tsx
+++ b/libraries/ui/src/SlideList.tsx
@@ -127,7 +127,7 @@ export const SlideList: React.FC<SlideListProps> = ({
   );
 
   return (
-    <div className={clsx('slide-list relative overflow-hidden flex flex-col gap-space-between', className)}>
+    <div className={clsx('slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0', className)}>
       <div className="slide-list__gradient-wrapper relative flex-1">
         {!allChildrenFit && (
           <div className="slide-list__gradient-overlay absolute inset-0 pointer-events-none z-10 flex">
@@ -143,7 +143,7 @@ export const SlideList: React.FC<SlideListProps> = ({
         <div
           ref={slidesRef}
           className={clsx(
-            'slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y',
+            'slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between',
             'scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory',
             allChildrenFit && 'flex-wrap',
           )}
@@ -151,7 +151,7 @@ export const SlideList: React.FC<SlideListProps> = ({
         >
           {React.Children.map(children, (child) => (
             <div
-              className="slide-list__slide shrink-0 snap-start"
+              className="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
               data-width={itemWidth} // style.width can't be picked up in tests, so add it as an attr that can be read
               style={{
                 width: itemWidth,

--- a/libraries/ui/src/__snapshots__/SlideList.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/SlideList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SlideList > renders correctly 1`] = `
 <div>
   <div
-    class="slide-list relative overflow-hidden flex flex-col gap-space-between"
+    class="slide-list relative overflow-hidden flex flex-col gap-space-between -mx-spacing-x md:mx-0"
   >
     <div
       class="slide-list__gradient-wrapper relative flex-1"
@@ -16,11 +16,11 @@ exports[`SlideList > renders correctly 1`] = `
         />
       </div>
       <div
-        class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-x-space-between gap-y-spacing-y scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
+        class="slide-list__slides flex flex-1 h-full items-stretch overflow-x-scroll gap-y-spacing-y md:gap-x-space-between scrollbar-hidden transition-transform duration-300 snap-x snap-mandatory"
         style="scroll-padding-inline: 0px;"
       >
         <div
-          class="slide-list__slide shrink-0 snap-start"
+          class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
           data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
           style="scroll-margin-left: -0px;"
         >
@@ -29,7 +29,7 @@ exports[`SlideList > renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="slide-list__slide shrink-0 snap-start"
+          class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
           data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
           style="scroll-margin-left: -0px;"
         >
@@ -38,7 +38,7 @@ exports[`SlideList > renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="slide-list__slide shrink-0 snap-start"
+          class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
           data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
           style="scroll-margin-left: -0px;"
         >


### PR DESCRIPTION
# Summary

SlideList should overflow to full width on mobile

## Issue
This has been bothering me

## Description

- Use negative margins to accommodate standard mobile px wells

## Screenshot

https://github.com/user-attachments/assets/a1e0d657-716f-4b2e-88d9-9b05d4013cc3

https://github.com/user-attachments/assets/76d05b32-8ada-4e33-8c50-e9fa64b4ed5a

### Before

<img width="415" alt="image" src="https://github.com/user-attachments/assets/6f3b1d8e-bde3-48a5-8d06-4363f5517621" />

## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```