### PR TITLE
website: Update mission statement to focus on workforce building

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`AboutPage > should render correctly 1`] = `
         <h1
           class="hero-section__title text-color-text-on-dark text-center bluedot-h1"
         >
-          Our mission is to ensure humanity safely navigates the transition to transformative AI.
+          Our mission is to build the workforce needed to safely navigate to transformative AI.
         </h1>
         <div
           class="flex justify-center mt-8"

--- a/apps/website/src/pages/about.tsx
+++ b/apps/website/src/pages/about.tsx
@@ -23,11 +23,11 @@ const AboutPage = () => {
     <div>
       <Head>
         <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
-        <meta name="description" content="Our mission is to ensure humanity safely navigates the transition to transformative AI." />
+        <meta name="description" content="Our mission is to build the workforce needed to safely navigate to transformative AI." />
       </Head>
       <HeroSection>
         <HeroMiniTitle>{CURRENT_ROUTE.title}</HeroMiniTitle>
-        <HeroH1>Our mission is to ensure humanity safely navigates the transition to transformative AI.</HeroH1>
+        <HeroH1>Our mission is to build the workforce needed to safely navigate to transformative AI.</HeroH1>
         <HeroCTAContainer>
           <CTALinkOrButton url={ROUTES.joinUs.url} withChevron>Join us</CTALinkOrButton>
         </HeroCTAContainer>


### PR DESCRIPTION
Refine the mission statement from "ensure humanity safely navigates" to "build the workforce needed to safely navigate" to better reflect the organization's focus on talent development and capacity building for AI safety.