### PR TITLE
Enable public database access for airtable-sync-pg service

### DIFF
--- a/apps/infra/src/k8s/ingress.ts
+++ b/apps/infra/src/k8s/ingress.ts
@@ -24,10 +24,10 @@ export const ingressNginx = new k8s.helm.v3.Release('ingress-nginx', {
         default: 'true',
       },
     },
-    // This enables public connections to the database
-    // In general, use `kubectl port-forward svc/postgres-cluster-rw 5433:5432` instead
-    // tcp: {
-    //   5432: cluster.metadata.name.apply((v) => `default/${v}-rw:5432`),
-    // },
+    // This enables public connections to the airtable-sync-pg database
+    // For others, use `./tools/connectDb.sh` or `kubectl port-forward svc/postgres-cluster-rw 5433:5432`
+    tcp: {
+      5432: 'default/airtable-sync-pg-rw:5432',
+    },
   },
 }, { provider });


### PR DESCRIPTION
- Uncomment and configure TCP port forwarding for airtable-sync-pg database