### PR TITLE
website: Remove old website-25 domain

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -58,8 +58,7 @@ export const services: ServiceDefinition[] = [
         ],
       }],
     },
-    // TODO: remove website-25-staging after people stop going to it
-    hosts: ['website-staging.k8s.bluedot.org', 'website-25-staging.k8s.bluedot.org'],
+    hosts: ['website-staging.k8s.bluedot.org'],
   },
   {
     name: 'bluedot-website-production',

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import '../globals.css';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
-import { CTALinkOrButton, Footer } from '@bluedot/ui';
+import { Footer } from '@bluedot/ui';
 import { useRouter } from 'next/router';
 import { GoogleTagManager } from '../components/analytics/GoogleTagManager';
 import { PostHogProvider } from '../components/analytics/PostHogProvider';
@@ -23,37 +23,25 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
       </Head>
-      {/* TODO: remove this logic after people stop going here */}
-      {/* eslint-disable-next-line no-nested-ternary */}
-      {typeof window !== 'undefined' && window.location.host === 'website-25-staging.k8s.bluedot.org' ? (
-        <main className="section-base my-16 prose">
-          <h1>You're using the old URL</h1>
-          <p>Hey, this is the old URL for the staging website. We dropped the '25' from the URL on 25th April 2025. This URL will stop working soon so update your bookmarks/clear this from your history :)</p>
-          <p><code>website<span className="font-bold bg-red-100">-25</span>-staging.k8s.bluedot.org → <br />website-staging.k8s.bluedot.org</code></p>
-          <CTALinkOrButton url={typeof window === 'undefined' ? 'https://website-staging.k8s.bluedot.org' : window.location.href.replace(window.location.host, 'website-staging.k8s.bluedot.org')} className="not-prose" withChevron>
-            View this page on the new site
-          </CTALinkOrButton>
-        </main>
-      )
-        : ('rawLayout' in Component && Component.rawLayout
-          ? <Component {...pageProps} />
-          : (
-            <>
-              <Nav logo="/images/logo/BlueDot_Impact_Logo.svg" />
-              {fromSite && (
-                <AnnouncementBanner ctaText="Learn more" ctaUrl="/blog/course-website-consolidation">
-                  <b>Welcome from {fromSite === 'aisf' ? 'AI Safety Fundamentals' : 'Biosecurity Fundamentals'}!</b> We've consolidated our course sites in the BlueDot Impact platform to provide a more consistent and higher-quality experience.
-                </AnnouncementBanner>
-              )}
-              <AnnouncementBanner ctaText="Reserve your free spot" ctaUrl="https://lu.ma/sa52ofdf?utm_source=website&utm_campaign=banner" hideAfter={new Date('2025-04-25T18:30:00+01:00')}>
-                <b>Don't miss this Friday: </b>Planning a career in the age of A(G)I - an online panel with Luke Drago, Josh Landes & Ben Todd
+      {'rawLayout' in Component && Component.rawLayout
+        ? <Component {...pageProps} />
+        : (
+          <>
+            <Nav logo="/images/logo/BlueDot_Impact_Logo.svg" />
+            {fromSite && (
+              <AnnouncementBanner ctaText="Learn more" ctaUrl="/blog/course-website-consolidation">
+                <b>Welcome from {fromSite === 'aisf' ? 'AI Safety Fundamentals' : 'Biosecurity Fundamentals'}!</b> We've consolidated our course sites in the BlueDot Impact platform to provide a more consistent and higher-quality experience.
               </AnnouncementBanner>
-              <main className="bluedot-base">
-                <Component {...pageProps} />
-              </main>
-              {!hideFooter && <Footer logo="/images/logo/BlueDot_Impact_Logo_White.svg" />}
-            </>
-          ))}
+            )}
+            <AnnouncementBanner ctaText="Reserve your free spot" ctaUrl="https://lu.ma/sa52ofdf?utm_source=website&utm_campaign=banner" hideAfter={new Date('2025-04-25T18:30:00+01:00')}>
+              <b>Don't miss this Friday: </b>Planning a career in the age of A(G)I - an online panel with Luke Drago, Josh Landes & Ben Todd
+            </AnnouncementBanner>
+            <main className="bluedot-base">
+              <Component {...pageProps} />
+            </main>
+            {!hideFooter && <Footer logo="/images/logo/BlueDot_Impact_Logo_White.svg" />}
+          </>
+        )}
       <CookieBanner />
       <GoogleTagManager />
       <CircleWidget />


### PR DESCRIPTION
Delete deprecated domain to clean things up. Has been a warning there for over a month to migrate.

Other option could be to set up a permanent redirect, but this is more faff for something that's basically developer internal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed outdated warning and redirect for the old staging URL.
- **Chores**
  - Cleaned up references to deprecated staging hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->