### PR TITLE
fixes: cadance shown in coursecard

### DIFF
--- a/apps/website/src/components/courses/CourseSearchCard.tsx
+++ b/apps/website/src/components/courses/CourseSearchCard.tsx
@@ -60,7 +60,7 @@ export const CourseSearchCard: React.FC<CourseSearchCardProps> = ({
               <Tag className="course-search-card__level">{level}</Tag>
             )}
             {cadence && (
-              <Tag className="course-search-card__duration">{cadence === 'MOOC' ? 'Self-paced' : cadence}</Tag>
+              <Tag className="course-search-card__duration">{cadence}</Tag>
             )}
           </div>
           {typeof averageRating === 'number' && (

--- a/apps/website/src/components/courses/__snapshots__/CourseDirectory.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/CourseDirectory.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`CourseDirectory > renders default as expected 1`] = `
                       class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-color-secondary-text container-lined course-search-card__duration"
                       role="status"
                     >
-                      Self-paced
+                      MOOC
                     </span>
                   </div>
                   <div

--- a/apps/website/src/components/lander/FutureOfAiLander.tsx
+++ b/apps/website/src/components/lander/FutureOfAiLander.tsx
@@ -134,7 +134,7 @@ const FutureOfAiLander = ({
               <FaClock /> Just 2 hours
             </div>
             <div className="flex gap-2 items-center border border-color-border rounded-lg p-4 text-color-text-on-dark">
-              <FaBoltLightning /> Self-paced
+              <FaBoltLightning /> {courseData.course.cadence || 'Self-paced'}
             </div>
             <div className="flex gap-2 items-center border border-color-border rounded-lg p-4 text-color-text-on-dark">
               <FaAward /> Free certificate
@@ -164,7 +164,7 @@ const FutureOfAiLander = ({
                   <FaClock /> Just 2 hours
                 </div>
                 <div className="flex gap-2 items-center border border-color-border rounded-lg p-4 text-color-text-on-dark">
-                  <FaBoltLightning /> Self-paced
+                  <FaBoltLightning /> {courseData.course.cadence}
                 </div>
                 <div className="flex gap-2 items-center border border-color-border rounded-lg p-4 text-color-text-on-dark">
                   <FaAward /> Free certificate

--- a/apps/website/src/components/lander/__snapshots__/FutureOfAiLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/FutureOfAiLander.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
                 d="M0 256L28.5 28c2-16 15.6-28 31.8-28H228.9c15 0 27.1 12.1 27.1 27.1c0 3.2-.6 6.5-1.7 9.5L208 160H347.3c20.2 0 36.7 16.4 36.7 36.7c0 7.4-2.2 14.6-6.4 20.7l-192.2 281c-5.9 8.6-15.6 13.7-25.9 13.7h-2.9c-15.7 0-28.5-12.8-28.5-28.5c0-2.3 .3-4.6 .9-6.9L176 288H32c-17.7 0-32-14.3-32-32z"
               />
             </svg>
-             Self-paced
+             
           </div>
           <div
             class="flex gap-2 items-center border border-color-border rounded-lg p-4 text-color-text-on-dark"

--- a/libraries/ui/src/CourseCard.test.tsx
+++ b/libraries/ui/src/CourseCard.test.tsx
@@ -8,6 +8,8 @@ describe('CourseCard', () => {
     title: 'Title',
     description: 'Description',
     url: 'https://bluedot.org/courses/what-the-fish',
+    cadence: 'Self-paced',
+    courseLength: '10 hours',
   };
 
   test('renders default as expected', () => {
@@ -29,7 +31,7 @@ describe('CourseCard', () => {
       <CourseCard
         {...defaultProps}
         applicationDeadline="Feb 1"
-        courseType="Self-paced"
+        cadence="Self-paced"
         imageSrc="/images/team/custom-size.jpg"
       />,
     );

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -57,12 +57,16 @@ exports[`CourseCard > renders Featured as expected 1`] = `
       >
         <span
           class="course-card__length font-medium"
-        />
+        >
+          10 hours
+        </span>
       </p>
       <span
         class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-color-secondary-text container-lined course-card__type"
         role="status"
-      />
+      >
+        Self-paced
+      </span>
     </div>
   </a>
 </div>
@@ -117,12 +121,16 @@ exports[`CourseCard > renders default as expected 1`] = `
               >
                 <span
                   class="course-card__length font-medium"
-                />
+                >
+                  10 hours
+                </span>
               </p>
               <span
                 class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit text-color-secondary-text container-lined course-card__type"
                 role="status"
-              />
+              >
+                Self-paced
+              </span>
             </div>
           </div>
         </div>
@@ -135,7 +143,9 @@ exports[`CourseCard > renders default as expected 1`] = `
 exports[`CourseCard > renders with optional args 1`] = `
 <span
   class="course-card__length font-medium"
-/>
+>
+  10 hours
+</span>
 `;
 
 exports[`CourseCard > renders with optional args 2`] = `


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->
We want to directly show the cadance set in the airtable on the website without previously changing it as done before. 


## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<img width="1445" alt="Screenshot 2025-06-19 at 12 47 22" src="https://github.com/user-attachments/assets/3e0b30d0-c92a-4122-ae75-173c4e8d35bd" />

