### PR TITLE
Reorder nav links, add About dropdown

### DIFF
--- a/apps/website/src/components/Nav/Nav.stories.tsx
+++ b/apps/website/src/components/Nav/Nav.stories.tsx
@@ -20,12 +20,7 @@ const meta = {
     layout: 'fullscreen',
   },
   // Note: autodocs removed because it doesn't work with the global logged in/out
-  args: {
-    courses: [
-      { title: 'Course 1', url: '#1' },
-      { title: 'Course 2', url: '#2' },
-    ],
-  },
+  args: {},
   ...loggedOutStory(),
 } satisfies Meta<typeof NavWrapper>;
 

--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -12,17 +12,11 @@ import { ExpandedSectionsState, TRANSITION_DURATION_CLASS } from './utils';
 export type NavProps = {
   className?: string;
   logo?: string;
-  courses: {
-    title: string;
-    url: string;
-    isNew?: boolean;
-  }[];
 };
 
 export const Nav: React.FC<NavProps> = ({
   className,
   logo,
-  courses,
 }) => {
   const isLoggedIn = !!useAuthStore((s) => s.auth);
   const [isScrolled, setIsScrolled] = useState(false);

--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -68,9 +68,7 @@ export const Nav: React.FC<NavProps> = ({
             <MobileNavLinks
               expandedSections={expandedSections}
               updateExpandedSections={updateExpandedSections}
-              courses={courses}
               isScrolled={isScrolled}
-              isLoggedIn={isLoggedIn}
             />
 
             {/* Logo */}
@@ -80,7 +78,6 @@ export const Nav: React.FC<NavProps> = ({
             <DesktopNavLinks
               expandedSections={expandedSections}
               updateExpandedSections={updateExpandedSections}
-              courses={courses}
               isScrolled={isScrolled}
             />
 

--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -28,8 +28,9 @@ export const Nav: React.FC<NavProps> = ({
   const [isScrolled, setIsScrolled] = useState(false);
 
   const [expandedSections, setExpandedSections] = useState<ExpandedSectionsState>({
-    mobileNav: false,
+    about: false,
     explore: false,
+    mobileNav: false,
     profile: false,
   });
 
@@ -54,7 +55,13 @@ export const Nav: React.FC<NavProps> = ({
         className,
       )}
     >
-      <ClickAwayListener onClickAway={() => setExpandedSections({ mobileNav: false, explore: false, profile: false })}>
+      <ClickAwayListener onClickAway={() => setExpandedSections({
+        about: false,
+        explore: false,
+        mobileNav: false,
+        profile: false,
+      })}
+      >
         <div className="nav__container section-base">
           <div className="nav__bar w-full flex justify-between items-center h-16">
             {/* Mobile & Tablet: Hamburger Button */}

--- a/apps/website/src/components/Nav/_DesktopNavLinks.tsx
+++ b/apps/website/src/components/Nav/_DesktopNavLinks.tsx
@@ -2,19 +2,16 @@ import { NavLinks } from './_NavLinks';
 import { ExpandedSectionsState } from './utils';
 
 export const DesktopNavLinks: React.FC<{
-  courses: { title: string; url: string; isNew?: boolean }[];
   expandedSections: ExpandedSectionsState;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
   isScrolled: boolean;
 }> = ({
-  courses,
   expandedSections,
   updateExpandedSections,
   isScrolled,
 }) => {
   return (
     <NavLinks
-      courses={courses}
       expandedSections={expandedSections}
       updateExpandedSections={updateExpandedSections}
       isScrolled={isScrolled}

--- a/apps/website/src/components/Nav/_MobileNavLinks.tsx
+++ b/apps/website/src/components/Nav/_MobileNavLinks.tsx
@@ -8,13 +8,10 @@ import { DRAWER_CLASSES, ExpandedSectionsState } from './utils';
 export const MobileNavLinks: React.FC<{
   expandedSections: ExpandedSectionsState;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
-  courses: { title: string; url: string; isNew?: boolean }[];
   isScrolled: boolean;
-  isLoggedIn: boolean;
 }> = ({
   expandedSections,
   updateExpandedSections,
-  courses,
   isScrolled,
 }) => {
   const onToggleMobileNav = () => {
@@ -39,7 +36,6 @@ export const MobileNavLinks: React.FC<{
             className="mobile-nav-links__nav-links flex-col"
             expandedSections={expandedSections}
             updateExpandedSections={updateExpandedSections}
-            courses={courses}
             isScrolled={isScrolled}
           />
         </div>

--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -3,7 +3,7 @@ import { FaChevronUp, FaChevronDown } from 'react-icons/fa6';
 import { constants } from '@bluedot/ui';
 
 import { ROUTES } from '../../lib/routes';
-import { A, H3 } from '../Text';
+import { A } from '../Text';
 import {
   DRAWER_CLASSES,
   ExpandedSectionsState,
@@ -105,7 +105,7 @@ const NavDropdown: React.FC<{
           className,
         )}
       >
-        <div className={clsx('nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty', !isExpanded && 'hidden')}>
+        <div className={clsx('nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty', !isExpanded && 'hidden')}>
           {links?.map((link) => (
             <A key={link.url} href={link.url} className={clsx(NAV_LINK_CLASSES(isScrolled), 'pt-1')}>
               {link.title}

--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { FaChevronUp, FaChevronDown } from 'react-icons/fa6';
+import { constants } from '@bluedot/ui';
 
 import { ROUTES } from '../../lib/routes';
 import { A, H3 } from '../Text';
@@ -10,6 +11,12 @@ import {
   TRANSITION_DURATION_CLASS,
 } from './utils';
 
+const ABOUT = [
+  { title: 'Our story', url: ROUTES.about.url },
+  { title: 'Careers', url: ROUTES.joinUs.url },
+  { title: 'Contact', url: ROUTES.contact.url },
+];
+
 const isCurrentPath = (url: string): boolean => {
   if (typeof window === 'undefined') return false;
   const currentPath = window.location.pathname;
@@ -17,13 +24,11 @@ const isCurrentPath = (url: string): boolean => {
 };
 
 export const NavLinks: React.FC<{
-  courses: { title: string; url: string; isNew?: boolean }[];
   expandedSections: ExpandedSectionsState;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
   className?: string;
   isScrolled: boolean;
 }> = ({
-  courses,
   expandedSections,
   updateExpandedSections,
   className,
@@ -31,70 +36,84 @@ export const NavLinks: React.FC<{
 }) => {
   return (
     <div className={clsx('nav-links flex gap-9 [&>*]:w-fit', className)}>
-      <ExploreDropdown
-        expanded={expandedSections.explore}
-        courses={courses}
-        isScrolled={isScrolled}
+      <NavDropdown
         expandedSections={expandedSections}
-        updateExpandedSections={updateExpandedSections}
+        isExpanded={expandedSections.explore}
+        isScrolled={isScrolled}
+        links={constants.COURSES}
+        onToggle={() => updateExpandedSections({
+          about: false,
+          explore: !expandedSections.explore,
+          mobileNav: expandedSections.mobileNav,
+          profile: false,
+        })}
+        title="Courses"
       />
-      <A href={ROUTES.about.url} className={NAV_LINK_CLASSES(isScrolled, isCurrentPath(ROUTES.about.url))}>About us</A>
-      <A href={ROUTES.joinUs.url} className={NAV_LINK_CLASSES(isScrolled, isCurrentPath(ROUTES.joinUs.url))}>Join us</A>
+      <NavDropdown
+        expandedSections={expandedSections}
+        isExpanded={expandedSections.about}
+        isScrolled={isScrolled}
+        links={ABOUT}
+        onToggle={() => updateExpandedSections({
+          about: !expandedSections.about,
+          explore: false,
+          mobileNav: expandedSections.mobileNav,
+          profile: false,
+        })}
+        title="About"
+      />
       <A href={ROUTES.blog.url} className={NAV_LINK_CLASSES(isScrolled, isCurrentPath(ROUTES.blog.url))}>Blog</A>
       <A href="https://lu.ma/aisafetycommunityevents?utm_source=website&utm_campaign=nav" className={NAV_LINK_CLASSES(isScrolled)}>Events</A>
     </div>
   );
 };
 
-const ExploreDropdown: React.FC<{
-  expanded: boolean;
-  className?: string;
-  courses: { title: string; url: string; isNew?: boolean }[];
-  isScrolled: boolean;
+const NavDropdown: React.FC<{
+  // Required
   expandedSections: ExpandedSectionsState;
-  updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
+  isExpanded: boolean;
+  isScrolled: boolean;
+  links: { title: string; url: string; isNew?: boolean }[];
+  onToggle: () => void;
+  title: string;
+  // Optional
+  className?: string;
 }> = ({
-  expanded,
-  className,
-  courses,
-  isScrolled,
   expandedSections,
-  updateExpandedSections,
+  isExpanded,
+  isScrolled,
+  links,
+  onToggle,
+  title,
+  className,
 }) => {
-  const onToggleExplore = () => updateExpandedSections({
-    mobileNav: expandedSections.mobileNav,
-    explore: !expandedSections.explore,
-    profile: false,
-  });
-
   return (
-    <div className="explore-dropdown">
+    <div className="nav-dropdown">
       <button
         type="button"
-        onClick={onToggleExplore}
-        className={clsx('explore-dropdown__btn flex items-center gap-2 cursor-pointer', NAV_LINK_CLASSES(isScrolled))}
+        onClick={onToggle}
+        className={clsx('nav-dropdown__btn flex items-center gap-2 cursor-pointer', NAV_LINK_CLASSES(isScrolled))}
       >
-        Explore
-        {expandedSections.explore ? <FaChevronUp /> : <FaChevronDown />}
+        {title}
+        {isExpanded ? <FaChevronUp /> : <FaChevronDown />}
       </button>
       <div
         className={clsx(
-          `explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] ${TRANSITION_DURATION_CLASS}`,
-          expanded ? 'max-h-96 opacity-100' : 'max-h-0 hidden',
-          !expandedSections.mobileNav && DRAWER_CLASSES(isScrolled, expanded),
+          `nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] ${TRANSITION_DURATION_CLASS}`,
+          isExpanded ? 'max-h-96 opacity-100' : 'max-h-0 hidden',
+          !expandedSections.mobileNav ? DRAWER_CLASSES(isScrolled, isExpanded) : 'pt-4',
           className,
         )}
       >
-        <div className={clsx('explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty', !expandedSections.explore && 'hidden')}>
-          <H3 className="explore-dropdown__dropdown-title font-bold pt-4">Our courses</H3>
-          {courses?.map((course) => (
-            <A key={course.url} href={course.url} className={NAV_LINK_CLASSES(isScrolled)}>
-              {course.isNew && (
-                <span className="explore-dropdown__new-badge text-bluedot-normal font-black pr-2">
-                  New!
+        <div className={clsx('nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty', !isExpanded && 'hidden')}>
+          {links?.map((link) => (
+            <A key={link.url} href={link.url} className={clsx(NAV_LINK_CLASSES(isScrolled), 'pt-1')}>
+              {link.title}
+              {link.isNew && (
+                <span className="nav-dropdown__new-badge bg-bluedot-lighter rounded-sm p-1 text-bluedot-normal text-size-xxs font-bold uppercase ml-2">
+                  New
                 </span>
               )}
-              {course.title}
             </A>
           ))}
         </div>

--- a/apps/website/src/components/Nav/_ProfileLinks.tsx
+++ b/apps/website/src/components/Nav/_ProfileLinks.tsx
@@ -16,9 +16,10 @@ export const ProfileLinks: React.FC<{
   updateExpandedSections,
 }) => {
   const onToggleProfile = () => updateExpandedSections({
-    profile: !expandedSections.profile,
-    mobileNav: false,
+    about: false,
     explore: false,
+    mobileNav: false,
+    profile: !expandedSections.profile,
   });
 
   return (

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -55,13 +55,13 @@ exports[`Nav > renders with courses 1`] = `
                 class="nav-links flex gap-9 [&>*]:w-fit mobile-nav-links__nav-links flex-col"
               >
                 <div
-                  class="explore-dropdown"
+                  class="nav-dropdown"
                 >
                   <button
-                    class="explore-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline"
+                    class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline"
                     type="button"
                   >
-                    Explore
+                    Courses
                     <svg
                       fill="currentColor"
                       height="1em"
@@ -77,52 +77,99 @@ exports[`Nav > renders with courses 1`] = `
                     </svg>
                   </button>
                   <div
-                    class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+                    class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
                   >
                     <div
-                      class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty hidden"
+                      class="nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
                     >
-                      <h3
-                        class="bluedot-h3 not-prose explore-dropdown__dropdown-title font-bold pt-4"
-                      >
-                        Our courses
-                      </h3>
                       <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
-                        href="/course1"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/courses/future-of-ai"
                         tabindex="0"
                       >
-                        Course 1
+                        The Future of AI Course
+                        <span
+                          class="nav-dropdown__new-badge bg-bluedot-lighter rounded-sm p-1 text-bluedot-normal text-size-xxs font-bold uppercase ml-2"
+                        >
+                          New
+                        </span>
                       </a>
                       <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
-                        href="/course2"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/courses/economics-of-tai"
                         tabindex="0"
                       >
-                        <span
-                          class="explore-dropdown__new-badge text-bluedot-normal font-black pr-2"
-                        >
-                          New!
-                        </span>
-                        Course 2
+                        Economics of Transformative AI
+                      </a>
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/courses/alignment"
+                        tabindex="0"
+                      >
+                        AI Alignment
+                      </a>
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/courses/governance"
+                        tabindex="0"
+                      >
+                        AI Governance
                       </a>
                     </div>
                   </div>
                 </div>
-                <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
-                  href="/about"
-                  tabindex="0"
+                <div
+                  class="nav-dropdown"
                 >
-                  About us
-                </a>
-                <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
-                  href="/join-us"
-                  tabindex="0"
-                >
-                  Join us
-                </a>
+                  <button
+                    class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline"
+                    type="button"
+                  >
+                    About
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"
+                      />
+                    </svg>
+                  </button>
+                  <div
+                    class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+                  >
+                    <div
+                      class="nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
+                    >
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/about"
+                        tabindex="0"
+                      >
+                        Our story
+                      </a>
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/join-us"
+                        tabindex="0"
+                      >
+                        Careers
+                      </a>
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/contact"
+                        tabindex="0"
+                      >
+                        Contact
+                      </a>
+                    </div>
+                  </div>
+                </div>
                 <a
                   class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
                   href="/blog"
@@ -156,13 +203,13 @@ exports[`Nav > renders with courses 1`] = `
           class="nav-links flex gap-9 [&>*]:w-fit hidden lg:flex"
         >
           <div
-            class="explore-dropdown"
+            class="nav-dropdown"
           >
             <button
-              class="explore-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline"
+              class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline"
               type="button"
             >
-              Explore
+              Courses
               <svg
                 fill="currentColor"
                 height="1em"
@@ -178,52 +225,99 @@ exports[`Nav > renders with courses 1`] = `
               </svg>
             </button>
             <div
-              class="explore-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+              class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
             >
               <div
-                class="explore-dropdown___dropdown-content flex flex-col gap-[14px] w-fit overflow-hidden mx-auto text-pretty hidden"
+                class="nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
               >
-                <h3
-                  class="bluedot-h3 not-prose explore-dropdown__dropdown-title font-bold pt-4"
-                >
-                  Our courses
-                </h3>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
-                  href="/course1"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/courses/future-of-ai"
                   tabindex="0"
                 >
-                  Course 1
+                  The Future of AI Course
+                  <span
+                    class="nav-dropdown__new-badge bg-bluedot-lighter rounded-sm p-1 text-bluedot-normal text-size-xxs font-bold uppercase ml-2"
+                  >
+                    New
+                  </span>
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
-                  href="/course2"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/courses/economics-of-tai"
                   tabindex="0"
                 >
-                  <span
-                    class="explore-dropdown__new-badge text-bluedot-normal font-black pr-2"
-                  >
-                    New!
-                  </span>
-                  Course 2
+                  Economics of Transformative AI
+                </a>
+                <a
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/courses/alignment"
+                  tabindex="0"
+                >
+                  AI Alignment
+                </a>
+                <a
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/courses/governance"
+                  tabindex="0"
+                >
+                  AI Governance
                 </a>
               </div>
             </div>
           </div>
-          <a
-            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
-            href="/about"
-            tabindex="0"
+          <div
+            class="nav-dropdown"
           >
-            About us
-          </a>
-          <a
-            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
-            href="/join-us"
-            tabindex="0"
-          >
-            Join us
-          </a>
+            <button
+              class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline"
+              type="button"
+            >
+              About
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"
+                />
+              </svg>
+            </button>
+            <div
+              class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+            >
+              <div
+                class="nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
+              >
+                <a
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/about"
+                  tabindex="0"
+                >
+                  Our story
+                </a>
+                <a
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/join-us"
+                  tabindex="0"
+                >
+                  Careers
+                </a>
+                <a
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact
+                </a>
+              </div>
+            </div>
+          </div>
           <a
             class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline"
             href="/blog"

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Nav > renders with courses 1`] = `
                     class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
                   >
                     <div
-                      class="nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
+                      class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
                     >
                       <a
                         class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
@@ -144,7 +144,7 @@ exports[`Nav > renders with courses 1`] = `
                     class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
                   >
                     <div
-                      class="nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
+                      class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
                     >
                       <a
                         class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
@@ -228,7 +228,7 @@ exports[`Nav > renders with courses 1`] = `
               class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
             >
               <div
-                class="nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
+                class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
               >
                 <a
                   class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
@@ -292,7 +292,7 @@ exports[`Nav > renders with courses 1`] = `
               class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
             >
               <div
-                class="nav-dropdown___dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
+                class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
               >
                 <a
                   class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"

--- a/apps/website/src/components/Nav/utils.ts
+++ b/apps/website/src/components/Nav/utils.ts
@@ -5,7 +5,7 @@ export const TRANSITION_DURATION_CLASS = 'duration-300';
 export const DRAWER_CLASSES = (isScrolled: boolean, isOpen: boolean) => clsx(
   `absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] ${TRANSITION_DURATION_CLASS}`,
   isScrolled ? 'bg-color-canvas-dark' : 'bg-color-canvas',
-  isOpen ? 'max-h-[700px] opacity-100 pb-10' : 'max-h-0 hidden pb-0',
+  isOpen ? 'max-h-[700px] opacity-100 pt-4 pb-10 border-b border-color-border' : 'max-h-0 hidden pb-0',
 );
 
 export const NAV_LINK_CLASSES = (isScrolled: boolean, isCurrentPath?: boolean) => (
@@ -13,7 +13,8 @@ export const NAV_LINK_CLASSES = (isScrolled: boolean, isCurrentPath?: boolean) =
 );
 
 export type ExpandedSectionsState = {
-  mobileNav: boolean;
+  about: boolean;
   explore: boolean;
+  mobileNav: boolean;
   profile: boolean;
 };

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -37,7 +37,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
           ? <Component {...pageProps} />
           : (
             <>
-              <Nav logo="/images/logo/BlueDot_Impact_Logo.svg" courses={constants.COURSES} />
+              <Nav logo="/images/logo/BlueDot_Impact_Logo.svg" />
               {fromSite && (
                 <AnnouncementBanner ctaText="Learn more" ctaUrl="/blog/course-website-consolidation">
                   <b>Welcome from {fromSite === 'aisf' ? 'AI Safety Fundamentals' : 'Biosecurity Fundamentals'}!</b> We've consolidated our course sites in the BlueDot Impact platform to provide a more consistent and higher-quality experience.

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import '../globals.css';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
-import { CTALinkOrButton, Footer, constants } from '@bluedot/ui';
+import { CTALinkOrButton, Footer } from '@bluedot/ui';
 import { useRouter } from 'next/router';
 import { GoogleTagManager } from '../components/analytics/GoogleTagManager';
 import { PostHogProvider } from '../components/analytics/PostHogProvider';


### PR DESCRIPTION
# Description
- Reorder nav links for new nav proposal
- Abstract the ExploreDropdown to NavDropdown for use in both `explore` and new `about` dropdown menus

## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot


https://github.com/user-attachments/assets/0263395a-1bbe-4cf4-81bb-673386251b9e

https://github.com/user-attachments/assets/3a396227-2818-4e18-88bd-13cb69528af2


https://github.com/user-attachments/assets/f3db7cd0-37d4-4b43-beca-5a8cbca32b57




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified "About" dropdown in the navigation bar, consolidating related links under a single menu.
  - Navigation dropdowns are now more flexible and consistent, supporting dynamic links and improved styling.

- **Bug Fixes**
  - Ensured all navigation dropdowns, including "About," properly collapse when clicking outside the menu.

- **Style**
  - Updated navigation drawer styling with enhanced padding and border for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->