### PR TITLE
website: Support tables, footnotes in markdown with remark-gfm

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -40,6 +40,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.56.0",
     "react-icons": "^5.5.0",
+    "remark-gfm": "^4.0.1",
     "zod": "^3.24.2",
     "zustand": "^4.5.2"
   },

--- a/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -7,6 +7,7 @@ import { visit } from 'unist-util-visit';
 import type { Plugin } from 'unified';
 import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 import { Collapsible } from '@bluedot/ui';
+import remarkGfm from 'remark-gfm';
 import Greeting from './Greeting';
 import Embed from './Embed';
 import Callout from './Callout';
@@ -67,7 +68,7 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, c
 
     (async () => {
       const evalResult = await evaluate(children, {
-        remarkPlugins: [remarkUnescapeMdxAttributes],
+        remarkPlugins: [remarkUnescapeMdxAttributes, remarkGfm],
         Fragment: React.Fragment,
         jsx: React.createElement,
         jsxs: React.createElement,

--- a/package-lock.json
+++ b/package-lock.json
@@ -489,6 +489,7 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.56.0",
         "react-icons": "^5.5.0",
+        "remark-gfm": "^4.0.1",
         "zod": "^3.24.2",
         "zustand": "^4.5.2"
       },


### PR DESCRIPTION
As per title

<img width="648" alt="image" src="https://github.com/user-attachments/assets/29f559a7-dc6a-4dd9-9002-1c148cbc507d" />

<img width="648" alt="image" src="https://github.com/user-attachments/assets/b470a1be-b17a-4e7e-af10-2358a8a546b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced markdown rendering to support GitHub Flavored Markdown (GFM) features, such as tables, task lists, and strikethrough, in course content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->