### PR TITLE
website: Add ops bootcamp to homepage

### DIFF
--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -88,18 +88,18 @@ exports[`Nav > renders with courses 1`] = `
                         tabindex="0"
                       >
                         The Future of AI Course
+                      </a>
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/courses/ops"
+                        tabindex="0"
+                      >
+                        AI Safety Operations Bootcamp
                         <span
                           class="nav-dropdown__new-badge bg-bluedot-lighter rounded-sm p-1 text-bluedot-normal text-size-xxs font-bold uppercase ml-2"
                         >
                           New
                         </span>
-                      </a>
-                      <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
-                        href="/courses/economics-of-tai"
-                        tabindex="0"
-                      >
-                        Economics of Transformative AI
                       </a>
                       <a
                         class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
@@ -114,6 +114,13 @@ exports[`Nav > renders with courses 1`] = `
                         tabindex="0"
                       >
                         AI Governance
+                      </a>
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                        href="/courses/economics-of-tai"
+                        tabindex="0"
+                      >
+                        Economics of Transformative AI
                       </a>
                     </div>
                   </div>
@@ -236,18 +243,18 @@ exports[`Nav > renders with courses 1`] = `
                   tabindex="0"
                 >
                   The Future of AI Course
+                </a>
+                <a
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/courses/ops"
+                  tabindex="0"
+                >
+                  AI Safety Operations Bootcamp
                   <span
                     class="nav-dropdown__new-badge bg-bluedot-lighter rounded-sm p-1 text-bluedot-normal text-size-xxs font-bold uppercase ml-2"
                   >
                     New
                   </span>
-                </a>
-                <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
-                  href="/courses/economics-of-tai"
-                  tabindex="0"
-                >
-                  Economics of Transformative AI
                 </a>
                 <a
                   class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
@@ -262,6 +269,13 @@ exports[`Nav > renders with courses 1`] = `
                   tabindex="0"
                 >
                   AI Governance
+                </a>
+                <a
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
+                  href="/courses/economics-of-tai"
+                  tabindex="0"
+                >
+                  Economics of Transformative AI
                 </a>
               </div>
             </div>

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -124,15 +124,15 @@ exports[`CourseSection > renders as expected 1`] = `
                   >
                     <a
                       class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
-                      href="/courses/economics-of-tai"
+                      href="/courses/ops"
                     >
                       <div
                         class="card__image-container w-full mb-4"
                       >
                         <img
-                          alt="Economics of Transformative AI"
+                          alt="AI Safety Operations Bootcamp"
                           class="card__image max-w-full max-h-full object-cover rounded-lg course-card__image w-full h-[165px] object-cover rounded-none"
-                          src="/images/courses/econ.jpg"
+                          src="https://images.unsplash.com/photo-1552664688-cf412ec27db2?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8d2hpdGVib2FyZHxlbnwwfHwwfHx8MA%3D%3D"
                         />
                       </div>
                       <div
@@ -144,12 +144,12 @@ exports[`CourseSection > renders as expected 1`] = `
                           <p
                             class="card__title bluedot-h4 mb-2"
                           >
-                            Economics of Transformative AI
+                            AI Safety Operations Bootcamp
                           </p>
                           <p
                             class="card__subtitle bluedot-p grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >
-                            The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.
+                            Excel at early-to-mid-career operations roles in AI safety.
                           </p>
                         </div>
                         <div
@@ -167,14 +167,14 @@ exports[`CourseSection > renders as expected 1`] = `
                                 <span
                                   class="course-card__length font-medium"
                                 >
-                                  9 weeks
+                                  6 hours
                                 </span>
                               </p>
                               <span
                                 class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text course-card__type"
                                 role="status"
                               >
-                                In-depth course
+                                Crash course
                               </span>
                             </div>
                           </div>
@@ -326,6 +326,77 @@ exports[`CourseSection > renders as expected 1`] = `
                   </div>
                 </span>
               </div>
+              <div
+                class="slide-list__slide shrink-0 snap-start pl-spacing-x md:pl-0 last:pr-spacing-x md:last:pr-0"
+                data-width="calc((100% - var(--space-between) * 0) * (1 - 0.15))"
+                style="scroll-margin-left: -0px;"
+              >
+                <span>
+                  <div
+                    class="p-[3px] h-full"
+                  >
+                    <a
+                      class="card flex items-start transition-transform duration-200 flex-col hover:scale-[1.01] course-card course-card--regular container-lined p-5 flex flex-col max-w-full h-full hover:container-elevated"
+                      href="/courses/economics-of-tai"
+                    >
+                      <div
+                        class="card__image-container w-full mb-4"
+                      >
+                        <img
+                          alt="Economics of Transformative AI"
+                          class="card__image max-w-full max-h-full object-cover rounded-lg course-card__image w-full h-[165px] object-cover rounded-none"
+                          src="/images/courses/econ.jpg"
+                        />
+                      </div>
+                      <div
+                        class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                      >
+                        <div
+                          class="card__text"
+                        >
+                          <p
+                            class="card__title bluedot-h4 mb-2"
+                          >
+                            Economics of Transformative AI
+                          </p>
+                          <p
+                            class="card__subtitle bluedot-p grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
+                          >
+                            The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.
+                          </p>
+                        </div>
+                        <div
+                          class="card__bottom-section flex flex-col gap-space-between"
+                        >
+                          <div
+                            class="card__footer flex items-center justify-between w-full"
+                          >
+                            <div
+                              class="course-card__footer flex justify-between w-full"
+                            >
+                              <p
+                                class="course-card__footer-left text-left text-size-xs text-bluedot-black bluedot-p"
+                              >
+                                <span
+                                  class="course-card__length font-medium"
+                                >
+                                  9 weeks
+                                </span>
+                              </p>
+                              <span
+                                class="tag container-lined inline-flex items-center px-4 py-2 text-xs font-semibold text-color-secondary-text course-card__type"
+                                role="status"
+                              >
+                                In-depth course
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                </span>
+              </div>
             </div>
           </div>
           <div
@@ -359,7 +430,7 @@ exports[`CourseSection > renders as expected 1`] = `
               />
               <div
                 class="slide-list__progress-track absolute h-full bg-bluedot-normal"
-                style="width: 33.33333333333333%;"
+                style="width: 25%;"
               />
             </div>
             <button

--- a/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
@@ -191,10 +191,10 @@ exports[`Footer > renders default as expected 1`] = `
               >
                 <a
                   class="bluedot-a not-prose footer__link text-bluedot-lighter hover:text-white no-underline"
-                  href="/courses/economics-of-tai"
+                  href="/courses/ops"
                   tabindex="0"
                 >
-                  Economics of Transformative AI
+                  AI Safety Operations Bootcamp
                 </a>
               </li>
               <li
@@ -217,6 +217,17 @@ exports[`Footer > renders default as expected 1`] = `
                   tabindex="0"
                 >
                   AI Governance
+                </a>
+              </li>
+              <li
+                class="footer__item leading-tight"
+              >
+                <a
+                  class="bluedot-a not-prose footer__link text-bluedot-lighter hover:text-white no-underline"
+                  href="/courses/economics-of-tai"
+                  tabindex="0"
+                >
+                  Economics of Transformative AI
                 </a>
               </li>
             </ul>
@@ -517,10 +528,10 @@ exports[`Footer > renders with optional args 1`] = `
               >
                 <a
                   class="bluedot-a not-prose footer__link text-bluedot-lighter hover:text-white no-underline"
-                  href="/courses/economics-of-tai"
+                  href="/courses/ops"
                   tabindex="0"
                 >
-                  Economics of Transformative AI
+                  AI Safety Operations Bootcamp
                 </a>
               </li>
               <li
@@ -543,6 +554,17 @@ exports[`Footer > renders with optional args 1`] = `
                   tabindex="0"
                 >
                   AI Governance
+                </a>
+              </li>
+              <li
+                class="footer__item leading-tight"
+              >
+                <a
+                  class="bluedot-a not-prose footer__link text-bluedot-lighter hover:text-white no-underline"
+                  href="/courses/economics-of-tai"
+                  tabindex="0"
+                >
+                  Economics of Transformative AI
                 </a>
               </li>
             </ul>

--- a/libraries/ui/src/constants.ts
+++ b/libraries/ui/src/constants.ts
@@ -19,16 +19,16 @@ export const COURSES: Course[] = [
     courseLength: '',
     imageSrc: '/images/courses/future-of-ai.png',
     url: '/courses/future-of-ai',
-    isNew: true,
     isFeatured: true,
   },
   {
-    title: 'Economics of Transformative AI',
-    description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
-    courseType: 'In-depth course',
-    courseLength: '9 weeks',
-    imageSrc: '/images/courses/econ.jpg',
-    url: '/courses/economics-of-tai',
+    title: 'AI Safety Operations Bootcamp',
+    description: 'Excel at early-to-mid-career operations roles in AI safety.',
+    courseType: 'Crash course',
+    courseLength: '6 hours',
+    imageSrc: 'https://images.unsplash.com/photo-1552664688-cf412ec27db2?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8M3x8d2hpdGVib2FyZHxlbnwwfHwwfHx8MA%3D%3D',
+    url: '/courses/ops',
+    isNew: true,
   },
   {
     title: 'AI Alignment',
@@ -45,6 +45,14 @@ export const COURSES: Course[] = [
     courseLength: '12 weeks',
     imageSrc: '/images/courses/gov.jpg',
     url: '/courses/governance',
+  },
+  {
+    title: 'Economics of Transformative AI',
+    description: 'The risks and opportunities of advanced AI are evolving at unprecedented speed—and economists play a crucial role in shaping how society prepares for this transformation. This 9-week course is designed for economists who want to develop their understanding of transformative AI and its economic impacts.',
+    courseType: 'In-depth course',
+    courseLength: '9 weeks',
+    imageSrc: '/images/courses/econ.jpg',
+    url: '/courses/economics-of-tai',
   },
 ] as const;
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

website: Add ops bootcamp to homepage

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

![image](https://github.com/user-attachments/assets/1fe73e9d-e6ce-497a-970f-6dca82152280)

nav:

<img width="927" alt="image" src="https://github.com/user-attachments/assets/b1048b75-626b-4485-87f4-bf3ccf7f0e4f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "AI Safety Operations Bootcamp" course, highlighted as new and featuring updated imagery.

- **Updates**
  - The "Economics of Transformative AI" course has been moved to the end of the course list.
  - The "The Future of AI Course" is no longer marked as new.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->