### PR TITLE
website-proxy: Fix contact page

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -85,6 +85,10 @@ http {
             proxy_pass https://website-production.k8s.bluedot.org;
         }
 
+        location = /contact {
+            proxy_pass https://website-production.k8s.bluedot.org;
+        }
+
         location = /contact/ {
             proxy_pass https://website-production.k8s.bluedot.org;
         }


### PR DESCRIPTION
I think this got deleted accidentally in #768. This results in a weird redirect to `https://bluedot.org:8080/contact/` when trying to view this page.