### PR TITLE
website: Correct usage of terms unitId and unitNumber

### DIFF
--- a/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitNumber].test.tsx
+++ b/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitNumber].test.tsx
@@ -5,7 +5,7 @@ import {
 import { useRouter } from 'next/router';
 import type { NextRouter } from 'next/router';
 import { unitTable, chunkTable, InferSelectModel } from '@bluedot/db';
-import CourseUnitPage from '../../../../../pages/courses/[courseSlug]/[unitId]';
+import CourseUnitPage from '../../../../../pages/courses/[courseSlug]/[unitNumber]';
 
 type Unit = InferSelectModel<typeof unitTable.pg>;
 type Chunk = InferSelectModel<typeof chunkTable.pg>;
@@ -13,7 +13,7 @@ type Chunk = InferSelectModel<typeof chunkTable.pg>;
 // Mock next/router
 vi.mock('next/router', () => ({
   useRouter: vi.fn(() => ({
-    query: { courseSlug: 'test-course', unitId: '3' },
+    query: { courseSlug: 'test-course', unitNumber: '3' },
   })),
 }));
 
@@ -38,7 +38,7 @@ const createMockUnit = (unitNumber: string, title: string, content: string): Uni
   description: `${title} description`,
   learningOutcomes: `Learning outcomes for ${title}`,
   unitPodcastUrl: '',
-  id: `unit-${unitNumber}`,
+  id: `recUnit${unitNumber}`,
 });
 
 const createMockChunk = (unitId: string): Chunk => ({
@@ -54,7 +54,7 @@ const createMockChunk = (unitId: string): Chunk => ({
 describe('CourseUnitPage', () => {
   test('renders unit 0 correctly with 0-indexed units', async () => {
     vi.mocked(useRouter).mockReturnValueOnce({
-      query: { courseSlug: 'test-course', unitId: '0' },
+      query: { courseSlug: 'test-course', unitNumber: '0' },
     } as unknown as NextRouter);
 
     const mockUnits = [

--- a/apps/website/src/components/courses/ResourceListCourseContent.tsx
+++ b/apps/website/src/components/courses/ResourceListCourseContent.tsx
@@ -8,7 +8,7 @@ import {
 import { ErrorView } from '@bluedot/ui/src/ErrorView';
 import { FaRegSquare, FaSquareCheck } from 'react-icons/fa6';
 import { unitResourceTable, InferSelectModel } from '@bluedot/db';
-import { GetUnitResourcesResponse } from '../../pages/api/courses/[courseSlug]/[unitId]/resources';
+import { GetUnitResourcesResponse } from '../../pages/api/courses/[courseSlug]/[unitNumber]/resources';
 import { GetResourceCompletionResponse, PutResourceCompletionRequest } from '../../pages/api/courses/resource-completion/[unitResourceId]';
 import StarRating from './StarRating';
 import {
@@ -18,23 +18,23 @@ import { ROUTES } from '../../lib/routes';
 import Callout from './Callout';
 // eslint-disable-next-line import/no-cycle
 import Exercise from './exercises/Exercise';
-import { GetUnitResponse } from '../../pages/api/courses/[courseSlug]/[unitId]';
+import { GetUnitResponse } from '../../pages/api/courses/[courseSlug]/[unitNumber]';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
 
 type UnitResource = InferSelectModel<typeof unitResourceTable.pg>;
 
 const ResourceListCourseContent: React.FC = () => {
-  const { query: { courseSlug, unitId } } = useRouter();
+  const { query: { courseSlug, unitNumber } } = useRouter();
 
   const [{ data: resourcesData, loading: resourcesLoading, error: resourcesError }] = useAxios<GetUnitResourcesResponse>({
     method: 'get',
-    url: `/api/courses/${courseSlug}/${unitId}/resources`,
+    url: `/api/courses/${courseSlug}/${unitNumber}/resources`,
   });
 
   // This will almost always hit useAxios's built-in cache, because we render this on the unit page
   const [{ data: unitData, loading: unitLoading, error: unitError }] = useAxios<GetUnitResponse>({
     method: 'get',
-    url: `/api/courses/${courseSlug}/${unitId}`,
+    url: `/api/courses/${courseSlug}/${unitNumber}`,
   });
 
   if (resourcesLoading || unitLoading) {

--- a/apps/website/src/components/courses/UnitFeedback.test.tsx
+++ b/apps/website/src/components/courses/UnitFeedback.test.tsx
@@ -70,7 +70,7 @@ describe('UnitFeedback', () => {
 
     await waitFor(() => {
       expect(axios.put).toHaveBeenCalledWith(
-        '/api/courses/slug/unit123/feedback',
+        '/api/courses/slug/1/feedback',
         { overallRating: 4, anythingElse: '' },
         { headers: { Authorization: 'Bearer mockToken' } },
       );
@@ -94,7 +94,7 @@ describe('UnitFeedback', () => {
 
     await waitFor(() => {
       expect(axios.put).toHaveBeenCalledWith(
-        '/api/courses/slug/unit123/feedback',
+        '/api/courses/slug/1/feedback',
         { overallRating: 5, anythingElse: 'Great course!' },
         { headers: { Authorization: 'Bearer mockToken' } },
       );

--- a/apps/website/src/components/courses/UnitFeedback.test.tsx
+++ b/apps/website/src/components/courses/UnitFeedback.test.tsx
@@ -40,7 +40,7 @@ vi.mock('@bluedot/ui', async () => {
 });
 
 describe('UnitFeedback', () => {
-  const fakeUnit = { courseSlug: 'slug', id: 'unit123' };
+  const fakeUnit = { courseSlug: 'slug', id: 'unit123', unitNumber: '1' };
 
   test('should render correctly', () => {
     const { container } = render(<UnitFeedback unit={fakeUnit} />);

--- a/apps/website/src/components/courses/UnitFeedback.tsx
+++ b/apps/website/src/components/courses/UnitFeedback.tsx
@@ -6,14 +6,14 @@ import { FaCircleCheck } from 'react-icons/fa6';
 import axios from 'axios';
 
 import { unitTable, InferSelectModel } from '@bluedot/db';
-import { GetUnitFeedbackResponse, PutUnitFeedbackRequest } from '../../pages/api/courses/[courseSlug]/[unitId]/feedback';
+import { GetUnitFeedbackResponse, PutUnitFeedbackRequest } from '../../pages/api/courses/[courseSlug]/[unitNumber]/feedback';
 import StarRating from './StarRating';
 import { H4, P } from '../Text';
 
 type Unit = InferSelectModel<typeof unitTable.pg>;
 
 type UnitFeedbackProps = {
-  unit: Pick<Unit, 'id' | 'courseSlug'>;
+  unit: Pick<Unit, 'id' | 'courseSlug' | 'unitNumber'>;
 };
 
 const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
@@ -24,11 +24,11 @@ const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
   const [error, setError] = useState<unknown | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { courseSlug, id: unitId } = unit;
+  const { courseSlug, unitNumber } = unit;
 
   const [{ data, loading }, refetch] = useAxios<GetUnitFeedbackResponse>({
     method: 'get',
-    url: `/api/courses/${courseSlug}/${unitId}/feedback`,
+    url: `/api/courses/${courseSlug}/${unitNumber}/feedback`,
     headers: {
       Authorization: `Bearer ${auth?.token}`,
     },
@@ -47,7 +47,7 @@ const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
 
     try {
       await axios.put<unknown, unknown, PutUnitFeedbackRequest>(
-        `/api/courses/${courseSlug}/${unitId}/feedback`,
+        `/api/courses/${courseSlug}/${unitNumber}/feedback`,
         {
           overallRating: rating,
           anythingElse: feedbackText,
@@ -65,7 +65,7 @@ const UnitFeedback: React.FC<UnitFeedbackProps> = ({ unit }) => {
     } finally {
       setIsSubmitting(false);
     }
-  }, [rating, feedbackText, courseSlug, unitId, auth, refetch]);
+  }, [rating, feedbackText, courseSlug, unitNumber, auth, refetch]);
 
   // Don't show for logged out users
   if (!data || !auth) {

--- a/apps/website/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website/src/components/courses/UnitLayout.test.tsx
@@ -43,6 +43,7 @@ const COURSE_UNITS = [
     learningOutcomes: 'Understand fish anatomy, behavior, and aquatic principles',
     unitPodcastUrl: '',
     id: 'recySscaN1b0Cm1jn',
+    unitStatus: 'Active',
   },
   {
     chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
@@ -60,6 +61,7 @@ const COURSE_UNITS = [
     learningOutcomes: 'Understand modern fishing practices and their economic impact',
     unitPodcastUrl: '',
     id: 'recyGMcsDLhp9mPqH',
+    unitStatus: 'Active',
   },
   {
     chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
@@ -77,6 +79,7 @@ const COURSE_UNITS = [
     learningOutcomes: 'Explore innovative applications of fish technology',
     unitPodcastUrl: '',
     id: 'recjPDtSupcowWbmw',
+    unitStatus: 'Active',
   },
   {
     chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
@@ -94,6 +97,7 @@ const COURSE_UNITS = [
     learningOutcomes: 'Understand potential risks and challenges in fish technology',
     unitPodcastUrl: '',
     id: 'recc6cSN9fn3VfTvZ',
+    unitStatus: 'Active',
   },
   {
     chunks: ['recuC87TILbjW4eF4', 'recuC87TILbjW4eF4', 'recuC87TILbjW4eF4'],
@@ -111,6 +115,7 @@ const COURSE_UNITS = [
     learningOutcomes: 'Apply knowledge to improve fish-human relations',
     unitPodcastUrl: '',
     id: 'recIztjGqTNNpLTe1',
+    unitStatus: 'Active',
   },
 ];
 

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/index.ts
@@ -25,11 +25,11 @@ export default makeApiRoute({
     chunks: z.array(z.any()),
   }),
 }, async (body, { raw }) => {
-  const { courseSlug, unitId } = raw.req.query;
+  const { courseSlug, unitNumber } = raw.req.query;
   if (typeof courseSlug !== 'string') {
     throw new createHttpError.BadRequest('Invalid course slug');
   }
-  if (typeof unitId !== 'string') {
+  if (typeof unitNumber !== 'string') {
     throw new createHttpError.BadRequest('Invalid unit number');
   }
 
@@ -41,7 +41,7 @@ export default makeApiRoute({
     ))
     .orderBy(asc(unitTable.pg.unitNumber));
 
-  const unit = units.find((u) => parseInt(u.unitNumber) === parseInt(unitId));
+  const unit = units.find((u) => parseInt(u.unitNumber) === parseInt(unitNumber));
   if (!unit) {
     throw new createHttpError.NotFound('Unit not found');
   }

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/resources.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/resources.ts
@@ -23,11 +23,11 @@ export default makeApiRoute({
     unitExercises: z.array(z.any()),
   }),
 }, async (body, { raw }) => {
-  const { courseSlug, unitId } = raw.req.query;
+  const { courseSlug, unitNumber } = raw.req.query;
   if (typeof courseSlug !== 'string') {
     throw new createHttpError.BadRequest('Invalid course slug');
   }
-  if (typeof unitId !== 'string') {
+  if (typeof unitNumber !== 'string') {
     throw new createHttpError.BadRequest('Invalid unit number');
   }
 
@@ -35,7 +35,7 @@ export default makeApiRoute({
     .from(unitTable.pg)
     .where(and(
       eq(unitTable.pg.courseSlug, courseSlug),
-      eq(unitTable.pg.unitNumber, unitId),
+      eq(unitTable.pg.unitNumber, unitNumber),
     ));
 
   const unit = units[0];

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber].tsx
@@ -3,15 +3,19 @@ import useAxios from 'axios-hooks';
 import { ErrorSection, ProgressDots, useAuthStore } from '@bluedot/ui';
 import { useEffect } from 'react';
 import UnitLayout from '../../../components/courses/UnitLayout';
-import { GetUnitResponse } from '../../api/courses/[courseSlug]/[unitId]';
+import { GetUnitResponse } from '../../api/courses/[courseSlug]/[unitNumber]';
 import { GetCourseRegistrationResponse } from '../../api/course-registrations/[courseId]';
 
 const CourseUnitPage = () => {
-  const { query: { courseSlug, unitId } } = useRouter();
+  const { query: { courseSlug, unitNumber } } = useRouter();
+
+  if (typeof unitNumber !== 'string') {
+    return <ProgressDots />;
+  }
 
   const [{ data, loading, error }] = useAxios<GetUnitResponse>({
     method: 'get',
-    url: `/api/courses/${courseSlug}/${unitId}`,
+    url: `/api/courses/${courseSlug}/${unitNumber}`,
   });
 
   // If we're logged in, ensures a course registration is recorded for this course
@@ -31,8 +35,6 @@ const CourseUnitPage = () => {
     }
   }, [auth, data?.unit.courseId]);
 
-  const unitNumber = typeof unitId === 'string' ? parseInt(unitId) : 0;
-
   if (loading) {
     return <ProgressDots />;
   }
@@ -46,7 +48,7 @@ const CourseUnitPage = () => {
       chunks={data.chunks}
       unit={data.unit}
       units={data.units}
-      unitNumber={unitNumber}
+      unitNumber={parseInt(unitNumber)}
     />
   );
 };


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Reduce confusion about what is a unitId and unitNumber

This did require changing the feedback component and API to always use unitNumber, because otherwise Next complains with:

```
Error: You cannot use different slug names for the same dynamic path ('unitId' !== 'unitNumber').
    at Array.forEach (<anonymous>)
```

(we could have avoided this by doing something like `/unit/by-number/{number}` but given it's just one route it's easier to be consistent)

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1046

## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

No visual changes
