### PR TITLE
[BUG] Prevent the non-existing "settings" page from being linked

### DIFF
--- a/apps/website/src/components/settings/SettingsLayout.tsx
+++ b/apps/website/src/components/settings/SettingsLayout.tsx
@@ -112,7 +112,7 @@ const SettingsBreadcrumbs = ({ route }: { route: BluedotRoute }) => {
           {breadcrumbItems.map((item, index) => {
             const isLast = index === breadcrumbItems.length - 1;
             const isSettingsItem = item.url === '/settings';
-            
+
             return (
               <li key={item.url} className="breadcrumbs__item flex items-center">
                 {isSettingsItem ? (

--- a/apps/website/src/components/settings/SettingsLayout.tsx
+++ b/apps/website/src/components/settings/SettingsLayout.tsx
@@ -111,18 +111,31 @@ const SettingsBreadcrumbs = ({ route }: { route: BluedotRoute }) => {
         <ol className="breadcrumbs__list flex">
           {breadcrumbItems.map((item, index) => {
             const isLast = index === breadcrumbItems.length - 1;
+            const isSettingsItem = item.url === '/settings';
+            
             return (
               <li key={item.url} className="breadcrumbs__item flex items-center">
-                <NewText.A
-                  className={clsx(
-                    'breadcrumbs__link no-underline',
-                    isLast && 'opacity-50',
-                  )}
-                  href={item.url}
-                  aria-current={isLast ? 'page' : undefined}
-                >
-                  {item.title}
-                </NewText.A>
+                {isSettingsItem ? (
+                  <NewText.P
+                    className={clsx(
+                      'breadcrumbs__link !m-0',
+                      isLast && 'opacity-50',
+                    )}
+                  >
+                    {item.title}
+                  </NewText.P>
+                ) : (
+                  <NewText.A
+                    className={clsx(
+                      'breadcrumbs__link no-underline',
+                      isLast && 'opacity-50',
+                    )}
+                    href={item.url}
+                    aria-current={isLast ? 'page' : undefined}
+                  >
+                    {item.title}
+                  </NewText.A>
+                )}
                 {!isLast && (
                   <span className="breadcrumbs__separator mx-2" aria-hidden="true">{'>'}</span>
                 )}

--- a/apps/website/src/components/settings/SettingsLayout.tsx
+++ b/apps/website/src/components/settings/SettingsLayout.tsx
@@ -121,6 +121,7 @@ const SettingsBreadcrumbs = ({ route }: { route: BluedotRoute }) => {
                       'breadcrumbs__link !m-0',
                       isLast && 'opacity-50',
                     )}
+                    aria-current={isLast ? 'page' : undefined}
                   >
                     {item.title}
                   </NewText.P>

--- a/apps/website/src/components/settings/__snapshots__/SettingsLayout.test.tsx.snap
+++ b/apps/website/src/components/settings/__snapshots__/SettingsLayout.test.tsx.snap
@@ -32,13 +32,11 @@ exports[`SettingsLayout > renders complete layout structure with correct active 
         <li
           class="breadcrumbs__item flex items-center"
         >
-          <a
-            class="bluedot-a not-prose breadcrumbs__link no-underline"
-            href="/settings"
-            tabindex="0"
+          <p
+            class="bluedot-p not-prose breadcrumbs__link !m-0"
           >
             Settings
-          </a>
+          </p>
           <span
             aria-hidden="true"
             class="breadcrumbs__separator mx-2"


### PR DESCRIPTION
# Description
Fixes #1090. The settings text in the breadcrumb is no longer hyperlinked. 

## Developer checklist

Not applicable since we're just fixing a bug.

## Screenshot
No visual changes
