### PR TITLE
website: Enable cross-origin fonts hosting

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -1,3 +1,18 @@
 const { withDefaultBlueDotNextConfig } = require('@bluedot/ui/src/default-config/next');
 
-module.exports = withDefaultBlueDotNextConfig();
+module.exports = withDefaultBlueDotNextConfig({
+  headers: [
+    {
+      source: '/fonts/:path*',
+      headers: [
+        {
+          key: 'Access-Control-Allow-Origin',
+          value: '*',
+        },
+        {
+          key: 'Access-Control-Allow-Methods',
+          value: 'GET, OPTIONS',
+        },
+      ],
+    }],
+});


### PR DESCRIPTION
Follow up from #765

This just reduces the clutter in the logs when developing locally