### PR TITLE
website-proxy: Add course subdomain redirects to main bluedot.org site

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -50,6 +50,14 @@ http {
         add_header X-BlueDot-Version '$VERSION_TAG';
         server_name course.bluedot.org course.aisafetyfundamentals.com course.biosecurityfundamentals.com;
 
+        # Handle /home without course slug - redirect to courses index
+        location = /home {
+            return 301 $scheme://bluedot.org/courses$is_args$args;
+        }
+        location = /home/ {
+            return 301 $scheme://bluedot.org/courses$is_args$args;
+        }
+        
         # course.bluedot.org/home/[course-name] -> bluedot.org/courses/[course-name]
         location ~ ^/home/([^/]+)/?$ {
             return 301 $scheme://bluedot.org/courses/$1$is_args$args;

--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -44,6 +44,28 @@ http {
         }
     }
 
+    # Redirect course.bluedot.org -> bluedot.org/courses/[course]
+    server {
+        listen 8080;
+        add_header X-BlueDot-Version '$VERSION_TAG';
+        server_name course.bluedot.org course.aisafetyfundamentals.com course.biosecurityfundamentals.com;
+
+        # course.bluedot.org/home/[course-name] -> bluedot.org/courses/[course-name]
+        location ~ ^/home/([^/]+)/?$ {
+            return 301 $scheme://bluedot.org/courses/$1$is_args$args;
+        }
+        
+        # course.bluedot.org/[course-name] -> bluedot.org/courses/[course-name]
+        location ~ ^/([^/]+)/?$ {
+            return 301 $scheme://bluedot.org/courses/$1$is_args$args;
+        }
+        
+        # Fallback for any other paths
+        location / {
+            return 301 $scheme://bluedot.org/courses$is_args$args;
+        }
+    }
+
     # Redirect www.bluedot.org -> bluedot.org
     server {
         listen 8080;
@@ -52,6 +74,7 @@ http {
         return 301 $scheme://bluedot.org$request_uri;
     }
 
+    # Main bluedot.org
     server {
         listen 8080 default_server;
         add_header X-BlueDot-Version '$VERSION_TAG';


### PR DESCRIPTION
Configure nginx to redirect course.bluedot.org and related course subdomains to bluedot.org/courses/[course-name] with proper URL pattern matching for /home/[course] and /[course] paths.

Fixes #965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for course-specific domains, automatically redirecting requests to the relevant course pages on bluedot.org with query parameters preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->