### PR TITLE
website: hide unnecessary scrollbar for unit content

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -181,7 +181,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
         <div className="unit__content-container flex flex-col md:flex-row">
           <SideBar
             courseTitle={unit.courseTitle}
-            className="hidden md:block md:fixed md:overflow-y-scroll md:max-h-[calc(100vh-57px-65px-42px)]" // Adjust for Nav, Breadcrumb, and padding heights
+            className="hidden md:block md:fixed md:overflow-y-auto md:max-h-[calc(100vh-57px-65px-42px)]" // Adjust for Nav, Breadcrumb, and padding heights
             units={units}
             currentUnitNumber={unitNumber}
             chunks={chunks}

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="unit__content-container flex flex-col md:flex-row"
         >
           <div
-            class="sidebar w-full md:w-[320px] flex flex-col hidden md:block md:fixed md:overflow-y-scroll md:max-h-[calc(100vh-57px-65px-42px)]"
+            class="sidebar w-full md:w-[320px] flex flex-col hidden md:block md:fixed md:overflow-y-auto md:max-h-[calc(100vh-57px-65px-42px)]"
           >
             <div
               class="sidebar__header-container flex flex-row gap-2 pb-6"

--- a/libraries/eslint-config/src/index.js
+++ b/libraries/eslint-config/src/index.js
@@ -80,6 +80,7 @@ const rules = {
 
   // Custom rules
   '@bluedot/custom/no-default-tailwind-tokens': ['error'],
+  '@bluedot/custom/no-overflow-scroll': ['error'],
 };
 
 /** @type {import("eslint").Linter.RulesRecord} */

--- a/libraries/eslint-plugin-custom/src/index.js
+++ b/libraries/eslint-plugin-custom/src/index.js
@@ -2,5 +2,6 @@
 module.exports = {
   rules: {
     'no-default-tailwind-tokens': require('./rules/no-default-tailwind-tokens'),
+    'no-overflow-scroll': require('./rules/no-overflow-scroll'),
   },
 };

--- a/libraries/eslint-plugin-custom/src/rules/no-overflow-scroll.js
+++ b/libraries/eslint-plugin-custom/src/rules/no-overflow-scroll.js
@@ -1,0 +1,55 @@
+// Map of overflow-scroll tokens to their overflow-auto equivalents
+const overflowScrollTokens = {
+  'overflow-scroll': 'overflow-auto',
+  'overflow-y-scroll': 'overflow-y-auto',
+  'overflow-x-scroll': 'overflow-x-auto',
+};
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Discourage usage of overflow-scroll in favor of overflow-auto',
+      category: 'Best Practices',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== 'className') return;
+
+        if (node.value.type !== 'Literal') return;
+
+        const classNames = node.value.value.split(' ');
+
+        classNames.forEach((className) => {
+          // Check if the className ends with any of the overflow-scroll tokens
+          const matchingToken = Object.keys(overflowScrollTokens).find((token) => className === token || className.endsWith(`-${token}`) || className.endsWith(`:${token}`));
+
+          if (matchingToken) {
+            const replacement = overflowScrollTokens[matchingToken];
+            // Create the replacement by replacing just the matching part at the end
+            const newClassName = className.replace(matchingToken, replacement);
+
+            context.report({
+              node,
+              message: `Use '${replacement}' instead of '${matchingToken}'. The 'auto' value only shows scrollbars when needed, while 'scroll' always shows them even when content fits the container.`,
+              fix(fixer) {
+                const newClassNames = classNames.map((cn) => {
+                  if (cn === className) {
+                    return newClassName;
+                  }
+                  return cn;
+                }).join(' ');
+                return fixer.replaceText(node.value, `"${newClassNames}"`);
+              },
+            });
+          }
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
# Description

https://stackoverflow.com/questions/6689412/difference-between-html-overflow-auto-and-overflow-scroll

note: Mac uses a more subtle scrollbar when a mouse is not connected (e.g. only trackpads), which makes this less noticeable in these setups. It's more of a problem when you have a mouse or are using windows/linux.

## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

Before

<img width="455" alt="image" src="https://github.com/user-attachments/assets/b9061fa5-7dfa-47c1-a184-e54874f59f4d" />

After

<img width="455" alt="image" src="https://github.com/user-attachments/assets/19aeb321-2fcf-4b20-800d-a0346a0ea823" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar scrollbar behavior so that scrollbars now appear only when needed on medium and larger screens.

- **Chores**
  - Introduced a linting rule to discourage the use of always-visible scrollbars, recommending scrollbars appear only when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->