### PR TITLE
website: nav: hotfix overlap issues

### DIFF
--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -80,7 +80,7 @@ const ExploreDropdown: React.FC<{
       <div
         className={clsx(
           `explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] ${TRANSITION_DURATION_CLASS}`,
-          expanded ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0',
+          expanded ? 'max-h-96 opacity-100' : 'max-h-0 hidden',
           !expandedSections.mobileNav && DRAWER_CLASSES(isScrolled, expanded),
           className,
         )}

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Nav > renders with courses 1`] = `
             </svg>
           </button>
           <div
-            class="mobile-nav-links__drawer absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 opacity-0 pb-0"
+            class="mobile-nav-links__drawer absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
           >
             <div
               class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
@@ -77,7 +77,7 @@ exports[`Nav > renders with courses 1`] = `
                     </svg>
                   </button>
                   <div
-                    class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 opacity-0 pb-0"
+                    class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
                   >
                     <div
                       class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty hidden"
@@ -193,7 +193,7 @@ exports[`Nav > renders with courses 1`] = `
               </svg>
             </button>
             <div
-              class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 opacity-0 absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 opacity-0 pb-0"
+              class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
             >
               <div
                 class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty hidden"

--- a/apps/website/src/components/Nav/utils.ts
+++ b/apps/website/src/components/Nav/utils.ts
@@ -5,7 +5,7 @@ export const TRANSITION_DURATION_CLASS = 'duration-300';
 export const DRAWER_CLASSES = (isScrolled: boolean, isOpen: boolean) => clsx(
   `absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] ${TRANSITION_DURATION_CLASS}`,
   isScrolled ? 'bg-color-canvas-dark' : 'bg-color-canvas',
-  isOpen ? 'max-h-[700px] opacity-100 pb-10' : 'max-h-0 opacity-0 pb-0',
+  isOpen ? 'max-h-[700px] opacity-100 pb-10' : 'max-h-0 hidden pb-0',
 );
 
 export const NAV_LINK_CLASSES = (isScrolled: boolean, isCurrentPath?: boolean) => (


### PR DESCRIPTION
On mobile the opacity-0 element was blocking users from clicking almost anything on the page - because it is still there, just transparent :(

This change sets the element to be hidden when closed, so it doesn't intercept any touch events.

It does mean we lose the nice animations, but the site becomes useable on mobile again - can fix this up more properly when we're back next week.