### PR TITLE
Remove 'Invalid course slug' error

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -21,10 +21,6 @@ import { CourseUnitsSection } from '../../../components/courses/CourseUnitsSecti
 const CoursePage = () => {
   const { query: { courseSlug } } = useRouter();
 
-  if (typeof courseSlug !== 'string') {
-    return 'Invalid course slug';
-  }
-
   const [{ data, loading, error }] = useAxios<GetCourseResponse>({
     method: 'get',
     url: `/api/courses/${courseSlug}`,


### PR DESCRIPTION
# Summary

Remove 'Invalid course slug' error

## Issue
Fixes [#804](https://github.com/bluedotimpact/bluedot/issues/804)

## Description

- Remove "Invalid course slug" text, as this renders in a flash as client-side request resolves
- We already have loading and error states defined for this route

## Screenshot

| Before | After |
|--------|--------|
| https://github.com/user-attachments/assets/5dd0d1f9-776f-4446-9f99-a98a21ee9c4a | https://github.com/user-attachments/assets/85f09406-e6f7-451c-b284-bb47d291388a |

## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```