### PR TITLE
Add new Chunk types to Unit GET API

### DIFF
--- a/apps/website/src/lib/api/db/tables.ts
+++ b/apps/website/src/lib/api/db/tables.ts
@@ -152,7 +152,7 @@ export const unitFeedbackTable: Table<UnitFeedback> = {
 
 export type Unit = {
   id: string,
-  chunks: string[],
+  chunks: string[] | null,
   courseId: string,
   courseTitle: string,
   coursePath: string,
@@ -189,7 +189,7 @@ export const unitTable: Table<Unit> = {
     unitPodcastUrl: 'fldwByN7lbmcjc3Fj',
   },
   schema: {
-    chunks: 'string[]',
+    chunks: 'string[] | null',
     courseId: 'string',
     courseTitle: 'string',
     coursePath: 'string',

--- a/apps/website/src/lib/api/db/tables.ts
+++ b/apps/website/src/lib/api/db/tables.ts
@@ -1,5 +1,36 @@
 import { Item, Table } from 'airtable-ts';
 
+export type Chunk = {
+  chunkId: string,
+  unitId: string,
+  chunkTitle: string,
+  chunkOrder: string,
+  chunkType: string,
+  chunkContent: string,
+} & Item;
+
+export const chunkTable: Table<Chunk> = {
+  name: 'Chunk',
+  baseId: 'appbiNKDcn1sGPGOG',
+  tableId: 'tblNeBgFeQ5Qmebfc',
+  mappings: {
+    chunkId: 'fldzijTU9OYrA2pPR',
+    unitId: 'flddMzU52lvSPS88e',
+    chunkTitle: 'fldsx5tA91DiSejw2',
+    chunkOrder: 'fld20cLGpEqVoDADz',
+    chunkType: 'fldEVAjbup2EIaQaj',
+    chunkContent: 'fldiv4wuePLO9UtHr',
+  },
+  schema: {
+    chunkId: 'string',
+    unitId: 'string',
+    chunkTitle: 'string',
+    chunkOrder: 'string',
+    chunkType: 'string',
+    chunkContent: 'string',
+  },
+};
+
 export type Course = {
   certificationBadgeImage: string,
   certificatonDescription: string,
@@ -121,6 +152,7 @@ export const unitFeedbackTable: Table<UnitFeedback> = {
 
 export type Unit = {
   id: string,
+  chunks: string[],
   courseId: string,
   courseTitle: string,
   coursePath: string,
@@ -141,6 +173,7 @@ export const unitTable: Table<Unit> = {
   baseId: 'appbiNKDcn1sGPGOG',
   tableId: 'tblsDKJ8VCyO619nk',
   mappings: {
+    chunks: 'fld0TFVKXKf2rIDiT',
     courseId: 'fldLmQZ0ISTr7xQUE',
     courseTitle: 'fld4AYVyIcfnzfE3Z',
     coursePath: 'fldlCrg7Nv1TPTorZ',
@@ -156,6 +189,7 @@ export const unitTable: Table<Unit> = {
     unitPodcastUrl: 'fldwByN7lbmcjc3Fj',
   },
   schema: {
+    chunks: 'string[]',
     courseId: 'string',
     courseTitle: 'string',
     coursePath: 'string',

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitId]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitId]/index.ts
@@ -47,8 +47,6 @@ export default makeApiRoute({
     throw new createHttpError.NotFound('Unit not found');
   }
 
-  console.log('looking for matching chunks for unit: ', unit.id);
-
   const chunks = (await db.scan(chunkTable, {
     filterByFormula: formula(await db.table(chunkTable) as AirtableTsTable<Chunk>, [
       '=',

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitId]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitId]/index.ts
@@ -1,14 +1,20 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { formula } from 'airtable-ts-formula';
+import { AirtableTsTable, formula } from 'airtable-ts-formula';
 import db from '../../../../../lib/api/db';
 import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
-import { Unit, unitTable } from '../../../../../lib/api/db/tables';
+import {
+  chunkTable,
+  Unit,
+  unitTable,
+  Chunk,
+} from '../../../../../lib/api/db/tables';
 
 export type GetUnitResponse = {
   type: 'success',
   units: Unit[],
   unit: Unit,
+  chunks: Chunk[],
 };
 
 export default makeApiRoute({
@@ -17,6 +23,7 @@ export default makeApiRoute({
     type: z.literal('success'),
     units: z.array(z.any()),
     unit: z.any(),
+    chunks: z.array(z.any()),
   }),
 }, async (body, { raw }) => {
   const { courseSlug, unitId } = raw.req.query;
@@ -26,8 +33,9 @@ export default makeApiRoute({
   if (typeof unitId !== 'string') {
     throw new createHttpError.BadRequest('Invalid unit number');
   }
+
   const units = (await db.scan(unitTable, {
-    filterByFormula: formula(await db.table(unitTable), [
+    filterByFormula: formula(await db.table(unitTable) as AirtableTsTable<Unit>, [
       '=',
       { field: 'courseSlug' },
       courseSlug,
@@ -35,14 +43,24 @@ export default makeApiRoute({
   })).sort((a, b) => Number(a.unitNumber) - Number(b.unitNumber));
 
   const unit = units.find((u) => u.unitNumber === unitId);
-
   if (!unit) {
     throw new createHttpError.NotFound('Unit not found');
   }
+
+  console.log('looking for matching chunks for unit: ', unit.id);
+
+  const chunks = (await db.scan(chunkTable, {
+    filterByFormula: formula(await db.table(chunkTable) as AirtableTsTable<Chunk>, [
+      '=',
+      { field: 'unitId' },
+      unit.id,
+    ]),
+  })).sort((a, b) => Number(a.chunkOrder) - Number(b.chunkOrder));
 
   return {
     type: 'success' as const,
     units,
     unit,
+    chunks,
   };
 });

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitId]/resources.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitId]/resources.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { formula } from 'airtable-ts-formula';
+import { AirtableTsTable, formula } from 'airtable-ts-formula';
 import db from '../../../../../lib/api/db';
 import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
 import {
-  Exercise, exerciseTable, UnitResource, unitResourceTable, unitTable,
+  Exercise, exerciseTable, Unit, UnitResource, unitResourceTable, unitTable,
 } from '../../../../../lib/api/db/tables';
 
 export type GetUnitResourcesResponse = {
@@ -30,7 +30,7 @@ export default makeApiRoute({
   }
 
   const unit = (await db.scan(unitTable, {
-    filterByFormula: formula(await db.table(unitTable), [
+    filterByFormula: formula(await db.table(unitTable) as AirtableTsTable<Unit>, [
       'AND',
       ['=', { field: 'courseSlug' }, courseSlug],
       ['=', { field: 'unitNumber' }, unitId],

--- a/apps/website/src/pages/api/courses/[courseSlug]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/index.ts
@@ -31,14 +31,22 @@ export default makeApiRoute({
 
   const course = (await db.scan(courseTable, {
     // TODO: remove this unnecessary cast after we drop array support for mappings in airtable-ts
-    filterByFormula: formula(await db.table(courseTable) as AirtableTsTable<Course>, ['=', { field: 'slug' }, courseSlug]),
+    filterByFormula: formula(await db.table(courseTable) as AirtableTsTable<Course>, [
+      '=',
+      { field: 'slug' },
+      courseSlug,
+    ]),
   }))[0];
   if (!course) {
     throw new createHttpError.NotFound('Course not found');
   }
 
   const units = (await db.scan(unitTable, {
-    filterByFormula: formula(await db.table(unitTable), ['=', { field: 'courseSlug' }, courseSlug]),
+    filterByFormula: formula(await db.table(unitTable) as AirtableTsTable<Unit>, [
+      '=',
+      { field: 'courseSlug' },
+      courseSlug,
+    ]),
   })).sort((a, b) => Number(a.unitNumber) - Number(b.unitNumber));
 
   return {


### PR DESCRIPTION
NB: WIP. Updating UI.

# Description
- Add new `Chunk` type
- Unit GET response returns all `Chunk`s (we can later use this to provide a more seamless experience when navigating within a Unit)

## Screenshot

### No visual change to existing course
<img width="1250" alt="Screenshot 2025-05-22 at 11 31 19 AM" src="https://github.com/user-attachments/assets/741873b8-e49e-4f26-b47f-325f183abdb7" />

### Updated API responses
<img width="1255" alt="Screenshot 2025-05-22 at 11 31 06 AM" src="https://github.com/user-attachments/assets/a2f052ee-1105-4476-ac6f-18ceeef5217e" />
<img width="1259" alt="Screenshot 2025-05-22 at 11 30 55 AM" src="https://github.com/user-attachments/assets/ca9cd814-7761-41d7-9676-5a006f4d1ad7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving and displaying chunks associated with a unit in the course API.
  - API responses for individual units now include a list of related chunks.

- **Refactor**
  - Improved code organization for database queries and type assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->