### PR TITLE
pg-sync-service: Perform a full sync on schema additions

### DIFF
--- a/apps/pg-sync-service/src/lib/scan.ts
+++ b/apps/pg-sync-service/src/lib/scan.ts
@@ -85,12 +85,12 @@ export async function processTableForInitialSync(
 }
 
 /**
- * Performs initial sync by discovering all tracked tables and processing each one.
+ * Performs full sync by discovering all tracked tables and processing each one.
  */
-export async function performInitialSync(
+export async function performFullSync(
   addToQueue: (actions: AirtableAction[], priority: 'low' | 'high') => void,
 ): Promise<void> {
-  logger.info('🚀 Starting initial sync...');
+  logger.info('🚀 Starting full sync...');
 
   const tableFieldMappings = await db.pg
     .select({
@@ -155,5 +155,5 @@ export async function performInitialSync(
     }
   }
 
-  logger.info(`🎉 Initial sync completed! Total records queued: ${totalRecords}`);
+  logger.info(`🎉 Full sync completed! Total records queued: ${totalRecords}`);
 }

--- a/apps/pg-sync-service/src/lib/schema-sync.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.ts
@@ -56,119 +56,106 @@ async function cleanupRemovedColumns(pgTables: Record<string, PgAirtableTable['p
 
 /**
  * Wraps pushSchema with a timeout to prevent hanging migrations
+ * Returns true if schema changes were applied, false otherwise
  */
-async function pushSchemaWithTimeout(pgTables: Record<string, PgAirtableTable['pg']>): Promise<void> {
+async function pushSchemaWithTimeout(pgTables: Record<string, PgAirtableTable['pg']>): Promise<boolean> {
   const timeoutPromise = new Promise<never>((_, reject) => {
     setTimeout(() => {
       reject(new Error(
-        'Schema migration hung after 120 seconds. This is likely because you have made a change that breaks drizzle\'s pushSchema function. Also see https://github.com/drizzle-team/drizzle-orm/issues/4651.',
+        'Schema push migration hung after 120 seconds. This is likely because you have made a change that breaks drizzle\'s pushSchema function. Also see https://github.com/drizzle-team/drizzle-orm/issues/4651.',
       ));
     }, 120_000);
   });
 
-  const migrationPromise = (async () => {
+  const migrationPromise = (async (): Promise<boolean> => {
     const result = await pushSchema(pgTables, db.pg);
     await result.apply();
+    if (result.statementsToExecute.length > 0) {
+      logger.info(`[schema-sync] Schema pushed with ${result.statementsToExecute.length} statements`);
+      return true;
+    }
+    return false;
   })();
 
-  try {
-    await Promise.race([migrationPromise, timeoutPromise]);
-  } catch (error) {
-    logger.error('[schema-sync] Migration failed or timed out:', error);
-    process.exit(1);
-  }
+  return Promise.race([migrationPromise, timeoutPromise]);
 }
 
 /**
  * Runs drizzle-kit push to sync schema changes to the database
+ * Returns true if schema changes were applied, false otherwise
  */
-async function runDrizzlePush(): Promise<void> {
-  try {
-    logger.info('[schema-sync] Running schema push...');
+async function runDrizzlePush(): Promise<boolean> {
+  const pgTables = Object.fromEntries(Object.entries(schema)
+    .filter(([, value]) => isTable(value) || 'pg' in value)
+    .map(([name, value]) => ([name, (value instanceof PgAirtableTable ? value.pg : value) as unknown as PgAirtableTable['pg']])));
+  logger.info(`[schema-sync] Running schema push with tables: ${Object.keys(pgTables).join(', ')}`);
 
-    const pgTables = Object.fromEntries(Object.entries(schema)
-      .filter(([, value]) => isTable(value) || 'pg' in value)
-      .map(([name, value]) => ([name, (value instanceof PgAirtableTable ? value.pg : value) as unknown as PgAirtableTable['pg']])));
-    logger.info(`[schema-sync] Pushing tables: ${Object.keys(pgTables).join(', ')}`);
+  // Step 1: Clean up removed columns first to prevent migration hangs
+  // These are usually caused by adding and removing columns at the same time,
+  // which causes drizzle-kit to try to get stuck waiting for interactive input.
+  // See https://github.com/drizzle-team/drizzle-orm/issues/4651
+  await cleanupRemovedColumns(pgTables);
 
-    // Step 1: Clean up removed columns first to prevent migration hangs
-    // These are usually caused by adding and removing columns at the same time,
-    // which causes drizzle-kit to try to get stuck waiting for interactive input.
-    // See https://github.com/drizzle-team/drizzle-orm/issues/4651
-    await cleanupRemovedColumns(pgTables);
+  // Step 2: Run Drizzle's pushSchema
+  const hasChanges = await pushSchemaWithTimeout(pgTables);
 
-    // Step 2: Run Drizzle's pushSchema
-    await pushSchemaWithTimeout(pgTables);
-
-    logger.info('[schema-sync] ✅ Schema push completed successfully');
-  } catch (error) {
-    logger.error('[schema-sync] ❌ Schema push failed:', error);
-    throw error;
-  }
+  logger.info('[schema-sync] ✅ Schema push completed successfully');
+  return hasChanges;
 }
 
 /**
  * Syncs field mappings between PostgreSQL tables and Airtable fields
  */
 async function syncFields(): Promise<void> {
-  try {
-    logger.info('[schema-sync] Syncing field mappings...');
+  logger.info('[schema-sync] Syncing field mappings...');
 
-    const rowsToInsert: (typeof metaTable.$inferInsert)[] = [];
+  const rowsToInsert: (typeof metaTable.$inferInsert)[] = [];
 
-    for (const table of Object.values(schema)) {
-      if (table instanceof PgAirtableTable) {
-        const tableName = getTableName(table.pg);
+  for (const table of Object.values(schema)) {
+    if (table instanceof PgAirtableTable) {
+      const tableName = getTableName(table.pg);
 
-        for (const [pgFieldName, airtableFieldId] of table.airtableFieldMap.entries()) {
-          rowsToInsert.push({
-            airtableBaseId: table.airtable.baseId,
-            airtableTableId: table.airtable.tableId,
-            airtableFieldId,
-            pgTable: tableName,
-            pgField: pgFieldName,
-          });
-        }
+      for (const [pgFieldName, airtableFieldId] of table.airtableFieldMap.entries()) {
+        rowsToInsert.push({
+          airtableBaseId: table.airtable.baseId,
+          airtableTableId: table.airtable.tableId,
+          airtableFieldId,
+          pgTable: tableName,
+          pgField: pgFieldName,
+        });
       }
     }
-
-    if (rowsToInsert.length === 0) {
-      logger.info('[schema-sync] No PgAirtableTable metadata found in schema to insert.');
-      return;
-    }
-
-    logger.info(`[schema-sync] Preparing to insert ${rowsToInsert.length} rows into meta table...`);
-
-    // Clear meta table
-    logger.info('[schema-sync] Clearing meta table...');
-    await db.pg.transaction(async (tx) => {
-      await tx.delete(metaTable);
-
-      // Insert new metadata
-      logger.info('[schema-sync] Inserting new metadata...');
-      const result = await tx.insert(metaTable).values(rowsToInsert).returning();
-      logger.info(`[schema-sync] ✅ Successfully inserted ${result.length} rows into meta table.`);
-    });
-  } catch (error) {
-    logger.error('[schema-sync] ❌ Field sync failed:', error);
-    throw error;
   }
+
+  if (rowsToInsert.length === 0) {
+    logger.info('[schema-sync] No PgAirtableTable metadata found in schema to insert.');
+    return;
+  }
+
+  // Reset meta table
+  await db.pg.transaction(async (tx) => {
+    await tx.delete(metaTable);
+    await tx.insert(metaTable).values(rowsToInsert);
+  });
+  logger.info(`[schema-sync] ✅ Synced ${rowsToInsert.length} field mapping rows into meta table.`);
 }
 
 /**
  * Ensures the database schema is up to date by running validation, push, and field sync
+ * Returns true if schema changes were detected, false otherwise
  */
-export async function ensureSchemaUpToDate(): Promise<void> {
+export async function ensureSchemaUpToDate(): Promise<boolean> {
   try {
     logger.info('[schema-sync] 🔄 Ensuring database schema is up to date...');
 
-    // Step 1: Push schema changes to database
-    await runDrizzlePush();
+    // Step 1: Push schema changes to database and detect if changes were made
+    const schemaChangesDetected = await runDrizzlePush();
 
     // Step 2: Sync field mappings
     await syncFields();
 
-    logger.info('[schema-sync] ✅ Database schema sync completed successfully');
+    logger.info(`[schema-sync] ✅ Schema is now up to date. ${schemaChangesDetected ? 'Changes applied.' : 'No changes needed.'}`);
+    return schemaChangesDetected;
   } catch (error) {
     logger.error('[schema-sync] ❌ Failed to update database schema:', error);
     throw error;


### PR DESCRIPTION
**The Problem:**
When database schema changes occur (new columns, renamed fields, data type changes, etc.), the existing synced data in PostgreSQL may become inconsistent or incomplete relative to the new schema structure.

**Why Full Sync is Required:**

1. **New Columns**: When new columns are added to track additional Airtable fields, existing records won't have data for these new fields
2. **Data Type Changes**: Schema changes might require data transformation that only a full re-sync can handle

**The Solution:**
Automatically trigger a full sync when schema changes are detected to ensure:
- New columns are populated with current Airtable data
- All existing records are updated with the correct data e.g. for data type changes

**Example Scenario:**
If you add a new field mapping to sync an Airtable "Priority" field that wasn't previously tracked, all existing records in PostgreSQL would be missing this priority data until a full sync repopulates them with the current Airtable values.

This automation eliminates the need for manual full syncs after schema changes.