### PR TITLE
website: Add attendance policy and course running guide

### DIFF
--- a/apps/website/src/pages/attendance-policy.tsx
+++ b/apps/website/src/pages/attendance-policy.tsx
@@ -1,0 +1,76 @@
+import {
+  HeroSection,
+  HeroH1,
+  Section,
+  Breadcrumbs,
+  BluedotRoute,
+} from '@bluedot/ui';
+import Head from 'next/head';
+import { ROUTES } from '../lib/routes';
+import MarkdownExtendedRenderer from '../components/courses/MarkdownExtendedRenderer';
+
+const CURRENT_ROUTE: BluedotRoute = {
+  title: 'Course Attendance Policy',
+  url: '/attendance-policy',
+  parentPages: [ROUTES.home],
+};
+
+const ContentPage = () => {
+  return (
+    <div>
+      <Head>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
+      </Head>
+      <HeroSection>
+        <HeroH1>{CURRENT_ROUTE.title}</HeroH1>
+      </HeroSection>
+      <Breadcrumbs route={CURRENT_ROUTE} />
+      <Section className="max-w-3xl">
+        <MarkdownExtendedRenderer>{`
+## Course Attendance Policy
+
+We’re thrilled to have you onboard one of our courses. We’ve meticulously crafted the curriculum with experts, recruited awesome facilitators, and selected you – yes, you – as a stand-out applicant to join us.
+
+We’re keen for you to have a brilliant learning experience that equips you to tackle the world’s most pressing problems. Facilitated group discussions are a hugely important part of the learning experience, and both you and your fellow participants will get the most from the course if you engage deeply with the group discussions.
+
+This policy explains our expectations around group discussion attendance to ensure we support each other towards this shared goal.
+
+**1. Preparation 📚**
+
+Before you jump into facilitated group discussions, make sure to complete any mandatory readings and exercises. They’ll help you navigate and engage with group discussions and activities. We don’t want you feeling like you’re trying to solve a Rubik’s Cube in the dark (unless you’re weirdly good at that)!
+
+You should also double-check that your internet connection works and you have the appropriate equipment to attend the online group discussions. Need help? Ask in the logistics questions channel of the community Slack.
+
+**2. Attendance 🕒**
+
+There’s no way around it – you’ve got to be at each group discussion every week. Your presence makes the discussions come alive, and the group activities reach their full potential – both for you and your fellow participants. So, please mark your calendars, set reminders, and make it a habit! Also, we know life can be chaotic, but do your best to plan ahead and switch to a different group discussion if you can’t make your original one.
+
+**3. Absences 🔀**
+
+Life can sometimes be unpredictable. If you can’t make it to your regular discussion, use the switch group link in the Course Hub to join another group that week. Where possible, do this in advance so your facilitators can better plan their group discussions.
+
+If you miss a week, contact your facilitator to catch up on what you missed. They’re there to support you with your learning!
+
+**4. Active participation 🙌**
+
+We’re not looking for spectators; we want you to actively participate in the facilitated group discussions with your full attention. Engage wholeheartedly in discussions, fire away your curious questions, and shower us with your invaluable feedback. You’ll learn more and help your fantastic group peers learn more too!
+
+**5. Enforcement 🧑‍⚖️**
+
+If you miss two consecutive discussions, we’ll consider you inactive and remove you from future group discussions until we hear from you again. This is because we want to ensure that the expected attendees for each group discussion are accurate so each discussion has between 4-8 participants in the discussion.
+
+If you miss four or more Learning Phase facilitated group discussions (i.e. units 1-8), we will remove you from the course and ask that you reapply for the next round of the course. It will be challenging to catch up with the course material at this stage and detract from potentially productive discussions.
+
+We reserve the right to remove participants from the course who consistently disrupt the learning environment or demonstrate behaviour that negatively impacts their group. This includes repeated instances of being unprepared, disrespecting other participants or facilitators, or otherwise hindering the collaborative learning atmosphere we strive to maintain.
+
+Note that to receive a certificate of completion at the end of the course, you need to attend six or more Learning Phase facilitated group discussions and submit a project!
+
+If you feel like poor attendance or disruptive behaviour from others in your group is disrupting your learning, please mention this to your facilitator or [our team](https://bluedot.org/contact).
+`}
+        </MarkdownExtendedRenderer>
+      </Section>
+    </div>
+  );
+};
+
+export default ContentPage;

--- a/apps/website/src/pages/running-versions-of-our-courses.tsx
+++ b/apps/website/src/pages/running-versions-of-our-courses.tsx
@@ -1,0 +1,94 @@
+import {
+  HeroSection,
+  HeroH1,
+  Section,
+  Breadcrumbs,
+  BluedotRoute,
+} from '@bluedot/ui';
+import Head from 'next/head';
+import { ROUTES } from '../lib/routes';
+import MarkdownExtendedRenderer from '../components/courses/MarkdownExtendedRenderer';
+
+const CURRENT_ROUTE: BluedotRoute = {
+  title: 'Running versions of our courses',
+  url: '/running-versions-of-our-courses',
+  parentPages: [ROUTES.home],
+};
+
+const ContentPage = () => {
+  return (
+    <div>
+      <Head>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
+      </Head>
+      <HeroSection>
+        <HeroH1>{CURRENT_ROUTE.title}</HeroH1>
+      </HeroSection>
+      <Breadcrumbs route={CURRENT_ROUTE} />
+      <Section className="max-w-3xl">
+        <MarkdownExtendedRenderer>{`
+## Running versions of our courses
+
+_To take part in our facilitated courses instead, see the courses linked on [our homepage](https://bluedot.org/)._
+
+_Let us know how you're using our courses [here](https://forms.bluedot.org/UdXLJKhY463CAI0Th2cj), so we can potentially offer more support in the future._
+
+We’re thrilled you’re excited to run an independent version of our course! We’re BlueDot Impact, the team behind [AI Safety Fundamentals](https://aisafetyfundamentals.com/) and [Biosecurity Fundamentals](https://biosecurityfundamentals.com/). This page sets out guidance for branding your course, as well as explains what support we can offer local groups.
+
+It's great when friends, workplace groups, student societies and other local organizations run versions of our courses. This helps further our mission of accelerating driven individuals to develop the knowledge, skills and connections needed to have a significant positive impact.
+
+To support this, you can share and adapt our course materials including resource lists, exercises, sample answers and discussion docs, provided that you:
+
+* **Brand it distinctly:** Market the course in a way that it’s clear who’s running the course. Don’t use our names like "AI Safety Fundamentals" or "BlueDot Impact" in a way that could confuse people as to who is offering the course.
+* **Give appropriate credit:** When presenting these materials, please give credit to the source, for example "AI Safety Fundamentals" or "BlueDot Impact".
+* **Don’t hold us liable for errors:** While we try our best to ensure the accuracy and relevancy of our course materials, they’re provided solely on an “as is” basis, without warranty of any kind.
+
+Note that we don’t own many of linked-to resources themselves, so you might need permission from their original owners if you want to copy or translate them.
+
+### Example
+
+Here’s an example of how you might market your course, following the guidelines above:
+
+> Calling all students interested in the future of AI safety and alignment!
+> 🤖 The Greendale Community College AI Society is excited to be hosting a AI alignment course this semester, based on the popular AI Safety Fundamentals courses developed by BlueDot Impact.
+> We’ll be following their curriculum, [available online here](https://course.aisafetyfundamentals.com/alignment). You should do the readings and exercises beforehand, and then each week we’ll host a facilitated group discussion adapted for our university setting.
+> The discussions will run every Wednesday from 6-8pm in Group Study Room F starting on 17 September. To join the seminar series, RSVP at https://greendale.edu/ai-soc/ai-alignment.
+> If you have any other questions, email ai.soc@greendale.edu. Looking forward to some fascinating discussions! 🙂
+
+Examples of things that would not be okay:
+
+*   "GCC AI Society is launching a round of the AI Safety Fundamentals course".
+*   "We're running the AI Safety Fundamentals course in Greendale, Colorado".
+*   "Apply to AI Safety Fundamentals", linking to your version of the course.
+*   "Run in collaboration with BlueDot Impact", unless we've explicitly agreed this.
+*   Issuing certificates "for completing the AI Safety Fundamentals course". But it's fine to issue certificates "for completing GCC AI Society's AI Alignment course, based on the AI Safety Fundamentals curriculum".
+
+This similarly applies to the names AISF, AGISF, AGI Safety Fundamentals, Biosecurity Fundamentals. We're fine with people using the generic course names: AI alignment, AI governance, and pandemics.
+
+### FAQs
+
+**Can local groups get copies of the discussion docs?**
+
+Yes! These are linked on the individual course webpages.
+
+**Can local groups use BlueDot’s infrastructure for running courses?**
+
+Yes, almost all our software and corresponding documentation is available [on GitHub](https://github.com/bluedotimpact/). You can raise issues there if you get stuck. We aren't currently able to provide hosted versions of our software, or technical support beyond this. Local groups are also welcome to direct users to our course hub to help learners track their own reading completions and exercises.
+
+**Can you we use your facilitator training program?**
+
+Yes! The resources and exercises for our facilitator training course are [available online](https://course.bluedot.org/home/facilitator-training) for self-study.
+
+**I’m planning to run a local group / previously participated in a local group run version. Could I join the BlueDot facilitated course?**
+
+Yes, please apply in the normal way and mention this in your application. Note that this does not guarantee you a place on our course.
+
+If you have any other questions, feel free to [contact us](https://bluedot.org/contact)!
+`}
+        </MarkdownExtendedRenderer>
+      </Section>
+    </div>
+  );
+};
+
+export default ContentPage;


### PR DESCRIPTION
Content taken directly from previous CMS

These are the only other pages on bluedot.org that are not migrated to the new website. With these two, we can shut off the old bluedot.org website for good (and kill website-proxy). (We do still need Wordpress for AISF and Biosecurity Fundamentals though right now).

An alternative would be to migrate these onto the blog. We might do this later, but that would require setting up redirects etc. which I thought would take longer and be more fiddly than this.