### PR TITLE
Drop elevation on Nav

### DIFF
--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -44,8 +44,8 @@ export const Nav: React.FC<NavProps> = ({
   return (
     <nav
       className={clsx(
-        `nav sticky top-0 z-50 w-full container-elevated transition-all ${TRANSITION_DURATION_CLASS}`,
-        isScrolled ? 'bg-color-canvas-dark **:text-white' : 'bg-color-canvas',
+        `nav sticky top-0 z-50 w-full transition-all ${TRANSITION_DURATION_CLASS}`,
+        isScrolled ? 'bg-color-canvas-dark **:text-white' : 'bg-white border-b border-color-divider',
         className,
       )}
     >

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Nav > renders with courses 1`] = `
 <div>
   <nav
-    class="nav sticky top-0 z-50 w-full container-elevated transition-all duration-300 bg-color-canvas"
+    class="nav sticky top-0 z-50 w-full transition-all duration-300 bg-white border-b border-color-divider"
   >
     <div
       class="nav__container section-base"
@@ -46,7 +46,7 @@ exports[`Nav > renders with courses 1`] = `
             </svg>
           </button>
           <div
-            class="mobile-nav-links__drawer absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+            class="mobile-nav-links__drawer absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-white max-h-0 hidden pb-0"
           >
             <div
               class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
@@ -77,7 +77,7 @@ exports[`Nav > renders with courses 1`] = `
                     </svg>
                   </button>
                   <div
-                    class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+                    class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-white max-h-0 hidden pb-0"
                   >
                     <div
                       class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
@@ -141,7 +141,7 @@ exports[`Nav > renders with courses 1`] = `
                     </svg>
                   </button>
                   <div
-                    class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+                    class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-white max-h-0 hidden pb-0"
                   >
                     <div
                       class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
@@ -225,7 +225,7 @@ exports[`Nav > renders with courses 1`] = `
               </svg>
             </button>
             <div
-              class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+              class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-white max-h-0 hidden pb-0"
             >
               <div
                 class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"
@@ -289,7 +289,7 @@ exports[`Nav > renders with courses 1`] = `
               </svg>
             </button>
             <div
-              class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-color-canvas max-h-0 hidden pb-0"
+              class="nav-dropdown__content-wrapper overflow-hidden transition-[max-height,opacity] duration-300 max-h-0 hidden absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] duration-300 bg-white max-h-0 hidden pb-0"
             >
               <div
                 class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty hidden"

--- a/apps/website/src/components/Nav/utils.ts
+++ b/apps/website/src/components/Nav/utils.ts
@@ -4,7 +4,7 @@ export const TRANSITION_DURATION_CLASS = 'duration-300';
 
 export const DRAWER_CLASSES = (isScrolled: boolean, isOpen: boolean) => clsx(
   `absolute top-16 left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-[max-height,opacity,padding] ${TRANSITION_DURATION_CLASS}`,
-  isScrolled ? 'bg-color-canvas-dark' : 'bg-color-canvas',
+  isScrolled ? 'bg-color-canvas-dark' : 'bg-white',
   isOpen ? 'max-h-[700px] opacity-100 pt-4 pb-10 border-b border-color-border' : 'max-h-0 hidden pb-0',
 );
 


### PR DESCRIPTION
# Description
- Replace elevation with border
- Make Nav bg white to contrast on Course Hub pages

## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<img width="354" alt="Screenshot 2025-05-20 at 5 47 35 PM" src="https://github.com/user-attachments/assets/67220998-3241-4e00-a1f4-bdd2fd528a46" />
<img width="1446" alt="Screenshot 2025-05-20 at 5 47 04 PM" src="https://github.com/user-attachments/assets/51266509-bd6d-401b-b89f-6fc0fa59273f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated navigation bar and drawer background and border styling for improved visual appearance, including a white background and bottom border in the default state and removal of elevation effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->