### PR TITLE
issue templates: remove bluebotimpact assignee

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -2,7 +2,7 @@ name: Bug Report
 description: Report a bug
 title: "[Bug] Short descriptive title"
 labels: [bug]
-assignees: [bluebotimpact]
+assignees: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -2,7 +2,7 @@ name: Feature Report
 description: Suggest a new feature or document an idea
 title: "[Feature] Short descriptive title"
 labels: [enhancement]
-assignees: [bluebotimpact]
+assignees: []
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Follow up from https://github.com/bluedotimpact/bluedot/pull/995/files#r2144913004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated bug and feature report templates to remove automatic assignment to a default user. Issues will no longer be auto-assigned upon creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->