### PR TITLE
Tolgadur/filter unit prompts

### DIFF
--- a/apps/website/src/pages/api/courses/[courseSlug]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/index.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
-  eq, asc, courseTable, unitTable, InferSelectModel,
+  eq, and, asc, courseTable, unitTable, InferSelectModel,
 } from '@bluedot/db';
 import db from '../../../../lib/api/db';
 import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
@@ -39,7 +39,10 @@ export default makeApiRoute({
 
   const units = await db.pg.select()
     .from(unitTable.pg)
-    .where(eq(unitTable.pg.courseSlug, courseSlug))
+    .where(and(
+      eq(unitTable.pg.courseSlug, courseSlug),
+      eq(unitTable.pg.unitStatus, 'Active'),
+    ))
     .orderBy(asc(unitTable.pg.unitNumber));
 
   return {


### PR DESCRIPTION
# Description
Course units that were tagged as not "Active" weren't filted out. Also in the course unit page they weren't sorted. I attached before and after screenshots below.


## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes https://github.com/bluedotimpact/bluedot/issues/1042

## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
**Before:**
<img width="1078" alt="Screenshot 2025-06-24 at 10 50 23" src="https://github.com/user-attachments/assets/3b4a9074-689a-4d7d-b0fd-6a85da76d08d" />
<img width="360" alt="Screenshot 2025-06-24 at 10 50 11" src="https://github.com/user-attachments/assets/5739037c-65a8-4843-bae7-3f6df343ebf8" />


**After:**
<img width="1394" alt="Screenshot 2025-06-24 at 10 33 56" src="https://github.com/user-attachments/assets/33494a13-bc33-44c8-b0fe-72502975e947" />
<img width="1144" alt="Screenshot 2025-06-24 at 10 33 38" src="https://github.com/user-attachments/assets/de0fcd38-8ec5-4eed-ad5d-25413fec6bbd" />

