### PR TITLE
website: Fix certificate request endpoint

### DIFF
--- a/apps/website/src/lib/api/db/tables.ts
+++ b/apps/website/src/lib/api/db/tables.ts
@@ -166,7 +166,8 @@ export const unitTable: Table<Unit> = {
 export type Exercise = {
   id: string,
   answer: string,
-  courseId: string,
+  courseIdWrite: string,
+  courseIdRead: string,
   exerciseNumber: string,
   description: string,
   options: string,
@@ -183,7 +184,8 @@ export const exerciseTable: Table<Exercise> = {
   tableId: 'tbla7lc2MtSSbWVvS',
   mappings: {
     answer: 'fldFcZVVo8Wg4GSmA',
-    courseId: 'fldxcJ5gCihs3iRyE',
+    courseIdWrite: 'fldxcJ5gCihs3iRyE',
+    courseIdRead: 'fldc9oyPwJSkeMiAW',
     exerciseNumber: 'fldOoKVFSrToAicfT',
     description: 'fldsoGDZ4d8Us64f1',
     options: 'fld38NpFZT4BdhWO3',
@@ -195,7 +197,8 @@ export const exerciseTable: Table<Exercise> = {
   },
   schema: {
     answer: 'string',
-    courseId: 'string',
+    courseIdWrite: 'string',
+    courseIdRead: 'string',
     exerciseNumber: 'string',
     description: 'string',
     options: 'string',

--- a/apps/website/src/pages/api/certificates/request.ts
+++ b/apps/website/src/pages/api/certificates/request.ts
@@ -58,7 +58,7 @@ export default makeApiRoute({
       const exercises: Exercise[] = await db.scan(exerciseTable, {
         filterByFormula: formula(await db.table(exerciseTable), [
           'AND',
-          ['=', { field: 'courseId' }, body.courseId],
+          ['=', { field: 'courseIdRead' }, body.courseId],
           ['=', { field: 'status' }, 'Active'],
         ]),
       });


### PR DESCRIPTION
This PR fixes the certificate request endpoint.

When upgrading filterByFormula expressions (#829) I think I made a mistake here - we can't filter on the actual linked record field because then Airtable tries to match the record name rather than ID. So we need to filter on a linked field that has the record id as a string. This is what we were doing previously, but I changed it to the linked record field.

This PR adds the record id string field, and filters using that. I've tested locally and it fetches the exercises correctly.

It would be nice to figure out how to clean this up a little, or at least have a convention for how to do this.

## Issue
<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
Fixes #845
