### PR TITLE
website: Replace dynamic certificate badge with hardcoded URL temporarily

### DIFF
--- a/apps/website/src/pages/certification.tsx
+++ b/apps/website/src/pages/certification.tsx
@@ -93,7 +93,8 @@ const CertificatePage = () => {
 
         <div className="flex flex-col sm:flex-row gap-8 my-12">
           <div className="max-w-sm mx-auto sm:w-1/3">
-            <img src={certificate.certificationBadgeImageSrc} alt="Certificate badge" />
+            {/* TODO: fix images with postgres sync <img src={certificate.certificationBadgeImageSrc} alt="Certificate badge" /> */}
+            <img src="https://storage.k8s.bluedot.org/website-assets/editor/8258c691-866c-4f81-826d-be26322d6681.svg" alt="Certificate badge" />
           </div>
 
           <div className="sm:w-2/3 space-y-4">


### PR DESCRIPTION
The Postgres sync service doesn't really work with images - it syncs an expiring Airtable URL, which expires some time after the sync. This then breaks after a while.

Putting in a hardcoded generic certification badge as a temporary fix until we sort this. I think an easy route might be simply to upload the cert badges to storage.k8s.bluedot.org and link to them in Airtable as strings.

> Nothing is more permanent than a temporary solution.