### PR TITLE
website: Allow lastSeenAt to be nullable

### DIFF
--- a/apps/website/src/lib/api/db/tables.ts
+++ b/apps/website/src/lib/api/db/tables.ts
@@ -342,7 +342,7 @@ export type User = {
   id: string,
   email: string,
   createdAt: string,
-  lastSeenAt: string,
+  lastSeenAt: string | null,
   name: string,
   referralId: string,
   referredById: string,
@@ -373,7 +373,7 @@ export const userTable: Table<User> = {
   schema: {
     email: 'string',
     createdAt: 'string',
-    lastSeenAt: 'string',
+    lastSeenAt: 'string | null',
     name: 'string',
     referralId: 'string',
     referredById: 'string',


### PR DESCRIPTION
I think this is because users created by the old course hub don't have this property set correctly? Unsure. But it's not critical that it is set when we fetch the user so we shouldn't throw errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated user information handling to support cases where the "last seen" time may be unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->