### PR TITLE
website-proxy: Redirect Bubble certificates

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -51,10 +51,10 @@ http {
         server_name course.bluedot.org course.aisafetyfundamentals.com course.biosecurityfundamentals.com;
 
         # Handle /certification path - redirect directly to bluedot.org/certification
-        location /certification {
+        location = /certification {
             return 301 $scheme://bluedot.org/certification$is_args$args;
         }
-        location /certification/ {
+        location = /certification/ {
             return 301 $scheme://bluedot.org/certification$is_args$args;
         }
 


### PR DESCRIPTION
Reported in https://bluedotimpact.slack.com/archives/C08JP2CKVA6/p1750037955396159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Requests to "/certification" and "/certification/" are now automatically redirected to "bluedot.org/certification", preserving any query parameters.
- **Documentation**
  - Updated comments to clarify the redirect behavior for course-related domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->