### PR TITLE
website: Hide OTel webpack warnings

### DIFF
--- a/libraries/ui/src/default-config/next.js
+++ b/libraries/ui/src/default-config/next.js
@@ -59,7 +59,7 @@ const withDefaultBlueDotNextConfig = async (config) => ({
     webpackConfig.ignoreWarnings = webpackConfig.ignoreWarnings ?? [];
     webpackConfig.ignoreWarnings.push({ module: /opentelemetry/, message: /the request of a dependency is an expression/ });
 
-    // Conditionally reuqired, but we don't actually use it
+    // Conditionally required, but we don't actually use it
     webpackConfig.externals.push('@opentelemetry/winston-transport');
     webpackConfig.externals.push('@opentelemetry/exporter-jaeger');
 


### PR DESCRIPTION
Fixes warnings like:

```
 ○ Compiling /instrumentation ...
 ⚠ ../../node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
../../node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
../../node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/index.js
../../node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/build/esm/platform/index.js
../../node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation/build/esm/index.js
../../node_modules/@opentelemetry/sdk-node/build/src/sdk.js
../../node_modules/@opentelemetry/sdk-node/build/src/index.js
../../libraries/ui/src/default-config/instrumentation.ts
```

See https://github.com/open-telemetry/opentelemetry-js/issues/4173