### PR TITLE
Removed regex requirement for name

### DIFF
--- a/apps/website/src/__tests__/pages/profile.test.tsx
+++ b/apps/website/src/__tests__/pages/profile.test.tsx
@@ -203,27 +203,6 @@ describe('ProfilePage - Edit Name Feature', () => {
     expect(mockedAxios.patch).not.toHaveBeenCalled();
   });
 
-  test('should show validation error for names with invalid characters', async () => {
-    const { container } = render(<ProfilePage />);
-
-    const input = await waitFor(() => {
-      const nameInput = getNameInput(container);
-      return nameInput;
-    });
-
-    // Test regex validation for invalid characters
-    fireEvent.change(input, { target: { value: 'John@123' } });
-    const saveButton = getNameSaveButton(container);
-    fireEvent.click(saveButton!);
-
-    await waitFor(() => {
-      expect(getErrorMessage(container, 'Name can only contain letters, spaces, hyphens, apostrophes, and periods')).toBeInTheDocument();
-    });
-
-    // Verify that no API call was made due to client-side validation
-    expect(mockedAxios.patch).not.toHaveBeenCalled();
-  });
-
   test('should not show buttons when name matches original', async () => {
     const { container } = render(<ProfilePage />);
 

--- a/apps/website/src/lib/schemas/user/me.schema.ts
+++ b/apps/website/src/lib/schemas/user/me.schema.ts
@@ -3,9 +3,8 @@ import z from 'zod';
 export const meRequestBodySchema = z.object({
   name: z.string()
     .trim()
-  // 50 characters for a name seemed reasonable
+    // 50 characters for a name seemed reasonable
     .max(50, 'Name must be under 50 characters')
-    .regex(/^[\p{L}\s\-'.]+$/u, 'Name can only contain letters, spaces, hyphens, apostrophes, and periods')
     .optional(),
   referredById: z.string()
     .trim()


### PR DESCRIPTION
# Description
Current regex prevents certain valid names, this fixes that
## Issue

Fixes #1057 
## Developer checklist

- [X] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [X] Considered adding tests
- [X] Considered adding Storybook stories

## Screenshot
No visual change
