### PR TITLE
website-proxy: Add legacy curriculum and course URL redirects to nginx config

### DIFF
--- a/apps/website-proxy/src/nginx.template.conf
+++ b/apps/website-proxy/src/nginx.template.conf
@@ -182,6 +182,44 @@ http {
             return 301 $scheme://$host/join-us/ai-safety-teaching-fellow$is_args$args;
         }
 
+        # Legacy curriculum and course redirects
+        location = /ai-alignment-curriculum {
+            return 301 $scheme://$host/courses/alignment$is_args$args;
+        }
+        location = /ai-alignment-curriculum/ {
+            return 301 $scheme://$host/courses/alignment$is_args$args;
+        }
+        location = /ai-governance-curriculum {
+            return 301 $scheme://$host/courses/governance$is_args$args;
+        }
+        location = /ai-governance-curriculum/ {
+            return 301 $scheme://$host/courses/governance$is_args$args;
+        }
+        location = /alignment-course-details {
+            return 301 $scheme://$host/courses/alignment$is_args$args;
+        }
+        location = /alignment-course-details/ {
+            return 301 $scheme://$host/courses/alignment$is_args$args;
+        }
+        location = /governance-course-details {
+            return 301 $scheme://$host/courses/governance$is_args$args;
+        }
+        location = /governance-course-details/ {
+            return 301 $scheme://$host/courses/governance$is_args$args;
+        }
+        location = /alignment-insession-readings {
+            return 301 $scheme://$host/courses/alignment$is_args$args;
+        }
+        location = /alignment-insession-readings/ {
+            return 301 $scheme://$host/courses/alignment$is_args$args;
+        }
+        location = /alignment-201-curriculum {
+            return 301 $scheme://$host/courses/alignment-201$is_args$args;
+        }
+        location = /alignment-201-curriculum/ {
+            return 301 $scheme://$host/courses/alignment-201$is_args$args;
+        }
+
         # Route /u/* paths to old site
         # These represent uploaded images, which are sometimes used by the AISF or BSF sites
         location /u/ {


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

website-proxy: Add legacy curriculum and course URL redirects to nginx config

Add 301 redirects for old curriculum and course detail pages to their new locations under /courses/, ensuring backward compatibility for bookmarked links and external references.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1033