### PR TITLE
website: Filter unit query to only return active units

### DIFF
--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/resources.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/resources.ts
@@ -31,7 +31,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid unit number');
   }
 
-  const unit = await db.get(unitTable, { courseSlug, unitNumber });
+  const unit = await db.get(unitTable, { courseSlug, unitNumber, unitStatus: 'Active' });
 
   // Get unit resources and filter for Core/Further, then sort
   const allUnitResources = await db.scan(unitResourceTable, { unitId: unit.id });


### PR DESCRIPTION
# Description

Add unitStatus: 'Active' condition to unit database query to ensure only active units are retrieved when fetching course unit resources.

This fixes https://bluedot.org/courses/pandemics/12, where there is also an inactive unit 12 that causes an error (because the .get() fails as there is more than one record).