### PR TITLE
Update Nav Courses links

### DIFF
--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -11,6 +11,12 @@ import {
   TRANSITION_DURATION_CLASS,
 } from './utils';
 
+const NAV_COURSES = [
+  constants.COURSES[0]!,
+  constants.COURSES[1]!,
+  { title: 'All courses', url: ROUTES.courses.url },
+];
+
 const ABOUT = [
   { title: 'Our story', url: ROUTES.about.url },
   { title: 'Careers', url: ROUTES.joinUs.url },
@@ -40,7 +46,7 @@ export const NavLinks: React.FC<{
         expandedSections={expandedSections}
         isExpanded={expandedSections.explore}
         isScrolled={isScrolled}
-        links={constants.COURSES}
+        links={NAV_COURSES}
         onToggle={() => updateExpandedSections({
           about: false,
           explore: !expandedSections.explore,

--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -12,9 +12,12 @@ import {
 } from './utils';
 
 const NAV_COURSES = [
-  constants.COURSES[0]!,
-  constants.COURSES[1]!,
-  { title: 'All courses', url: ROUTES.courses.url },
+  ...(constants?.COURSES.slice(0, 2) || []).map((course) => ({
+    title: course.title,
+    url: course.url,
+    isNew: course.isNew,
+  })),
+  { title: 'Browse all', url: ROUTES.courses.url },
 ];
 
 const ABOUT = [

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`Nav > renders with courses 1`] = `
                         href="/courses"
                         tabindex="0"
                       >
-                        All courses
+                        Browse all
                       </a>
                     </div>
                   </div>
@@ -247,7 +247,7 @@ exports[`Nav > renders with courses 1`] = `
                   href="/courses"
                   tabindex="0"
                 >
-                  All courses
+                  Browse all
                 </a>
               </div>
             </div>

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -103,24 +103,10 @@ exports[`Nav > renders with courses 1`] = `
                       </a>
                       <a
                         class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
-                        href="/courses/alignment"
+                        href="/courses"
                         tabindex="0"
                       >
-                        AI Alignment
-                      </a>
-                      <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
-                        href="/courses/governance"
-                        tabindex="0"
-                      >
-                        AI Governance
-                      </a>
-                      <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
-                        href="/courses/economics-of-tai"
-                        tabindex="0"
-                      >
-                        Economics of Transformative AI
+                        All courses
                       </a>
                     </div>
                   </div>
@@ -258,24 +244,10 @@ exports[`Nav > renders with courses 1`] = `
                 </a>
                 <a
                   class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
-                  href="/courses/alignment"
+                  href="/courses"
                   tabindex="0"
                 >
-                  AI Alignment
-                </a>
-                <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
-                  href="/courses/governance"
-                  tabindex="0"
-                >
-                  AI Governance
-                </a>
-                <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline pt-1"
-                  href="/courses/economics-of-tai"
-                  tabindex="0"
-                >
-                  Economics of Transformative AI
+                  All courses
                 </a>
               </div>
             </div>


### PR DESCRIPTION
# Description
- Replace inactive courses with an "All courses" option
- Requested: https://bluedotimpact.slack.com/archives/C08LQKWBX9B/p1747992006639049

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

<img width="1512" alt="Screenshot 2025-05-27 at 13 38 27" src="https://github.com/user-attachments/assets/42cd87b9-5676-45f3-b11a-a846e452c109" />

<img width="375" alt="Screenshot 2025-05-27 at 13 27 59" src="https://github.com/user-attachments/assets/935a574d-2816-4cc8-b9b7-77797bbaf926" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the "Courses" dropdown in the navigation to display only the first two courses and a "Browse all" option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->