### PR TITLE
Show unit title in mobile nav

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -61,7 +61,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({
           <img src="/icons/course.svg" className="size-8" alt="" />
           <div className="mobile-unit-header__course-title-container flex flex-col">
             <p className="mobile-unit-header__course-header text-size-xxs text-[#999eb3]">{unit.courseTitle}</p>
-            <p className="mobile-unit-header__course-title bluedot-h4 text-size-xs">{chunks[currentChunkIndex]?.chunkTitle}</p>
+            <p className="mobile-unit-header__course-title bluedot-h4 text-size-xs">{unit.title}</p>
           </div>
         </div>
         <A className="mobile-unit-header__next-unit-cta flex flex-row items-center gap-1 no-underline disabled:opacity-50" disabled={isLastChunk && !nextUnit} onClick={onNextClick} aria-label="Next unit">

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -27,8 +27,6 @@ type UnitLayoutProps = {
 };
 
 type MobileHeaderProps = {
-  chunks: Chunk[];
-  currentChunkIndex: number;
   className?: string;
   unit: Unit;
   prevUnit?: Unit;
@@ -42,8 +40,6 @@ type MobileHeaderProps = {
 const MobileHeader: React.FC<MobileHeaderProps> = ({
   className,
   unit,
-  chunks,
-  currentChunkIndex,
   prevUnit,
   nextUnit,
   isFirstChunk,
@@ -171,8 +167,6 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
       </Breadcrumbs>
 
       <MobileHeader
-        chunks={chunks}
-        currentChunkIndex={currentChunkIndex}
         className="unit__mobile-header md:hidden sticky top-16 z-10"
         unit={unit}
         prevUnit={prevUnit}

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             <p
               class="mobile-unit-header__course-title bluedot-h4 text-size-xs"
             >
-              What can AI do today?
+              Basic Principles of Fish
             </p>
           </div>
         </div>


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->
Prefer showing unit title instead of duplicating chunk titles in mobile UI view

## Screenshot
<img width="386" alt="image" src="https://github.com/user-attachments/assets/abe0ada6-ed6b-44a7-957c-9b2d7bd27fa4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the mobile header in the unit layout to display the unit's overall title instead of the current chunk's title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->