### PR TITLE
feat: modal to set name

### DIFF
--- a/apps/website/src/components/settings/ProfileNameEditor.tsx
+++ b/apps/website/src/components/settings/ProfileNameEditor.tsx
@@ -11,9 +11,10 @@ import { parseZodValidationError } from '../../lib/utils';
 type ProfileNameEditorProps = {
   initialName: string;
   authToken: string;
+  onSave?: () => void;
 };
 
-const ProfileNameEditor = ({ initialName, authToken }: ProfileNameEditorProps) => {
+const ProfileNameEditor = ({ initialName, authToken, onSave }: ProfileNameEditorProps) => {
   const [tempName, setTempName] = useState(initialName);
   const [isSaving, setIsSaving] = useState(false);
   const [nameError, setNameError] = useState('');
@@ -50,6 +51,8 @@ const ProfileNameEditor = ({ initialName, authToken }: ProfileNameEditorProps) =
 
       setCurrentSavedName(trimmedName);
       setTempName(trimmedName);
+      // Call onSave callback if provided
+      onSave?.();
     } catch (err) {
       if (!axios.isAxiosError(err)) {
         setNameError('Failed to update name. Please try again.');


### PR DESCRIPTION
# Description
This introduces a modal that prompts the user to add his name if he hasn't already. The main question is if this is enough or if we want to persist some state in the db to track whether this is the first time they visit the profile page and only show it then.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes https://github.com/bluedotimpact/bluedot/issues/1079#issuecomment-3102136931

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

https://github.com/user-attachments/assets/7148193d-e624-4466-a2ed-7ccd812f5b53

