### PR TITLE
Disable nav buttons for units

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -40,13 +40,9 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({
   return (
     <div className={clsx('mobile-unit-header bg-color-canvas border-b border-color-divider w-full p-3', className)}>
       <nav className="mobile-unit-header__nav flex flex-row justify-between">
-        <div className="mobile-unit-header__prev-unit-container size-8">
-          {prevUnit && (
-            <A className="mobile-unit-header__prev-unit-cta flex flex-row items-center gap-1 no-underline" href={prevUnit?.path} aria-label="Previous unit">
-              <img src="/icons/bubble-arrow.svg" alt="" className="size-8" />
-            </A>
-          )}
-        </div>
+        <A className="mobile-unit-header__prev-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50" disabled={!prevUnit} href={prevUnit?.path} aria-label="Previous unit">
+          <img src="/icons/bubble-arrow.svg" alt="" className="size-8" />
+        </A>
         <div className="mobile-unit-header__course-container flex flex-row gap-2 items-center">
           <img src="/icons/course.svg" className="size-8" alt="" />
           <div className="mobile-unit-header__course-title-container flex flex-col">
@@ -54,13 +50,9 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({
             <p className="mobile-unit-header__course-title bluedot-h4 text-size-xs">{unit.title}</p>
           </div>
         </div>
-        <div className="mobile-unit-header__next-unit-container size-8">
-          {nextUnit && (
-            <A className="mobile-unit-header__next-unit-cta flex flex-row items-center gap-1 no-underline" href={nextUnit?.path} aria-label="Next unit">
-              <img src="/icons/bubble-arrow.svg" alt="" className="size-8 rotate-180" />
-            </A>
-          )}
-        </div>
+        <A className="mobile-unit-header__next-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50" disabled={!nextUnit} href={nextUnit?.path} aria-label="Next unit">
+          <img src="/icons/bubble-arrow.svg" alt="" className="size-8 rotate-180" />
+        </A>
       </nav>
     </div>
   );
@@ -96,16 +88,12 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
         }}
       >
         <div className="unit__breadcrumbs-cta-container flex flex-row items-center gap-6">
-          {prevUnit && (
-            <A className="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline" href={prevUnit?.path} aria-label="Previous unit">
-              <FaArrowLeft className="size-3" /> Prev
-            </A>
-          )}
-          {nextUnit && (
-            <A className="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline" href={nextUnit?.path} aria-label="Next unit">
-              Next <FaArrowRight className="size-3" />
-            </A>
-          )}
+          <A className="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed" disabled={!prevUnit} href={prevUnit?.path} aria-label="Previous unit">
+            <FaArrowLeft className="size-3" /> Prev
+          </A>
+          <A className="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed" disabled={!nextUnit} href={nextUnit?.path} aria-label="Next unit">
+            Next <FaArrowRight className="size-3" />
+          </A>
         </div>
       </Breadcrumbs>
 

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -60,9 +60,31 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
         <div
           class="unit__breadcrumbs-cta-container flex flex-row items-center gap-6"
         >
+          <button
+            aria-label="Previous unit"
+            class="bluedot-a not-prose unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
+            disabled=""
+            type="button"
+          >
+            <svg
+              class="size-3"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 448 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.2 288 416 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-306.7 0L214.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+              />
+            </svg>
+             Prev
+          </button>
           <a
             aria-label="Next unit"
-            class="bluedot-a not-prose unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline"
+            class="bluedot-a not-prose unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
             href="/courses/test-course/2"
             tabindex="0"
           >
@@ -91,9 +113,18 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
       <nav
         class="mobile-unit-header__nav flex flex-row justify-between"
       >
-        <div
-          class="mobile-unit-header__prev-unit-container size-8"
-        />
+        <button
+          aria-label="Previous unit"
+          class="bluedot-a not-prose mobile-unit-header__prev-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50"
+          disabled=""
+          type="button"
+        >
+          <img
+            alt=""
+            class="size-8"
+            src="/icons/bubble-arrow.svg"
+          />
+        </button>
         <div
           class="mobile-unit-header__course-container flex flex-row gap-2 items-center"
         >
@@ -117,22 +148,18 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             </p>
           </div>
         </div>
-        <div
-          class="mobile-unit-header__next-unit-container size-8"
+        <a
+          aria-label="Next unit"
+          class="bluedot-a not-prose mobile-unit-header__next-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50"
+          href="/courses/test-course/2"
+          tabindex="0"
         >
-          <a
-            aria-label="Next unit"
-            class="bluedot-a not-prose mobile-unit-header__next-unit-cta flex flex-row items-center gap-1 no-underline"
-            href="/courses/test-course/2"
-            tabindex="0"
-          >
-            <img
-              alt=""
-              class="size-8 rotate-180"
-              src="/icons/bubble-arrow.svg"
-            />
-          </a>
-        </div>
+          <img
+            alt=""
+            class="size-8 rotate-180"
+            src="/icons/bubble-arrow.svg"
+          />
+        </a>
       </nav>
     </div>
     <section


### PR DESCRIPTION
# Description
- Design feedback

## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<img width="1231" alt="Screenshot 2025-05-21 at 1 12 13 PM" src="https://github.com/user-attachments/assets/ff6749bb-06e0-4c07-b239-a0eb295a5593" />
<img width="390" alt="Screenshot 2025-05-21 at 1 12 07 PM" src="https://github.com/user-attachments/assets/d87dee99-4a10-4cfd-b579-7991a10f7afb" />
<img width="380" alt="Screenshot 2025-05-21 at 1 12 03 PM" src="https://github.com/user-attachments/assets/d6ad0b00-6f10-4bc9-b868-def70d132abc" />
<img width="1212" alt="Screenshot 2025-05-21 at 1 11 54 PM" src="https://github.com/user-attachments/assets/bef38acf-a983-4acf-95e5-a3d902860701" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated navigation links for previous and next units to always be visible, displaying a disabled state when unavailable for improved consistency and clarity.
  - Enhanced visual feedback on disabled navigation links with reduced opacity and disabled styles to prevent interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->