### PR TITLE
Close mobile nav after navigation

### DIFF
--- a/apps/website/src/components/Nav/_MobileNavLinks.tsx
+++ b/apps/website/src/components/Nav/_MobileNavLinks.tsx
@@ -31,7 +31,32 @@ export const MobileNavLinks: React.FC<{
         className="mobile-nav-links__btn"
       />
       <div className={clsx('mobile-nav-links__drawer', DRAWER_CLASSES(isScrolled, expandedSections.mobileNav))}>
-        <div className="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden">
+        <div
+          className="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
+          onClick={(e) => {
+            // Close mobile nav when any link is clicked
+            if ((e.target as HTMLElement).tagName === 'A') {
+              updateExpandedSections({
+                about: false,
+                explore: false,
+                mobileNav: false,
+                profile: false,
+              });
+            }
+          }}
+          onKeyDown={(e) => {
+            // Also handle keyboard navigation
+            if (e.key === 'Enter' && (e.target as HTMLElement).tagName === 'A') {
+              updateExpandedSections({
+                about: false,
+                explore: false,
+                mobileNav: false,
+                profile: false,
+              });
+            }
+          }}
+          role="presentation"
+        >
           <NavLinks
             className="mobile-nav-links__nav-links flex-col"
             expandedSections={expandedSections}

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`Nav > renders with courses 1`] = `
           >
             <div
               class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
+              role="presentation"
             >
               <div
                 class="nav-links flex gap-9 [&>*]:w-fit mobile-nav-links__nav-links flex-col"


### PR DESCRIPTION
# Description
Rather than adding individual click handlers to each link, I've added a decorator pattern to the mobile menu so that it automatically closes the navigation menu whenever any link is clicked or accessed via keyboard navigation. This should make it consistent for any future links that are added in the future. 

## Issue
Fixes #1124 

## Developer checklist
N/A

## Screenshot
Not applicable