### PR TITLE
feat: add were hiring to navbar

### DIFF
--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -78,6 +78,7 @@ export const NavLinks: React.FC<{
       />
       <A href={ROUTES.blog.url} className={NAV_LINK_CLASSES(isScrolled, isCurrentPath(ROUTES.blog.url))}>Blog</A>
       <A href="https://lu.ma/aisafetycommunityevents?utm_source=website&utm_campaign=nav" className={NAV_LINK_CLASSES(isScrolled)}>Events</A>
+      <A href={ROUTES.joinUs.url} className={clsx(NAV_LINK_CLASSES(isScrolled), 'text-bluedot-primary font-medium')}>We're hiring!</A>
     </div>
   );
 };

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -178,6 +178,13 @@ exports[`Nav > renders with courses 1`] = `
                 >
                   Events
                 </a>
+                <a
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-bluedot-primary font-medium"
+                  href="/join-us"
+                  tabindex="0"
+                >
+                  We're hiring!
+                </a>
               </div>
             </div>
           </div>
@@ -319,6 +326,13 @@ exports[`Nav > renders with courses 1`] = `
             tabindex="0"
           >
             Events
+          </a>
+          <a
+            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-bluedot-primary font-medium"
+            href="/join-us"
+            tabindex="0"
+          >
+            We're hiring!
           </a>
         </div>
         <div


### PR DESCRIPTION
# Description
Adds "We're hiring!" to navbar.


## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes https://github.com/bluedotimpact/bluedot/issues/1118

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<img width="958" height="792" alt="Screenshot 2025-07-21 at 16 30 44" src="https://github.com/user-attachments/assets/70d35f9a-6ba2-4cee-ab1a-f9436284c0c4" />
<img width="1521" height="949" alt="Screenshot 2025-07-21 at 16 30 30" src="https://github.com/user-attachments/assets/87ba11b3-a7fe-44e1-a86d-9ba77a0f8e08" />
