### PR TITLE
Fix relative parent on Nav

### DIFF
--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -56,7 +56,7 @@ export const Nav: React.FC<NavProps> = ({
       )}
     >
       <ClickAwayListener onClickAway={() => setExpandedSections({ mobileNav: false, explore: false, profile: false })}>
-        <div className="relative nav__container section-base">
+        <div className="nav__container section-base">
           <div className="nav__bar w-full flex justify-between items-center h-[72px] sm:h-[100px]">
             {/* Mobile & Tablet: Hamburger Button */}
             <MobileNavLinks

--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -85,7 +85,7 @@ const ExploreDropdown: React.FC<{
           className,
         )}
       >
-        <div className="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty">
+        <div className={clsx('explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty', !expandedSections.explore && 'hidden')}>
           <H3 className="explore-dropdown__dropdown-title font-bold pt-4">Our courses</H3>
           {courses?.map((course) => (
             <A key={course.url} href={course.url} className={NAV_LINK_CLASSES(isScrolled)}>

--- a/apps/website/src/components/Nav/_ProfileLinks.tsx
+++ b/apps/website/src/components/Nav/_ProfileLinks.tsx
@@ -30,7 +30,7 @@ export const ProfileLinks: React.FC<{
         setOpen={onToggleProfile}
       />
       <div className={clsx('profile-links__drawer', DRAWER_CLASSES(isScrolled, expandedSections.profile))}>
-        <div className="profile-links__links flex flex-col gap-4 items-end section-base">
+        <div className={clsx('profile-links__links flex flex-col gap-4 items-end section-base', !expandedSections.profile && 'hidden')}>
           <A href={ROUTES.profile.url} className={NAV_LINK_CLASSES(isScrolled)}>Profile</A>
           <A href={ROUTES.contact.url} className={NAV_LINK_CLASSES(isScrolled)}>Help</A>
           <A href={ROUTES.logout.url} className={NAV_LINK_CLASSES(isScrolled)}>Log out</A>

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Nav > renders with courses 1`] = `
     class="nav sticky top-0 z-50 w-full container-elevated transition-all duration-300 bg-color-canvas"
   >
     <div
-      class="relative nav__container section-base"
+      class="nav__container section-base"
     >
       <div
         class="nav__bar w-full flex justify-between items-center h-[72px] sm:h-[100px]"

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Nav > renders with courses 1`] = `
             </svg>
           </button>
           <div
-            class="mobile-nav-links__drawer absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x pb-10 transition-[max-height,opacity] duration-300 bg-color-canvas max-h-0 opacity-0"
+            class="mobile-nav-links__drawer absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 opacity-0 pb-0"
           >
             <div
               class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
@@ -58,7 +58,7 @@ exports[`Nav > renders with courses 1`] = `
                   class="explore-dropdown"
                 >
                   <button
-                    class="explore-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation no-underline"
+                    class="explore-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline"
                     type="button"
                   >
                     Explore
@@ -77,10 +77,10 @@ exports[`Nav > renders with courses 1`] = `
                     </svg>
                   </button>
                   <div
-                    class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x pb-10 transition-[max-height,opacity] duration-300 bg-color-canvas max-h-0 opacity-0"
+                    class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 opacity-0 pb-0"
                   >
                     <div
-                      class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty"
+                      class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty hidden"
                     >
                       <h3
                         class="bluedot-h3 not-prose explore-dropdown__dropdown-title font-bold pt-4"
@@ -88,14 +88,14 @@ exports[`Nav > renders with courses 1`] = `
                         Our courses
                       </h3>
                       <a
-                        class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                         href="/course1"
                         tabindex="0"
                       >
                         Course 1
                       </a>
                       <a
-                        class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                         href="/course2"
                         tabindex="0"
                       >
@@ -110,28 +110,28 @@ exports[`Nav > renders with courses 1`] = `
                   </div>
                 </div>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                   href="/about"
                   tabindex="0"
                 >
                   About us
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                   href="/join-us"
                   tabindex="0"
                 >
                   Join us
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                   href="/blog"
                   tabindex="0"
                 >
                   Blog
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                   href="https://lu.ma/aisafetycommunityevents?utm_source=website&utm_campaign=nav"
                   tabindex="0"
                 >
@@ -174,7 +174,7 @@ exports[`Nav > renders with courses 1`] = `
             class="explore-dropdown"
           >
             <button
-              class="explore-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation no-underline"
+              class="explore-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline"
               type="button"
             >
               Explore
@@ -193,10 +193,10 @@ exports[`Nav > renders with courses 1`] = `
               </svg>
             </button>
             <div
-              class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x pb-10 transition-[max-height,opacity] duration-300 bg-color-canvas max-h-0 opacity-0"
+              class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 opacity-0 pb-0"
             >
               <div
-                class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty"
+                class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty hidden"
               >
                 <h3
                   class="bluedot-h3 not-prose explore-dropdown__dropdown-title font-bold pt-4"
@@ -204,14 +204,14 @@ exports[`Nav > renders with courses 1`] = `
                   Our courses
                 </h3>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                   href="/course1"
                   tabindex="0"
                 >
                   Course 1
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                   href="/course2"
                   tabindex="0"
                 >
@@ -226,28 +226,28 @@ exports[`Nav > renders with courses 1`] = `
             </div>
           </div>
           <a
-            class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
             href="/about"
             tabindex="0"
           >
             About us
           </a>
           <a
-            class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
             href="/join-us"
             tabindex="0"
           >
             Join us
           </a>
           <a
-            class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
             href="/blog"
             tabindex="0"
           >
             Blog
           </a>
           <a
-            class="bluedot-a not-prose nav-link nav-link-animation no-underline"
+            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
             href="https://lu.ma/aisafetycommunityevents?utm_source=website&utm_campaign=nav"
             tabindex="0"
           >

--- a/apps/website/src/components/Nav/utils.ts
+++ b/apps/website/src/components/Nav/utils.ts
@@ -3,13 +3,13 @@ import clsx from 'clsx';
 export const TRANSITION_DURATION_CLASS = 'duration-300';
 
 export const DRAWER_CLASSES = (isScrolled: boolean, isOpen: boolean) => clsx(
-  `absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x pb-10 transition-[max-height,opacity] ${TRANSITION_DURATION_CLASS}`,
+  `absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] ${TRANSITION_DURATION_CLASS}`,
   isScrolled ? 'bg-color-canvas-dark' : 'bg-color-canvas',
-  isOpen ? 'max-h-[700px] opacity-100' : 'max-h-0 opacity-0',
+  isOpen ? 'max-h-[700px] opacity-100 pb-10' : 'max-h-0 opacity-0 pb-0',
 );
 
 export const NAV_LINK_CLASSES = (isScrolled: boolean, isCurrentPath?: boolean) => (
-  clsx('nav-link nav-link-animation no-underline', isScrolled && 'nav-link-animation-dark', isCurrentPath && 'font-bold')
+  clsx('nav-link nav-link-animation w-fit no-underline', isScrolled && 'nav-link-animation-dark', isCurrentPath && 'font-bold')
 );
 
 export type ExpandedSectionsState = {


### PR DESCRIPTION
# Summary

Fix relative parent on Nav

## Description

- No need for `relative` nav__container parent
- Underline on hover should only cover width: fit-content
- Profile drawer would overlay the Explore drawer at certain interactions. Hide content as much as possible (but avoid using `hidden` to maintain the smooth open/close transition)

## Screenshot
<img width="1233" alt="Screenshot 2025-05-03 at 12 32 55 AM" src="https://github.com/user-attachments/assets/c72edd49-bf6b-47d6-b390-88cd139f69d9" />
<img width="1461" alt="Screenshot 2025-05-03 at 12 28 42 AM" src="https://github.com/user-attachments/assets/dffafdf6-448e-4a2e-bcd5-a51bd3c84c43" />
<img width="1461" alt="Screenshot 2025-05-03 at 12 28 36 AM" src="https://github.com/user-attachments/assets/854fe84b-00ef-4cb6-8113-3092ab7c74a6" />

<img width="1233" alt="Screenshot 2025-05-03 at 12 47 15 AM" src="https://github.com/user-attachments/assets/f7a444d2-2f68-4506-878a-176ffd4ccafa" />
<img width="1234" alt="Screenshot 2025-05-03 at 12 47 10 AM" src="https://github.com/user-attachments/assets/e2f1f35a-32aa-4ce5-99d4-a45fe959292d" />

<img width="368" alt="Screenshot 2025-05-03 at 12 48 46 AM" src="https://github.com/user-attachments/assets/13526308-9a1b-4357-a246-f82fedf44d73" />
<img width="375" alt="Screenshot 2025-05-03 at 12 48 42 AM" src="https://github.com/user-attachments/assets/137e5259-b445-4ee7-a541-3add2576ac46" />

## Testing
```
$ npm run test:update
<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
```