### PR TITLE
Add special case handling for SVG file extension in presigned upload

### DIFF
--- a/apps/editor/src/pages/api/presigned-upload.ts
+++ b/apps/editor/src/pages/api/presigned-upload.ts
@@ -59,6 +59,11 @@ export default makeApiRoute({
 });
 
 const getFileExtension = (contentType: string) => {
+  // Special case
+  if (contentType === 'image/svg+xml') {
+    return '.svg';
+  }
+
   const parts = contentType.split('/');
   return `.${parts[parts.length - 1]}`;
 };


### PR DESCRIPTION
Handle 'image/svg+xml' content type explicitly to return '.svg' extension instead of '.svg+xml' from generic parsing logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected file extension handling for SVG images to ensure they are saved with the `.svg` extension instead of `.xml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->