### PR TITLE
login: Be able to direct new users to register

### DIFF
--- a/apps/app-template/src/pages/login/index.tsx
+++ b/apps/app-template/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginRedirectPage loginPreset={loginPresets.keycloak} />;

--- a/apps/app-template/src/pages/login/oauth-callback.tsx
+++ b/apps/app-template/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginOauthCallbackPage loginPreset={loginPresets.keycloak} />;

--- a/apps/frontend-example/src/pages/login/index.tsx
+++ b/apps/frontend-example/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginRedirectPage loginPreset={loginPresets.keycloak} />;

--- a/apps/frontend-example/src/pages/login/oauth-callback.tsx
+++ b/apps/frontend-example/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginOauthCallbackPage loginPreset={loginPresets.keycloak} />;

--- a/apps/room/src/pages/login/index.tsx
+++ b/apps/room/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage oidcSettings={loginPresets.googleBlueDot.oidcSettings} />;
+export default () => <LoginRedirectPage loginPreset={loginPresets.googleBlueDot} />;

--- a/apps/room/src/pages/login/oauth-callback.tsx
+++ b/apps/room/src/pages/login/oauth-callback.tsx
@@ -1,3 +1,3 @@
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.googleBlueDot.oidcSettings} />;
+export default () => <LoginOauthCallbackPage loginPreset={loginPresets.googleBlueDot} />;

--- a/apps/website/src/components/courses/ResourceListCourseContent.tsx
+++ b/apps/website/src/components/courses/ResourceListCourseContent.tsx
@@ -269,7 +269,7 @@ const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) => {
           )}
         </div>
       ) : (
-        <P className="resource-item__login-prompt mt-4"><A href={addQueryParam(ROUTES.login.url, 'redirect_to', window.location.pathname)}>Create a free account</A> to track your progress and unlock access to the full course content.</P>
+        <P className="resource-item__login-prompt mt-4"><A href={addQueryParam(addQueryParam(ROUTES.login.url, 'redirect_to', window.location.pathname), 'register', 'true')}>Create a free account</A> to track your progress and unlock access to the full course content.</P>
       )}
     </div>
   );

--- a/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
@@ -67,7 +67,7 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
           className={`free-text-response__textarea p-4${
             (!isEditing && exerciseResponse) ? ' free-text-response__textarea--saved container-active bg-[#63C96533] border-[#63C965] text-[#2A5D2A]' : ' container-lined'
           }`}
-          placeholder={isLoggedIn ? 'Enter your answer here' : 'Login to save your answers'}
+          placeholder={isLoggedIn ? 'Enter your answer here' : 'Create an account to save your answers'}
           onChange={() => setIsEditing(true)}
           disabled={!isLoggedIn}
         />
@@ -85,10 +85,10 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
         <CTALinkOrButton
           className="free-text-response__login-cta"
           variant="primary"
-          url={addQueryParam(ROUTES.login.url, 'redirect_to', window.location.href)}
+          url={addQueryParam(addQueryParam(ROUTES.login.url, 'redirect_to', window.location.pathname), 'register', 'true')}
           withChevron
         >
-          Login to save your answers
+          Create a free account to save your answers
         </CTALinkOrButton>
       )}
       {(!isEditing && exerciseResponse) && <P className="free-text-response__saved-msg">Saved! 🎉</P>}

--- a/apps/website/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website/src/components/courses/exercises/MultipleChoice.tsx
@@ -126,10 +126,10 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
         <CTALinkOrButton
           className="multiple-choice__login-cta"
           variant="primary"
-          url={addQueryParam(ROUTES.login.url, 'redirect_to', window.location.href)}
+          url={addQueryParam(addQueryParam(ROUTES.login.url, 'redirect_to', window.location.pathname), 'register', 'true')}
           withChevron
         >
-          Login to check your answer
+          Create a free account to check your answer
         </CTALinkOrButton>
       )}
       {(!isEditing && isCorrect) && <P className="multiple-choice__correct-msg">Correct! Quiz completed. 🎉</P>}

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -37,18 +37,18 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
         class="free-text-response__textarea p-4 container-lined"
         disabled=""
         name="answer"
-        placeholder="Login to save your answers"
+        placeholder="Create an account to save your answers"
       />
     </div>
     <a
       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--primary bg-bluedot-normal link-on-dark free-text-response__login-cta"
-      href="http://localhost:3000/login?redirect_to=http%3A%2F%2Flocalhost%3A3000%2F"
+      href="http://localhost:3000/login?redirect_to=%2F&register=true"
       tabindex="0"
     >
       <span
         class="cta-button__text"
       >
-        Login to save your answers
+        Create a free account to save your answers
       </span>
       <span
         class="cta-button__chevron ml-3"

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -110,13 +110,13 @@ exports[`MultipleChoice > renders default as expected 1`] = `
     </div>
     <a
       class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--primary bg-bluedot-normal link-on-dark multiple-choice__login-cta"
-      href="http://localhost:3000/login?redirect_to=http%3A%2F%2Flocalhost%3A3000%2F"
+      href="http://localhost:3000/login?redirect_to=%2F&register=true"
       tabindex="0"
     >
       <span
         class="cta-button__text"
       >
-        Login to check your answer
+        Create a free account to check your answer
       </span>
       <span
         class="cta-button__chevron ml-3"

--- a/apps/website/src/pages/login/index.tsx
+++ b/apps/website/src/pages/login/index.tsx
@@ -1,3 +1,3 @@
 import { loginPresets, LoginRedirectPage } from '@bluedot/ui';
 
-export default () => <LoginRedirectPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginRedirectPage loginPreset={loginPresets.keycloak} />;

--- a/apps/website/src/pages/login/oauth-callback.tsx
+++ b/apps/website/src/pages/login/oauth-callback.tsx
@@ -4,7 +4,7 @@ import { GetUserResponse } from '../api/users/me';
 
 export default () => (
   <LoginOauthCallbackPage
-    oidcSettings={loginPresets.keycloak.oidcSettings}
+    loginPreset={loginPresets.keycloak}
     onLoginComplete={async (auth) => {
       // This ensures the user is created
       await axios.get<GetUserResponse>('/api/users/me', {

--- a/libraries/ui/README.md
+++ b/libraries/ui/README.md
@@ -141,14 +141,14 @@ For the above to work, you'll probably want to use the pre-built login flow page
 import { LoginRedirectPage, loginPresets } from '@bluedot/ui';
 
 // The login preset should match what you have on the backend
-export default () => <LoginRedirectPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginRedirectPage loginPreset={loginPresets.keycloak} />;
 ```
 
 ```typescript
 // In src/pages/login/oauth-callback.tsx
 import { LoginOauthCallbackPage, loginPresets } from '@bluedot/ui';
 
-export default () => <LoginOauthCallbackPage oidcSettings={loginPresets.keycloak.oidcSettings} />;
+export default () => <LoginOauthCallbackPage loginPreset={loginPresets.keycloak} />;
 ```
 
 ### Error Coercion

--- a/libraries/ui/src/Login.test.tsx
+++ b/libraries/ui/src/Login.test.tsx
@@ -26,7 +26,7 @@ vi.mock('./utils/getQueryParam', () => ({
 const CUSTOM_REDIRECT_PATH = '/custom-path';
 
 describe('LoginRedirectPage', () => {
-  const mockOidcSettings = loginPresets.keycloak.oidcSettings;
+  const mockLoginPreset = loginPresets.keycloak;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,7 +36,7 @@ describe('LoginRedirectPage', () => {
     vi.mocked(useAuthStore).mockReturnValue({ auth: { token: 'test-token' } });
     vi.mocked(getQueryParam).mockReturnValue(CUSTOM_REDIRECT_PATH);
 
-    render(<LoginRedirectPage oidcSettings={mockOidcSettings} />);
+    render(<LoginRedirectPage loginPreset={mockLoginPreset} />);
 
     expect(Navigate).toHaveBeenCalledWith({
       url: CUSTOM_REDIRECT_PATH,


### PR DESCRIPTION
- For places where we expect users to be new users rather than returning users, it's useful to be able to direct them to the registration page directly. This is fewer clicks for them, and hopefully results in more sign ups.
- This PR adds this functionality to Login.tsx, and uses it on the website where we prompt people to sign up

## Screenshot

https://github.com/user-attachments/assets/f7a9a794-1c00-4a71-b298-d006ee98c92c

