### PR TITLE
Disable YouTube related videos in course embeds

### DIFF
--- a/apps/website/src/components/courses/Embed.tsx
+++ b/apps/website/src/components/courses/Embed.tsx
@@ -19,7 +19,7 @@ const Embed: React.FC<EmbedProps> = ({
     ) : (
       // eslint-disable-next-line jsx-a11y/iframe-has-title
       <iframe
-        src={isYouTube ? url.replace('https://www.youtube.com/', 'https://www.youtube-nocookie.com/') : url}
+        src={isYouTube ? `${url.replace('https://www.youtube.com/', 'https://www.youtube-nocookie.com/')}${url.includes('?') ? '&rel=0' : '?rel=0'}` : url}
         // Width and height should be overriden in css
         width="100%"
         height="100%"


### PR DESCRIPTION
Add rel=0 parameter to YouTube nocookie URLs to prevent showing related videos at the end of embedded course content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Embedded YouTube videos now disable related videos from appearing at the end of playback for a more focused viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->