### PR TITLE
website: Fix build process env variables

### DIFF
--- a/libraries/docker-scripts/src/multistage/deploy-production.sh
+++ b/libraries/docker-scripts/src/multistage/deploy-production.sh
@@ -7,7 +7,7 @@ IMAGE_NAME="bluedot-$APP_NAME-production"
 VERSION_TAG="$(TZ=UTC date +'%Y%m%d.%H%M%S').$(git rev-parse --short HEAD)"
 
 # Use the corresponding env file for production environment.
-cp .env.production.template .env.production
+cp .env.production.template .env.production.local
 
 # Build
 APP_NAME=$APP_NAME VERSION_TAG=$VERSION_TAG npm run build --if-present

--- a/libraries/docker-scripts/src/multistage/deploy-staging.sh
+++ b/libraries/docker-scripts/src/multistage/deploy-staging.sh
@@ -7,7 +7,7 @@ IMAGE_NAME="bluedot-$APP_NAME"
 VERSION_TAG="$(TZ=UTC date +'%Y%m%d.%H%M%S').$(git rev-parse --short HEAD)"
 
 # Use the corresponding env file for staging environment.
-cp .env.staging.template .env.production
+cp .env.staging.template .env.production.local
 
 # Add no index robots.txt to the public folder.
 mkdir -p public


### PR DESCRIPTION
See https://nextjs.org/docs/pages/guides/environment-variables#environment-variable-load-order

Things load in order:

- process.env
- .env.$(NODE_ENV).local
- .env.local
- .env.$(NODE_ENV)

Because `.env.local` will exist at build time (created by postinstall), this will override `.env.production`. This PR fixes this behaviour by using the file `.env.production.local` as it has higher priority. It's also gitignored which makes building locally less annoying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated production and staging deployment scripts to use a different environment configuration file during the build and deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->