### PR TITLE
Refactor database queries to use db.get() helper method

### DIFF
--- a/apps/availability/src/pages/api/public/get-form.ts
+++ b/apps/availability/src/pages/api/public/get-form.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
-import createHttpError from 'http-errors';
-import { eq, formConfigurationTable } from '@bluedot/db';
+import { formConfigurationTable } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db from '../../../lib/api/db';
 
@@ -18,12 +17,7 @@ export default makeApiRoute({
     minimumLength: z.number(),
   }),
 }, async (body, { raw }) => {
-  const records = await db.pg.select().from(formConfigurationTable.pg).where(eq(formConfigurationTable.pg.slug, raw.req.query.slug as string));
-  const targetRecord = records[0];
-
-  if (!targetRecord) {
-    throw new createHttpError.NotFound('Form not found');
-  }
+  const targetRecord = await db.get(formConfigurationTable, { slug: raw.req.query.slug as string });
 
   return {
     type: 'success' as const,

--- a/apps/availability/src/pages/api/public/submit.ts
+++ b/apps/availability/src/pages/api/public/submit.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { parseIntervals } from 'weekly-availabilities';
 import axios from 'axios';
 import createHttpError from 'http-errors';
-import { eq, formConfigurationTable } from '@bluedot/db';
+import { formConfigurationTable } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db from '../../../lib/api/db';
 
@@ -38,12 +38,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid time availability expression');
   }
 
-  const records = await db.pg.select().from(formConfigurationTable.pg).where(eq(formConfigurationTable.pg.slug, raw.req.query.slug as string));
-  const targetRecord = records[0];
-
-  if (!targetRecord) {
-    throw new createHttpError.NotFound('Form not found');
-  }
+  const targetRecord = await db.get(formConfigurationTable, { slug: raw.req.query.slug as string });
 
   if (!targetRecord.webhook) {
     throw new createHttpError.InternalServerError('Form webhook not configured');

--- a/apps/course-demos/src/pages/api/saved-output/[savedDemoOutputId].ts
+++ b/apps/course-demos/src/pages/api/saved-output/[savedDemoOutputId].ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { eq, sharedDemoOutputTable } from '@bluedot/db';
+import { sharedDemoOutputTable } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db, { demoTypes } from '../../../lib/api/db';
 
@@ -20,12 +20,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Missing savedDemoOutputId');
   }
 
-  const records = await db.pg.select().from(sharedDemoOutputTable.pg).where(eq(sharedDemoOutputTable.pg.id, savedDemoOutputId));
-  const record = records[0];
-
-  if (!record) {
-    throw new createHttpError.NotFound('Saved demo output not found');
-  }
+  const record = await db.get(sharedDemoOutputTable, { id: savedDemoOutputId });
 
   return {
     type: record.type as SavedDemoOutput['type'],

--- a/apps/editor/src/pages/api/blogs/[slug]/index.ts
+++ b/apps/editor/src/pages/api/blogs/[slug]/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { eq, blogTable, InferSelectModel } from '@bluedot/db';
+import { blogTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../../lib/api/db';
 import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
 
@@ -26,12 +26,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const blogs = await db.pg.select().from(blogTable.pg).where(eq(blogTable.pg.slug, slug));
-  const blog = blogs[0];
-
-  if (!blog) {
-    throw new createHttpError.NotFound('Blog post not found');
-  }
+  const blog = await db.get(blogTable, { slug });
 
   switch (raw.req.method) {
     case 'GET': {
@@ -44,7 +39,7 @@ export default makeApiRoute({
       if (!body) {
         throw new createHttpError.BadRequest('Expected PUT request to include body');
       }
-      await db.airtableUpdate(blogTable, {
+      await db.update(blogTable, {
         id: blog.id,
         body: body.body,
       });

--- a/apps/editor/src/pages/api/blogs/index.ts
+++ b/apps/editor/src/pages/api/blogs/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { desc, blogTable, InferSelectModel } from '@bluedot/db';
+import { blogTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../lib/api/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 
@@ -17,10 +17,12 @@ export default makeApiRoute({
     blogs: z.array(z.any()),
   }),
 }, async () => {
-  const allBlogs = await db.pg.select().from(blogTable.pg).orderBy(desc(blogTable.pg.publishedAt));
+  const allBlogs = await db.scan(blogTable);
 
-  // Remove the body field from each blog to make the response lighter
-  const blogSummaries = allBlogs.map(({ body, ...rest }) => rest);
+  // Sort by publishedAt descending and remove the body field from each blog to make the response lighter
+  const blogSummaries = allBlogs
+    .sort((a, b) => (b.publishedAt || 0) - (a.publishedAt || 0))
+    .map(({ body, ...rest }) => rest);
 
   return {
     type: 'success' as const,

--- a/apps/editor/src/pages/api/jobs/[slug]/index.ts
+++ b/apps/editor/src/pages/api/jobs/[slug]/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { eq, jobPostingTable, InferSelectModel } from '@bluedot/db';
+import { jobPostingTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../../lib/api/db';
 import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
 
@@ -26,12 +26,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const jobs = await db.pg.select().from(jobPostingTable.pg).where(eq(jobPostingTable.pg.slug, slug));
-  const job = jobs[0];
-
-  if (!job) {
-    throw new createHttpError.NotFound('Job posting not found');
-  }
+  const job = await db.get(jobPostingTable, { slug });
 
   switch (raw.req.method) {
     case 'GET': {
@@ -44,7 +39,7 @@ export default makeApiRoute({
       if (!body) {
         throw new createHttpError.BadRequest('Expected PUT request to include body');
       }
-      await db.airtableUpdate(jobPostingTable, {
+      await db.update(jobPostingTable, {
         id: job.id,
         body: body.body,
       });

--- a/apps/editor/src/pages/api/jobs/index.ts
+++ b/apps/editor/src/pages/api/jobs/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { asc, jobPostingTable, InferSelectModel } from '@bluedot/db';
+import { jobPostingTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../lib/api/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 
@@ -17,10 +17,12 @@ export default makeApiRoute({
     jobs: z.array(z.any()),
   }),
 }, async () => {
-  const allJobs = await db.pg.select().from(jobPostingTable.pg).orderBy(asc(jobPostingTable.pg.title));
+  const allJobs = await db.scan(jobPostingTable);
 
-  // Remove the body field from each job to make the response lighter
-  const jobSummaries = allJobs.map(({ body, ...rest }) => rest);
+  // Sort by title ascending and remove the body field from each job to make the response lighter
+  const jobSummaries = allJobs
+    .sort((a, b) => (a.title || '').localeCompare(b.title || ''))
+    .map(({ body, ...rest }) => rest);
 
   return {
     type: 'success' as const,

--- a/apps/editor/src/pages/api/projects/[slug]/index.ts
+++ b/apps/editor/src/pages/api/projects/[slug]/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { eq, projectTable, InferSelectModel } from '@bluedot/db';
+import { projectTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../../lib/api/db';
 import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
 
@@ -26,12 +26,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const projects = await db.pg.select().from(projectTable.pg).where(eq(projectTable.pg.slug, slug));
-  const project = projects[0];
-
-  if (!project) {
-    throw new createHttpError.NotFound('Project not found');
-  }
+  const project = await db.get(projectTable, { slug });
 
   switch (raw.req.method) {
     case 'GET': {
@@ -44,7 +39,7 @@ export default makeApiRoute({
       if (!body) {
         throw new createHttpError.BadRequest('Expected PUT request to include body');
       }
-      await db.airtableUpdate(projectTable, {
+      await db.update(projectTable, {
         id: project.id,
         body: body.body,
       });

--- a/apps/editor/src/pages/api/projects/index.ts
+++ b/apps/editor/src/pages/api/projects/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { asc, projectTable, InferSelectModel } from '@bluedot/db';
+import { projectTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../lib/api/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 
@@ -17,10 +17,12 @@ export default makeApiRoute({
     projects: z.array(z.any()),
   }),
 }, async () => {
-  const allProjects = await db.pg.select().from(projectTable.pg).orderBy(asc(projectTable.pg.title));
+  const allProjects = await db.scan(projectTable);
 
-  // Remove the body field from each project to make the response lighter
-  const projectSummaries = allProjects.map(({ body, ...rest }) => rest);
+  // Sort by title ascending and remove the body field from each project to make the response lighter
+  const projectSummaries = allProjects
+    .sort((a, b) => (a.title || '').localeCompare(b.title || ''))
+    .map(({ body, ...rest }) => rest);
 
   return {
     type: 'success' as const,

--- a/apps/frontend-example/src/pages/api/public/people.ts
+++ b/apps/frontend-example/src/pages/api/public/people.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { eq, personTable, InferSelectModel } from '@bluedot/db';
+import { personTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../lib/api/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 
@@ -17,7 +17,7 @@ export default makeApiRoute({
     persons: z.array(z.any()),
   }),
 }, async () => {
-  const publicPeople = await db.pg.select().from(personTable.pg).where(eq(personTable.pg.isProfilePublic, true));
+  const publicPeople = await db.scan(personTable, { isProfilePublic: true });
 
   return {
     type: 'success' as const,

--- a/apps/frontend-example/src/pages/api/public/update-name.ts
+++ b/apps/frontend-example/src/pages/api/public/update-name.ts
@@ -15,5 +15,5 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('First name cannot be blank.');
   }
 
-  await db.airtableUpdate(personTable, { id: body.personId, firstName: body.newFirstName });
+  await db.update(personTable, { id: body.personId, firstName: body.newFirstName });
 });

--- a/apps/meet/src/pages/api/public/record-attendance.ts
+++ b/apps/meet/src/pages/api/public/record-attendance.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { eq, groupDiscussionTable } from '@bluedot/db';
+import { groupDiscussionTable } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db from '../../../lib/api/db';
 
@@ -35,15 +35,11 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Missing participant id.');
   }
 
-  const groupDiscussions = await db.pg.select().from(groupDiscussionTable.pg).where(eq(groupDiscussionTable.pg.id, body.groupDiscussionId));
-  const groupDiscussion = groupDiscussions[0];
-  if (!groupDiscussion) {
-    throw new createHttpError.NotFound('Group discussion not found.');
-  }
+  const groupDiscussion = await db.get(groupDiscussionTable, { id: body.groupDiscussionId });
 
   const currentAttendees = groupDiscussion.attendees || [];
   if (!currentAttendees.includes(body.participantId)) {
-    await db.airtableUpdate(groupDiscussionTable, {
+    await db.update(groupDiscussionTable, {
       id: body.groupDiscussionId,
       attendees: [...currentAttendees, body.participantId],
     });

--- a/apps/website/src/pages/api/certificates/[certificateId].ts
+++ b/apps/website/src/pages/api/certificates/[certificateId].ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { eq, courseRegistrationTable, courseTable } from '@bluedot/db';
+import { courseRegistrationTable, courseTable } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db from '../../../lib/api/db';
 
@@ -31,23 +31,9 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Missing certificateId');
   }
 
-  const courseRegistrations = await db.pg.select()
-    .from(courseRegistrationTable.pg)
-    .where(eq(courseRegistrationTable.pg.certificateId, certificateId));
+  const courseRegistration = await db.get(courseRegistrationTable, { certificateId });
 
-  const courseRegistration = courseRegistrations[0];
-  if (!courseRegistration) {
-    throw new createHttpError.NotFound('Certificate not found');
-  }
-
-  const courses = await db.pg.select()
-    .from(courseTable.pg)
-    .where(eq(courseTable.pg.id, courseRegistration.courseId));
-
-  const course = courses[0];
-  if (!course) {
-    throw new createHttpError.NotFound('Course not found');
-  }
+  const course = await db.get(courseTable, { id: courseRegistration.courseId });
 
   const certificate: Certificate = {
     certificateId,

--- a/apps/website/src/pages/api/cms/blogs/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/blogs/[slug]/index.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
-  eq, and, ne, blogTable, InferSelectModel,
+  blogTable, InferSelectModel,
 } from '@bluedot/db';
 import db from '../../../../../lib/api/db';
 import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
@@ -25,18 +25,8 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const blogs = await db.pg.select()
-    .from(blogTable.pg)
-    .where(and(
-      ne(blogTable.pg.publicationStatus, 'Unpublished'),
-      eq(blogTable.pg.slug, slug),
-    ));
-
-  const blog = blogs[0];
-
-  if (!blog) {
-    throw new createHttpError.NotFound('Blog post not found');
-  }
+  // Get blog by slug and filter out unpublished ones
+  const blog = await db.get(blogTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
 
   return {
     type: 'success' as const,

--- a/apps/website/src/pages/api/cms/jobs/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/jobs/[slug]/index.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
-  eq, and, ne, jobPostingTable, InferSelectModel,
+  jobPostingTable, InferSelectModel,
 } from '@bluedot/db';
 import db from '../../../../../lib/api/db';
 import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
@@ -25,18 +25,8 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const jobs = await db.pg.select()
-    .from(jobPostingTable.pg)
-    .where(and(
-      ne(jobPostingTable.pg.publicationStatus, 'Unpublished'),
-      eq(jobPostingTable.pg.slug, slug),
-    ));
-
-  const job = jobs[0];
-
-  if (!job) {
-    throw new createHttpError.NotFound('Job posting not found');
-  }
+  // Get job by slug and filter out unpublished ones
+  const job = await db.get(jobPostingTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
 
   return {
     type: 'success' as const,

--- a/apps/website/src/pages/api/cms/jobs/index.ts
+++ b/apps/website/src/pages/api/cms/jobs/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { eq, jobPostingTable, InferSelectModel } from '@bluedot/db';
+import { jobPostingTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../../lib/api/db';
 import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
 
@@ -17,15 +17,12 @@ export default makeApiRoute({
     jobs: z.array(z.any()),
   }),
 }, async () => {
-  const allJobs = await db.pg.select()
-    .from(jobPostingTable.pg)
-    .where(eq(jobPostingTable.pg.publicationStatus, 'Published'));
+  const allJobs = await db.scan(jobPostingTable, { publicationStatus: 'Published' });
 
-  // Sort jobs alphabetically by title
-  const sortedJobs = allJobs.sort((a, b) => (a.title).localeCompare(b.title));
-
-  // Remove the body field from each job to make the response lighter
-  const jobSummaries = sortedJobs.map(({ body, ...rest }) => rest);
+  // Sort jobs alphabetically by title and remove the body field from each job to make the response lighter
+  const jobSummaries = allJobs
+    .sort((a, b) => (a.title).localeCompare(b.title))
+    .map(({ body, ...rest }) => rest);
 
   return {
     type: 'success' as const,

--- a/apps/website/src/pages/api/cms/projects/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/projects/[slug]/index.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
-  eq, and, ne, projectTable, InferSelectModel,
+  projectTable, InferSelectModel,
 } from '@bluedot/db';
 import db from '../../../../../lib/api/db';
 import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
@@ -25,18 +25,8 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const projects = await db.pg.select()
-    .from(projectTable.pg)
-    .where(and(
-      ne(projectTable.pg.publicationStatus, 'Unpublished'),
-      eq(projectTable.pg.slug, slug),
-    ));
-
-  const project = projects[0];
-
-  if (!project) {
-    throw new createHttpError.NotFound('Project post not found');
-  }
+  // Get project by slug and filter out unpublished ones
+  const project = await db.get(projectTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
 
   return {
     type: 'success' as const,

--- a/apps/website/src/pages/api/course-registrations/index.tsx
+++ b/apps/website/src/pages/api/course-registrations/index.tsx
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
-  eq, and, courseRegistrationTable, InferSelectModel,
+  courseRegistrationTable, InferSelectModel,
 } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db from '../../../lib/api/db';
@@ -22,12 +22,10 @@ export default makeApiRoute({
 }, async (body, { auth, raw }) => {
   switch (raw.req.method) {
     case 'GET': {
-      const courseRegistrations = await db.pg.select()
-        .from(courseRegistrationTable.pg)
-        .where(and(
-          eq(courseRegistrationTable.pg.email, auth.email),
-          eq(courseRegistrationTable.pg.decision, 'Accept'),
-        ));
+      const courseRegistrations = await db.scan(courseRegistrationTable, {
+        email: auth.email,
+        decision: 'Accept',
+      });
 
       return {
         type: 'success' as const,

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/feedback.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/feedback.ts
@@ -43,7 +43,7 @@ export default makeApiRoute(
 
     const { method } = raw.req;
     if (method !== 'GET' && method !== 'PUT') {
-      createHttpError.MethodNotAllowed();
+      throw createHttpError.MethodNotAllowed();
     }
 
     const unit = await db.get(unitTable, { courseSlug, unitNumber });

--- a/apps/website/src/pages/api/courses/exercises/[exerciseId]/index.ts
+++ b/apps/website/src/pages/api/courses/exercises/[exerciseId]/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { eq, exerciseTable, InferSelectModel } from '@bluedot/db';
+import { exerciseTable, InferSelectModel } from '@bluedot/db';
 import db from '../../../../../lib/api/db';
 import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
 
@@ -25,14 +25,7 @@ export default makeApiRoute({
 
   switch (raw.req.method) {
     case 'GET': {
-      const exercises = await db.pg.select()
-        .from(exerciseTable.pg)
-        .where(eq(exerciseTable.pg.id, exerciseId));
-
-      const exercise = exercises[0];
-      if (!exercise) {
-        throw new createHttpError.NotFound('Exercise not found');
-      }
+      const exercise = await db.get(exerciseTable, { id: exerciseId });
 
       return {
         type: 'success' as const,

--- a/apps/website/src/pages/api/courses/index.ts
+++ b/apps/website/src/pages/api/courses/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-  eq, courseTable, InferSelectModel,
+  courseTable, InferSelectModel,
 } from '@bluedot/db';
 import db from '../../../lib/api/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
@@ -48,9 +48,7 @@ export default makeApiRoute({
   }),
 }, async () => {
   // For now, just get all courses that should be displayed on the course hub
-  const courses = await db.pg.select()
-    .from(courseTable.pg)
-    .where(eq(courseTable.pg.displayOnCourseHubIndex, true));
+  const courses = await db.scan(courseTable, { displayOnCourseHubIndex: true });
 
   return {
     type: 'success' as const,

--- a/apps/website/src/pages/api/referrals.ts
+++ b/apps/website/src/pages/api/referrals.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
-import { eq, userTable } from '@bluedot/db';
+import { userTable } from '@bluedot/db';
 import { makeApiRoute } from '../../lib/api/makeApiRoute';
 import db from '../../lib/api/db';
 
@@ -20,15 +20,7 @@ export default makeApiRoute({
     throw new createHttpError.MethodNotAllowed();
   }
 
-  const users = await db.pg.select()
-    .from(userTable.pg)
-    .where(eq(userTable.pg.email, auth.email));
-
-  const user = users[0];
-
-  if (!user) {
-    throw new createHttpError.NotFound(`User not found for email: ${auth.email}`);
-  }
+  const user = await db.get(userTable, { email: auth.email });
 
   return {
     type: 'success' as const,

--- a/libraries/db/README.md
+++ b/libraries/db/README.md
@@ -2,7 +2,7 @@
 
 An abstraction layer for using Airtable mirrored to PostgreSQL as if it were (approximately) just PostgreSQL.
 
-## Usage
+## Quick start
 
 ```typescript
 import { PgAirtableDb, courseTable } from '@bluedot/db';
@@ -22,9 +22,75 @@ const course = await db.insert(courseTable, {
 const courses = await db.scan(courseTable);
 ```
 
+## Usage
+
+### Get a single record
+
+This will throw an error if 0 or >1 records match the filter.
+
+```typescript
+// Get by ID
+const course = await db.get(courseTable, 'course123');
+
+// Get by other fields
+const course = await db.get(courseTable, { slug: 'aisf' });
+
+// Get with multiple filters (all must match)
+const registration = await db.get(courseRegistrationTable, { 
+  email: 'user@example.com', 
+  courseId: 'course123',
+  decision: 'Accept'
+});
+
+// Comparison operators
+// Available operators: '>', '<', '>=', '<=', '=', '!='
+const courses = await db.scan(courseTable, {
+  durationHours: { '>': 10 },
+  averageRating: { '>=': 4.5 },
+  publicationStatus: { '!=': 'Unpublished' },
+  courseLeadFirstName: "Adam",
+  courseLeadLastName: { '=': 'Jones' } // (this is equivalent to just 'Jones', as we default to equality)
+});
+
+// You can also combine things with an OR or AND (default is AND)
+const coreOrFurtherResources = await db.scan(unitResourceTable, {
+  OR: [
+    { coreFurtherMaybe: 'Core' },
+    { coreFurtherMaybe: 'Further' }
+  ]
+})
+```
+
+### Insert new records
+
+```typescript
+const newCourse = await db.insert(courseTable, {
+  // id is always required to NOT be present
+  title: 'Advanced AI Safety',
+  slug: 'advanced-aisf',
+  description: 'Deep dive into AI safety concepts'
+});
+```
+
+### Update existing records
+
+```typescript
+const updatedCourse = await db.update(courseTable, {
+  id: 'course123', // id is always required
+  title: 'Updated Course Title',
+  description: 'Updated description'
+});
+```
+
+### Remove records
+
+```typescript
+const deletedCourse = await db.remove(courseTable, 'course123');
+```
+
 ## Important
 
-- **Use `db.get`, `db.scan` or `db.pg.select`** for reads - this queries PostgreSQL directly for speed
+- **Use `db.get`, `db.scan`** for reads - these query PostgreSQL directly for speed
 - **Use `db.insert`, `db.update`, `db.remove`** for writes - these update Airtable and sync to PostgreSQL
 - **Don't use raw `db.pg.insert`/`db.pg.update`/`db.pg.delete`** - these only write to PostgreSQL and break sync
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Replace manual pg.select().where(eq()) patterns with the simpler db.get() helper method across all API routes. This improves code consistency and reduces boilerplate while maintaining the same functionality.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1054

## Developer checklist

- [x] Front-end code follows the [BEM class name convention](https://getbem.com/naming/)
- [x] Considered adding tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

No visual changes