### PR TITLE
[BUG + FEATURE] Change how we proxy events to posthog + add user agents + add referrer

### DIFF
--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -1,4 +1,13 @@
 http {
+    # Define allowed origins
+    map $http_origin $cors_origin {
+        default "";
+        "~^https://(.*\.)?bluedot\.org$" $http_origin;
+        "~^https://(.*\.)?k8s\.bluedot\.org$" $http_origin;
+        "~^http://localhost:3000$" $http_origin;
+        "~^http://localhost:3001$" $http_origin;
+    }
+
     server {
         listen 8080;
         add_header X-BlueDot-Version '$VERSION_TAG';
@@ -12,13 +21,37 @@ http {
         }
 
         location / {
-            proxy_pass https://eu.posthog.com;
+            # Handle CORS preflight requests
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' '$cors_origin' always;
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+                add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
+                add_header 'Access-Control-Allow-Credentials' 'true' always;
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain; charset=utf-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+
+            # Add CORS headers to all responses
+            add_header 'Access-Control-Allow-Origin' '$cors_origin' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
+            add_header 'Access-Control-Allow-Credentials' 'true' always;
+
+            # PostHog requires these headers - route to ingestion API
+            proxy_pass https://eu.i.posthog.com;
             proxy_redirect off;
             proxy_ssl_session_reuse off;
             proxy_ssl_server_name on;
-            proxy_set_header Host eu.posthog.com;
+            proxy_set_header Host eu.i.posthog.com;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Real-IP $remote_addr;
+            
+            # Pass through important headers
+            proxy_set_header Referer $http_referer;
+            proxy_set_header User-Agent $http_user_agent;
         }
     }
 }


### PR DESCRIPTION
# Description
PostHog events have been down for 9 days.
Errors Identified:
When examining Chrome network tabs, we're encountering three types of errors:

Captcha requests
405 errors (Method Not Allowed)
CORS errors (Cross-Origin Resource Sharing)

The fix includes switching the domain we use for sending analytics data, which should resolve the CORS and 405 errors, and potentially eliminate the captcha request issues as well.

## Issue
We're not tracking events to posthog. 

## Developer checklist
Not applicable
## Screenshot
Not visual
