### PR TITLE
Remove API route and Slack alert utilities from ui exports

### DIFF
--- a/apps/postgres-demo/src/lib/api/makeApiRoute.ts
+++ b/apps/postgres-demo/src/lib/api/makeApiRoute.ts
@@ -1,4 +1,5 @@
-import { loginPresets, makeMakeApiRoute } from '@bluedot/ui';
+import { loginPresets } from '@bluedot/ui';
+import { makeMakeApiRoute } from '@bluedot/ui/src/api';
 import env from './env';
 
 export const makeApiRoute = makeMakeApiRoute({

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -82,10 +82,6 @@ export { addQueryParam } from './utils/addQueryParam';
 export { maybePlural } from './utils';
 export { asError } from './utils/asError';
 export { useAuthStore, withAuth, type Auth } from './utils/auth';
-export {
-  makeMakeApiRoute, StreamingResponseSchema, type Handler, type MakeMakeApiRouteEnv, type RouteOptions,
-} from './utils/makeMakeApiRoute';
-export { slackAlert } from './utils/slackAlert';
 export * as constants from './constants';
 
 export { loggedOutStory, loggedInStory } from './utils/storybook';


### PR DESCRIPTION
# Description

Follow-up to #872 to fix frontend builds, to avoid importing server-side only deps to the frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal import paths for improved code organization.
- **Chores**
  - Removed certain internal utilities from being exported, streamlining the available public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->