### PR TITLE
Nit picks: greys and titles

### DIFF
--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -6,6 +6,7 @@ import { Unit } from '../../lib/api/db/tables';
 
 type SideBarProps = {
   // Required
+  courseTitle: string;
   units: Unit[];
   currentUnitNumber: number;
   // Optional
@@ -46,6 +47,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   );
 };
 const SideBar: React.FC<SideBarProps> = ({
+  courseTitle,
   className,
   units,
   currentUnitNumber,
@@ -58,8 +60,8 @@ const SideBar: React.FC<SideBarProps> = ({
       <div className="sidebar__header-container flex flex-row gap-2 pb-6">
         <img src="/icons/course.svg" className="size-11" alt="" />
         <div className="sidebar__title-container flex flex-col">
-          <p className="sidebar__course-header text-size-sm text-charcoal-light">Course</p>
-          <p className="sidebar__course-title bluedot-h4">The Future of AI</p>
+          <p className="sidebar__course-header text-size-sm text-[#999eb3]">Course</p>
+          <p className="sidebar__course-title bluedot-h4">{courseTitle}</p>
         </div>
       </div>
       <div className="sidebar__content flex flex-col container-lined bg-white">

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -46,7 +46,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({
         <div className="mobile-unit-header__course-container flex flex-row gap-2 items-center">
           <img src="/icons/course.svg" className="size-8" alt="" />
           <div className="mobile-unit-header__course-title-container flex flex-col">
-            <p className="mobile-unit-header__course-header text-size-xxs text-charcoal-light">{unit.courseTitle}</p>
+            <p className="mobile-unit-header__course-header text-size-xxs text-[#999eb3]">{unit.courseTitle}</p>
             <p className="mobile-unit-header__course-title bluedot-h4 text-size-xs">{unit.title}</p>
           </div>
         </div>

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -101,7 +101,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
 
       <Section className="unit__main">
         <div className="unit__content-container flex flex-col md:flex-row">
-          <SideBar className="hidden md:block" units={units} currentUnitNumber={unitNumber} />
+          <SideBar courseTitle={unit.courseTitle} className="hidden md:block" units={units} currentUnitNumber={unitNumber} />
           <div className="unit__content flex flex-col flex-1 max-w-[680px] mx-auto gap-6 px-0 md:px-spacing-x">
             <div className="unit__title-container">
               <P className="unit__course-title text-size-sm mb-2">Unit {unit.unitNumber}</P>

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -17,15 +17,13 @@ exports[`SideBar > renders default as expected 1`] = `
         class="sidebar__title-container flex flex-col"
       >
         <p
-          class="sidebar__course-header text-size-sm text-charcoal-light"
+          class="sidebar__course-header text-size-sm text-[#999eb3]"
         >
           Course
         </p>
         <p
           class="sidebar__course-title bluedot-h4"
-        >
-          The Future of AI
-        </p>
+        />
       </div>
     </div>
     <div

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -186,14 +186,14 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 class="sidebar__title-container flex flex-col"
               >
                 <p
-                  class="sidebar__course-header text-size-sm text-charcoal-light"
+                  class="sidebar__course-header text-size-sm text-[#999eb3]"
                 >
                   Course
                 </p>
                 <p
                   class="sidebar__course-title bluedot-h4"
                 >
-                  The Future of AI
+                  What the fish [Test Course]
                 </p>
               </div>
             </div>

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             class="mobile-unit-header__course-title-container flex flex-col"
           >
             <p
-              class="mobile-unit-header__course-header text-size-xxs text-charcoal-light"
+              class="mobile-unit-header__course-header text-size-xxs text-[#999eb3]"
             >
               What the fish [Test Course]
             </p>


### PR DESCRIPTION
# Description
- Correct unique grey color
- Correct dynamic title

## Screenshot

<img width="373" alt="Screenshot 2025-05-21 at 2 24 37 PM" src="https://github.com/user-attachments/assets/8aa696fb-5123-42bf-b21b-71449a53c655" />
<img width="1226" alt="Screenshot 2025-05-21 at 2 22 18 PM" src="https://github.com/user-attachments/assets/8602b1dc-69d2-4808-b847-21cde78e39de" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The sidebar now displays the current course title dynamically instead of a fixed text.

- **Style**
  - Updated the course title color in both the sidebar and mobile header for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->