### PR TITLE
Make zoomAccount field nullable in groupDiscussionTable schema

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -304,7 +304,7 @@ export const groupDiscussionTable = pgAirtable('group_discussion', {
       airtableId: 'fldjISs1XFGAwT5k5',
     },
     zoomAccount: {
-      pgColumn: text().notNull(),
+      pgColumn: text(),
       airtableId: 'fldH0pKnEELPI65Qs',
     },
   },


### PR DESCRIPTION
Not present on all records, and was causing errors when trying to sync