### PR TITLE
editor: Fix presigned URL generation

### DIFF
--- a/apps/editor/src/pages/api/presigned-upload.ts
+++ b/apps/editor/src/pages/api/presigned-upload.ts
@@ -6,6 +6,7 @@ import env from '../../lib/api/env';
 import { makeApiRoute } from '../../lib/api/makeApiRoute';
 
 const s3Client = new S3Client({
+  region: 'minio',
   endpoint: 'https://storage.k8s.bluedot.org',
   forcePathStyle: true,
   credentials: {
@@ -33,7 +34,7 @@ export default makeApiRoute({
     fileUrl: z.string(),
   }),
 }, async (body) => {
-  const fileName = `editor/${randomUUID()}`;
+  const fileName = `editor/${randomUUID()}${getFileExtension(body.contentType)}`;
 
   const { url: uploadUrl, fields } = await createPresignedPost(s3Client, {
     Bucket: BUCKET_NAME,
@@ -56,3 +57,8 @@ export default makeApiRoute({
     fileUrl,
   };
 });
+
+const getFileExtension = (contentType: string) => {
+  const parts = contentType.split('/');
+  return `.${parts[parts.length - 1]}`;
+};


### PR DESCRIPTION
S3 SDK needs to have region specified, even though it's not used

Also set file extension so that things like `<Embed>` play nicer, as they detect file type in the URL. Maybe at some point we should just create an `<Image>` component instead (or use native markdown images).

Related to #880, #877