### PR TITLE
Add CircleSpaceEmbed with Events on the Profile page

### DIFF
--- a/apps/website/src/components/courses/exercises/CircleSpaceEmbed.test.tsx
+++ b/apps/website/src/components/courses/exercises/CircleSpaceEmbed.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import CircleSpaceEmbed from './CircleSpaceEmbed';
+
+describe('CircleSpaceEmbed', () => {
+  test('renders default as expected', () => {
+    const { container } = render(
+      <CircleSpaceEmbed
+        spaceSlug="events"
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders with custom args', () => {
+    const { container } = render(
+      <CircleSpaceEmbed
+        spaceSlug="events"
+        style={{ width: '100%', height: '100%', minHeight: '510px' }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/apps/website/src/components/courses/exercises/CircleSpaceEmbed.tsx
+++ b/apps/website/src/components/courses/exercises/CircleSpaceEmbed.tsx
@@ -1,0 +1,29 @@
+import React, { CSSProperties } from 'react';
+
+type CircleSpaceEmbedProps = {
+  // Required
+  spaceSlug: string;
+  // Optional
+  style?: CSSProperties;
+};
+
+const CircleSpaceEmbed: React.FC<CircleSpaceEmbedProps> = ({
+  spaceSlug,
+  style,
+}) => {
+  return (
+    <iframe
+      title={`Community discussion for ${spaceSlug}`}
+      style={{
+        border: '0',
+        boxShadow: 'none',
+        width: '800px',
+        height: '80vh',
+        ...style,
+      }}
+      src={`https://community.bluedot.org/c/${spaceSlug}?iframe=true`}
+    />
+  );
+};
+
+export default CircleSpaceEmbed;

--- a/apps/website/src/components/courses/exercises/__snapshots__/CircleSpaceEmbed.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/CircleSpaceEmbed.test.tsx.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CircleSpaceEmbed > renders default as expected 1`] = `
+<div>
+  <iframe
+    src="https://community.bluedot.org/c/events?iframe=true"
+    style="border: 0px; box-shadow: none; width: 800px; height: 80vh;"
+    title="Community discussion for events"
+  />
+</div>
+`;
+
+exports[`CircleSpaceEmbed > renders with custom args 1`] = `
+<div>
+  <iframe
+    src="https://community.bluedot.org/c/events?iframe=true"
+    style="border: 0px; box-shadow: none; width: 100%; height: 100%; min-height: 510px;"
+    title="Community discussion for events"
+  />
+</div>
+`;

--- a/apps/website/src/pages/profile.tsx
+++ b/apps/website/src/pages/profile.tsx
@@ -25,6 +25,7 @@ import { H2, H3, P } from '../components/Text';
 import SocialShare from '../components/courses/SocialShare';
 import { Course, CourseRegistration } from '../lib/api/db/tables';
 import MarkdownExtendedRenderer from '../components/courses/MarkdownExtendedRenderer';
+import CircleSpaceEmbed from '../components/courses/exercises/CircleSpaceEmbed';
 
 const CURRENT_ROUTE = ROUTES.profile;
 
@@ -86,14 +87,12 @@ const ProfilePage = withAuth(({ auth }) => {
           className="profile"
         >
           <div className="grid lg:grid-cols-2 gap-8">
-            <div className="profile__account-details flex flex-col gap-4">
+            <div className="profile__enrolled-courses flex flex-col gap-4">
               <H3>Account details</H3>
               <div className="flex flex-col gap-4 container-lined bg-white p-8 h-fit">
                 <P><span className="font-bold">Name:</span> {userData.user.name}</P>
                 <P><span className="font-bold">Email:</span> {userData.user.email}</P>
               </div>
-            </div>
-            <div className="profile__enrolled-courses flex flex-col gap-4">
               <H3>Your courses</H3>
               {enrolledCourses.length === 0 && (
               <div className="profile__no-courses flex flex-col gap-4 container-lined bg-white p-8 mb-4">
@@ -107,6 +106,10 @@ const ProfilePage = withAuth(({ auth }) => {
                   <CTALinkOrButton url={ROUTES.courses.url}>Join another course</CTALinkOrButton>
                 </>
               )}
+            </div>
+            <div className="profile__events flex flex-col gap-4">
+              <H3>Connect with your community</H3>
+              <CircleSpaceEmbed spaceSlug="events" style={{ width: '100%', height: '100%', minHeight: '510px' }} />
             </div>
           </div>
         </Section>


### PR DESCRIPTION
# Description
- New `CircleSpaceEmbed` component to support dynamic Circle Spaces embeds
- Use-case introduced in Profile page for events space


## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<img width="371" alt="Screenshot 2025-05-30 at 11 50 56" src="https://github.com/user-attachments/assets/f6708d2d-bb2c-4cf0-9347-42c8bd250ee2" />
<img width="363" alt="Screenshot 2025-05-30 at 11 47 34" src="https://github.com/user-attachments/assets/693c25af-f3e1-491d-a46f-01d7d70d721b" />
<img width="1507" alt="Screenshot 2025-05-30 at 11 47 20" src="https://github.com/user-attachments/assets/9397e524-b7b0-4221-884d-922fecf357f7" />

### Before
<img width="1880" alt="image" src="https://github.com/user-attachments/assets/6c16553f-4dac-49ea-ba09-93ee533b898c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Connect with your community" section to the profile page, embedding a community events space for users to engage with.
- **Tests**
  - Introduced snapshot tests to ensure the new community embed component renders consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->