### PR TITLE
fix: autohide navbar after selection

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`AboutPage > should render correctly 1`] = `
           </div>
           <img
             alt="BlueDot Impact team"
-            class="intro-section__image max-w-[570px] w-full h-auto rounded-md mt-6 sm:mt-0"
+            class="intro-section__image max-w-[570px] w-full h-auto rounded-md mt-6 sm:mt-0 shrink-0"
             src="/images/culture/About-Us_v1.jpg"
           />
         </div>

--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -128,7 +128,14 @@ const NavDropdown: React.FC<{
             </div>
           ) : (
             links?.map((link) => (
-              <A key={link.url} href={link.url} className={clsx(NAV_LINK_CLASSES(isScrolled), 'pt-1')}>
+              <A
+                key={link.url}
+                href={link.url}
+                className={clsx(NAV_LINK_CLASSES(isScrolled), 'pt-1')}
+                onClick={() => {
+                  onToggle();
+                }}
+              >
                 {link.title}
                 {link.isNew && (
                   <Tag variant="secondary" className="uppercase ml-2 !p-1">

--- a/apps/website/src/components/about/__snapshots__/IntroSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/IntroSection.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`IntroSection > renders default as expected 1`] = `
         </div>
         <img
           alt="BlueDot Impact team"
-          class="intro-section__image max-w-[570px] w-full h-auto rounded-md mt-6 sm:mt-0"
+          class="intro-section__image max-w-[570px] w-full h-auto rounded-md mt-6 sm:mt-0 shrink-0"
           src="/images/culture/About-Us_v1.jpg"
         />
       </div>


### PR DESCRIPTION
# Description
This autohides the navbar ones a selection has been made. 

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes https://github.com/bluedotimpact/bluedot/issues/1116

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
https://github.com/user-attachments/assets/ebf27db5-607d-409e-90eb-65396106632c
