### PR TITLE
docs: Update security contact email from security@ to software@bluedot.org

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,5 +1,5 @@
 # Security Policy
 
-If you have identified a potential security flaw, email [security@bluedot.org](mailto:security@bluedot.org).
+If you have identified a potential security flaw, email [software@bluedot.org](mailto:software@bluedot.org).
 
 Please don't open an issue on this repository, as this is public and may highlight the vulnerability to others.

--- a/apps/website/public/.well-known/security.txt
+++ b/apps/website/public/.well-known/security.txt
@@ -1,2 +1,2 @@
-Contact: mailto:security@bluedot.org
+Contact: mailto:software@bluedot.org
 Preferred-Languages: en


### PR DESCRIPTION
# Description

docs: Update security contact email from security@ to software@bluedot.org

As the software team changes shape, we discussed combining security@ and software@ for simplicity, since they'll almost certainly go to the same person for a while.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1039