### PR TITLE
Add isFullWidth Card option

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -664,6 +664,24 @@ exports[`AboutPage > should render correctly 1`] = `
                         >
                           LinkedIn
                         </span>
+                        <span
+                          class="cta-button__chevron ml-3"
+                        >
+                          <svg
+                            class="cta-button__chevron-icon size-2"
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </div>
                   </div>
@@ -715,6 +733,24 @@ exports[`AboutPage > should render correctly 1`] = `
                           class="cta-button__text"
                         >
                           LinkedIn
+                        </span>
+                        <span
+                          class="cta-button__chevron ml-3"
+                        >
+                          <svg
+                            class="cta-button__chevron-icon size-2"
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                            />
+                          </svg>
                         </span>
                       </a>
                     </div>
@@ -768,6 +804,24 @@ exports[`AboutPage > should render correctly 1`] = `
                         >
                           LinkedIn
                         </span>
+                        <span
+                          class="cta-button__chevron ml-3"
+                        >
+                          <svg
+                            class="cta-button__chevron-icon size-2"
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </div>
                   </div>
@@ -819,6 +873,24 @@ exports[`AboutPage > should render correctly 1`] = `
                           class="cta-button__text"
                         >
                           LinkedIn
+                        </span>
+                        <span
+                          class="cta-button__chevron ml-3"
+                        >
+                          <svg
+                            class="cta-button__chevron-icon size-2"
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                            />
+                          </svg>
                         </span>
                       </a>
                     </div>
@@ -872,6 +944,24 @@ exports[`AboutPage > should render correctly 1`] = `
                         >
                           LinkedIn
                         </span>
+                        <span
+                          class="cta-button__chevron ml-3"
+                        >
+                          <svg
+                            class="cta-button__chevron-icon size-2"
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                            />
+                          </svg>
+                        </span>
                       </a>
                     </div>
                   </div>
@@ -923,6 +1013,24 @@ exports[`AboutPage > should render correctly 1`] = `
                           class="cta-button__text"
                         >
                           LinkedIn
+                        </span>
+                        <span
+                          class="cta-button__chevron ml-3"
+                        >
+                          <svg
+                            class="cta-button__chevron-icon size-2"
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            stroke-width="0"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                            />
+                          </svg>
                         </span>
                       </a>
                     </div>

--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 beliefs-section__belief"
+                  class="card flex items-start transition-transform duration-200 flex-col beliefs-section__belief"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -211,7 +211,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -236,7 +236,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 beliefs-section__belief"
+                  class="card flex items-start transition-transform duration-200 flex-col beliefs-section__belief"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -248,7 +248,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -273,7 +273,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 beliefs-section__belief"
+                  class="card flex items-start transition-transform duration-200 flex-col beliefs-section__belief"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -285,7 +285,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -310,7 +310,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 beliefs-section__belief"
+                  class="card flex items-start transition-transform duration-200 flex-col beliefs-section__belief"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -322,7 +322,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -623,7 +623,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                  class="card flex items-start transition-transform duration-200 flex-col team-section__card"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -635,7 +635,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -675,7 +675,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                  class="card flex items-start transition-transform duration-200 flex-col team-section__card"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -687,7 +687,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -727,7 +727,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                  class="card flex items-start transition-transform duration-200 flex-col team-section__card"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -739,7 +739,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -779,7 +779,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                  class="card flex items-start transition-transform duration-200 flex-col team-section__card"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -791,7 +791,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -831,7 +831,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                  class="card flex items-start transition-transform duration-200 flex-col team-section__card"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -843,7 +843,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -883,7 +883,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                  class="card flex items-start transition-transform duration-200 flex-col team-section__card"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -895,7 +895,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -214,7 +214,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 values-section__value"
+                  class="card flex items-start transition-transform duration-200 flex-col values-section__value"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -226,7 +226,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -251,7 +251,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 values-section__value"
+                  class="card flex items-start transition-transform duration-200 flex-col values-section__value"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -263,7 +263,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"
@@ -288,7 +288,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 style="scroll-margin-left: -0px;"
               >
                 <div
-                  class="card flex flex-col items-start transition-transform duration-200 values-section__value"
+                  class="card flex items-start transition-transform duration-200 flex-col values-section__value"
                 >
                   <div
                     class="card__image-container w-full mb-4"
@@ -300,7 +300,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                   >
                     <div
                       class="card__text"

--- a/apps/website/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 beliefs-section__belief"
+                class="card flex items-start transition-transform duration-200 flex-col beliefs-section__belief"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -56,7 +56,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -81,7 +81,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 beliefs-section__belief"
+                class="card flex items-start transition-transform duration-200 flex-col beliefs-section__belief"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -93,7 +93,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -118,7 +118,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 beliefs-section__belief"
+                class="card flex items-start transition-transform duration-200 flex-col beliefs-section__belief"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -130,7 +130,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -155,7 +155,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 beliefs-section__belief"
+                class="card flex items-start transition-transform duration-200 flex-col beliefs-section__belief"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -167,7 +167,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"

--- a/apps/website/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`TeamSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                class="card flex items-start transition-transform duration-200 flex-col team-section__card"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -56,7 +56,7 @@ exports[`TeamSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -96,7 +96,7 @@ exports[`TeamSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                class="card flex items-start transition-transform duration-200 flex-col team-section__card"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -108,7 +108,7 @@ exports[`TeamSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -148,7 +148,7 @@ exports[`TeamSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                class="card flex items-start transition-transform duration-200 flex-col team-section__card"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -160,7 +160,7 @@ exports[`TeamSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -200,7 +200,7 @@ exports[`TeamSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                class="card flex items-start transition-transform duration-200 flex-col team-section__card"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -212,7 +212,7 @@ exports[`TeamSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -252,7 +252,7 @@ exports[`TeamSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                class="card flex items-start transition-transform duration-200 flex-col team-section__card"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -264,7 +264,7 @@ exports[`TeamSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -304,7 +304,7 @@ exports[`TeamSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 team-section__card"
+                class="card flex items-start transition-transform duration-200 flex-col team-section__card"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -316,7 +316,7 @@ exports[`TeamSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"

--- a/apps/website/src/components/about/__snapshots__/TeamSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/TeamSection.test.tsx.snap
@@ -85,6 +85,24 @@ exports[`TeamSection > renders as expected 1`] = `
                       >
                         LinkedIn
                       </span>
+                      <span
+                        class="cta-button__chevron ml-3"
+                      >
+                        <svg
+                          class="cta-button__chevron-icon size-2"
+                          fill="currentColor"
+                          height="1em"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </div>
                 </div>
@@ -136,6 +154,24 @@ exports[`TeamSection > renders as expected 1`] = `
                         class="cta-button__text"
                       >
                         LinkedIn
+                      </span>
+                      <span
+                        class="cta-button__chevron ml-3"
+                      >
+                        <svg
+                          class="cta-button__chevron-icon size-2"
+                          fill="currentColor"
+                          height="1em"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                          />
+                        </svg>
                       </span>
                     </a>
                   </div>
@@ -189,6 +225,24 @@ exports[`TeamSection > renders as expected 1`] = `
                       >
                         LinkedIn
                       </span>
+                      <span
+                        class="cta-button__chevron ml-3"
+                      >
+                        <svg
+                          class="cta-button__chevron-icon size-2"
+                          fill="currentColor"
+                          height="1em"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </div>
                 </div>
@@ -240,6 +294,24 @@ exports[`TeamSection > renders as expected 1`] = `
                         class="cta-button__text"
                       >
                         LinkedIn
+                      </span>
+                      <span
+                        class="cta-button__chevron ml-3"
+                      >
+                        <svg
+                          class="cta-button__chevron-icon size-2"
+                          fill="currentColor"
+                          height="1em"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                          />
+                        </svg>
                       </span>
                     </a>
                   </div>
@@ -293,6 +365,24 @@ exports[`TeamSection > renders as expected 1`] = `
                       >
                         LinkedIn
                       </span>
+                      <span
+                        class="cta-button__chevron ml-3"
+                      >
+                        <svg
+                          class="cta-button__chevron-icon size-2"
+                          fill="currentColor"
+                          height="1em"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                          />
+                        </svg>
+                      </span>
                     </a>
                   </div>
                 </div>
@@ -344,6 +434,24 @@ exports[`TeamSection > renders as expected 1`] = `
                         class="cta-button__text"
                       >
                         LinkedIn
+                      </span>
+                      <span
+                        class="cta-button__chevron ml-3"
+                      >
+                        <svg
+                          class="cta-button__chevron-icon size-2"
+                          fill="currentColor"
+                          height="1em"
+                          stroke="currentColor"
+                          stroke-width="0"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                          />
+                        </svg>
                       </span>
                     </a>
                   </div>

--- a/apps/website/src/components/blog/BlogListSection.tsx
+++ b/apps/website/src/components/blog/BlogListSection.tsx
@@ -63,13 +63,13 @@ export const BlogListItem = ({ blog }: {
   return (
     <div className="blog-list__listing">
       <Card
-        className="blog-list__card container-lined"
+        className="blog-list__card container-lined hover:container-elevated p-8"
         ctaText="Read more"
         ctaUrl={url}
+        isEntireCardClickable={!isMobile}
         isFullWidth={!isMobile}
         subtitle={`${blog.authorName} • ${formattedDate}`}
         title={blog.title}
-        withCTA
       />
     </div>
   );

--- a/apps/website/src/components/blog/BlogListSection.tsx
+++ b/apps/website/src/components/blog/BlogListSection.tsx
@@ -62,30 +62,15 @@ export const BlogListItem = ({ blog }: {
 
   return (
     <div className="blog-list__listing">
-      {isMobile ? (
-        <Card
-          className="blog-list__card--mobile container-lined p-6 max-w-full"
-          title={blog.title}
-          subtitle={`${formattedDate} • ${blog.authorName}`}
-          ctaText="Read more"
-          ctaUrl={url}
-        />
-      ) : (
-        <div className="blog-list__card--desktop w-full flex flex-row items-center justify-between p-8 container-lined">
-          <div className="flex-1">
-            <strong className="blog-list__title">{blog.title}</strong>
-            <P className="blog-list__subtitle">{formattedDate} • {blog.authorName}</P>
-          </div>
-          <CTALinkOrButton
-            className="blog-list__cta-button"
-            variant="secondary"
-            withChevron
-            url={url}
-          >
-            Read more
-          </CTALinkOrButton>
-        </div>
-      )}
+      <Card
+        className="blog-list__card container-lined"
+        ctaText="Read more"
+        ctaUrl={url}
+        isFullWidth={!isMobile}
+        subtitle={`${blog.authorName} • ${formattedDate}`}
+        title={blog.title}
+        withCTA
+      />
     </div>
   );
 };

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultiSelect.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultiSelect.test.tsx.snap
@@ -1,0 +1,320 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MultiSelect > renders default as expected 1`] = `
+<div>
+  <form
+    class="multiselect container-lined bg-white p-8 flex flex-col gap-6"
+  >
+    <div
+      class="multiselect__header flex flex-col gap-4"
+    >
+      <div
+        class="multiselect__header-icon"
+      >
+        <img
+          alt=""
+          class="w-15 h-15"
+          src="/icons/lightning_bolt.svg"
+        />
+      </div>
+      <div
+        class="multiselect__header-content flex flex-col gap-2"
+      >
+        <p
+          class="multiselect__title bluedot-h4"
+        >
+          Understanding LLMs
+        </p>
+        <p
+          class="bluedot-p not-prose multiselect__description"
+        >
+          Why is a language model's ability to predict 'the next word' capable of producing complex behaviors like solving maths problems?
+        </p>
+      </div>
+    </div>
+    <div
+      class="multiselect__options flex flex-col gap-2"
+    >
+      <label
+        class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              container-lined"
+      >
+        <input
+          class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+          disabled=""
+          name="answers"
+          type="checkbox"
+          value="The community's preference for low-tech fishing traditions"
+        />
+        <span
+          class="input__label"
+        >
+          The community's preference for low-tech fishing traditions
+        </span>
+      </label>
+      <label
+        class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              container-lined"
+      >
+        <input
+          class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+          disabled=""
+          name="answers"
+          type="checkbox"
+          value="Rising consumer demand for fish with more Omega-3s"
+        />
+        <span
+          class="input__label"
+        >
+          Rising consumer demand for fish with more Omega-3s
+        </span>
+      </label>
+      <label
+        class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              container-lined"
+      >
+        <input
+          class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+          disabled=""
+          name="answers"
+          type="checkbox"
+          value="Environmental regulations and declining cod stocks"
+        />
+        <span
+          class="input__label"
+        >
+          Environmental regulations and declining cod stocks
+        </span>
+      </label>
+      <label
+        class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              container-lined"
+      >
+        <input
+          class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+          disabled=""
+          name="answers"
+          type="checkbox"
+          value="A cultural shift toward vegetarianism in the region"
+        />
+        <span
+          class="input__label"
+        >
+          A cultural shift toward vegetarianism in the region
+        </span>
+      </label>
+    </div>
+    <a
+      class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--primary bg-bluedot-normal link-on-dark multiselect__login-cta"
+      href="http://localhost:3000/login?redirect_to=http%3A%2F%2Flocalhost%3A3000%2F"
+      tabindex="0"
+    >
+      <span
+        class="cta-button__text"
+      >
+        Login to check your answer
+      </span>
+      <span
+        class="cta-button__chevron ml-3"
+      >
+        <svg
+          class="cta-button__chevron-icon size-2"
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 320 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+          />
+        </svg>
+      </span>
+    </a>
+  </form>
+</div>
+`;
+
+exports[`MultiSelect > renders logged in as expected 1`] = `
+<div>
+  <form
+    class="multiselect container-lined bg-white p-8 flex flex-col gap-6"
+  >
+    <div
+      class="multiselect__header flex flex-col gap-4"
+    >
+      <div
+        class="multiselect__header-icon"
+      >
+        <img
+          alt=""
+          class="w-15 h-15"
+          src="/icons/lightning_bolt.svg"
+        />
+      </div>
+      <div
+        class="multiselect__header-content flex flex-col gap-2"
+      >
+        <p
+          class="multiselect__title bluedot-h4"
+        >
+          Understanding LLMs
+        </p>
+        <p
+          class="bluedot-p not-prose multiselect__description"
+        >
+          Why is a language model's ability to predict 'the next word' capable of producing complex behaviors like solving maths problems?
+        </p>
+      </div>
+    </div>
+    <div
+      class="multiselect__options flex flex-col gap-2"
+    >
+      <label
+        class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              container-lined"
+      >
+        <input
+          class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+          name="answers"
+          type="checkbox"
+          value="The community's preference for low-tech fishing traditions"
+        />
+        <span
+          class="input__label"
+        >
+          The community's preference for low-tech fishing traditions
+        </span>
+      </label>
+      <label
+        class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              container-lined"
+      >
+        <input
+          class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+          name="answers"
+          type="checkbox"
+          value="Rising consumer demand for fish with more Omega-3s"
+        />
+        <span
+          class="input__label"
+        >
+          Rising consumer demand for fish with more Omega-3s
+        </span>
+      </label>
+      <label
+        class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              container-lined"
+      >
+        <input
+          class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+          name="answers"
+          type="checkbox"
+          value="Environmental regulations and declining cod stocks"
+        />
+        <span
+          class="input__label"
+        >
+          Environmental regulations and declining cod stocks
+        </span>
+      </label>
+      <label
+        class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              container-lined"
+      >
+        <input
+          class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+          name="answers"
+          type="checkbox"
+          value="A cultural shift toward vegetarianism in the region"
+        />
+        <span
+          class="input__label"
+        >
+          A cultural shift toward vegetarianism in the region
+        </span>
+      </label>
+    </div>
+    <button
+      class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--primary bg-bluedot-normal link-on-dark multiselect__submit"
+      type="button"
+    >
+      <span
+        class="cta-button__text"
+      >
+        Check
+      </span>
+    </button>
+  </form>
+</div>
+`;
+
+exports[`MultiSelect > updates styles for correct options 1`] = `
+<label
+  class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              multiselect__option--selected container-active
+                multiselect__option--correct bg-[#63C96533] border-[#63C965]
+                false"
+>
+  <input
+    class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+    name="answers"
+    type="checkbox"
+    value="The community's preference for low-tech fishing traditions"
+  />
+  <span
+    class="input__label"
+  >
+    The community's preference for low-tech fishing traditions
+  </span>
+</label>
+`;
+
+exports[`MultiSelect > updates styles for correct options 2`] = `
+<p
+  class="bluedot-p not-prose multiselect__correct-msg"
+>
+  Correct! Quiz completed. 🎉
+</p>
+`;
+
+exports[`MultiSelect > updates styles for incorrect options 1`] = `
+<label
+  class="input flex items-center gap-2 cursor-pointer 
+              multiselect__option flex items-center gap-2 p-4 hover:cursor-pointer
+              multiselect__option--selected container-active
+                false
+                multiselect__option--incorrect bg-[#FF636333] border-[#FF6363]"
+>
+  <input
+    class="input--checkbox size-6 accent-bluedot-normal rounded cursor-pointer"
+    name="answers"
+    type="checkbox"
+    value="Environmental regulations and declining cod stocks"
+  />
+  <span
+    class="input__label"
+  >
+    Environmental regulations and declining cod stocks
+  </span>
+</label>
+`;
+
+exports[`MultiSelect > updates styles for incorrect options 2`] = `
+<p
+  class="bluedot-p not-prose multiselect__incorrect-msg"
+>
+  Try again. 🤔
+</p>
+`;

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
             style="scroll-margin-left: -0px;"
           >
             <div
-              class="card flex flex-col items-start transition-transform duration-200 community-values-section__value"
+              class="card flex items-start transition-transform duration-200 flex-col community-values-section__value"
             >
               <div
                 class="card__image-container w-full mb-4"
@@ -53,7 +53,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
               >
                 <div
                   class="card__text"
@@ -73,7 +73,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
             style="scroll-margin-left: -0px;"
           >
             <div
-              class="card flex flex-col items-start transition-transform duration-200 community-values-section__value"
+              class="card flex items-start transition-transform duration-200 flex-col community-values-section__value"
             >
               <div
                 class="card__image-container w-full mb-4"
@@ -85,7 +85,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
               >
                 <div
                   class="card__text"
@@ -105,7 +105,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
             style="scroll-margin-left: -0px;"
           >
             <div
-              class="card flex flex-col items-start transition-transform duration-200 community-values-section__value"
+              class="card flex items-start transition-transform duration-200 flex-col community-values-section__value"
             >
               <div
                 class="card__image-container w-full mb-4"
@@ -117,7 +117,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
               >
                 <div
                   class="card__text"
@@ -137,7 +137,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
             style="scroll-margin-left: -0px;"
           >
             <div
-              class="card flex flex-col items-start transition-transform duration-200 community-values-section__value"
+              class="card flex items-start transition-transform duration-200 flex-col community-values-section__value"
             >
               <div
                 class="card__image-container w-full mb-4"
@@ -149,7 +149,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
               >
                 <div
                   class="card__text"

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <a
-                class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] projects__project"
+                class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] projects__project"
                 href="https://aisafetyfundamentals.com/projects/contextual-constitutional-ai/"
               >
                 <div
@@ -62,7 +62,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -87,7 +87,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <a
-                class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] projects__project"
+                class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] projects__project"
                 href="https://aisafetyfundamentals.com/projects/safety-haven-justifying-and-exploring-an-antitrust-safe-haven-for-ai-safety-research-collaboration/"
               >
                 <div
@@ -100,7 +100,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -125,7 +125,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <a
-                class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] projects__project"
+                class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] projects__project"
                 href="https://aisafetyfundamentals.com/projects/societal-adaptation-to-ai-human-labor-automation/"
               >
                 <div
@@ -138,7 +138,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -163,7 +163,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <a
-                class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] projects__project"
+                class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] projects__project"
                 href="https://aisafetyfundamentals.com/projects/are-you-secretly-training-ai-methods-for-uncovering-covert-ai-training-a-framework-for-feasibility-and-future-research/"
               >
                 <div
@@ -176,7 +176,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
             style="scroll-margin-left: -0px;"
           >
             <div
-              class="card flex flex-col items-start transition-transform duration-200 community-values-section__value"
+              class="card flex items-start transition-transform duration-200 flex-col community-values-section__value"
             >
               <div
                 class="card__image-container w-full mb-4"
@@ -53,7 +53,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
               >
                 <div
                   class="card__text"
@@ -73,7 +73,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
             style="scroll-margin-left: -0px;"
           >
             <div
-              class="card flex flex-col items-start transition-transform duration-200 community-values-section__value"
+              class="card flex items-start transition-transform duration-200 flex-col community-values-section__value"
             >
               <div
                 class="card__image-container w-full mb-4"
@@ -85,7 +85,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
               >
                 <div
                   class="card__text"
@@ -105,7 +105,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
             style="scroll-margin-left: -0px;"
           >
             <div
-              class="card flex flex-col items-start transition-transform duration-200 community-values-section__value"
+              class="card flex items-start transition-transform duration-200 flex-col community-values-section__value"
             >
               <div
                 class="card__image-container w-full mb-4"
@@ -117,7 +117,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
               >
                 <div
                   class="card__text"
@@ -137,7 +137,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
             style="scroll-margin-left: -0px;"
           >
             <div
-              class="card flex flex-col items-start transition-transform duration-200 community-values-section__value"
+              class="card flex items-start transition-transform duration-200 flex-col community-values-section__value"
             >
               <div
                 class="card__image-container w-full mb-4"
@@ -149,7 +149,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
               >
                 <div
                   class="card__text"

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`CourseSection > renders as expected 1`] = `
                     class="p-[3px] h-full"
                   >
                     <a
-                      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
+                      class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
                       href="https://aisafetyfundamentals.com/economics-of-tai/"
                     >
                       <div
@@ -136,7 +136,7 @@ exports[`CourseSection > renders as expected 1`] = `
                         />
                       </div>
                       <div
-                        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                        class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                       >
                         <div
                           class="card__text"
@@ -194,7 +194,7 @@ exports[`CourseSection > renders as expected 1`] = `
                     class="p-[3px] h-full"
                   >
                     <a
-                      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
+                      class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
                       href="https://aisafetyfundamentals.com/alignment/"
                     >
                       <div
@@ -207,7 +207,7 @@ exports[`CourseSection > renders as expected 1`] = `
                         />
                       </div>
                       <div
-                        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                        class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                       >
                         <div
                           class="card__text"
@@ -265,7 +265,7 @@ exports[`CourseSection > renders as expected 1`] = `
                     class="p-[3px] h-full"
                   >
                     <a
-                      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
+                      class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
                       href="https://aisafetyfundamentals.com/governance/"
                     >
                       <div
@@ -278,7 +278,7 @@ exports[`CourseSection > renders as expected 1`] = `
                         />
                       </div>
                       <div
-                        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                        class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                       >
                         <div
                           class="card__text"

--- a/apps/website/src/components/join-us/JobsListSection.test.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.test.tsx
@@ -29,8 +29,6 @@ const mockJobs = [
 describe('JobsListSection', () => {
   test('renders default as expected', () => {
     const { container } = render(<JobsListSection jobs={mockJobs} />);
-    expect(container.querySelector('.jobs-list__card--desktop')).not.toBeNull();
-    expect(container.querySelector('.jobs-list__card--mobile')).toBeNull();
     expect(container).toMatchSnapshot();
   });
 
@@ -38,8 +36,6 @@ describe('JobsListSection', () => {
     vi.spyOn(deviceDetect, 'isMobile', 'get').mockReturnValue(true);
     const { container } = render(<JobsListSection jobs={mockJobs} />);
     expect(container).toMatchSnapshot();
-    expect(container.querySelector('.jobs-list__card--desktop')).toBeNull();
-    expect(container.querySelector('.jobs-list__card--mobile')).not.toBeNull();
     vi.clearAllMocks();
   });
 

--- a/apps/website/src/components/join-us/JobsListSection.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.tsx
@@ -1,4 +1,4 @@
-import { Card, CTALinkOrButton, Section } from '@bluedot/ui';
+import { Card, Section } from '@bluedot/ui';
 import { isMobile } from 'react-device-detect';
 import { P } from '../Text';
 import { CmsJobPosting } from '../../lib/api/db/tables';

--- a/apps/website/src/components/join-us/JobsListSection.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.tsx
@@ -35,13 +35,13 @@ const JobListItem = ({ job }: {
   return (
     <div className="jobs-list__listing">
       <Card
-        className="jobs-list__card container-lined"
+        className="jobs-list__card container-lined hover:container-elevated p-8"
         ctaText="Learn more"
         ctaUrl={url}
+        isEntireCardClickable={!isMobile}
         isFullWidth={!isMobile}
         subtitle={job.subtitle}
         title={job.title}
-        withCTA
       />
     </div>
   );

--- a/apps/website/src/components/join-us/JobsListSection.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.tsx
@@ -34,30 +34,15 @@ const JobListItem = ({ job }: {
 
   return (
     <div className="jobs-list__listing">
-      {isMobile ? (
-        <Card
-          className="jobs-list__card--mobile container-lined p-6 max-w-full"
-          title={job.title}
-          subtitle={job.subtitle}
-          ctaText="Learn more"
-          ctaUrl={url}
-        />
-      ) : (
-        <div className="jobs-list__card--desktop w-full flex flex-row items-center justify-between p-8 container-lined">
-          <div className="flex-1">
-            <strong className="jobs-list__title">{job.title}</strong>
-            <P className="jobs-list__subtitle">{job.subtitle}</P>
-          </div>
-          <CTALinkOrButton
-            className="jobs-list__cta-button"
-            variant="secondary"
-            withChevron
-            url={url}
-          >
-            Learn more
-          </CTALinkOrButton>
-        </div>
-      )}
+      <Card
+        className="jobs-list__card container-lined"
+        ctaText="Learn more"
+        ctaUrl={url}
+        isFullWidth={!isMobile}
+        subtitle={job.subtitle}
+        title={job.title}
+        withCTA
+      />
     </div>
   );
 };

--- a/apps/website/src/components/join-us/__snapshots__/JobsListSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/JobsListSection.test.tsx.snap
@@ -1,5 +1,121 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`JobsListSection > renders default as expected 1`] = `
+<div>
+  <section
+    class="section section-body jobs-list-section"
+  >
+    <div
+      class="section-heading__title-container flex justify-between items-center gap-space-between mb-6"
+    >
+      <div
+        class="section-heading__content flex-1 flex flex-col gap-2"
+      >
+        <h2
+          class="section-heading__title relative ml-[-0.08em] bluedot-h2"
+        >
+          Careers at BlueDot Impact
+        </h2>
+      </div>
+    </div>
+    <div
+      class="section__body"
+    >
+      <div
+        class="invisible relative bottom-48"
+        id="open-roles-anchor"
+      />
+      <div
+        class="jobs-list__container flex flex-col gap-8"
+      >
+        <div
+          class="jobs-list__listing"
+        >
+          <div
+            class="card flex items-start transition-transform duration-200 flex-row w-full jobs-list__card container-lined"
+          >
+            <div
+              class="card__content flex gap-6 w-full flex-1 justify-between flex-row w-full"
+            >
+              <div
+                class="card__text"
+              >
+                <p
+                  class="card__title bluedot-h4 mb-2"
+                >
+                  Software Engineer
+                </p>
+                <p
+                  class="card__subtitle bluedot-p "
+                >
+                  Full-time position
+                </p>
+              </div>
+              <div
+                class="card__bottom-section flex flex-col gap-space-between"
+              >
+                <a
+                  class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  href="/join-us/software-engineer"
+                  tabindex="0"
+                >
+                  <span
+                    class="cta-button__text"
+                  >
+                    Learn more
+                  </span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="jobs-list__listing"
+        >
+          <div
+            class="card flex items-start transition-transform duration-200 flex-row w-full jobs-list__card container-lined"
+          >
+            <div
+              class="card__content flex gap-6 w-full flex-1 justify-between flex-row w-full"
+            >
+              <div
+                class="card__text"
+              >
+                <p
+                  class="card__title bluedot-h4 mb-2"
+                >
+                  Product Manager
+                </p>
+                <p
+                  class="card__subtitle bluedot-p "
+                >
+                  Full-time position
+                </p>
+              </div>
+              <div
+                class="card__bottom-section flex flex-col gap-space-between"
+              >
+                <a
+                  class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+                  href="/join-us/product-manager"
+                  tabindex="0"
+                >
+                  <span
+                    class="cta-button__text"
+                  >
+                    Learn more
+                  </span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
 exports[`JobsListSection > renders empty state when no jobs are provided 1`] = `
 <div>
   <section

--- a/apps/website/src/components/join-us/__snapshots__/JobsListSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/JobsListSection.test.tsx.snap
@@ -1,141 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`JobsListSection > renders default as expected 1`] = `
-<div>
-  <section
-    class="section section-body jobs-list-section"
-  >
-    <div
-      class="section-heading__title-container flex justify-between items-center gap-space-between mb-6"
-    >
-      <div
-        class="section-heading__content flex-1 flex flex-col gap-2"
-      >
-        <h2
-          class="section-heading__title relative ml-[-0.08em] bluedot-h2"
-        >
-          Careers at BlueDot Impact
-        </h2>
-      </div>
-    </div>
-    <div
-      class="section__body"
-    >
-      <div
-        class="invisible relative bottom-48"
-        id="open-roles-anchor"
-      />
-      <div
-        class="jobs-list__container flex flex-col gap-8"
-      >
-        <div
-          class="jobs-list__listing"
-        >
-          <div
-            class="jobs-list__card--desktop w-full flex flex-row items-center justify-between p-8 container-lined"
-          >
-            <div
-              class="flex-1"
-            >
-              <strong
-                class="jobs-list__title"
-              >
-                Software Engineer
-              </strong>
-              <p
-                class="bluedot-p not-prose jobs-list__subtitle"
-              >
-                Full-time position
-              </p>
-            </div>
-            <a
-              class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter jobs-list__cta-button"
-              href="/join-us/software-engineer"
-              tabindex="0"
-            >
-              <span
-                class="cta-button__text"
-              >
-                Learn more
-              </span>
-              <span
-                class="cta-button__chevron ml-3"
-              >
-                <svg
-                  class="cta-button__chevron-icon size-2"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-        <div
-          class="jobs-list__listing"
-        >
-          <div
-            class="jobs-list__card--desktop w-full flex flex-row items-center justify-between p-8 container-lined"
-          >
-            <div
-              class="flex-1"
-            >
-              <strong
-                class="jobs-list__title"
-              >
-                Product Manager
-              </strong>
-              <p
-                class="bluedot-p not-prose jobs-list__subtitle"
-              >
-                Full-time position
-              </p>
-            </div>
-            <a
-              class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter jobs-list__cta-button"
-              href="/join-us/product-manager"
-              tabindex="0"
-            >
-              <span
-                class="cta-button__text"
-              >
-                Learn more
-              </span>
-              <span
-                class="cta-button__chevron ml-3"
-              >
-                <svg
-                  class="cta-button__chevron-icon size-2"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-</div>
-`;
-
 exports[`JobsListSection > renders empty state when no jobs are provided 1`] = `
 <div>
   <section
@@ -203,10 +67,10 @@ exports[`JobsListSection > renders mobile as expected 1`] = `
           class="jobs-list__listing"
         >
           <div
-            class="card flex flex-col items-start transition-transform duration-200 jobs-list__card--mobile container-lined p-6 max-w-full"
+            class="card flex items-start transition-transform duration-200 flex-col jobs-list__card container-lined"
           >
             <div
-              class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+              class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
             >
               <div
                 class="card__text"
@@ -244,10 +108,10 @@ exports[`JobsListSection > renders mobile as expected 1`] = `
           class="jobs-list__listing"
         >
           <div
-            class="card flex flex-col items-start transition-transform duration-200 jobs-list__card--mobile container-lined p-6 max-w-full"
+            class="card flex items-start transition-transform duration-200 flex-col jobs-list__card container-lined"
           >
             <div
-              class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+              class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
             >
               <div
                 class="card__text"

--- a/apps/website/src/components/join-us/__snapshots__/JobsListSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/JobsListSection.test.tsx.snap
@@ -31,8 +31,9 @@ exports[`JobsListSection > renders default as expected 1`] = `
         <div
           class="jobs-list__listing"
         >
-          <div
-            class="card flex items-start transition-transform duration-200 flex-row w-full jobs-list__card container-lined"
+          <a
+            class="card flex items-start transition-transform duration-200 flex-row w-full hover:scale-[1.01] jobs-list__card container-lined hover:container-elevated p-8"
+            href="/join-us/software-engineer"
           >
             <div
               class="card__content flex gap-6 w-full flex-1 justify-between flex-row w-full"
@@ -54,26 +55,44 @@ exports[`JobsListSection > renders default as expected 1`] = `
               <div
                 class="card__bottom-section flex flex-col gap-space-between"
               >
-                <a
+                <button
                   class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                  href="/join-us/software-engineer"
-                  tabindex="0"
+                  type="button"
                 >
                   <span
                     class="cta-button__text"
                   >
                     Learn more
                   </span>
-                </a>
+                  <span
+                    class="cta-button__chevron ml-3"
+                  >
+                    <svg
+                      class="cta-button__chevron-icon size-2"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </div>
             </div>
-          </div>
+          </a>
         </div>
         <div
           class="jobs-list__listing"
         >
-          <div
-            class="card flex items-start transition-transform duration-200 flex-row w-full jobs-list__card container-lined"
+          <a
+            class="card flex items-start transition-transform duration-200 flex-row w-full hover:scale-[1.01] jobs-list__card container-lined hover:container-elevated p-8"
+            href="/join-us/product-manager"
           >
             <div
               class="card__content flex gap-6 w-full flex-1 justify-between flex-row w-full"
@@ -95,20 +114,37 @@ exports[`JobsListSection > renders default as expected 1`] = `
               <div
                 class="card__bottom-section flex flex-col gap-space-between"
               >
-                <a
+                <button
                   class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
-                  href="/join-us/product-manager"
-                  tabindex="0"
+                  type="button"
                 >
                   <span
                     class="cta-button__text"
                   >
                     Learn more
                   </span>
-                </a>
+                  <span
+                    class="cta-button__chevron ml-3"
+                  >
+                    <svg
+                      class="cta-button__chevron-icon size-2"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </div>
             </div>
-          </div>
+          </a>
         </div>
       </div>
     </div>
@@ -183,7 +219,7 @@ exports[`JobsListSection > renders mobile as expected 1`] = `
           class="jobs-list__listing"
         >
           <div
-            class="card flex items-start transition-transform duration-200 flex-col jobs-list__card container-lined"
+            class="card flex items-start transition-transform duration-200 flex-col jobs-list__card container-lined hover:container-elevated p-8"
           >
             <div
               class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
@@ -215,6 +251,24 @@ exports[`JobsListSection > renders mobile as expected 1`] = `
                   >
                     Learn more
                   </span>
+                  <span
+                    class="cta-button__chevron ml-3"
+                  >
+                    <svg
+                      class="cta-button__chevron-icon size-2"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
+                  </span>
                 </a>
               </div>
             </div>
@@ -224,7 +278,7 @@ exports[`JobsListSection > renders mobile as expected 1`] = `
           class="jobs-list__listing"
         >
           <div
-            class="card flex items-start transition-transform duration-200 flex-col jobs-list__card container-lined"
+            class="card flex items-start transition-transform duration-200 flex-col jobs-list__card container-lined hover:container-elevated p-8"
           >
             <div
               class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
@@ -255,6 +309,24 @@ exports[`JobsListSection > renders mobile as expected 1`] = `
                     class="cta-button__text"
                   >
                     Learn more
+                  </span>
+                  <span
+                    class="cta-button__chevron ml-3"
+                  >
+                    <svg
+                      class="cta-button__chevron-icon size-2"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
                   </span>
                 </a>
               </div>

--- a/apps/website/src/components/join-us/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/ValuesSection.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 values-section__value"
+                class="card flex items-start transition-transform duration-200 flex-col values-section__value"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -56,7 +56,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -81,7 +81,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 values-section__value"
+                class="card flex items-start transition-transform duration-200 flex-col values-section__value"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -93,7 +93,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"
@@ -118,7 +118,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
               style="scroll-margin-left: -0px;"
             >
               <div
-                class="card flex flex-col items-start transition-transform duration-200 values-section__value"
+                class="card flex items-start transition-transform duration-200 flex-col values-section__value"
               >
                 <div
                   class="card__image-container w-full mb-4"
@@ -130,7 +130,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
                 >
                   <div
                     class="card__text"

--- a/libraries/ui/src/Card.stories.tsx
+++ b/libraries/ui/src/Card.stories.tsx
@@ -15,43 +15,32 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    imageSrc: '/images/intro-course.png',
-    title: 'Default card',
-    subtitle: 'This is a default card.',
-    ctaUrl: 'https://example.com',
     ctaText: 'Learn More',
+    ctaUrl: 'https://example.com',
+    imageSrc: '/images/intro-course.png',
+    subtitle: 'This is a default card.',
+    title: 'Default card',
   },
 };
 
 export const ClickableCard: Story = {
   args: {
+    ctaUrl: 'https://example.com',
     imageSrc: '/images/intro-course.png',
-    title: 'Clickable card',
+    isEntireCardClickable: true,
     subtitle: 'This entire card is clickable.',
+    title: 'Clickable card',
+  },
+};
+
+export const FullWidthCard: Story = {
+  args: {
+    ctaText: 'Learn More',
     ctaUrl: 'https://example.com',
     isEntireCardClickable: true,
-  },
-};
-
-export const CardWithFooter: Story = {
-  args: {
-    imageSrc: '/images/intro-course.png',
-    title: 'Card with footer',
-    subtitle: 'This card has footer content.',
-    ctaUrl: 'https://example.com',
-    ctaText: 'Learn More',
-    footerContent: <div>Footer Content Here</div>,
-  },
-};
-
-export const CardWithCustomStyling: Story = {
-  args: {
-    imageSrc: '/images/intro-course.png',
-    title: 'Card with border',
-    subtitle: 'This card has a border.',
-    ctaUrl: 'https://example.com',
-    ctaText: 'Learn More',
-    footerContent: <span>Commonly you will want to add a border or similar via `className`</span>,
-    className: 'w-[250px] container-lined p-4',
+    isFullWidth: true,
+    subtitle: 'This entire card is clickable.',
+    title: 'Clickable card',
+    withCTA: true,
   },
 };

--- a/libraries/ui/src/Card.stories.tsx
+++ b/libraries/ui/src/Card.stories.tsx
@@ -41,6 +41,5 @@ export const FullWidthCard: Story = {
     isFullWidth: true,
     subtitle: 'This entire card is clickable.',
     title: 'Clickable card',
-    withCTA: true,
   },
 };

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -70,10 +70,10 @@ export const Card: React.FC<CardProps> = ({
           <p className="card__title bluedot-h4 mb-2">{title}</p>
           {subtitle && (<p className={`card__subtitle bluedot-p ${subtitleClassName}`}>{subtitle}</p>)}
         </div>
+        {/* When isEntireCardClickable is true, the CTALinkOrButton does not render a URL because nested URLs are invalid HTML. */}
         {showBottomSection && (
           <div className="card__bottom-section flex flex-col gap-space-between">
             {showCTA && (
-              {/* When isEntireCardClickable is true, the CTALinkOrButton does not render a URL because the Wrapper already handles the clickability. */}
               <CTALinkOrButton
                 className="card__cta"
                 url={isEntireCardClickable ? undefined : ctaUrl}

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -73,6 +73,7 @@ export const Card: React.FC<CardProps> = ({
         {showBottomSection && (
           <div className="card__bottom-section flex flex-col gap-space-between">
             {showCTA && (
+              {/* When isEntireCardClickable is true, the CTALinkOrButton does not render a URL because the Wrapper already handles the clickability. */}
               <CTALinkOrButton
                 className="card__cta"
                 url={isEntireCardClickable ? undefined : ctaUrl}

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -60,11 +60,12 @@ export const Card: React.FC<CardProps> = ({
           />
         </div>
       )}
-
-      <div className={clsx(
-        'card__content flex gap-6 w-full flex-1 justify-between',
-        isFullWidth ? 'flex-row w-full' : 'flex-col',
-      )}>
+      <div
+        className={clsx(
+          'card__content flex gap-6 w-full flex-1 justify-between',
+          isFullWidth ? 'flex-row w-full' : 'flex-col',
+        )}
+      >
         <div className="card__text">
           <p className="card__title bluedot-h4 mb-2">{title}</p>
           {subtitle && (<p className={`card__subtitle bluedot-p ${subtitleClassName}`}>{subtitle}</p>)}

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -33,7 +33,6 @@ export const Card: React.FC<CardProps> = ({
   isFullWidth = false,
   subtitle,
   subtitleClassName = '',
-  withCTA = false,
 }) => {
   const Wrapper = isEntireCardClickable ? 'a' : 'div';
   const wrapperClassName = clsx(
@@ -43,7 +42,7 @@ export const Card: React.FC<CardProps> = ({
     className,
   );
 
-  const showCTA = withCTA || (!isEntireCardClickable && ctaUrl);
+  const showCTA = ctaText || (!isEntireCardClickable && ctaUrl);
   const showBottomSection = !!(showCTA || children);
 
   return (
@@ -78,7 +77,7 @@ export const Card: React.FC<CardProps> = ({
                 className="card__cta"
                 url={isEntireCardClickable ? undefined : ctaUrl}
                 variant="secondary"
-                withChevron={false}
+                withChevron
               >
                 {ctaText}
               </CTALinkOrButton>

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -14,7 +14,6 @@ export type CardProps = {
   imageSrc?: string;
   isEntireCardClickable?: boolean;
   isFullWidth?: boolean;
-  withCTA?: boolean;
   subtitle?: string;
   subtitleClassName?: string;
 };

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -6,37 +6,44 @@ export type CardProps = {
   // Required
   title: string;
   // Optional
-  imageSrc?: string;
-  subtitle?: string;
-  ctaUrl?: string;
-  ctaText?: string;
-  isEntireCardClickable?: boolean;
-  className?: string;
-  imageClassName?: string;
-  subtitleClassName?: string;
   children?: React.ReactNode;
+  className?: string;
+  ctaText?: string;
+  ctaUrl?: string;
+  imageClassName?: string;
+  imageSrc?: string;
+  isEntireCardClickable?: boolean;
+  isFullWidth?: boolean;
+  withCTA?: boolean;
+  subtitle?: string;
+  subtitleClassName?: string;
 };
 
 export const Card: React.FC<CardProps> = ({
-  imageSrc,
+  // Required
   title,
-  subtitle,
-  ctaUrl,
-  ctaText,
-  isEntireCardClickable = false,
-  className = '',
-  imageClassName = '',
-  subtitleClassName = '',
+  // Optional
   children,
+  className = '',
+  ctaText,
+  ctaUrl,
+  imageClassName = '',
+  imageSrc,
+  isEntireCardClickable = false,
+  isFullWidth = false,
+  subtitle,
+  subtitleClassName = '',
+  withCTA = false,
 }) => {
   const Wrapper = isEntireCardClickable ? 'a' : 'div';
   const wrapperClassName = clsx(
-    'card flex flex-col items-start transition-transform duration-200',
+    'card flex items-start transition-transform duration-200',
+    isFullWidth ? 'flex-row w-full' : 'flex-col',
     isEntireCardClickable && 'hover:scale-[1.01]',
     className,
   );
 
-  const showCTA = !isEntireCardClickable && ctaUrl;
+  const showCTA = withCTA || (!isEntireCardClickable && ctaUrl);
   const showBottomSection = !!(showCTA || children);
 
   return (
@@ -54,7 +61,10 @@ export const Card: React.FC<CardProps> = ({
         </div>
       )}
 
-      <div className="card__content flex flex-col gap-6 w-full flex-1 justify-between">
+      <div className={clsx(
+        'card__content flex gap-6 w-full flex-1 justify-between',
+        isFullWidth ? 'flex-row w-full' : 'flex-col',
+      )}>
         <div className="card__text">
           <p className="card__title bluedot-h4 mb-2">{title}</p>
           {subtitle && (<p className={`card__subtitle bluedot-p ${subtitleClassName}`}>{subtitle}</p>)}
@@ -64,7 +74,7 @@ export const Card: React.FC<CardProps> = ({
             {showCTA && (
               <CTALinkOrButton
                 className="card__cta"
-                url={ctaUrl}
+                url={isEntireCardClickable ? undefined : ctaUrl}
                 variant="secondary"
                 withChevron={false}
               >

--- a/libraries/ui/src/__snapshots__/Card.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Card.test.tsx.snap
@@ -44,6 +44,24 @@ exports[`Card > renders default as expected 1`] = `
           >
             LinkedIn
           </span>
+          <span
+            class="cta-button__chevron ml-3"
+          >
+            <svg
+              class="cta-button__chevron-icon size-2"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </span>
         </a>
       </div>
     </div>
@@ -82,6 +100,38 @@ exports[`Card > renders with isEntireCardClickable as expected 1`] = `
         >
           Developer
         </p>
+      </div>
+      <div
+        class="card__bottom-section flex flex-col gap-space-between"
+      >
+        <button
+          class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+          type="button"
+        >
+          <span
+            class="cta-button__text"
+          >
+            LinkedIn
+          </span>
+          <span
+            class="cta-button__chevron ml-3"
+          >
+            <svg
+              class="cta-button__chevron-icon size-2"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </span>
+        </button>
       </div>
     </div>
   </a>

--- a/libraries/ui/src/__snapshots__/Card.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Card.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Card > renders default as expected 1`] = `
 <div>
   <div
-    class="card flex flex-col items-start transition-transform duration-200"
+    class="card flex items-start transition-transform duration-200 flex-col"
   >
     <div
       class="card__image-container w-full mb-4"
@@ -15,7 +15,7 @@ exports[`Card > renders default as expected 1`] = `
       />
     </div>
     <div
-      class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+      class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
     >
       <div
         class="card__text"
@@ -54,7 +54,7 @@ exports[`Card > renders default as expected 1`] = `
 exports[`Card > renders with isEntireCardClickable as expected 1`] = `
 <div>
   <a
-    class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01]"
+    class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01]"
     href="https://linkedin.com/in/johndoe"
   >
     <div
@@ -67,7 +67,7 @@ exports[`Card > renders with isEntireCardClickable as expected 1`] = `
       />
     </div>
     <div
-      class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+      class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
     >
       <div
         class="card__text"

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`CourseCard > renders default as expected 1`] = `
     class="p-[3px] h-full"
   >
     <a
-      class="card flex flex-col items-start transition-transform duration-200 hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
+      class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
       href="https://bluedot.org/courses/what-the-fish"
     >
       <div
@@ -87,7 +87,7 @@ exports[`CourseCard > renders default as expected 1`] = `
         />
       </div>
       <div
-        class="card__content flex flex-col gap-6 w-full flex-1 justify-between"
+        class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
       >
         <div
           class="card__text"


### PR DESCRIPTION
# Summary

Add isFullWidth Card option

## Description

- Add `isFullWidth` option for Cards
- Allow CTAs even if `isEntireCardClickable` by omitting URLs to the `CTALinkOrButton`

### To-do

- BlogListSection and JobListSection is not rendering locally for me. Investigating access tokens.

## Developer checklist
- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
- [ ] Added or updated Jest tests
- [ ] Added or updated Storybook stories

## Screenshot

<img width="1487" alt="Screenshot 2025-04-30 at 22 16 45" src="https://github.com/user-attachments/assets/9683bb14-237d-4294-b7ca-f19e84b9784e" />
<img width="1511" alt="Screenshot 2025-04-30 at 22 17 13" src="https://github.com/user-attachments/assets/5aecca8b-118b-438b-bfc0-74c28f93bc8d" />
<img width="1501" alt="Screenshot 2025-04-30 at 22 16 57" src="https://github.com/user-attachments/assets/b11abe91-ade8-4ba9-97a2-03deac8a9eaa" />


## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```