### PR TITLE
infra: Add extra domains to website proxy for old course subdomain redirects

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -43,7 +43,7 @@ export const services: ServiceDefinition[] = [
         image: 'ghcr.io/bluedotimpact/bluedot-website-proxy:latest',
       }],
     },
-    hosts: ['website-proxy.k8s.bluedot.org', 'www.bluedot.org', 'bluedot.org', 'www.aisafetyfundamentals.com', 'aisafetyfundamentals.com', 'www.biosecurityfundamentals.com', 'biosecurityfundamentals.com'],
+    hosts: ['website-proxy.k8s.bluedot.org', 'www.bluedot.org', 'bluedot.org', 'www.aisafetyfundamentals.com', 'aisafetyfundamentals.com', 'www.biosecurityfundamentals.com', 'biosecurityfundamentals.com', 'course.bluedot.org', 'course.aisafetyfundamentals.com', 'course.biosecurityfundamentals.com'],
   },
   {
     name: 'bluedot-website',


### PR DESCRIPTION
infra: Add extra domains to website proxy for old course subdomain redirects

Follow-up from #1009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for accessing the service via three new hostnames: course.bluedot.org, course.aisafetyfundamentals.com, and course.biosecurityfundamentals.com.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->