### PR TITLE
Update e-learning UI for Chunks

### DIFF
--- a/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitId].test.tsx
+++ b/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitId].test.tsx
@@ -5,6 +5,8 @@ import {
 import { useRouter } from 'next/router';
 import type { NextRouter } from 'next/router';
 import CourseUnitPage from '../../../../../pages/courses/[courseSlug]/[unitId]';
+import { Unit, Chunk } from '../../../../../lib/api/db/tables';
+
 // Mock next/router
 vi.mock('next/router', () => ({
   useRouter: vi.fn(() => ({
@@ -18,6 +20,34 @@ vi.mock('axios-hooks', () => ({
   default: (...args: unknown[]) => mockUseAxios(...args),
 }));
 
+const createMockUnit = (unitNumber: string, title: string, content: string): Unit => ({
+  chunks: ['recuC87TILbjW4eF4'],
+  courseId: 'rec8CeVOWU0mGu2Jf',
+  courseTitle: 'Test Course',
+  coursePath: '/courses/test-course',
+  courseSlug: 'test-course',
+  path: `/courses/test-course/${unitNumber}`,
+  title,
+  content,
+  duration: 30,
+  unitNumber,
+  menuText: title,
+  description: `${title} description`,
+  learningOutcomes: `Learning outcomes for ${title}`,
+  unitPodcastUrl: '',
+  id: `unit-${unitNumber}`,
+});
+
+const createMockChunk = (unitId: string): Chunk => ({
+  chunkId: 'recuC87TILbjW4eF4',
+  unitId,
+  chunkTitle: 'Test Chunk',
+  chunkOrder: '1',
+  chunkType: 'Reading',
+  chunkContent: 'Test chunk content',
+  id: 'recuC87TILbjW4eF4',
+});
+
 describe('CourseUnitPage', () => {
   test('renders unit 0 correctly with 0-indexed units', async () => {
     vi.mocked(useRouter).mockReturnValueOnce({
@@ -25,80 +55,100 @@ describe('CourseUnitPage', () => {
     } as unknown as NextRouter);
 
     const mockUnits = [
-      { unitNumber: '0', title: 'Icebreaker', content: 'Welcome to the course' },
-      { unitNumber: '1', title: 'Unit 1', content: 'First unit content' },
-      { unitNumber: '2', title: 'Unit 2', content: 'Second unit content' },
-      { unitNumber: '3', title: 'Unit 3', content: 'Third unit content' },
+      createMockUnit('0', 'Icebreaker', 'Welcome to the course'),
+      createMockUnit('1', 'Unit 1', 'First unit content'),
+      createMockUnit('2', 'Unit 2', 'Second unit content'),
+      createMockUnit('3', 'Unit 3', 'Third unit content'),
     ];
 
+    const mockChunks = [createMockChunk(mockUnits[0]!.id)];
+
     mockUseAxios.mockReturnValue([{
-      data: { units: mockUnits, unit: mockUnits[0] },
+      data: {
+        units: mockUnits,
+        unit: mockUnits[0]!,
+        chunks: mockChunks,
+      },
       loading: false,
     }]);
 
     const { getByRole, getByText } = render(<CourseUnitPage />);
 
-    expect(getByRole('heading', { level: 1 }).textContent).toBe('Icebreaker');
-    // Markdown renders async
-    waitFor(() => expect(getByText('Welcome to the course')).toBeTruthy());
+    expect(getByRole('heading', { level: 1 }).textContent).toBe('Test Chunk');
+    await waitFor(() => expect(getByText('Test chunk content')).toBeTruthy());
   });
 
-  test('renders unit 3 correctly with 0-indexed units', () => {
+  test('renders unit 3 correctly with 0-indexed units', async () => {
     const mockUnits = [
-      { unitNumber: '0', title: 'Icebreaker', content: 'Welcome to the course' },
-      { unitNumber: '1', title: 'Unit 1', content: 'First unit content' },
-      { unitNumber: '2', title: 'Unit 2', content: 'Second unit content' },
-      { unitNumber: '3', title: 'Unit 3', content: 'Third unit content' },
+      createMockUnit('0', 'Icebreaker', 'Welcome to the course'),
+      createMockUnit('1', 'Unit 1', 'First unit content'),
+      createMockUnit('2', 'Unit 2', 'Second unit content'),
+      createMockUnit('3', 'Unit 3', 'Third unit content'),
     ];
 
+    const mockChunks = [createMockChunk(mockUnits[3]!.id)];
+
     mockUseAxios.mockReturnValue([{
-      data: { units: mockUnits, unit: mockUnits[3] },
+      data: {
+        units: mockUnits,
+        unit: mockUnits[3]!,
+        chunks: mockChunks,
+      },
       loading: false,
     }]);
 
     const { getByRole, getByText } = render(<CourseUnitPage />);
 
-    expect(getByRole('heading', { level: 1 }).textContent).toBe('Unit 3');
-    // Markdown renders async
-    waitFor(() => expect(getByText('Third unit content')).toBeTruthy());
+    expect(getByRole('heading', { level: 1 }).textContent).toBe('Test Chunk');
+    await waitFor(() => expect(getByText('Test chunk content')).toBeTruthy());
   });
 
-  test('renders unit 3 correctly with 1-indexed units', () => {
+  test('renders unit 3 correctly with 1-indexed units', async () => {
     const mockUnits = [
-      { unitNumber: '1', title: 'Unit 1', content: 'First unit content' },
-      { unitNumber: '2', title: 'Unit 2', content: 'Second unit content' },
-      { unitNumber: '3', title: 'Unit 3', content: 'Third unit content' },
-      { unitNumber: '4', title: 'Unit 4', content: 'Fourth unit content' },
+      createMockUnit('1', 'Unit 1', 'First unit content'),
+      createMockUnit('2', 'Unit 2', 'Second unit content'),
+      createMockUnit('3', 'Unit 3', 'Third unit content'),
+      createMockUnit('4', 'Unit 4', 'Fourth unit content'),
     ];
 
+    const mockChunks = [createMockChunk(mockUnits[2]!.id)];
+
     mockUseAxios.mockReturnValue([{
-      data: { units: mockUnits, unit: mockUnits[2] },
+      data: {
+        units: mockUnits,
+        unit: mockUnits[2]!,
+        chunks: mockChunks,
+      },
       loading: false,
     }]);
 
     const { getByRole, getByText } = render(<CourseUnitPage />);
 
-    expect(getByRole('heading', { level: 1 }).textContent).toBe('Unit 3');
-    // Markdown renders async
-    waitFor(() => expect(getByText('Third unit content')).toBeTruthy());
+    expect(getByRole('heading', { level: 1 }).textContent).toBe('Test Chunk');
+    await waitFor(() => expect(getByText('Test chunk content')).toBeTruthy());
   });
 
-  test('renders unit 3 correctly when unit 2 is missing', () => {
+  test('renders unit 3 correctly when unit 2 is missing', async () => {
     const mockUnits = [
-      { unitNumber: '1', title: 'Unit 1', content: 'First unit content' },
-      { unitNumber: '3', title: 'Unit 3', content: 'Third unit content' },
-      { unitNumber: '4', title: 'Unit 4', content: 'Fourth unit content' },
+      createMockUnit('1', 'Unit 1', 'First unit content'),
+      createMockUnit('3', 'Unit 3', 'Third unit content'),
+      createMockUnit('4', 'Unit 4', 'Fourth unit content'),
     ];
 
+    const mockChunks = [createMockChunk(mockUnits[1]!.id)];
+
     mockUseAxios.mockReturnValue([{
-      data: { units: mockUnits, unit: mockUnits[1] },
+      data: {
+        units: mockUnits,
+        unit: mockUnits[1]!,
+        chunks: mockChunks,
+      },
       loading: false,
     }]);
 
     const { getByRole, getByText } = render(<CourseUnitPage />);
 
-    expect(getByRole('heading', { level: 1 }).textContent).toBe('Unit 3');
-    // Markdown renders async
-    waitFor(() => expect(getByText('Third unit content')).toBeTruthy());
+    expect(getByRole('heading', { level: 1 }).textContent).toBe('Test Chunk');
+    await waitFor(() => expect(getByText('Test chunk content')).toBeTruthy());
   });
 });

--- a/apps/website/src/components/courses/SideBar.test.tsx
+++ b/apps/website/src/components/courses/SideBar.test.tsx
@@ -1,5 +1,10 @@
 import { render } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import {
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
 import SideBar from './SideBar';
 import { Unit, Chunk } from '../../lib/api/db/tables';
 
@@ -112,7 +117,7 @@ describe('SideBar', () => {
         currentUnitNumber={1}
         chunks={CHUNKS}
         currentChunkIndex={0}
-        onChunkSelect={() => {}}
+        onChunkSelect={vi.fn()}
       />,
     );
     expect(container).toMatchSnapshot();

--- a/apps/website/src/components/courses/SideBar.test.tsx
+++ b/apps/website/src/components/courses/SideBar.test.tsx
@@ -1,73 +1,120 @@
 import { render } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import SideBar from './SideBar';
+import { Unit, Chunk } from '../../lib/api/db/tables';
 
-const COURSE_UNITS = [
+const COURSE_UNITS: Unit[] = [
   {
+    chunks: ['recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/1',
     title: 'Basic Principles of Fish',
     content: "## Welcome to the deep end! \nThis unit explores the core concepts that _every_ fish enthusiast needs to understand, from basic anatomy to the physics of water movement.\nWe'll explore how fish \n[ ] communicate,\n[ ] navigate,\n[ ] and survive in their watery world\n...with special attention to the unique adaptations that make each species special.\nThrough hands-on exercises and detailed study materials, you'll develop a strong foundation in **_[ichthyology](https://en.wikipedia.org/wiki/Ichthyology)_** (that's fish science for those who don't speak fluent marine biologist).\n",
     duration: 12,
     unitNumber: '1',
+    menuText: 'Basic Principles of Fish',
     description: 'Master the fundamental concepts of fish biology, behavior, and basic aquatic principles.',
+    learningOutcomes: 'Understand fish anatomy, behavior, and aquatic principles',
+    unitPodcastUrl: '',
     id: 'recySscaN1b0Cm1jn',
   },
   {
+    chunks: ['recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/2',
     title: 'What Fish Are People Catching, and Why?',
     content: "Ever wondered why some fishermen chase tuna while others pursue cod? This unit dives into the complex world of modern fishing practices, from traditional line-fishing to industrial-scale operations. We'll examine the technological innovations driving the industry, the economic forces at play, and the eternal question of why that one weird fish at the bottom of the ocean looks like that. Through case studies and practical examples, you'll understand the delicate balance between feeding humanity and keeping our oceans stocked with sufficiently sassy fish.\n",
     duration: 5,
     unitNumber: '2',
+    menuText: 'What Fish Are People Catching, and Why?',
     description: 'Explore current trends in fishing technology and the motives behind different fishing approaches.',
+    learningOutcomes: 'Understand modern fishing practices and their economic impact',
+    unitPodcastUrl: '',
     id: 'recyGMcsDLhp9mPqH',
   },
   {
+    chunks: ['recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/3',
     title: 'The Promise of Fish',
     content: "Fish: they're not just for dinner anymore. This unit explores the untapped potential of our scaly friends in solving global challenges. From fish-powered renewable energy to underwater real estate development, we'll examine how piscine innovations are reshaping our world. We'll also delve into fish-based social networks (Fishbook), fish-inspired fashion trends, and why salmon make excellent financial advisors. Special attention will be paid to the emerging field of fish-human diplomacy.\n",
     duration: 110,
     unitNumber: '3',
+    menuText: 'The Promise of Fish',
     description: 'Understand how fish will revolutionize everything from the economy to your social life.',
+    learningOutcomes: 'Explore innovative applications of fish technology',
+    unitPodcastUrl: '',
     id: 'recjPDtSupcowWbmw',
   },
   {
+    chunks: ['recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/4',
     title: 'The Risks of Fish',
     content: "Not all that glitters is goldfish. This unit examines the darker side of piscine potential, from the threat of fish becoming too self-aware to the risks of sharks learning to use smartphones. Through careful analysis and possibly paranoid speculation, we'll prepare for worst-case scenarios like fish developing opposable fins or deciding to implement their own cryptocurrency. Includes emergency protocols for dealing with fish uprising scenarios.\n",
     duration: 8,
     unitNumber: '4',
+    menuText: 'The Risks of Fish',
     description: 'Explore what could go wrong when fish gain too much power.',
+    learningOutcomes: 'Understand potential risks and challenges in fish technology',
+    unitPodcastUrl: '',
     id: 'recc6cSN9fn3VfTvZ',
   },
   {
+    chunks: ['recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/5',
     title: 'Contributing to Fish Safety',
     content: "### The future of fish-human relations depends on you! \nThis capstone unit brings together everything we've learned about our aquatic [overlords-in-waiting](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBWqLpd7QgEtYIur4g48rq8PhAApbpOuO2fwoRB1aPvZpijMnS) and channels it into practical action. \nWe'll explore how to make the world a safer place for fish while maintaining appropriate species boundaries. \nThrough \n- case studies,\n- hands-on projects,\n- and possibly underwater meditation sessions,\n\nyou'll learn to bridge the gap between gill and lung breathers. \n\n> Warning: May cause increased empathy for tuna sandwiches.\n",
     duration: 15,
     unitNumber: '5',
+    menuText: 'Contributing to Fish Safety',
     description: 'Learn how you can help create a better world for fish (and their reluctant human neighbors).',
+    learningOutcomes: 'Apply knowledge to improve fish-human relations',
+    unitPodcastUrl: '',
     id: 'recIztjGqTNNpLTe1',
+  },
+];
+
+const CHUNKS: Chunk[] = [
+  {
+    chunkId: 'recuC87TILbjW4eF4',
+    unitId: 'recySscaN1b0Cm1jn',
+    chunkTitle: 'What can AI do today?',
+    chunkOrder: '1',
+    chunkType: 'Reading',
+    chunkContent: 'Five years ago, AI systems struggled to form coherent sentences. Today, >5% of the world use AI products like ChatGPT every week for help with work, studies, and creative projects. These systems extend far beyond a simple chat. They can produce art, write complex code, and control robots to do real-world tasks. \n\nThis unit explores how AI is evolving from simple "tools" into autonomous "agents",  capable of setting goals, making complex plans, and acting in the real world.\n',
+    id: 'recuC87TILbjW4eF4',
   },
 ];
 
 describe('SideBar', () => {
   test('renders default as expected', () => {
-    const { container } = render(<SideBar units={COURSE_UNITS} currentUnitNumber={1} />);
+    const { container } = render(
+      <SideBar
+        courseTitle="What the fish [Test Course]"
+        units={COURSE_UNITS}
+        currentUnitNumber={1}
+        chunks={CHUNKS}
+        currentChunkIndex={0}
+        onChunkSelect={() => {}}
+      />,
+    );
     expect(container).toMatchSnapshot();
   });
 });

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import clsx from 'clsx';
 
 import { FaChevronRight } from 'react-icons/fa6';
-import { Unit } from '../../lib/api/db/tables';
+import { Unit, Chunk } from '../../lib/api/db/tables';
+import { A } from '../Text';
 
 type SideBarProps = {
   // Required
   courseTitle: string;
   units: Unit[];
   currentUnitNumber: number;
+  chunks: Chunk[];
+  currentChunkIndex: number;
+  onChunkSelect: (index: number) => void;
   // Optional
   className?: string;
 };
@@ -16,45 +20,70 @@ type SideBarProps = {
 type SideBarCollapsibleProps = {
   unit: Unit;
   isCurrentUnit: boolean;
+  chunks: Chunk[];
+  currentChunkIndex: number;
+  onChunkSelect: (index: number) => void;
 };
 
 const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   unit,
   isCurrentUnit,
+  chunks,
+  currentChunkIndex,
+  onChunkSelect,
 }) => {
   return (
-    <details
-      open={isCurrentUnit}
-      className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
-    >
-      <summary className={clsx('sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider', unit.menuText && 'cursor-pointer')}>
-        <p className="sidebar-collapsible__title font-bold">{unit.unitNumber}. {unit.title}</p>
-        {unit.menuText && (
+    isCurrentUnit ? (
+      <details
+        open={isCurrentUnit}
+        className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+      >
+        <summary className={clsx('sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider', unit.menuText && 'cursor-pointer')}>
+          <p className="sidebar-collapsible__title font-bold">{unit.unitNumber}. {unit.title}</p>
           <span className="sidebar-collapsible__button flex items-center">
             <FaChevronRight className="size-3 transition-transform group-open:rotate-90" />
           </span>
-        )}
-      </summary>
-      {unit.menuText && (
-        <a
-          className={clsx('sidebar-collapsible__content block p-4 hover:bg-bluedot-lightest', isCurrentUnit && 'border-l-4 border-color-primary bg-bluedot-lightest')}
-          href={unit.path}
-        >
-          {unit.menuText}
-        </a>
-      )}
-    </details>
+        </summary>
+        {chunks.map((chunk, index) => (
+          <button
+            type="button"
+            key={chunk.id}
+            onClick={() => onChunkSelect(index)}
+            className={clsx(
+              'sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer',
+              currentChunkIndex === index && 'border-l-4 border-color-primary bg-bluedot-lightest',
+            )}
+          >
+            {chunk.chunkTitle}
+          </button>
+        ))}
+      </details>
+    ) : (
+      <A href={unit.path} className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text">
+        <div className="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider">
+          <p className="sidebar-collapsible__title font-bold">{unit.unitNumber}. {unit.title}</p>
+          <span className="sidebar-collapsible__button flex items-center">
+            <FaChevronRight className="size-3" />
+          </span>
+        </div>
+      </A>
+    )
   );
 };
+
 const SideBar: React.FC<SideBarProps> = ({
   courseTitle,
   className,
   units,
   currentUnitNumber,
+  chunks,
+  currentChunkIndex,
+  onChunkSelect,
 }) => {
   const isCurrentUnit = (unit: Unit) => {
     return currentUnitNumber === Number(unit.unitNumber);
   };
+
   return (
     <div className={clsx('sidebar w-full md:w-[320px] flex flex-col', className)}>
       <div className="sidebar__header-container flex flex-row gap-2 pb-6">
@@ -67,8 +96,12 @@ const SideBar: React.FC<SideBarProps> = ({
       <div className="sidebar__content flex flex-col container-lined bg-white">
         {units.map((unit) => (
           <SideBarCollapsible
+            key={unit.id}
             unit={unit}
             isCurrentUnit={isCurrentUnit(unit)}
+            chunks={chunks}
+            currentChunkIndex={currentChunkIndex}
+            onChunkSelect={onChunkSelect}
           />
         ))}
       </div>

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -60,7 +60,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
       </details>
     ) : (
       <A href={unit.path} className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text">
-        <div className="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider">
+        <div className="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider">
           <p className="sidebar-collapsible__title font-bold">{unit.unitNumber}. {unit.title}</p>
           <span className="sidebar-collapsible__button flex items-center">
             <FaChevronRight className="size-3" />

--- a/apps/website/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website/src/components/courses/UnitLayout.test.tsx
@@ -1,67 +1,127 @@
 import { render } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import {
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
 import UnitLayout from './UnitLayout';
+
+// Mock next/router
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: { chunk: '0' },
+    pathname: '/courses/test-course/1',
+    push: vi.fn(),
+  }),
+}));
 
 const COURSE_UNITS = [
   {
+    chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/1',
     title: 'Basic Principles of Fish',
     content: "## Welcome to the deep end! \nThis unit explores the core concepts that _every_ fish enthusiast needs to understand, from basic anatomy to the physics of water movement.\nWe'll explore how fish \n[ ] communicate,\n[ ] navigate,\n[ ] and survive in their watery world\n...with special attention to the unique adaptations that make each species special.\nThrough hands-on exercises and detailed study materials, you'll develop a strong foundation in **_[ichthyology](https://en.wikipedia.org/wiki/Ichthyology)_** (that's fish science for those who don't speak fluent marine biologist).\n",
     duration: 12,
     unitNumber: '1',
+    menuText: 'Basic Principles of Fish',
     description: 'Master the fundamental concepts of fish biology, behavior, and basic aquatic principles.',
+    learningOutcomes: 'Understand fish anatomy, behavior, and aquatic principles',
+    unitPodcastUrl: '',
     id: 'recySscaN1b0Cm1jn',
   },
   {
+    chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/2',
     title: 'What Fish Are People Catching, and Why?',
     content: "Ever wondered why some fishermen chase tuna while others pursue cod? This unit dives into the complex world of modern fishing practices, from traditional line-fishing to industrial-scale operations. We'll examine the technological innovations driving the industry, the economic forces at play, and the eternal question of why that one weird fish at the bottom of the ocean looks like that. Through case studies and practical examples, you'll understand the delicate balance between feeding humanity and keeping our oceans stocked with sufficiently sassy fish.\n",
     duration: 5,
     unitNumber: '2',
+    menuText: 'What Fish Are People Catching, and Why?',
     description: 'Explore current trends in fishing technology and the motives behind different fishing approaches.',
+    learningOutcomes: 'Understand modern fishing practices and their economic impact',
+    unitPodcastUrl: '',
     id: 'recyGMcsDLhp9mPqH',
   },
   {
+    chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/3',
     title: 'The Promise of Fish',
     content: "Fish: they're not just for dinner anymore. This unit explores the untapped potential of our scaly friends in solving global challenges. From fish-powered renewable energy to underwater real estate development, we'll examine how piscine innovations are reshaping our world. We'll also delve into fish-based social networks (Fishbook), fish-inspired fashion trends, and why salmon make excellent financial advisors. Special attention will be paid to the emerging field of fish-human diplomacy.\n",
     duration: 110,
     unitNumber: '3',
+    menuText: 'The Promise of Fish',
     description: 'Understand how fish will revolutionize everything from the economy to your social life.',
+    learningOutcomes: 'Explore innovative applications of fish technology',
+    unitPodcastUrl: '',
     id: 'recjPDtSupcowWbmw',
   },
   {
+    chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/4',
     title: 'The Risks of Fish',
     content: "Not all that glitters is goldfish. This unit examines the darker side of piscine potential, from the threat of fish becoming too self-aware to the risks of sharks learning to use smartphones. Through careful analysis and possibly paranoid speculation, we'll prepare for worst-case scenarios like fish developing opposable fins or deciding to implement their own cryptocurrency. Includes emergency protocols for dealing with fish uprising scenarios.\n",
     duration: 8,
     unitNumber: '4',
+    menuText: 'The Risks of Fish',
     description: 'Explore what could go wrong when fish gain too much power.',
+    learningOutcomes: 'Understand potential risks and challenges in fish technology',
+    unitPodcastUrl: '',
     id: 'recc6cSN9fn3VfTvZ',
   },
   {
+    chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
     courseId: 'rec8CeVOWU0mGu2Jf',
     courseTitle: 'What the fish [Test Course]',
     coursePath: '/courses/test-course',
+    courseSlug: 'test-course',
     path: '/courses/test-course/5',
     title: 'Contributing to Fish Safety',
     content: "### The future of fish-human relations depends on you! \nThis capstone unit brings together everything we've learned about our aquatic [overlords-in-waiting](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBWqLpd7QgEtYIur4g48rq8PhAApbpOuO2fwoRB1aPvZpijMnS) and channels it into practical action. \nWe'll explore how to make the world a safer place for fish while maintaining appropriate species boundaries. \nThrough \n- case studies,\n- hands-on projects,\n- and possibly underwater meditation sessions,\n\nyou'll learn to bridge the gap between gill and lung breathers. \n\n> Warning: May cause increased empathy for tuna sandwiches.\n",
     duration: 15,
     unitNumber: '5',
+    menuText: 'Contributing to Fish Safety',
     description: 'Learn how you can help create a better world for fish (and their reluctant human neighbors).',
+    learningOutcomes: 'Apply knowledge to improve fish-human relations',
+    unitPodcastUrl: '',
     id: 'recIztjGqTNNpLTe1',
+  },
+];
+
+const CHUNKS = [
+  {
+    chunkId: 'recuC87TILbjW4eF4',
+    unitId: 'reca9wvy33rEtzSBX',
+    chunkTitle: 'What can AI do today?',
+    chunkOrder: '1',
+    chunkType: 'Reading',
+    chunkContent: 'Five years ago, AI systems struggled to form coherent sentences. Today, \u003E5% of the world use AI products like ChatGPT every week for help with work, studies, and creative projects. These systems extend far beyond a simple chat. They can produce art, write complex code, and control robots to do real-world tasks. \n\nThis unit explores how AI is evolving from simple "tools" into autonomous "agents",  capable of setting goals, making complex plans, and acting in the real world.\n',
+    id: 'recuC87TILbjW4eF4',
+  },
+  {
+    chunkId: 'recuC87TILbjW4eF4',
+    unitId: 'reca9wvy33rEtzSBX',
+    chunkTitle: 'What can AI do today?',
+    chunkOrder: '1',
+    chunkType: 'Reading',
+    chunkContent: 'Five years ago, AI systems struggled to form coherent sentences. Today, \u003E5% of the world use AI products like ChatGPT every week for help with work, studies, and creative projects. These systems extend far beyond a simple chat. They can produce art, write complex code, and control robots to do real-world tasks. \n\nThis unit explores how AI is evolving from simple "tools" into autonomous "agents",  capable of setting goals, making complex plans, and acting in the real world.\n',
+    id: 'recuC87TILbjW4eF4',
   },
 ];
 
@@ -69,6 +129,7 @@ describe('UnitLayout', () => {
   test('renders first unit as expected', () => {
     const { container } = render(
       <UnitLayout
+        chunks={CHUNKS}
         unit={COURSE_UNITS[0]!}
         unitNumber={1}
         units={COURSE_UNITS}
@@ -80,6 +141,7 @@ describe('UnitLayout', () => {
   test('renders previous and next unit buttons for middle unit', () => {
     const { container } = render(
       <UnitLayout
+        chunks={CHUNKS}
         unit={COURSE_UNITS[1]!}
         unitNumber={2}
         units={COURSE_UNITS}
@@ -91,6 +153,7 @@ describe('UnitLayout', () => {
   test('renders Congratulations section on final unit', () => {
     const { container } = render(
       <UnitLayout
+        chunks={CHUNKS}
         unit={COURSE_UNITS[COURSE_UNITS.length - 1]!}
         unitNumber={COURSE_UNITS.length}
         units={COURSE_UNITS}

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -105,9 +105,9 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
   };
 
   const handlePrevClick = () => {
-    if (isFirstChunk && prevUnit) {
+    if ((isFirstChunk || chunks.length === 0) && prevUnit) {
       // Navigate to last chunk of previous unit
-      router.push(`${prevUnit.path}?chunk=${chunks.length - 1}`);
+      router.push(`${prevUnit.path}?chunk=${(prevUnit.chunks?.length ?? 0) - 1}`);
     } else if (!isFirstChunk) {
       // Navigate to previous chunk
       handleChunkSelect(currentChunkIndex - 1);
@@ -115,7 +115,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
   };
 
   const handleNextClick = () => {
-    if (isLastChunk && nextUnit) {
+    if ((isLastChunk || chunks.length === 0) && nextUnit) {
       // Navigate to first chunk of next unit
       router.push(`${nextUnit.path}?chunk=0`);
     } else if (!isLastChunk) {
@@ -194,7 +194,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
               <H1 className="unit__title font-serif text-[32px]">{chunks[currentChunkIndex]?.chunkTitle}</H1>
             </div>
             <MarkdownExtendedRenderer>
-              {chunks[currentChunkIndex]?.chunkContent}
+              {chunks[currentChunkIndex]?.chunkContent || unit.content}
             </MarkdownExtendedRenderer>
 
             {isLastChunk && (

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import clsx from 'clsx';
+import { useRouter } from 'next/router';
 import {
   Section,
   CTALinkOrButton,
@@ -9,7 +10,7 @@ import {
 import { FaArrowRight, FaArrowLeft } from 'react-icons/fa6';
 
 import SideBar from './SideBar';
-import { Unit } from '../../lib/api/db/tables';
+import { Unit, Chunk } from '../../lib/api/db/tables';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
 import Congratulations from './Congratulations';
 import { ROUTES } from '../../lib/routes';
@@ -19,38 +20,47 @@ import { A, H1, P } from '../Text';
 
 type UnitLayoutProps = {
   // Required
+  chunks: Chunk[];
   unit: Unit;
   unitNumber: number;
   units: Unit[];
 };
 
 type MobileHeaderProps = {
+  chunks: Chunk[];
+  currentChunkIndex: number;
   className?: string;
   unit: Unit;
   prevUnit?: Unit;
   nextUnit?: Unit;
+  onPrevClick: () => void;
+  onNextClick: () => void;
 };
 
 const MobileHeader: React.FC<MobileHeaderProps> = ({
   className,
   unit,
+  chunks,
+  currentChunkIndex,
   prevUnit,
   nextUnit,
+  onPrevClick,
+  onNextClick,
 }) => {
   return (
     <div className={clsx('mobile-unit-header bg-color-canvas border-b border-color-divider w-full p-3', className)}>
       <nav className="mobile-unit-header__nav flex flex-row justify-between">
-        <A className="mobile-unit-header__prev-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50" disabled={!prevUnit} href={prevUnit?.path} aria-label="Previous unit">
+        <A className="mobile-unit-header__prev-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50" disabled={!prevUnit} onClick={onPrevClick} aria-label="Previous unit">
           <img src="/icons/bubble-arrow.svg" alt="" className="size-8" />
         </A>
         <div className="mobile-unit-header__course-container flex flex-row gap-2 items-center">
           <img src="/icons/course.svg" className="size-8" alt="" />
           <div className="mobile-unit-header__course-title-container flex flex-col">
             <p className="mobile-unit-header__course-header text-size-xxs text-[#999eb3]">{unit.courseTitle}</p>
-            <p className="mobile-unit-header__course-title bluedot-h4 text-size-xs">{unit.title}</p>
+            <p className="mobile-unit-header__course-title bluedot-h4 text-size-xs">{chunks[currentChunkIndex]?.chunkTitle}</p>
           </div>
         </div>
-        <A className="mobile-unit-header__next-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50" disabled={!nextUnit} href={nextUnit?.path} aria-label="Next unit">
+        <A className="mobile-unit-header__next-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50" disabled={!nextUnit} onClick={onNextClick} aria-label="Next unit">
           <img src="/icons/bubble-arrow.svg" alt="" className="size-8 rotate-180" />
         </A>
       </nav>
@@ -59,13 +69,60 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({
 };
 
 const UnitLayout: React.FC<UnitLayoutProps> = ({
+  chunks,
   unit,
   unitNumber,
   units,
 }) => {
+  const router = useRouter();
+  const [currentChunkIndex, setCurrentChunkIndex] = useState(0);
   const unitArrIndex = units.findIndex((u) => u.id === unit.id);
+
+  const isFirstChunk = currentChunkIndex === 0;
+  const isLastChunk = currentChunkIndex === chunks.length - 1;
+
   const nextUnit = units[unitArrIndex + 1];
   const prevUnit = units[unitArrIndex - 1];
+
+  // Update chunk index when query param changes
+  useEffect(() => {
+    const chunkParam = router.query.chunk;
+    if (typeof chunkParam === 'string') {
+      const chunkIndex = parseInt(chunkParam, 10);
+      if (!Number.isNaN(chunkIndex) && chunkIndex >= 0 && chunkIndex < chunks.length) {
+        setCurrentChunkIndex(chunkIndex);
+      }
+    }
+  }, [router.query.chunk, chunks.length]);
+
+  const handleChunkSelect = (index: number) => {
+    setCurrentChunkIndex(index);
+    router.push({
+      pathname: router.pathname,
+      query: { ...router.query, chunk: index },
+    }, undefined, { shallow: true });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handlePrevClick = () => {
+    if (isFirstChunk && prevUnit) {
+      // Navigate to last chunk of previous unit
+      router.push(`${prevUnit.path}?chunk=${chunks.length - 1}`);
+    } else if (!isFirstChunk) {
+      // Navigate to previous chunk
+      handleChunkSelect(currentChunkIndex - 1);
+    }
+  };
+
+  const handleNextClick = () => {
+    if (isLastChunk && nextUnit) {
+      // Navigate to first chunk of next unit
+      router.push(`${nextUnit.path}?chunk=0`);
+    } else if (!isLastChunk) {
+      // Navigate to next chunk
+      handleChunkSelect(currentChunkIndex + 1);
+    }
+  };
 
   if (!unit || unitArrIndex === -1) {
     // Should never happen
@@ -88,30 +145,61 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
         }}
       >
         <div className="unit__breadcrumbs-cta-container flex flex-row items-center gap-6">
-          <A className="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed" disabled={!prevUnit} href={prevUnit?.path} aria-label="Previous unit">
+          <button
+            type="button"
+            className="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline cursor-pointer hover:text-color-primary disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
+            disabled={isFirstChunk && !prevUnit}
+            onClick={handlePrevClick}
+            aria-label="Previous"
+          >
             <FaArrowLeft className="size-3" /> Prev
-          </A>
-          <A className="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed" disabled={!nextUnit} href={nextUnit?.path} aria-label="Next unit">
+          </button>
+          <button
+            type="button"
+            className="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline cursor-pointer hover:text-color-primary disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
+            disabled={isLastChunk && !nextUnit}
+            onClick={handleNextClick}
+            aria-label="Next"
+          >
             Next <FaArrowRight className="size-3" />
-          </A>
+          </button>
         </div>
       </Breadcrumbs>
 
-      <MobileHeader className="unit__mobile-header md:hidden sticky top-16 z-10" unit={unit} prevUnit={prevUnit} nextUnit={nextUnit} />
+      <MobileHeader
+        chunks={chunks}
+        currentChunkIndex={currentChunkIndex}
+        className="unit__mobile-header md:hidden sticky top-16 z-10"
+        unit={unit}
+        prevUnit={prevUnit}
+        nextUnit={nextUnit}
+        onPrevClick={handlePrevClick}
+        onNextClick={handleNextClick}
+      />
 
       <Section className="unit__main">
         <div className="unit__content-container flex flex-col md:flex-row">
-          <SideBar courseTitle={unit.courseTitle} className="hidden md:block" units={units} currentUnitNumber={unitNumber} />
+          <SideBar
+            courseTitle={unit.courseTitle}
+            className="hidden md:block"
+            units={units}
+            currentUnitNumber={unitNumber}
+            chunks={chunks}
+            currentChunkIndex={currentChunkIndex}
+            onChunkSelect={handleChunkSelect}
+          />
           <div className="unit__content flex flex-col flex-1 max-w-[680px] mx-auto gap-6 px-0 md:px-spacing-x">
             <div className="unit__title-container">
               <P className="unit__course-title text-size-sm mb-2">Unit {unit.unitNumber}</P>
-              <H1 className="unit__title font-serif text-[32px]">{unit.title}</H1>
+              <H1 className="unit__title font-serif text-[32px]">{chunks[currentChunkIndex]?.chunkTitle}</H1>
             </div>
             <MarkdownExtendedRenderer>
-              {unit.content}
+              {chunks[currentChunkIndex]?.chunkContent}
             </MarkdownExtendedRenderer>
 
-            <UnitFeedback unit={unit} />
+            {isLastChunk && (
+              <UnitFeedback unit={unit} />
+            )}
 
             {!nextUnit ? (
               <>
@@ -125,7 +213,12 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
               </>
             ) : (
               <div className="unit__cta-container flex flex-row justify-between mt-6 mx-1">
-                <CTALinkOrButton className="unit__cta-link ml-auto" url={nextUnit.path} variant="primary" withChevron>
+                <CTALinkOrButton
+                  className="unit__cta-link ml-auto"
+                  onClick={handleNextClick}
+                  variant="primary"
+                  withChevron
+                >
                   Complete and continue
                 </CTALinkOrButton>
               </div>

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -23,7 +23,9 @@ exports[`SideBar > renders default as expected 1`] = `
         </p>
         <p
           class="sidebar__course-title bluedot-h4"
-        />
+        >
+          What the fish [Test Course]
+        </p>
       </div>
     </div>
     <div
@@ -34,7 +36,7 @@ exports[`SideBar > renders default as expected 1`] = `
         open=""
       >
         <summary
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider cursor-pointer"
         >
           <p
             class="sidebar-collapsible__title font-bold"
@@ -43,12 +45,38 @@ exports[`SideBar > renders default as expected 1`] = `
             . 
             Basic Principles of Fish
           </p>
+          <span
+            class="sidebar-collapsible__button flex items-center"
+          >
+            <svg
+              class="size-3 transition-transform group-open:rotate-90"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </span>
         </summary>
+        <button
+          class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer border-l-4 border-color-primary bg-bluedot-lightest"
+          type="button"
+        >
+          What can AI do today?
+        </button>
       </details>
-      <details
-        class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+      <a
+        class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
+        href="/courses/test-course/2"
+        tabindex="0"
       >
-        <summary
+        <div
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
         >
           <p
@@ -58,12 +86,32 @@ exports[`SideBar > renders default as expected 1`] = `
             . 
             What Fish Are People Catching, and Why?
           </p>
-        </summary>
-      </details>
-      <details
-        class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+          <span
+            class="sidebar-collapsible__button flex items-center"
+          >
+            <svg
+              class="size-3"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </span>
+        </div>
+      </a>
+      <a
+        class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
+        href="/courses/test-course/3"
+        tabindex="0"
       >
-        <summary
+        <div
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
         >
           <p
@@ -73,12 +121,32 @@ exports[`SideBar > renders default as expected 1`] = `
             . 
             The Promise of Fish
           </p>
-        </summary>
-      </details>
-      <details
-        class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+          <span
+            class="sidebar-collapsible__button flex items-center"
+          >
+            <svg
+              class="size-3"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </span>
+        </div>
+      </a>
+      <a
+        class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
+        href="/courses/test-course/4"
+        tabindex="0"
       >
-        <summary
+        <div
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
         >
           <p
@@ -88,12 +156,32 @@ exports[`SideBar > renders default as expected 1`] = `
             . 
             The Risks of Fish
           </p>
-        </summary>
-      </details>
-      <details
-        class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+          <span
+            class="sidebar-collapsible__button flex items-center"
+          >
+            <svg
+              class="size-3"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </span>
+        </div>
+      </a>
+      <a
+        class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
+        href="/courses/test-course/5"
+        tabindex="0"
       >
-        <summary
+        <div
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
         >
           <p
@@ -103,8 +191,26 @@ exports[`SideBar > renders default as expected 1`] = `
             . 
             Contributing to Fish Safety
           </p>
-        </summary>
-      </details>
+          <span
+            class="sidebar-collapsible__button flex items-center"
+          >
+            <svg
+              class="size-3"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </span>
+        </div>
+      </a>
     </div>
   </div>
 </div>

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`SideBar > renders default as expected 1`] = `
         tabindex="0"
       >
         <div
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
         >
           <p
             class="sidebar-collapsible__title font-bold"
@@ -112,7 +112,7 @@ exports[`SideBar > renders default as expected 1`] = `
         tabindex="0"
       >
         <div
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
         >
           <p
             class="sidebar-collapsible__title font-bold"
@@ -147,7 +147,7 @@ exports[`SideBar > renders default as expected 1`] = `
         tabindex="0"
       >
         <div
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
         >
           <p
             class="sidebar-collapsible__title font-bold"
@@ -182,7 +182,7 @@ exports[`SideBar > renders default as expected 1`] = `
         tabindex="0"
       >
         <div
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
         >
           <p
             class="sidebar-collapsible__title font-bold"

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
         >
           <button
             aria-label="Previous"
-            class="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
+            class="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline cursor-pointer hover:text-color-primary disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
             disabled=""
             type="button"
           >
@@ -84,7 +84,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           </button>
           <button
             aria-label="Next"
-            class="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
+            class="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline cursor-pointer hover:text-color-primary disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
             type="button"
           >
             Next 
@@ -250,7 +250,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 tabindex="0"
               >
                 <div
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
                 >
                   <p
                     class="sidebar-collapsible__title font-bold"
@@ -285,7 +285,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 tabindex="0"
               >
                 <div
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
                 >
                   <p
                     class="sidebar-collapsible__title font-bold"
@@ -320,7 +320,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 tabindex="0"
               >
                 <div
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
                 >
                   <p
                     class="sidebar-collapsible__title font-bold"
@@ -355,7 +355,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 tabindex="0"
               >
                 <div
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
                 >
                   <p
                     class="sidebar-collapsible__title font-bold"

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -61,8 +61,8 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="unit__breadcrumbs-cta-container flex flex-row items-center gap-6"
         >
           <button
-            aria-label="Previous unit"
-            class="bluedot-a not-prose unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
+            aria-label="Previous"
+            class="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
             disabled=""
             type="button"
           >
@@ -82,11 +82,10 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             </svg>
              Prev
           </button>
-          <a
-            aria-label="Next unit"
-            class="bluedot-a not-prose unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
-            href="/courses/test-course/2"
-            tabindex="0"
+          <button
+            aria-label="Next"
+            class="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed"
+            type="button"
           >
             Next 
             <svg
@@ -103,7 +102,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
               />
             </svg>
-          </a>
+          </button>
         </div>
       </nav>
     </div>
@@ -144,22 +143,21 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             <p
               class="mobile-unit-header__course-title bluedot-h4 text-size-xs"
             >
-              Basic Principles of Fish
+              What can AI do today?
             </p>
           </div>
         </div>
-        <a
+        <button
           aria-label="Next unit"
           class="bluedot-a not-prose mobile-unit-header__next-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50"
-          href="/courses/test-course/2"
-          tabindex="0"
+          type="button"
         >
           <img
             alt=""
             class="size-8 rotate-180"
             src="/icons/bubble-arrow.svg"
           />
-        </a>
+        </button>
       </nav>
     </div>
     <section
@@ -205,7 +203,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 open=""
               >
                 <summary
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
+                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider cursor-pointer"
                 >
                   <p
                     class="sidebar-collapsible__title font-bold"
@@ -214,12 +212,44 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                     . 
                     Basic Principles of Fish
                   </p>
+                  <span
+                    class="sidebar-collapsible__button flex items-center"
+                  >
+                    <svg
+                      class="size-3 transition-transform group-open:rotate-90"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
+                  </span>
                 </summary>
+                <button
+                  class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer border-l-4 border-color-primary bg-bluedot-lightest"
+                  type="button"
+                >
+                  What can AI do today?
+                </button>
+                <button
+                  class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer"
+                  type="button"
+                >
+                  What can AI do today?
+                </button>
               </details>
-              <details
-                class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+              <a
+                class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
+                href="/courses/test-course/2"
+                tabindex="0"
               >
-                <summary
+                <div
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
                 >
                   <p
@@ -229,12 +259,32 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                     . 
                     What Fish Are People Catching, and Why?
                   </p>
-                </summary>
-              </details>
-              <details
-                class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+                  <span
+                    class="sidebar-collapsible__button flex items-center"
+                  >
+                    <svg
+                      class="size-3"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </a>
+              <a
+                class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
+                href="/courses/test-course/3"
+                tabindex="0"
               >
-                <summary
+                <div
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
                 >
                   <p
@@ -244,12 +294,32 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                     . 
                     The Promise of Fish
                   </p>
-                </summary>
-              </details>
-              <details
-                class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+                  <span
+                    class="sidebar-collapsible__button flex items-center"
+                  >
+                    <svg
+                      class="size-3"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </a>
+              <a
+                class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
+                href="/courses/test-course/4"
+                tabindex="0"
               >
-                <summary
+                <div
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
                 >
                   <p
@@ -259,12 +329,32 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                     . 
                     The Risks of Fish
                   </p>
-                </summary>
-              </details>
-              <details
-                class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+                  <span
+                    class="sidebar-collapsible__button flex items-center"
+                  >
+                    <svg
+                      class="size-3"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </a>
+              <a
+                class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
+                href="/courses/test-course/5"
+                tabindex="0"
               >
-                <summary
+                <div
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider"
                 >
                   <p
@@ -274,8 +364,26 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                     . 
                     Contributing to Fish Safety
                   </p>
-                </summary>
-              </details>
+                  <span
+                    class="sidebar-collapsible__button flex items-center"
+                  >
+                    <svg
+                      class="size-3"
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </a>
             </div>
           </div>
           <div
@@ -293,7 +401,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               <h1
                 class="bluedot-h1 not-prose unit__title font-serif text-[32px]"
               >
-                Basic Principles of Fish
+                What can AI do today?
               </h1>
             </div>
             <div
@@ -302,10 +410,9 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             <div
               class="unit__cta-container flex flex-row justify-between mt-6 mx-1"
             >
-              <a
+              <button
                 class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
-                href="/courses/test-course/2"
-                tabindex="0"
+                type="button"
               >
                 <span
                   class="cta-button__text"
@@ -330,7 +437,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                     />
                   </svg>
                 </span>
-              </a>
+              </button>
             </div>
           </div>
         </div>
@@ -341,10 +448,9 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
 `;
 
 exports[`UnitLayout > renders previous and next unit buttons for middle unit 1`] = `
-<a
+<button
   class="cta-button flex items-center justify-center rounded-sm transition-all duration-200 text-sm px-4 py-3 w-fit font-[650] whitespace-nowrap cursor-pointer not-prose cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
-  href="/courses/test-course/3"
-  tabindex="0"
+  type="button"
 >
   <span
     class="cta-button__text"
@@ -369,5 +475,5 @@ exports[`UnitLayout > renders previous and next unit buttons for middle unit 1`]
       />
     </svg>
   </span>
-</a>
+</button>
 `;

--- a/apps/website/src/pages/courses/[courseSlug]/[unitId].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitId].tsx
@@ -43,6 +43,7 @@ const CourseUnitPage = () => {
 
   return (
     <UnitLayout
+      chunks={data.chunks}
       unit={data.unit}
       units={data.units}
       unitNumber={unitNumber}


### PR DESCRIPTION
# Description
- Chunks are pre-loaded for the current Unit
- Use Router to handle navigation within unit (advancing chunks) and between units
- Update tests and mock data


## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

<img width="370" alt="Screenshot 2025-05-22 at 1 00 17 PM" src="https://github.com/user-attachments/assets/86d7f3d8-bdc9-436a-927e-bbd8a166926f" />

https://github.com/user-attachments/assets/d131a53f-a154-4292-a54d-1f80d16e09a9

### Legacy courses render OK without chunks

<img width="1235" alt="Screenshot 2025-05-22 at 1 09 44 PM" src="https://github.com/user-attachments/assets/30f9f0e4-76da-44d0-a795-7da9950ef6e4" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced chunk-level navigation within course units, allowing users to view and navigate multiple chunks inside a unit.
  - Enhanced the sidebar and mobile header to support chunk selection and display.
  - Navigation buttons now allow seamless movement between chunks and across units.

- **Bug Fixes**
  - Improved synchronization between chunk navigation and the URL for a smoother user experience.

- **Tests**
  - Updated and expanded test data and scenarios to cover chunk-level navigation and enriched unit metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->