### PR TITLE
Add register interest button to course landing pages

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -67,11 +67,16 @@ const StandardCoursePage = ({ courseData }: { courseData: GetCourseResponse }) =
           <HeroSection>
             <HeroH1>{courseData.course.title}</HeroH1>
             <MarkdownExtendedRenderer className="invert my-8">{courseData.course.description}</MarkdownExtendedRenderer>
-            {courseData.units?.[0]?.path && (
+            <div className="flex flex-row gap-4 justify-center items-center">
+              {courseData.units?.[0]?.path && (
+                <HeroCTAContainer>
+                  <CTALinkOrButton url={courseData.units[0].path}>Browse the curriculum</CTALinkOrButton>
+                </HeroCTAContainer>
+              )}
               <HeroCTAContainer>
-                <CTALinkOrButton url={courseData.units[0].path}>Browse the curriculum for free</CTALinkOrButton>
+                <CTALinkOrButton url="https://forms.bluedot.org/aGd0mXnpcN1gfqlnYNZc">Register interest</CTALinkOrButton>
               </HeroCTAContainer>
-            )}
+            </div>
           </HeroSection>
           <Breadcrumbs
             className="course-serp__breadcrumbs"


### PR DESCRIPTION
# Description
https://bluedotimpact.slack.com/archives/C08LQKWBX9B/p1747910487024989


## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

<img width="371" alt="Screenshot 2025-05-22 at 6 47 48 AM" src="https://github.com/user-attachments/assets/b03de500-e230-42a5-9a7b-64e28d7219f3" />
<img width="1230" alt="Screenshot 2025-05-22 at 6 47 34 AM" src="https://github.com/user-attachments/assets/f12dd4b7-7a6e-42b2-ab8d-96dc1bc5efe0" />
<img width="1232" alt="Screenshot 2025-05-22 at 6 47 25 AM" src="https://github.com/user-attachments/assets/3b5cdcf5-fd08-4b60-9e57-f0ef690270b4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the course page hero section to display both "Browse the curriculum" and "Register interest" buttons side-by-side for improved visibility and access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->