### PR TITLE
infra: Deploy new keycloak

### DIFF
--- a/apps/infra/src/k8s/postgres.ts
+++ b/apps/infra/src/k8s/postgres.ts
@@ -26,20 +26,6 @@ export const keycloakPg = new k8s.apiextensions.CustomResource('keycloak-pg', {
   },
 }, { provider, dependsOn: [cloudNativePg] });
 
-export const keycloakNewPg = new k8s.apiextensions.CustomResource('keycloak-new-pg', {
-  apiVersion: 'postgresql.cnpg.io/v1',
-  kind: 'Cluster',
-  metadata: {
-    name: 'keycloak-new-pg',
-  },
-  spec: {
-    instances: 1,
-    storage: {
-      size: '5Gi',
-    },
-  },
-}, { provider, dependsOn: [cloudNativePg] });
-
 export const grafanaPg = new k8s.apiextensions.CustomResource('grafana-pg', {
   apiVersion: 'postgresql.cnpg.io/v1',
   kind: 'Cluster',

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -1,6 +1,6 @@
 import { core } from '@pulumi/kubernetes/types/input';
 import { envVarSources } from './secrets';
-import { getConnectionDetails, keycloakNewPg, keycloakPg } from './postgres';
+import { getConnectionDetails, keycloakPg } from './postgres';
 
 export const services: ServiceDefinition[] = [
   {
@@ -204,36 +204,6 @@ export const services: ServiceDefinition[] = [
       containers: [{
         name: 'bluedot-login',
         image: 'ghcr.io/bluedotimpact/bluedot-login:latest',
-        env: [
-          { name: 'KC_DB_URL', valueFrom: getConnectionDetails(keycloakNewPg).jdbcUri },
-          { name: 'KC_BOOTSTRAP_ADMIN_USERNAME', value: 'admin' },
-          { name: 'KC_BOOTSTRAP_ADMIN_PASSWORD', value: 'admin' },
-        ],
-        startupProbe: {
-          httpGet: { path: '/health/started', port: 9000 },
-          failureThreshold: 18,
-        },
-        livenessProbe: {
-          httpGet: { path: '/health/live', port: 9000 },
-        },
-        readinessProbe: {
-          httpGet: { path: '/health/ready', port: 9000 },
-        },
-        resources: {
-          limits: {
-            memory: '1000Mi',
-          },
-        },
-      }],
-    },
-    hosts: ['login-new.k8s.bluedot.org'],
-  },
-  {
-    name: 'bluedot-login-old',
-    spec: {
-      containers: [{
-        name: 'bluedot-login-old',
-        image: 'ghcr.io/bluedotimpact/bluedot-login-old:latest',
         env: [
           { name: 'KC_DB_URL', valueFrom: getConnectionDetails(keycloakPg).jdbcUri },
         ],


### PR DESCRIPTION
Undeploys login-old, and moves the new login to login.bluedot.org. Also deletes the spare database we created that we're no longer using.

Fixes #679 
