### PR TITLE
Update Feedback Unit ID field lookup to show saved responses

### DIFF
--- a/apps/website/src/components/courses/UnitFeedback.tsx
+++ b/apps/website/src/components/courses/UnitFeedback.tsx
@@ -20,10 +20,11 @@ const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
   const [rating, setRating] = useState<number>(0);
   const [feedbackText, setFeedbackText] = useState<string>('');
   const [error, setError] = useState<unknown | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { courseSlug, id: unitId } = unit;
 
-  const [{ data }, refetch] = useAxios<GetUnitFeedbackResponse>({
+  const [{ data, loading }, refetch] = useAxios<GetUnitFeedbackResponse>({
     method: 'get',
     url: `/api/courses/${courseSlug}/${unitId}/feedback`,
     headers: {
@@ -40,6 +41,7 @@ const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
     }
 
     setError(null);
+    setIsSubmitting(true);
 
     try {
       await axios.put<unknown, unknown, PutUnitFeedbackRequest>(
@@ -58,6 +60,8 @@ const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
       await refetch();
     } catch (e) {
       setError(e);
+    } finally {
+      setIsSubmitting(false);
     }
   }, [rating, feedbackText, courseSlug, unitId, auth, refetch]);
 
@@ -109,8 +113,9 @@ const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
             variant="primary"
             className="unit-feedback__submit self-start"
             onClick={() => handleSubmit()}
+            disabled={isSubmitting || loading}
           >
-            Send feedback
+            {isSubmitting ? 'Sending...' : 'Send feedback'}
           </CTALinkOrButton>
         </>
       )}

--- a/apps/website/src/lib/api/db/tables.ts
+++ b/apps/website/src/lib/api/db/tables.ts
@@ -117,11 +117,11 @@ export const applicationsCourseTable: Table<ApplicationsCourse> = {
 };
 
 export type UnitFeedback = {
+  unit: string,
   unitId: string,
   overallRating: number,
   anythingElse: string,
   userEmail: string,
-  userFullName: string,
   createdAt: string | null,
   lastModified: string | null,
 } & Item;
@@ -131,20 +131,20 @@ export const unitFeedbackTable: Table<UnitFeedback> = {
   baseId: 'appbiNKDcn1sGPGOG',
   tableId: 'tblBwjMjul1c6l7ea',
   mappings: {
-    unitId: 'fldYqvWII6kuxCCmH',
+    unit: 'fldYqvWII6kuxCCmH',
+    unitId: 'fldggWmmAWzgqEGy6',
     overallRating: 'fld3B8HUudN5NxPIU',
     anythingElse: 'fldYdcPZPdJAqn06w',
     userEmail: 'fld9JsHJXjud5Bhle',
-    userFullName: 'fldPG0z0SRFcGJhNW',
     createdAt: 'fldWyJJz3OVNK0kTn',
     lastModified: 'fldCQ0O6oOf4BcMpJ',
   },
   schema: {
+    unit: 'string',
     unitId: 'string',
     overallRating: 'number',
     anythingElse: 'string',
     userEmail: 'string',
-    userFullName: 'string',
     createdAt: 'string | null',
     lastModified: 'string | null',
   },

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitId]/feedback.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitId]/feedback.ts
@@ -47,7 +47,6 @@ export default makeApiRoute(
 
     const existingFeedback = (
       await db.scan(unitFeedbackTable, {
-        // Note: Requires adding a Lookup field called "[>] Unit ID", that gets "[*] RecordID" from the Unit table
         filterByFormula: formula(await db.table(unitFeedbackTable), [
           'AND',
           ['=', { field: 'unitId' }, unitId],
@@ -83,7 +82,7 @@ export default makeApiRoute(
       } else {
         // If the feedback does NOT exist, create it
         upsertedFeedback = await db.insert(unitFeedbackTable, {
-          unitId,
+          unit: unitId,
           createdAt: new Date().toISOString(),
           lastModified: new Date().toISOString(),
           userEmail: auth.email,


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->
- Update to GET via Unit ID lookup field rather than actual Unit linked record itself
- Also added "Submitting..." state


## Issue
https://bluedotimpact.slack.com/archives/C08DC9SSA66/p1748294763877639

## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

<img width="1512" alt="Screenshot 2025-05-27 at 15 29 13" src="https://github.com/user-attachments/assets/32fa8140-9e2f-406a-97c3-1fcc6dfb5d59" />


https://github.com/user-attachments/assets/7cc49bc9-ed7e-4179-88c9-d52f2fe952cf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The feedback submission button now displays a "Sending..." label and is disabled during submission or loading, providing clearer feedback to users and preventing duplicate submissions.

- **Bug Fixes**
  - Improved handling of feedback submission state to ensure users cannot submit multiple times or interact while loading.

- **Refactor**
  - Updated feedback data structure, replacing the user name with a unit identifier for improved data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->