### PR TITLE
feat(website-proxy): Add special redirect for BSF homepage to pandemics course

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -25,16 +25,23 @@ http {
         add_header X-BlueDot-Version '$VERSION_TAG';
         server_name biosecurityfundamentals.com www.biosecurityfundamentals.com;
         
-        # Preserve path and query params, add from_site=bsf
-        set $new_uri $request_uri;
-        if ($request_uri ~ ^(.*)\?(.*)$) {
-            set $new_uri $1?$2&from_site=bsf;
-        }
-        if ($request_uri !~ \?) {
-            set $new_uri $request_uri?from_site=bsf;
+        # Special case for homepage: redirect to /courses/pandemics
+        location = / {
+            return 301 $scheme://bluedot.org/courses/pandemics?from_site=bsf;
         }
         
-        return 301 $scheme://bluedot.org$new_uri;
+        # For all other paths, preserve path and query params, add from_site=bsf
+        location / {
+            set $new_uri $request_uri;
+            if ($request_uri ~ ^(.*)\?(.*)$) {
+                set $new_uri $1?$2&from_site=bsf;
+            }
+            if ($request_uri !~ \?) {
+                set $new_uri $request_uri?from_site=bsf;
+            }
+            
+            return 301 $scheme://bluedot.org$new_uri;
+        }
     }
 
     # Redirect www.bluedot.org -> bluedot.org


### PR DESCRIPTION
Update nginx configuration to redirect biosecurityfundamentals.com root path to bluedot.org/courses/pandemics while maintaining the existing redirect behavior for all other paths.