### PR TITLE
fix: hide signup on very small screens

### DIFF
--- a/apps/website/src/components/Nav/_NavCta.tsx
+++ b/apps/website/src/components/Nav/_NavCta.tsx
@@ -49,7 +49,7 @@ export const NavCta: React.FC<{
             Login
           </CTALinkOrButton>
           <CTALinkOrButton
-            className="nav-cta__primary-cta"
+            className="nav-cta__primary-cta min-[370px]:flex hidden" // Hide on very small screens smaller than 380px
             variant="primary"
             url={joinUrl}
           >

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -350,7 +350,7 @@ exports[`Nav > renders with courses 1`] = `
             </span>
           </a>
           <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav-cta__primary-cta"
+            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav-cta__primary-cta min-[370px]:flex hidden"
             href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-page"
             tabindex="0"
           >


### PR DESCRIPTION
# Description
For very small phones below 370px there isn't enough space on the navbar for the CTA which resulted in no padding and ackward design. This is hiding the CTA in the navbar for these phones. 

Note that this affects a very small number of phones (iPhone 5 below, Samsung Galaxy s8 etc.)


## Issue

Fixes https://github.com/bluedotimpact/bluedot/issues/986

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

https://github.com/user-attachments/assets/f7bbb500-81d6-449e-99e3-6d2c300855f2

