### PR TITLE
website: fix favicon urls to be absolute so they work on all pages

### DIFF
--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -17,9 +17,9 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
     <PostHogProvider>
       <Head>
         <title>BlueDot Impact</title>
-        <link rel="icon" href="images/logo/favicon/favicon.ico" />
-        <link rel="icon" type="image/svg+xml" href="images/logo/favicon/favicon.svg" />
-        <link rel="apple-touch-icon" sizes="180x180" href="images/logo/favicon/apple-touch-icon.png" />
+        <link rel="icon" href="/images/logo/favicon/favicon.ico" />
+        <link rel="icon" type="image/svg+xml" href="/images/logo/favicon/favicon.svg" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/images/logo/favicon/apple-touch-icon.png" />
         <GoogleTagManager />
       </Head>
       {/* TODO: remove this logic after people stop going here */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated favicon and apple-touch-icon references to use absolute paths, ensuring consistent display across different pages and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->