### PR TITLE
devex: Streamline PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 
 ## Issue
-<!-- If this PR is related to a project, and there's no related issue, link this PR the project -->
+<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->
 
 Fixes #
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,25 @@
-# Summary
+# Description
+<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->
 
-<!-- One line summary of your change -->
+
 
 ## Issue
-<!-- Link to the relevant GitHub issue. Learn more about [linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
-Fixes # (issue)
-<!-- If you have no related issue, make sure to link this PR to the relevant project -->
+<!-- If this PR is related to a project, and there's no related issue, link this PR the project -->
 
-## Description
-
-<!-- Description of the changes you've made -->
+Fixes #
 
 ## Developer checklist
-- [ ] Used [BEM naming convention](https://getbem.com/naming/) for classNames
-- [ ] Added or updated Jest tests
-- [ ] Added or updated Storybook stories
+
+- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
+- [ ] Considered adding tests
+- [ ] Considered adding Storybook stories
+
+<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->
 
 ## Screenshot
+<!-- If this PR results in visual changes -->
 
 | 📸 |  |
 |---------|---|
-| 📕 | <!-- Include a **Storybook** screenshot or screen recording demonstrating your change--> |
-| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
 | 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
-
-## Testing
-```
-$ npm run test:update
-<!-- Run `npm run test` from the base `bluedot` dir and include the output here -->
-```
+| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |


### PR DESCRIPTION
The current template is quite heavy - adds friction to PRs. Have tried to keep the most useful parts of it.

Key changes:
- Dropping the description section, as this usually duplicates the summary section
- Dropping extra comments in the issue section
- Dropping the manual `npm run test` step. We previously discussed removing the `npm run test` guidance, but wanted to keep it as a reminder for devs given CI was slow. Now CI is faster (e.g. website-only changes pass in 1-2 minutes) I think this is less crucial as a section and I've folded it into the checklist.
- Prioritise mobile > desktop screenshots (given more usage on mobile), drop storybook screenshots (as we've almost never used this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the pull request template for improved clarity and consistency.
  - Enhanced instructions and prompts for describing changes, linking issues, and providing screenshots.
  - Expanded and clarified the developer checklist, including reminders about naming conventions, tests, and Storybook stories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->