### PR TITLE
infra: Unexpose pg-sync-service

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -250,7 +250,6 @@ export const services: ServiceDefinition[] = [
         ],
       }],
     },
-    hosts: ['pg-sync-service.k8s.bluedot.org'],
   },
   {
     name: 'minio',


### PR DESCRIPTION
Remove the hosts array from pg-sync-service definition in serviceDefinitions.ts given this app does not have any need to be exposed publicly.