### PR TITLE
website, website-proxy, infra: Add redirects and landers for old websites

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -43,7 +43,7 @@ export const services: ServiceDefinition[] = [
         image: 'ghcr.io/bluedotimpact/bluedot-website-proxy:latest',
       }],
     },
-    hosts: ['website-proxy.k8s.bluedot.org', 'www.bluedot.org', 'bluedot.org'],
+    hosts: ['website-proxy.k8s.bluedot.org', 'www.bluedot.org', 'bluedot.org', 'www.aisafetyfundamentals.com', 'aisafetyfundamentals.com', 'www.biosecurityfundamentals.com', 'biosecurityfundamentals.com'],
   },
   {
     name: 'bluedot-website',

--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -1,6 +1,42 @@
 http {
     proxy_ssl_server_name on;
 
+    # Redirect aisafetyfundamentals.com -> bluedot.org with from_site=aisf
+    server {
+        listen 8080;
+        add_header X-BlueDot-Version '$VERSION_TAG';
+        server_name aisafetyfundamentals.com www.aisafetyfundamentals.com;
+        
+        # Preserve path and query params, add from_site=aisf
+        set $new_uri $request_uri;
+        if ($request_uri ~ ^(.*)\?(.*)$) {
+            set $new_uri $1?$2&from_site=aisf;
+        }
+        if ($request_uri !~ \?) {
+            set $new_uri $request_uri?from_site=aisf;
+        }
+        
+        return 301 $scheme://bluedot.org$new_uri;
+    }
+
+    # Redirect biosecurityfundamentals.com -> bluedot.org with from_site=bsf
+    server {
+        listen 8080;
+        add_header X-BlueDot-Version '$VERSION_TAG';
+        server_name biosecurityfundamentals.com www.biosecurityfundamentals.com;
+        
+        # Preserve path and query params, add from_site=bsf
+        set $new_uri $request_uri;
+        if ($request_uri ~ ^(.*)\?(.*)$) {
+            set $new_uri $1?$2&from_site=bsf;
+        }
+        if ($request_uri !~ \?) {
+            set $new_uri $request_uri?from_site=bsf;
+        }
+        
+        return 301 $scheme://bluedot.org$new_uri;
+    }
+
     # Redirect www.bluedot.org -> bluedot.org
     server {
         listen 8080;
@@ -14,28 +50,90 @@ http {
         add_header X-BlueDot-Version '$VERSION_TAG';
 
         # Redirects
-        location = /careers {
-            return 301 $scheme://$host/join-us;
+        # Course redirects
+        location = /intro-to-tai {
+            return 301 $scheme://$host/courses/intro-to-tai$is_args$args;
+        }
+        location = /intro-to-tai/ {
+            return 301 $scheme://$host/courses/intro-to-tai/$is_args$args;
         }
 
+        location = /writing {
+            return 301 $scheme://$host/courses/writing$is_args$args;
+        }
+        location = /writing/ {
+            return 301 $scheme://$host/courses/writing/$is_args$args;
+        }
+
+        location = /alignment {
+            return 301 $scheme://$host/courses/alignment$is_args$args;
+        }
+        location = /alignment/ {
+            return 301 $scheme://$host/courses/alignment/$is_args$args;
+        }
+
+        location = /alignment-fast-track {
+            return 301 $scheme://$host/courses/alignment$is_args$args;
+        }
+        location = /alignment-fast-track/ {
+            return 301 $scheme://$host/courses/alignment/$is_args$args;
+        }
+
+        location = /governance {
+            return 301 $scheme://$host/courses/governance$is_args$args;
+        }
+        location = /governance/ {
+            return 301 $scheme://$host/courses/governance/$is_args$args;
+        }
+
+        location = /governance-fast-track {
+            return 301 $scheme://$host/courses/governance$is_args$args;
+        }
+        location = /governance-fast-track/ {
+            return 301 $scheme://$host/courses/governance/$is_args$args;
+        }
+
+        location = /economics-of-tai {
+            return 301 $scheme://$host/courses/economics-of-tai$is_args$args;
+        }
+        location = /economics-of-tai/ {
+            return 301 $scheme://$host/courses/economics-of-tai/$is_args$args;
+        }
+        
+        location = /economics-of-tai-fast-track {
+            return 301 $scheme://$host/courses/economics-of-tai$is_args$args;
+        }
+        location = /economics-of-tai-fast-track/ {
+            return 301 $scheme://$host/courses/economics-of-tai/$is_args$args;
+        }
+
+        location = /pandemics {
+            return 301 $scheme://$host/courses/pandemics$is_args$args;
+        }
+        location = /pandemics/ {
+            return 301 $scheme://$host/courses/pandemics/$is_args$args;
+        }
+
+        # Career redirects
+        location = /careers {
+            return 301 $scheme://$host/join-us$is_args$args;
+        }
         location = /careers/ {
-            return 301 $scheme://$host/join-us;
+            return 301 $scheme://$host/join-us$is_args$args;
         }
 
         location = /careers/swe-contractor {
-            return 301 $scheme://$host/join-us/swe-contractor;
+            return 301 $scheme://$host/join-us/swe-contractor$is_args$args;
         }
-
         location = /careers/swe-contractor/ {
-            return 301 $scheme://$host/join-us/swe-contractor;
+            return 301 $scheme://$host/join-us/swe-contractor$is_args$args;
         }
 
         location = /careers/ai-safety-teaching-fellow {
-            return 301 $scheme://$host/join-us/ai-safety-teaching-fellow;
+            return 301 $scheme://$host/join-us/ai-safety-teaching-fellow$is_args$args;
         }
-
         location = /careers/ai-safety-teaching-fellow/ {
-            return 301 $scheme://$host/join-us/ai-safety-teaching-fellow;
+            return 301 $scheme://$host/join-us/ai-safety-teaching-fellow$is_args$args;
         }
 
         # For the future of AI, use the new course hub

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -8,12 +8,15 @@ import {
   CookieBanner, Footer, constants,
 } from '@bluedot/ui';
 import { useEffect } from 'react';
-import { Router } from 'next/router';
+import { Router, useRouter } from 'next/router';
 import { Analytics } from '../components/Analytics';
 import { Nav } from '../components/Nav/Nav';
 import { AnnouncementBanner } from '../components/AnnouncementBanner';
 
 const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
+  const fromSiteParam = useRouter().query.from_site as string;
+  const fromSite = ['aisf', 'bsf'].includes(fromSiteParam) ? fromSiteParam as 'aisf' | 'bsf' : null;
+
   useEffect(() => {
     if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) {
       // eslint-disable-next-line no-console
@@ -69,6 +72,11 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
           : (
             <>
               <Nav logo="/images/logo/BlueDot_Impact_Logo.svg" courses={constants.COURSES} />
+              {fromSite && (
+                <AnnouncementBanner ctaText="Learn more" ctaUrl="/blog/course-website-consolidation">
+                  <b>Welcome from {fromSite === 'aisf' ? 'AI Safety Fundamentals' : 'Biosecurity Fundamentals'}!</b> We've consolidated our course sites in the BlueDot Impact platform to provide a more consistent and higher-quality experience.
+                </AnnouncementBanner>
+              )}
               <AnnouncementBanner ctaText="Reserve your free spot" ctaUrl="https://lu.ma/sa52ofdf?utm_source=website&utm_campaign=banner" hideAfter={new Date('2025-04-25T18:30:00+01:00')}>
                 <b>Don't miss this Friday: </b>Planning a career in the age of A(G)I - an online panel with Luke Drago, Josh Landes & Ben Todd
               </AnnouncementBanner>


### PR DESCRIPTION
- Add redirects in website-proxy to:
  - Handle old course URLs, e.g. `/alignment` -> `/courses/alignment`
  - Migrate people from old sites with redirect hint, e.g. `https://aisafetyfundamentals.com/` -> `https://bluedot.org/?from_site=aisf`
- Add announcement banner on website shown when `from_site` is set, which tells people about the migration (see screenshot below)
- New blog added in CMS: https://bluedot.org/blog/course-website-consolidation

Also see #882

## Issue

Fixes #876

## Screenshot

<img width="946" alt="image" src="https://github.com/user-attachments/assets/87b76a9c-fbb7-4c8f-aff2-d9490c0799c7" />