### PR TITLE
bug: stop white text from propagating to tags when navbar is scrolled

### DIFF
--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`Nav > renders with courses 1`] = `
                       >
                         AI Safety Operations Bootcamp
                         <span
-                          class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase ml-2 !p-1"
+                          class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase ml-2 !p-1"
                           role="status"
                         >
                           New
@@ -238,7 +238,7 @@ exports[`Nav > renders with courses 1`] = `
                 >
                   AI Safety Operations Bootcamp
                   <span
-                    class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase ml-2 !p-1"
+                    class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase ml-2 !p-1"
                     role="status"
                   >
                     New

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
       class="free-text-response__header flex flex-col gap-4"
     >
       <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
+        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
         role="status"
       >
         Think it through
@@ -79,7 +79,7 @@ exports[`FreeTextResponse > renders logged in as expected 1`] = `
       class="free-text-response__header flex flex-col gap-4"
     >
       <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
+        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
         role="status"
       >
         Think it through
@@ -129,7 +129,7 @@ exports[`FreeTextResponse > renders with saved exercise response 1`] = `
       class="free-text-response__header flex flex-col gap-4"
     >
       <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
+        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
         role="status"
       >
         Think it through

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
       class="multiple-choice__header flex flex-col gap-4"
     >
       <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
+        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
         role="status"
       >
         Quiz
@@ -145,7 +145,7 @@ exports[`MultipleChoice > renders logged in as expected 1`] = `
       class="multiple-choice__header flex flex-col gap-4"
     >
       <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
+        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
         role="status"
       >
         Quiz

--- a/libraries/ui/src/Tag.tsx
+++ b/libraries/ui/src/Tag.tsx
@@ -20,7 +20,7 @@ export const Tag: React.FC<TagProps> = ({
       className={clsx(
         'tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit',
         variant === 'default' && 'text-color-secondary-text container-lined',
-        variant === 'secondary' && 'text-bluedot-normal bg-[#E5EDFE] rounded-sm',
+        variant === 'secondary' && '!text-bluedot-normal bg-[#E5EDFE] rounded-sm',
         className,
       )}
     >


### PR DESCRIPTION
# Description
When scrolling the text on the button appeared white when the navbar is dark (as shown in the issue [here](https://github.com/bluedotimpact/bluedot/issues/988)).

## Issue
https://github.com/bluedotimpact/bluedot/issues/988

Fixes #

## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<img width="1453" alt="Screenshot 2025-06-17 at 11 02 49" src="https://github.com/user-attachments/assets/53f1bedb-48df-40c4-bc31-8f43ebe4ef2d" />
* screenshot or screen recording demonstrating your change--> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the visual consistency of the Tag component when using the secondary variant by ensuring the correct text color is always applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->