### PR TITLE
feat: updating line height to 1.6 for improved readability

### DIFF
--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -86,7 +86,7 @@
         @apply text-color-secondary-text font-sans text-size-md font-[650];
     }
     .bluedot-p {
-        @apply text-color-text font-sans text-size-sm font-normal;
+        @apply text-color-text font-sans text-size-sm font-normal leading-[1.6];
     }
     .bluedot-a {
         @apply text-color-secondary-text hover:text-color-primary-accent cursor-pointer underline;


### PR DESCRIPTION
## Description
The line spacing on the About page, and other parts of the website, were super compressed. This pull request increases the line spacing to 1.6.

## Developer checklist

- [ ] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [ ] Considered adding tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
### Before
![CleanShot 2025-06-14 at 19 16 21@2x](https://github.com/user-attachments/assets/baf422ca-d658-46a4-870a-853c356c44df)
### After
![CleanShot 2025-06-14 at 19 16 30@2x](https://github.com/user-attachments/assets/a9ec2b90-2b71-4bfa-8e46-8e0804b78eef)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved paragraph text readability by increasing the line height for styled paragraphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->