### PR TITLE
Update button text between units and chunks

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -225,7 +225,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
                   variant="primary"
                   withChevron
                 >
-                  Complete and continue
+                  {isLastChunk ? 'Complete unit and continue' : 'Continue'}
                 </CTALinkOrButton>
               </div>
             )}

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -417,7 +417,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 <span
                   class="cta-button__text"
                 >
-                  Complete and continue
+                  Continue
                 </span>
                 <span
                   class="cta-button__chevron ml-3"
@@ -455,7 +455,7 @@ exports[`UnitLayout > renders previous and next unit buttons for middle unit 1`]
   <span
     class="cta-button__text"
   >
-    Complete and continue
+    Continue
   </span>
   <span
     class="cta-button__chevron ml-3"


### PR DESCRIPTION
# Description
Alex request

## Screenshot

<img width="1230" alt="Screenshot 2025-05-23 at 8 14 35 AM" src="https://github.com/user-attachments/assets/57565b4c-f2e1-4f31-b7e1-3d1a584a2eaf" />
<img width="1230" alt="Screenshot 2025-05-23 at 8 13 38 AM" src="https://github.com/user-attachments/assets/a522ac7b-f749-4bd2-9e49-00104d0b66a5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the primary action button label to reflect progress: it now shows "Complete unit and continue" on the last chunk of a unit, and "Continue" otherwise, providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->