### PR TITLE
Shrink nav height

### DIFF
--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -56,7 +56,7 @@ export const Nav: React.FC<NavProps> = ({
     >
       <ClickAwayListener onClickAway={() => setExpandedSections({ mobileNav: false, explore: false, profile: false })}>
         <div className="nav__container section-base">
-          <div className="nav__bar w-full flex justify-between items-center h-[72px] sm:h-[100px]">
+          <div className="nav__bar w-full flex justify-between items-center h-16">
             {/* Mobile & Tablet: Hamburger Button */}
             <MobileNavLinks
               expandedSections={expandedSections}

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Nav > renders with courses 1`] = `
       class="nav__container section-base"
     >
       <div
-        class="nav__bar w-full flex justify-between items-center h-[72px] sm:h-[100px]"
+        class="nav__bar w-full flex justify-between items-center h-16"
       >
         <div
           class="mobile-nav-links lg:hidden"
@@ -46,7 +46,7 @@ exports[`Nav > renders with courses 1`] = `
             </svg>
           </button>
           <div
-            class="mobile-nav-links__drawer absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+            class="mobile-nav-links__drawer absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
           >
             <div
               class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
@@ -77,7 +77,7 @@ exports[`Nav > renders with courses 1`] = `
                     </svg>
                   </button>
                   <div
-                    class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+                    class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
                   >
                     <div
                       class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty hidden"
@@ -178,7 +178,7 @@ exports[`Nav > renders with courses 1`] = `
               </svg>
             </button>
             <div
-              class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+              class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
             >
               <div
                 class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty hidden"

--- a/apps/website/src/components/Nav/utils.ts
+++ b/apps/website/src/components/Nav/utils.ts
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 export const TRANSITION_DURATION_CLASS = 'duration-300';
 
 export const DRAWER_CLASSES = (isScrolled: boolean, isOpen: boolean) => clsx(
-  `absolute top-[71px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] lg:top-[92px] px-spacing-x transition-[max-height,opacity,padding] ${TRANSITION_DURATION_CLASS}`,
+  `absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] ${TRANSITION_DURATION_CLASS}`,
   isScrolled ? 'bg-color-canvas-dark' : 'bg-color-canvas',
   isOpen ? 'max-h-[700px] opacity-100 pb-10' : 'max-h-0 hidden pb-0',
 );

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -89,7 +89,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
       </Head>
 
       <Breadcrumbs
-        className="unit__breadcrumbs hidden md:block md:sticky md:top-[100px] z-10"
+        className="unit__breadcrumbs hidden md:block md:sticky md:top-16 z-10"
         route={{
           title: unit.courseTitle,
           url: unit.coursePath,
@@ -110,7 +110,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
         </div>
       </Breadcrumbs>
 
-      <MobileHeader className="unit__mobile-header md:hidden sticky top-[72px] z-10" unit={unit} prevUnit={prevUnit} nextUnit={nextUnit} />
+      <MobileHeader className="unit__mobile-header md:hidden sticky top-16 z-10" unit={unit} prevUnit={prevUnit} nextUnit={nextUnit} />
 
       <Section className="unit__main">
         <div className="unit__content-container flex flex-col md:flex-row">

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
 <div>
   <div>
     <div
-      class="breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between unit__breadcrumbs hidden md:block md:sticky md:top-[100px] z-10"
+      class="breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between unit__breadcrumbs hidden md:block md:sticky md:top-16 z-10"
     >
       <nav
         aria-label="Breadcrumbs"
@@ -86,7 +86,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
       </nav>
     </div>
     <div
-      class="mobile-unit-header bg-color-canvas border-b border-color-divider w-full p-3 unit__mobile-header md:hidden sticky top-[72px] z-10"
+      class="mobile-unit-header bg-color-canvas border-b border-color-divider w-full p-3 unit__mobile-header md:hidden sticky top-16 z-10"
     >
       <nav
         class="mobile-unit-header__nav flex flex-row justify-between"


### PR DESCRIPTION
# Description
- Redesigned nav is always 64px

## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

<img width="533" alt="Screenshot 2025-05-20 at 2 24 44 PM" src="https://github.com/user-attachments/assets/ae59ac59-34b8-4f97-b2c3-6a1c08810e99" />
<img width="529" alt="Screenshot 2025-05-20 at 2 24 29 PM" src="https://github.com/user-attachments/assets/e0b50d0d-6d81-43f1-9711-9c8f1121726a" />
<img width="1250" alt="Screenshot 2025-05-20 at 2 15 48 PM" src="https://github.com/user-attachments/assets/8802e33b-47c9-44d8-96e4-9cdad196f5a6" />
<img width="1246" alt="Screenshot 2025-05-20 at 2 15 41 PM" src="https://github.com/user-attachments/assets/d58ad3a7-58bc-4267-a26d-291fd91afb8b" />
<img width="1249" alt="Screenshot 2025-05-20 at 2 15 38 PM" src="https://github.com/user-attachments/assets/6894b88c-9e38-4f9b-bbb4-6a167d4a6891" />
<img width="1244" alt="Screenshot 2025-05-20 at 2 15 32 PM" src="https://github.com/user-attachments/assets/7b6a6b94-14bc-4bfb-bdd9-42f983d7416d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the height of the navigation bar to a consistent size across all screen sizes.
  - Updated the vertical positioning of the navigation drawer for improved alignment.
  - Modified sticky positioning of breadcrumbs and mobile header for better consistency on various devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->