### PR TITLE
Remove footer from learning ux. Fix sidebar.

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -181,7 +181,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
         <div className="unit__content-container flex flex-col md:flex-row">
           <SideBar
             courseTitle={unit.courseTitle}
-            className="hidden md:block md:fixed"
+            className="hidden md:block md:fixed md:overflow-y-scroll md:max-h-[calc(100vh-57px-65px-42px)]" // Adjust for Nav, Breadcrumb, and padding heights
             units={units}
             currentUnitNumber={unitNumber}
             chunks={chunks}

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -177,18 +177,18 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
         onNextClick={handleNextClick}
       />
 
-      <Section className="unit__main">
+      <Section className="unit__main !border-none">
         <div className="unit__content-container flex flex-col md:flex-row">
           <SideBar
             courseTitle={unit.courseTitle}
-            className="hidden md:block"
+            className="hidden md:block md:fixed"
             units={units}
             currentUnitNumber={unitNumber}
             chunks={chunks}
             currentChunkIndex={currentChunkIndex}
             onChunkSelect={handleChunkSelect}
           />
-          <div className="unit__content flex flex-col flex-1 max-w-[680px] mx-auto gap-6 px-0 md:px-spacing-x">
+          <div className="unit__content flex flex-col flex-1 max-w-[680px] mx-auto gap-6 px-0 md:px-spacing-x md:ml-[320px]">
             <div className="unit__title-container">
               <P className="unit__course-title text-size-sm mb-2">Unit {unit.unitNumber}</P>
               <H1 className="unit__title font-serif text-[32px]">{chunks[currentChunkIndex]?.chunkTitle}</H1>

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
       </nav>
     </div>
     <section
-      class="section section-body unit__main"
+      class="section section-body unit__main !border-none"
     >
       <div
         class="section__body"
@@ -170,7 +170,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="unit__content-container flex flex-col md:flex-row"
         >
           <div
-            class="sidebar w-full md:w-[320px] flex flex-col hidden md:block"
+            class="sidebar w-full md:w-[320px] flex flex-col hidden md:block md:fixed"
           >
             <div
               class="sidebar__header-container flex flex-row gap-2 pb-6"
@@ -387,7 +387,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             </div>
           </div>
           <div
-            class="unit__content flex flex-col flex-1 max-w-[680px] mx-auto gap-6 px-0 md:px-spacing-x"
+            class="unit__content flex flex-col flex-1 max-w-[680px] mx-auto gap-6 px-0 md:px-spacing-x md:ml-[320px]"
           >
             <div
               class="unit__title-container"

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="unit__content-container flex flex-col md:flex-row"
         >
           <div
-            class="sidebar w-full md:w-[320px] flex flex-col hidden md:block md:fixed"
+            class="sidebar w-full md:w-[320px] flex flex-col hidden md:block md:fixed md:overflow-y-scroll md:max-h-[calc(100vh-57px-65px-42px)]"
           >
             <div
               class="sidebar__header-container flex flex-row gap-2 pb-6"

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { CookieBanner } from '../components/CookieBanner';
 const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
   const fromSiteParam = useRouter().query.from_site as string;
   const fromSite = ['aisf', 'bsf'].includes(fromSiteParam) ? fromSiteParam as 'aisf' | 'bsf' : null;
+  const hideFooter = 'hideFooter' in Component;
 
   return (
     <PostHogProvider>
@@ -49,7 +50,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
               <main className="bluedot-base">
                 <Component {...pageProps} />
               </main>
-              <Footer logo="/images/logo/BlueDot_Impact_Logo_White.svg" />
+              {!hideFooter && <Footer logo="/images/logo/BlueDot_Impact_Logo_White.svg" />}
             </>
           ))}
       <CookieBanner />

--- a/apps/website/src/pages/courses/[courseSlug]/[unitId].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitId].tsx
@@ -51,4 +51,6 @@ const CourseUnitPage = () => {
   );
 };
 
+CourseUnitPage.hideFooter = true;
+
 export default CourseUnitPage;


### PR DESCRIPTION
# Description
A more focused learner experience


## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

https://github.com/user-attachments/assets/40b156f0-0e53-4c28-9ed6-af82d50db551


https://github.com/user-attachments/assets/bebe9ab5-4296-4c37-b837-ff00b28123cf

https://github.com/user-attachments/assets/9d313724-e5a1-46f9-910c-45f939c6545c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The footer is now hidden on individual course unit pages for a cleaner viewing experience.
- **Style**
  - Improved the layout and sidebar behavior in course units, making the sidebar fixed and scrollable on desktop for easier navigation. The main content area is now properly offset to accommodate the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->