### PR TITLE
Amend Congratulations logic for Chunks

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -201,7 +201,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
               <UnitFeedback unit={unit} />
             )}
 
-            {!nextUnit ? (
+            {(!nextUnit && isLastChunk) ? (
               <>
                 <Congratulations courseTitle={unit.courseTitle} coursePath={unit.coursePath} />
                 <CertificateLinkCard courseId={unit.courseId} />


### PR DESCRIPTION
# Description
Congraulations should only show on final _chunk_ of final unit


## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

<img width="1227" alt="Screenshot 2025-05-22 at 2 14 49 PM" src="https://github.com/user-attachments/assets/b2c33c8a-a14c-4717-87af-f8153160f59c" />
<img width="1234" alt="Screenshot 2025-05-22 at 2 14 41 PM" src="https://github.com/user-attachments/assets/91f39eb1-eaf9-4624-9a4c-bfe2d680b691" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The Congratulations and certificate sections now only appear after completing the final chunk of the last unit, ensuring they are not shown prematurely.

- **Tests**
  - Enhanced and added tests to verify the correct display of the Congratulations section based on chunk and unit position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->