### PR TITLE
Bug fix: Sidebar unit routing logic

### DIFF
--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import clsx from 'clsx';
-
+import { addQueryParam } from '@bluedot/ui';
 import { FaChevronRight } from 'react-icons/fa6';
+
 import { Unit, Chunk } from '../../lib/api/db/tables';
 import { A } from '../Text';
 
@@ -59,7 +60,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
         ))}
       </details>
     ) : (
-      <A href={unit.path} className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text">
+      <A href={addQueryParam(unit.path, 'chunk', '0')} className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text">
         <div className="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider">
           <p className="sidebar-collapsible__title font-bold">{unit.unitNumber}. {unit.title}</p>
           <span className="sidebar-collapsible__button flex items-center">

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`SideBar > renders default as expected 1`] = `
       </details>
       <a
         class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-        href="/courses/test-course/2"
+        href="http://localhost:3000/courses/test-course/2?chunk=0"
         tabindex="0"
       >
         <div
@@ -108,7 +108,7 @@ exports[`SideBar > renders default as expected 1`] = `
       </a>
       <a
         class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-        href="/courses/test-course/3"
+        href="http://localhost:3000/courses/test-course/3?chunk=0"
         tabindex="0"
       >
         <div
@@ -143,7 +143,7 @@ exports[`SideBar > renders default as expected 1`] = `
       </a>
       <a
         class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-        href="/courses/test-course/4"
+        href="http://localhost:3000/courses/test-course/4?chunk=0"
         tabindex="0"
       >
         <div
@@ -178,7 +178,7 @@ exports[`SideBar > renders default as expected 1`] = `
       </a>
       <a
         class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-        href="/courses/test-course/5"
+        href="http://localhost:3000/courses/test-course/5?chunk=0"
         tabindex="0"
       >
         <div

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -246,7 +246,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               </details>
               <a
                 class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-                href="/courses/test-course/2"
+                href="http://localhost:3000/courses/test-course/2?chunk=0"
                 tabindex="0"
               >
                 <div
@@ -281,7 +281,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               </a>
               <a
                 class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-                href="/courses/test-course/3"
+                href="http://localhost:3000/courses/test-course/3?chunk=0"
                 tabindex="0"
               >
                 <div
@@ -316,7 +316,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               </a>
               <a
                 class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-                href="/courses/test-course/4"
+                href="http://localhost:3000/courses/test-course/4?chunk=0"
                 tabindex="0"
               >
                 <div
@@ -351,7 +351,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               </a>
               <a
                 class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-                href="/courses/test-course/5"
+                href="http://localhost:3000/courses/test-course/5?chunk=0"
                 tabindex="0"
               >
                 <div


### PR DESCRIPTION
# Description
Explicitly add chunk query param in Sidebar routing so that we route directly to the unit. Without this, the query param would be maintained and we would jump from e.g. Unit 1: Chunk 4 to Unit 2: Chunk 4

## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

https://github.com/user-attachments/assets/7c4fb867-a46d-48d4-b40b-a62ba531510d




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated unit links in the sidebar to consistently include a query parameter in the URL, improving navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->