### PR TITLE
[P1 Bug] Fix Multiple Choice exercises being broken in Safari

### DIFF
--- a/apps/website/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website/src/components/courses/exercises/MultipleChoice.tsx
@@ -61,6 +61,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
 
   const handleOptionSelect = (option: string) => {
     setSelectedOption(option);
+    setValue('answer', option);
     setIsEditing(true);
   };
 


### PR DESCRIPTION
# Description
Weird quirk of how multiple choice exercises were implemented was causing Safari to always use the default value for MC selections.

## Issue
Fixes #1078 

## Developer checklist
N/A 

## Screenshot
N/A
