### PR TITLE
db: Refactor database client API to simplify usage and align more with airtable-ts

### DIFF
--- a/apps/app-template/src/pages/api/authed/update-name.ts
+++ b/apps/app-template/src/pages/api/authed/update-name.ts
@@ -17,5 +17,5 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Name must not be blank');
   }
 
-  await db.airtableUpdate(personTable, { id: body.personId, firstName: body.newFirstName });
+  await db.update(personTable, { id: body.personId, firstName: body.newFirstName });
 });

--- a/apps/app-template/src/pages/api/public/people.ts
+++ b/apps/app-template/src/pages/api/public/people.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { eq, personTable } from '@bluedot/db';
+import { personTable } from '@bluedot/db';
 import db from '../../../lib/api/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 
@@ -17,7 +17,7 @@ export default makeApiRoute({
     isProfilePublic: z.boolean(),
   })),
 }, async () => {
-  const allPeople = await db.pg.select().from(personTable.pg).where(eq(personTable.pg.isProfilePublic, true));
+  const allPeople = await db.scan(personTable, { isProfilePublic: true });
 
   return allPeople.map((person) => ({
     id: person.id,

--- a/libraries/db/README.md
+++ b/libraries/db/README.md
@@ -13,19 +13,19 @@ const db = new PgAirtableDb({
 });
 
 // Write to Airtable and sync to PostgreSQL
-const course = await db.airtableInsert(courseTable, {
+const course = await db.insert(courseTable, {
   title: 'AI Safety Fundamentals',
   slug: 'aisf'
 });
 
 // Read from PostgreSQL (fast)
-const courses = await db.pg.select().from(courseTable.pg);
+const courses = await db.scan(courseTable);
 ```
 
 ## Important
 
-- **Use `airtableInsert`, `airtableUpdate`, `airtableDelete`** for writes - these update Airtable and sync to PostgreSQL
-- **Use `db.pg.select()`** for reads - this queries PostgreSQL directly for speed
-- **Don't use raw `insert`/`update`/`delete`** - these only write to PostgreSQL and break sync
+- **Use `db.get`, `db.scan` or `db.pg.select`** for reads - this queries PostgreSQL directly for speed
+- **Use `db.insert`, `db.update`, `db.delete`** for writes - these update Airtable and sync to PostgreSQL
+- **Don't use raw `db.pg.insert`/`db.pg.update`/`db.pg.delete`** - these only write to PostgreSQL and break sync
 
 The [pg-sync-service](../../apps/pg-sync-service/) handles remotely syncing the databases via webhooks.

--- a/libraries/db/README.md
+++ b/libraries/db/README.md
@@ -25,7 +25,7 @@ const courses = await db.scan(courseTable);
 ## Important
 
 - **Use `db.get`, `db.scan` or `db.pg.select`** for reads - this queries PostgreSQL directly for speed
-- **Use `db.insert`, `db.update`, `db.delete`** for writes - these update Airtable and sync to PostgreSQL
+- **Use `db.insert`, `db.update`, `db.remove`** for writes - these update Airtable and sync to PostgreSQL
 - **Don't use raw `db.pg.insert`/`db.pg.update`/`db.pg.delete`** - these only write to PostgreSQL and break sync
 
 The [pg-sync-service](../../apps/pg-sync-service/) handles remotely syncing the databases via webhooks.

--- a/libraries/db/src/lib/client.ts
+++ b/libraries/db/src/lib/client.ts
@@ -1,9 +1,32 @@
-import { eq } from 'drizzle-orm';
-import { PgInsertValue, PgUpdateSetSource } from 'drizzle-orm/pg-core';
+import {
+  eq, and, or, gt, lt, gte, lte, ne, SQL,
+} from 'drizzle-orm';
+import { PgInsertValue, PgUpdateSetSource, PgColumn } from 'drizzle-orm/pg-core';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { AirtableTs } from 'airtable-ts';
+import { AirtableTs, AirtableTsError } from 'airtable-ts';
+import { ErrorType } from 'airtable-ts/dist/AirtableTsError';
 import { PgAirtableTable } from './db-core';
 import { AirtableItemFromColumnsMap, BasePgTableType, PgAirtableColumnInput } from './typeUtils';
+
+/**
+ * Filter operations for querying records
+ */
+export type FilterOperation<T> = {
+  [K in keyof T]?:
+  | T[K]
+  | { '>': T[K] }
+  | { '<': T[K] }
+  | { '>=': T[K] }
+  | { '<=': T[K] }
+  | { '=': T[K] }
+  | { '!=': T[K] };
+};
+
+export type Filter<T> = FilterOperation<T> | {
+  AND: Filter<T>[];
+} | {
+  OR: Filter<T>[];
+};
 
 /**
  * Postgres client which is identical to the standard client in terms of functionality, but
@@ -11,18 +34,18 @@ import { AirtableItemFromColumnsMap, BasePgTableType, PgAirtableColumnInput } fr
  */
 type RestrictedPgDatabase = Omit<ReturnType<typeof drizzle>, 'insert' | 'update' | 'delete'> & {
   /**
-   * @deprecated Please use `airtableInsert`, which will write to Airtable and mirror the result to Postgres.
-   * Using this raw `insert` function will only write to Postgres.
+   * @deprecated Use `db.insert`, which will write to Airtable and mirror the result to Postgres.
+   * Using this raw `db.pg.insert` function will only write to Postgres.
    */
   insert: ReturnType<typeof drizzle>['insert'];
   /**
-   * @deprecated Please use `airtableUpdate`, which will write to Airtable and mirror the result to Postgres.
-   * Using this raw `update` function will only write to Postgres.
+   * @deprecated Use `db.update` instead, which will write to Airtable and mirror the result to Postgres.
+   * Using this raw `db.pg.update` function will only write to Postgres.
    */
   update: ReturnType<typeof drizzle>['update'];
   /**
-   * @deprecated Please use `airtableDelete`, which will write to Airtable and mirror the result to Postgres.
-   * Using this raw `delete` function will only write to Postgres.
+   * @deprecated Use `remove`, which will write to Airtable and mirror the result to Postgres.
+   * Using this raw `db.pg.delete` function will only write to Postgres.
    */
   delete: ReturnType<typeof drizzle>['delete'];
 };
@@ -30,24 +53,158 @@ type RestrictedPgDatabase = Omit<ReturnType<typeof drizzle>, 'insert' | 'update'
 export class PgAirtableDb {
   private pgUnrestricted: ReturnType<typeof drizzle>;
 
+  /** @deprecated Usually, don't use this. Use the primary methods on PgAirtableDb instead */
+  public pg: RestrictedPgDatabase;
+
+  /** @deprecated Never use this, unless you know what you're doing. Use the primary methods on PgAirtableDb instead */
   public airtableClient: AirtableTs;
+
+  /** @deprecated Old name. Use .insert() instead */
+  public airtableInsert = this.insert.bind(this);
+
+  /** @deprecated Old name. Use .update() instead */
+  public airtableUpdate = this.update.bind(this);
+
+  /** @deprecated Old name. Use .remove() instead */
+  public airtableDelete = this.remove.bind(this);
 
   constructor({ pgConnString, airtableApiKey }: { pgConnString: string; airtableApiKey: string }) {
     this.airtableClient = new AirtableTs({
       apiKey: airtableApiKey,
     });
     this.pgUnrestricted = drizzle(pgConnString);
+    this.pg = this.pgUnrestricted as RestrictedPgDatabase;
   }
 
-  public get pg(): RestrictedPgDatabase {
-    return this.pgUnrestricted;
+  /**
+   * Get exactly one record matching the filter. Throws error if 0 or >1 records match.
+   */
+  async get<TTableName extends string, TColumnsMap extends Record<string, PgAirtableColumnInput>>(
+    table: PgAirtableTable<TTableName, TColumnsMap>,
+    idOrFilter: string | Filter<BasePgTableType<TTableName, TColumnsMap>['$inferSelect']>,
+  ): Promise<BasePgTableType<TTableName, TColumnsMap>['$inferSelect']> {
+    const results = await this.scan(
+      table,
+      typeof idOrFilter === 'string'
+        ? { id: idOrFilter } as Filter<BasePgTableType<TTableName, TColumnsMap>['$inferSelect']>
+        : idOrFilter,
+    );
+
+    if (results.length === 0) {
+      throw new AirtableTsError({
+        message: '[PgAirtableDb] No records found matching the filter',
+        type: ErrorType.RESOURCE_NOT_FOUND,
+        suggestion: 'Check the filter criteria or ensure the record exists.',
+      });
+    }
+
+    if (results.length > 1) {
+      throw new Error('Multiple records found: Filter must match exactly one record');
+    }
+
+    return results[0]!;
+  }
+
+  /**
+   * Scan for records matching the optional filter. Returns all matching records.
+   */
+  async scan<TTableName extends string, TColumnsMap extends Record<string, PgAirtableColumnInput>>(
+    table: PgAirtableTable<TTableName, TColumnsMap>,
+    filter?: Filter<BasePgTableType<TTableName, TColumnsMap>['$inferSelect']>,
+  ): Promise<BasePgTableType<TTableName, TColumnsMap>['$inferSelect'][]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const baseQuery = this.pgUnrestricted.select().from(table.pg as any);
+
+    if (filter) {
+      const whereClause = this.buildWhereClause(table.pg, filter);
+      return await baseQuery.where(whereClause) as BasePgTableType<TTableName, TColumnsMap>['$inferSelect'][];
+    }
+
+    return await baseQuery as BasePgTableType<TTableName, TColumnsMap>['$inferSelect'][];
+  }
+
+  /**
+   * Build a WHERE clause from a filter object
+   */
+  private buildWhereClause(
+    table: Record<string, PgColumn>,
+    filter: Filter<Record<string, unknown>>,
+  ): SQL {
+    if ('AND' in filter && Array.isArray(filter.AND)) {
+      const conditions = filter.AND.map((f: Filter<Record<string, unknown>>) => this.buildWhereClause(table, f));
+      const result = and(...conditions);
+      if (!result) {
+        throw new Error('Failed to build AND condition');
+      }
+      return result;
+    }
+
+    if ('OR' in filter && Array.isArray(filter.OR)) {
+      const conditions = filter.OR.map((f: Filter<Record<string, unknown>>) => this.buildWhereClause(table, f));
+      const result = or(...conditions);
+      if (!result) {
+        throw new Error('Failed to build OR condition');
+      }
+      return result;
+    }
+
+    // Handle field-level filters
+    const conditions: SQL[] = [];
+
+    for (const [fieldName, fieldFilter] of Object.entries(filter)) {
+      const column = table[fieldName];
+      if (!column) {
+        throw new Error(`Unknown field: ${fieldName}`);
+      }
+
+      if (fieldFilter && typeof fieldFilter === 'object' && !Array.isArray(fieldFilter)) {
+        // Handle operation objects like { $gt: value }
+        for (const [op, value] of Object.entries(fieldFilter)) {
+          switch (op) {
+            case '>':
+              conditions.push(gt(column, value));
+              break;
+            case '<':
+              conditions.push(lt(column, value));
+              break;
+            case '>=':
+              conditions.push(gte(column, value));
+              break;
+            case '<=':
+              conditions.push(lte(column, value));
+              break;
+            case '=':
+              conditions.push(eq(column, value));
+              break;
+            case '!=':
+              conditions.push(ne(column, value));
+              break;
+            default:
+              throw new Error(`Unknown operation: ${op}`);
+          }
+        }
+      } else {
+        // Handle direct equality
+        conditions.push(eq(column, fieldFilter));
+      }
+    }
+
+    if (conditions.length === 0) {
+      throw new Error('No valid filter conditions found');
+    }
+
+    const result = conditions.length === 1 ? conditions[0] : and(...conditions);
+    if (!result) {
+      throw new Error('Failed to build WHERE condition');
+    }
+    return result;
   }
 
   /**
    * Insert `data` into airtable and replicate synchronously to postgres (changes are readable immediately
    * after awaiting this).
    */
-  async airtableInsert<TTableName extends string, TColumnsMap extends Record<string, PgAirtableColumnInput>>(
+  async insert<TTableName extends string, TColumnsMap extends Record<string, PgAirtableColumnInput>>(
     table: PgAirtableTable<TTableName, TColumnsMap>,
     data: Partial<Omit<AirtableItemFromColumnsMap<TColumnsMap>, 'id'>>,
   ): Promise<BasePgTableType<TTableName, TColumnsMap>['$inferSelect']> {
@@ -62,7 +219,7 @@ export class PgAirtableDb {
    * Update the given record in airtable and replicate synchronously to postgres (changes are
    * readable immediately after awaiting this).
    */
-  async airtableUpdate<TTableName extends string, TColumnsMap extends Record<string, PgAirtableColumnInput>>(
+  async update<TTableName extends string, TColumnsMap extends Record<string, PgAirtableColumnInput>>(
     table: PgAirtableTable<TTableName, TColumnsMap>,
     data: Partial<AirtableItemFromColumnsMap<TColumnsMap>> & { id: string },
   ): Promise<BasePgTableType<TTableName, TColumnsMap>['$inferSelect']> {
@@ -77,7 +234,7 @@ export class PgAirtableDb {
    * Delete the given record in airtable and replicate synchronously to postgres (changes are
    * readable immediately after awaiting this).
    */
-  async airtableDelete<TTableName extends string, TColumnsMap extends Record<string, PgAirtableColumnInput>>(
+  async remove<TTableName extends string, TColumnsMap extends Record<string, PgAirtableColumnInput>>(
     table: PgAirtableTable<TTableName, TColumnsMap>,
     id: string,
   ): Promise<BasePgTableType<TTableName, TColumnsMap>['$inferSelect']> {


### PR DESCRIPTION
- Replace `airtableInsert/Update/Delete` with `insert/update/delete`
- Replace direct PostgreSQL queries with `scan` method
- Add filter operations support for querying records
- Update API routes to use new unified database methods
- Deprecate raw PostgreSQL write operations to prevent sync issues

---

Have only migrated app-template over. Should migrate all the other apps over sometime.