### PR TITLE
website: Fix refresh logic by using id_token instead of access_token

### DIFF
--- a/libraries/ui/src/Login.tsx
+++ b/libraries/ui/src/Login.tsx
@@ -97,8 +97,7 @@ export const loginPresets = {
       authority: 'https://login.bluedot.org/realms/customers/',
       client_id: 'bluedot-web-apps',
       redirect_uri: `${typeof window === 'undefined' ? '' : window.location.origin}/login/oauth-callback`,
-      // 2025-04-27: offline_access temporarily disabled - see https://github.com/bluedotimpact/bluedot/issues/761
-      // scope: 'openid email offline_access',
+      scope: 'openid email offline_access',
     },
     verifyAndDecodeToken: async (token: string) => {
       return verifyJwt(token, {

--- a/libraries/ui/src/utils/auth.test.tsx
+++ b/libraries/ui/src/utils/auth.test.tsx
@@ -35,7 +35,7 @@ const createAuth = (overrides?: Partial<Auth>): Auth => ({
 
 // Helper to create mock OIDC response
 const createMockOidcResponse = (overrides?: Record<string, unknown>) => ({
-  access_token: 'new-test-token',
+  id_token: 'new-test-token',
   expires_at: Math.floor(Date.now() / 1000) + 3600,
   refresh_token: 'new-refresh-token',
   ...overrides,
@@ -132,7 +132,7 @@ describe('auth', () => {
       useAuthStore.getState().setAuth(auth);
 
       const refreshResponse = createMockOidcResponse({
-        access_token: 'new-access-token',
+        id_token: 'new-access-token',
         refresh_token: 'new-refresh-token',
         expires_at: Math.floor(Date.now() / 1000) + 3600,
       });
@@ -145,7 +145,7 @@ describe('auth', () => {
       expect(mockUseRefreshToken).toHaveBeenCalledTimes(1);
 
       // Verify the token was updated
-      expect(useAuthStore.getState().auth?.token).toBe(refreshResponse.access_token);
+      expect(useAuthStore.getState().auth?.token).toBe(refreshResponse.id_token);
       expect(useAuthStore.getState().auth?.refreshToken).toBe(refreshResponse.refresh_token);
       expect(useAuthStore.getState().auth?.expiresAt).toBe(refreshResponse.expires_at * 1000);
 
@@ -197,7 +197,7 @@ describe('auth', () => {
       useAuthStore.getState().setAuth(auth);
 
       const refreshResponse = createMockOidcResponse({
-        access_token: 'new-access-token',
+        id_token: 'new-access-token',
         refresh_token: 'new-refresh-token',
         expires_at: Math.floor(Date.now() / 1000) + 3600,
       });
@@ -210,7 +210,7 @@ describe('auth', () => {
       expect(mockUseRefreshToken).toHaveBeenCalledTimes(1);
 
       // Verify the token was updated
-      expect(useAuthStore.getState().auth?.token).toBe(refreshResponse.access_token);
+      expect(useAuthStore.getState().auth?.token).toBe(refreshResponse.id_token);
       expect(useAuthStore.getState().auth?.refreshToken).toBe(refreshResponse.refresh_token);
       expect(useAuthStore.getState().auth?.expiresAt).toBe(refreshResponse.expires_at * 1000);
 
@@ -224,7 +224,7 @@ describe('auth', () => {
       const newToken = 'refreshed-token';
       const expiresAtSeconds = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
       const { mockUseRefreshToken } = setupMockOidcClient(true, createMockOidcResponse({
-        access_token: newToken,
+        id_token: newToken,
         expires_at: expiresAtSeconds,
       }));
 

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -99,7 +99,7 @@ export const useAuthStore = create<{
   internal_refreshTimer: null,
 }), {
   name: 'bluedot_auth',
-  version: 20250427,
+  version: 20250428,
 
   // On rehydration, set the state again
   // This starts the refresh and expiry logic

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -20,12 +20,12 @@ const oidcRefresh = async (auth: Auth): Promise<Auth> => {
     },
   });
 
-  if (!user || typeof user.expires_at !== 'number' || !user.access_token) {
+  if (!user || typeof user.expires_at !== 'number' || !user.id_token) {
     throw new Error('Invalid refresh response');
   }
 
   return {
-    token: user.access_token,
+    token: user.id_token,
     expiresAt: user.expires_at * 1000,
     refreshToken: user.refresh_token ?? auth.refreshToken,
     oidcSettings: auth.oidcSettings,


### PR DESCRIPTION
When initially authenticating, we used the `id_token` which has an `aud` claim. This works great.

When refreshing, we mistakenly used the `access_token` instead of `id_token`. This doesn't have an `aud` claim and was the source of our pain. I think we also got confused whether the scope was relevant, which now think wasn't.

## Issue

Fixes #761