### PR TITLE
[Feature] Add select to UI library for course settings

### DIFF
--- a/libraries/ui/src/Select.stories.tsx
+++ b/libraries/ui/src/Select.stories.tsx
@@ -89,17 +89,17 @@ export const WithBothIcons: Story = {
   args: {
     label: 'User Contact',
     icon: <FaUserGroup />,
-    placeholder: 'Select contact method',
+    placeholder: 'Cohort 22: Group A',
     options: [
       {
         value: 'switch-group',
         label: 'Switch Group',
-        icon: <FaRightLeft className="text-gray-600" />,
+        icon: <FaRightLeft className="text-black-200" />,
       },
       {
         value: 'drop-out',
         label: 'Drop out / Defer',
-        icon: <FaArrowRightToBracket className="text-gray-600" />,
+        icon: <FaArrowRightToBracket className="text-black-200" />,
       },
     ],
   },

--- a/libraries/ui/src/Select.stories.tsx
+++ b/libraries/ui/src/Select.stories.tsx
@@ -1,16 +1,33 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import {
-  FaUser, FaEnvelope, FaPhone, FaGlobe,
+  FaRegUser,
+  FaRightLeft,
+  FaArrowRightFromBracket,
+  FaEnvelope,
+  FaPhone,
+  FaGlobe,
+  FaArrowRightToBracket,
+  FaUser,
+  FaUsers,
+  FaUserGroup,
 } from 'react-icons/fa6';
 import { Select } from './Select';
 
 const meta: Meta<typeof Select> = {
-  title: 'Components/Select',
+  title: 'UI/Select',
   component: Select,
   args: {
     options: [
-      { value: 'option1', label: 'Option 1' },
-      { value: 'option2', label: 'Option 2' },
+      {
+        value: 'switch-group',
+        label: 'Switch Group',
+        icon: <FaRightLeft className="text-gray-600" />,
+      },
+      {
+        value: 'drop-out',
+        label: 'Drop out / Defer',
+        icon: <FaArrowRightFromBracket className="text-gray-600" />,
+      },
       { value: 'option3', label: 'Option 3' },
     ],
   },
@@ -22,14 +39,28 @@ type Story = StoryObj<typeof Select>;
 export const Default: Story = {
   args: {
     label: 'Select an option',
-    placeholder: 'Choose...',
+    placeholder: 'Example Placeholder',
+    icon: <FaRegUser />,
+    options: [
+      {
+        value: 'switch-group',
+        label: 'Switch Group',
+        icon: <FaRightLeft className="text-gray-600" />,
+      },
+      {
+        value: 'drop-out',
+        label: 'Drop out / Defer',
+        icon: <FaArrowRightFromBracket className="text-gray-600" />,
+      },
+      { value: 'cohort23-groupA', label: 'Cohort 23: Group A' },
+    ],
   },
 };
 
 export const WithIcon: Story = {
   args: {
     label: 'User',
-    icon: <FaUser />,
+    icon: <FaRegUser />,
     placeholder: 'Select a user',
   },
 };
@@ -47,9 +78,9 @@ export const WithIconsInOptions: Story = {
     label: 'Contact Method',
     placeholder: 'Choose contact method',
     options: [
-      { value: 'email', label: 'Email', icon: <FaEnvelope className="text-bluedot-normal" /> },
-      { value: 'phone', label: 'Phone', icon: <FaPhone className="text-bluedot-normal" /> },
-      { value: 'website', label: 'Website', icon: <FaGlobe className="text-bluedot-normal" /> },
+      { value: 'email', label: 'Email', icon: <FaEnvelope className="text-gray-600" /> },
+      { value: 'phone', label: 'Phone', icon: <FaPhone className="text-gray-600" /> },
+      { value: 'website', label: 'Website', icon: <FaGlobe className="text-gray-600" /> },
     ],
   },
 };
@@ -57,12 +88,19 @@ export const WithIconsInOptions: Story = {
 export const WithBothIcons: Story = {
   args: {
     label: 'User Contact',
-    icon: <FaUser />,
+    icon: <FaUserGroup />,
     placeholder: 'Select contact method',
     options: [
-      { value: 'email', label: 'john@example.com', icon: <FaEnvelope className="text-bluedot-normal" /> },
-      { value: 'phone', label: '+1 234 567 8900', icon: <FaPhone className="text-bluedot-normal" /> },
-      { value: 'website', label: 'www.example.com', icon: <FaGlobe className="text-bluedot-normal" /> },
+      {
+        value: 'switch-group',
+        label: 'Switch Group',
+        icon: <FaRightLeft className="text-gray-600" />,
+      },
+      {
+        value: 'drop-out',
+        label: 'Drop out / Defer',
+        icon: <FaArrowRightToBracket className="text-gray-600" />,
+      },
     ],
   },
 };

--- a/libraries/ui/src/Select.stories.tsx
+++ b/libraries/ui/src/Select.stories.tsx
@@ -7,8 +7,6 @@ import {
   FaPhone,
   FaGlobe,
   FaArrowRightToBracket,
-  FaUser,
-  FaUsers,
   FaUserGroup,
 } from 'react-icons/fa6';
 import { Select } from './Select';

--- a/libraries/ui/src/Select.stories.tsx
+++ b/libraries/ui/src/Select.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  FaUser, FaEnvelope, FaPhone, FaGlobe,
+} from 'react-icons/fa6';
+import { Select } from './Select';
+
+const meta: Meta<typeof Select> = {
+  title: 'Components/Select',
+  component: Select,
+  args: {
+    options: [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2' },
+      { value: 'option3', label: 'Option 3' },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {
+  args: {
+    label: 'Select an option',
+    placeholder: 'Choose...',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    label: 'User',
+    icon: <FaUser />,
+    placeholder: 'Select a user',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Disabled Select',
+    disabled: true,
+    value: 'option1',
+  },
+};
+
+export const WithIconsInOptions: Story = {
+  args: {
+    label: 'Contact Method',
+    placeholder: 'Choose contact method',
+    options: [
+      { value: 'email', label: 'Email', icon: <FaEnvelope className="text-bluedot-normal" /> },
+      { value: 'phone', label: 'Phone', icon: <FaPhone className="text-bluedot-normal" /> },
+      { value: 'website', label: 'Website', icon: <FaGlobe className="text-bluedot-normal" /> },
+    ],
+  },
+};
+
+export const WithBothIcons: Story = {
+  args: {
+    label: 'User Contact',
+    icon: <FaUser />,
+    placeholder: 'Select contact method',
+    options: [
+      { value: 'email', label: 'john@example.com', icon: <FaEnvelope className="text-bluedot-normal" /> },
+      { value: 'phone', label: '+1 234 567 8900', icon: <FaPhone className="text-bluedot-normal" /> },
+      { value: 'website', label: 'www.example.com', icon: <FaGlobe className="text-bluedot-normal" /> },
+    ],
+  },
+};

--- a/libraries/ui/src/Select.test.tsx
+++ b/libraries/ui/src/Select.test.tsx
@@ -1,0 +1,77 @@
+import {
+  describe, test, expect, vi,
+} from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Select } from './Select';
+
+describe('Select', () => {
+  const mockOptions = [
+    { value: 'cat', label: 'Cat' },
+    { value: 'dog', label: 'Dog' },
+    { value: 'bird', label: 'Bird' },
+  ];
+
+  test('renders with label', () => {
+    const { container } = render(
+      <Select
+        label="Pet"
+        options={mockOptions}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('shows placeholder when no value selected', () => {
+    const { container } = render(
+      <Select
+        placeholder="Choose a pet"
+        options={mockOptions}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders with icon', () => {
+    const { container } = render(
+      <Select
+        label="User"
+        icon={<span>👤</span>}
+        options={mockOptions}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders disabled state', () => {
+    const { container } = render(
+      <Select
+        label="Disabled Select"
+        disabled
+        value="cat"
+        options={mockOptions}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('calls onChange when option selected', async () => {
+    const onChange = vi.fn();
+    render(
+      <Select
+        label="Pet"
+        options={mockOptions}
+        onChange={onChange}
+      />,
+    );
+
+    // Open dropdown
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    // Select an option by role and accessible name
+    const option = screen.getByRole('option', { name: 'Dog' });
+    fireEvent.click(option);
+
+    expect(onChange).toHaveBeenCalledWith('dog');
+  });
+});

--- a/libraries/ui/src/Select.tsx
+++ b/libraries/ui/src/Select.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import {
+  Button,
+  Label,
+  ListBox,
+  ListBoxItem,
+  Popover,
+  Select as AriaSelect,
+  SelectValue,
+} from 'react-aria-components';
+import clsx from 'clsx';
+
+export type SelectProps = {
+  label?: string;
+  icon?: React.ReactNode;
+  placeholder?: string;
+  options: { value: string; label: string; icon?: React.ReactNode }[];
+  className?: string;
+  buttonClassName?: string;
+  disabled?: boolean;
+  value?: string;
+  onChange?: (value: string) => void;
+  name?: string;
+};
+
+const ChevronDownIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    className={className}
+  >
+    <path
+      d="M3.5 5.25L7 8.75L10.5 5.25"
+      stroke="#00114D"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const Select: React.FC<SelectProps> = ({
+  label,
+  icon,
+  placeholder = 'Select an option',
+  options,
+  className,
+  buttonClassName,
+  disabled,
+  value,
+  onChange,
+  name,
+}) => {
+  return (
+    <AriaSelect
+      className={clsx('flex flex-col gap-2', className)}
+      isDisabled={disabled}
+      selectedKey={value}
+      onSelectionChange={(key) => onChange?.(key as string)}
+      name={name}
+      placeholder={placeholder}
+    >
+      {label && <Label className="text-size-sm font-medium">{label}</Label>}
+      <Button className={clsx(
+        'flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors',
+        'data-[pressed]:bg-[rgba(0,17,77,0.1)]',
+        'disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]',
+        buttonClassName,
+      )}
+      >
+        {icon && <span className={clsx('size-4', disabled ? 'text-gray-400' : 'text-bluedot-darker')}>{icon}</span>}
+        <SelectValue className={clsx('font-medium text-[13px] leading-[22px] text-left', disabled ? 'text-gray-500' : 'text-bluedot-darker')} />
+        <ChevronDownIcon className={clsx('size-[14px]', disabled ? 'opacity-50' : '')} />
+      </Button>
+      <Popover className="w-[var(--trigger-width)] min-w-max max-h-60 overflow-auto rounded-md bg-white shadow-lg ring-1 ring-black/5 -mt-1">
+        <ListBox className="outline-none p-1 w-full">
+          {options.map((option) => (
+            <ListBoxItem
+              key={option.value}
+              id={option.value}
+              textValue={option.label}
+              className="flex items-center gap-2 cursor-default select-none py-2.5 px-4 outline-none hover:bg-[rgba(0,85,255,0.05)] focus:bg-[rgba(0,85,255,0.05)] focus:text-bluedot-darker w-full"
+            >
+              {option.icon && <span className="size-4">{option.icon}</span>}
+              <span className="flex-1 font-medium text-[13px] leading-[22px]">{option.label}</span>
+            </ListBoxItem>
+          ))}
+        </ListBox>
+      </Popover>
+    </AriaSelect>
+  );
+};

--- a/libraries/ui/src/Select.tsx
+++ b/libraries/ui/src/Select.tsx
@@ -79,8 +79,8 @@ export const Select: React.FC<SelectProps> = ({
   // Handle controlled/uncontrolled state
   const [internalValue, setInternalValue] = useState<string | undefined>(value);
   const selectedValue = value !== undefined ? value : internalValue;
-  const selectedOption = options.find(opt => opt.value === selectedValue);
-  
+  const selectedOption = options.find((opt) => opt.value === selectedValue);
+
   // Update both internal state and call onChange callback
   const handleChange = (key: React.Key | null) => {
     if (key !== null) {
@@ -89,7 +89,7 @@ export const Select: React.FC<SelectProps> = ({
       onChange?.(newValue);
     }
   };
-  
+
   return (
     <AriaSelect
       className={clsx('flex flex-col gap-2', className)}
@@ -113,7 +113,7 @@ export const Select: React.FC<SelectProps> = ({
             // Determine which icon to show: selected option's icon or placeholder icon
             const displayIcon = selectedOption?.icon || (isPlaceholder && icon);
             const displayText = selectedOption?.label || placeholder;
-            
+
             // Render icon + text if icon exists
             if (displayIcon) {
               return (

--- a/libraries/ui/src/__snapshots__/Select.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Select.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Select > renders disabled state 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="react-aria-:r15: react-aria-:r11:"
-      class="flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors data-[pressed]:bg-[rgba(0,17,77,0.1)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]"
+      class="flex items-center px-3 py-[10px] gap-2 w-fit h-[42px] bg-[rgba(0,85,255,0.05)] rounded-md focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors hover:bg-[rgba(0,85,255,0.1)] data-[pressed]:bg-[rgba(0,17,77,0.15)] data-[expanded]:bg-[rgba(0,17,77,0.15)] aria-expanded:bg-[rgba(0,17,77,0.15)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,85,255,0.05)]"
       data-disabled="true"
       data-rac=""
       data-react-aria-pressable="true"
@@ -33,11 +33,15 @@ exports[`Select > renders disabled state 1`] = `
         data-rac=""
         id="react-aria-:r15:"
       >
-        <span
-          class="flex-1 font-medium text-[13px] leading-[22px]"
+        <div
+          class="flex items-center gap-2 w-full"
         >
-          Cat
-        </span>
+          <span
+            class="flex-1 font-medium text-[13px] leading-[22px]"
+          >
+            Cat
+          </span>
+        </div>
       </span>
       <svg
         class="size-[14px] opacity-50"
@@ -110,7 +114,7 @@ exports[`Select > renders with icon 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="react-aria-:rr: react-aria-:rn:"
-      class="flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors data-[pressed]:bg-[rgba(0,17,77,0.1)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]"
+      class="flex items-center px-3 py-[10px] gap-2 w-fit h-[42px] bg-[rgba(0,85,255,0.05)] rounded-md focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors hover:bg-[rgba(0,85,255,0.1)] data-[pressed]:bg-[rgba(0,17,77,0.15)] data-[expanded]:bg-[rgba(0,17,77,0.15)] aria-expanded:bg-[rgba(0,17,77,0.15)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,85,255,0.05)]"
       data-rac=""
       data-react-aria-pressable="true"
       id="react-aria-:rm:"
@@ -118,19 +122,25 @@ exports[`Select > renders with icon 1`] = `
       type="button"
     >
       <span
-        class="size-4 text-bluedot-darker"
-      >
-        <span>
-          👤
-        </span>
-      </span>
-      <span
         class="font-medium text-[13px] leading-[22px] text-left text-bluedot-darker"
         data-placeholder="true"
         data-rac=""
         id="react-aria-:rr:"
       >
-        Select an option
+        <div
+          class="flex items-center gap-2"
+        >
+          <span
+            class="size-4 text-bluedot-darker"
+          >
+            <span>
+              👤
+            </span>
+          </span>
+          <span>
+            Select an option
+          </span>
+        </div>
       </span>
       <svg
         class="size-[14px]"
@@ -203,7 +213,7 @@ exports[`Select > renders with label 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="react-aria-:r7: react-aria-:r3:"
-      class="flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors data-[pressed]:bg-[rgba(0,17,77,0.1)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]"
+      class="flex items-center px-3 py-[10px] gap-2 w-fit h-[42px] bg-[rgba(0,85,255,0.05)] rounded-md focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors hover:bg-[rgba(0,85,255,0.1)] data-[pressed]:bg-[rgba(0,17,77,0.15)] data-[expanded]:bg-[rgba(0,17,77,0.15)] aria-expanded:bg-[rgba(0,17,77,0.15)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,85,255,0.05)]"
       data-rac=""
       data-react-aria-pressable="true"
       id="react-aria-:r2:"
@@ -283,7 +293,7 @@ exports[`Select > shows placeholder when no value selected 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="react-aria-:rh:"
-      class="flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors data-[pressed]:bg-[rgba(0,17,77,0.1)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]"
+      class="flex items-center px-3 py-[10px] gap-2 w-fit h-[42px] bg-[rgba(0,85,255,0.05)] rounded-md focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors hover:bg-[rgba(0,85,255,0.1)] data-[pressed]:bg-[rgba(0,17,77,0.15)] data-[expanded]:bg-[rgba(0,17,77,0.15)] aria-expanded:bg-[rgba(0,17,77,0.15)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,85,255,0.05)]"
       data-rac=""
       data-react-aria-pressable="true"
       id="react-aria-:rc:"

--- a/libraries/ui/src/__snapshots__/Select.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Select.test.tsx.snap
@@ -33,15 +33,7 @@ exports[`Select > renders disabled state 1`] = `
         data-rac=""
         id="react-aria-:r15:"
       >
-        <div
-          class="flex items-center gap-2 w-full"
-        >
-          <span
-            class="flex-1 font-medium text-[13px] leading-[22px]"
-          >
-            Cat
-          </span>
-        </div>
+        Cat
       </span>
       <svg
         class="size-[14px] opacity-50"

--- a/libraries/ui/src/__snapshots__/Select.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Select.test.tsx.snap
@@ -1,0 +1,351 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Select > renders disabled state 1`] = `
+<div>
+  <template
+    data-react-aria-hidden="true"
+  />
+  <div
+    class="flex flex-col gap-2"
+    data-disabled="true"
+    data-rac=""
+  >
+    <span
+      class="text-size-sm font-medium"
+      id="react-aria-:r11:"
+    >
+      Disabled Select
+    </span>
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby="react-aria-:r15: react-aria-:r11:"
+      class="flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors data-[pressed]:bg-[rgba(0,17,77,0.1)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]"
+      data-disabled="true"
+      data-rac=""
+      data-react-aria-pressable="true"
+      disabled=""
+      id="react-aria-:r10:"
+      type="button"
+    >
+      <span
+        class="font-medium text-[13px] leading-[22px] text-left text-gray-500"
+        data-rac=""
+        id="react-aria-:r15:"
+      >
+        <span
+          class="flex-1 font-medium text-[13px] leading-[22px]"
+        >
+          Cat
+        </span>
+      </span>
+      <svg
+        class="size-[14px] opacity-50"
+        fill="none"
+        height="14"
+        viewBox="0 0 14 14"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.25L7 8.75L10.5 5.25"
+          stroke="#00114D"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.25"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    aria-hidden="true"
+    data-a11y-ignore="aria-hidden-focus"
+    data-react-aria-prevent-focus="true"
+    data-testid="hidden-select-container"
+    style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+  >
+    <label>
+      <select
+        disabled=""
+        tabindex="-1"
+      >
+        <option />
+        <option
+          value="cat"
+        >
+          Cat
+        </option>
+        <option
+          value="dog"
+        >
+          Dog
+        </option>
+        <option
+          value="bird"
+        >
+          Bird
+        </option>
+      </select>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Select > renders with icon 1`] = `
+<div>
+  <template
+    data-react-aria-hidden="true"
+  />
+  <div
+    class="flex flex-col gap-2"
+    data-rac=""
+  >
+    <span
+      class="text-size-sm font-medium"
+      id="react-aria-:rn:"
+    >
+      User
+    </span>
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby="react-aria-:rr: react-aria-:rn:"
+      class="flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors data-[pressed]:bg-[rgba(0,17,77,0.1)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]"
+      data-rac=""
+      data-react-aria-pressable="true"
+      id="react-aria-:rm:"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="size-4 text-bluedot-darker"
+      >
+        <span>
+          👤
+        </span>
+      </span>
+      <span
+        class="font-medium text-[13px] leading-[22px] text-left text-bluedot-darker"
+        data-placeholder="true"
+        data-rac=""
+        id="react-aria-:rr:"
+      >
+        Select an option
+      </span>
+      <svg
+        class="size-[14px]"
+        fill="none"
+        height="14"
+        viewBox="0 0 14 14"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.25L7 8.75L10.5 5.25"
+          stroke="#00114D"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.25"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    aria-hidden="true"
+    data-a11y-ignore="aria-hidden-focus"
+    data-react-aria-prevent-focus="true"
+    data-testid="hidden-select-container"
+    style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+  >
+    <label>
+      <select
+        tabindex="-1"
+        title=""
+      >
+        <option />
+        <option
+          value="cat"
+        >
+          Cat
+        </option>
+        <option
+          value="dog"
+        >
+          Dog
+        </option>
+        <option
+          value="bird"
+        >
+          Bird
+        </option>
+      </select>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Select > renders with label 1`] = `
+<div>
+  <template
+    data-react-aria-hidden="true"
+  />
+  <div
+    class="flex flex-col gap-2"
+    data-rac=""
+  >
+    <span
+      class="text-size-sm font-medium"
+      id="react-aria-:r3:"
+    >
+      Pet
+    </span>
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby="react-aria-:r7: react-aria-:r3:"
+      class="flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors data-[pressed]:bg-[rgba(0,17,77,0.1)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]"
+      data-rac=""
+      data-react-aria-pressable="true"
+      id="react-aria-:r2:"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="font-medium text-[13px] leading-[22px] text-left text-bluedot-darker"
+        data-placeholder="true"
+        data-rac=""
+        id="react-aria-:r7:"
+      >
+        Select an option
+      </span>
+      <svg
+        class="size-[14px]"
+        fill="none"
+        height="14"
+        viewBox="0 0 14 14"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.25L7 8.75L10.5 5.25"
+          stroke="#00114D"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.25"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    aria-hidden="true"
+    data-a11y-ignore="aria-hidden-focus"
+    data-react-aria-prevent-focus="true"
+    data-testid="hidden-select-container"
+    style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+  >
+    <label>
+      <select
+        tabindex="-1"
+        title=""
+      >
+        <option />
+        <option
+          value="cat"
+        >
+          Cat
+        </option>
+        <option
+          value="dog"
+        >
+          Dog
+        </option>
+        <option
+          value="bird"
+        >
+          Bird
+        </option>
+      </select>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Select > shows placeholder when no value selected 1`] = `
+<div>
+  <template
+    data-react-aria-hidden="true"
+  />
+  <div
+    class="flex flex-col gap-2"
+    data-rac=""
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-labelledby="react-aria-:rh:"
+      class="flex items-center px-3 gap-2 w-fit h-[36px] bg-[rgba(0,17,77,0.05)] rounded-[6px] hover:bg-[rgba(0,17,77,0.1)] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal transition-colors data-[pressed]:bg-[rgba(0,17,77,0.1)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[rgba(0,17,77,0.05)]"
+      data-rac=""
+      data-react-aria-pressable="true"
+      id="react-aria-:rc:"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="font-medium text-[13px] leading-[22px] text-left text-bluedot-darker"
+        data-placeholder="true"
+        data-rac=""
+        id="react-aria-:rh:"
+      >
+        Choose a pet
+      </span>
+      <svg
+        class="size-[14px]"
+        fill="none"
+        height="14"
+        viewBox="0 0 14 14"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.5 5.25L7 8.75L10.5 5.25"
+          stroke="#00114D"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.25"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    aria-hidden="true"
+    data-a11y-ignore="aria-hidden-focus"
+    data-react-aria-prevent-focus="true"
+    data-testid="hidden-select-container"
+    style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+  >
+    <label>
+      <select
+        tabindex="-1"
+        title=""
+      >
+        <option />
+        <option
+          value="cat"
+        >
+          Cat
+        </option>
+        <option
+          value="dog"
+        >
+          Dog
+        </option>
+        <option
+          value="bird"
+        >
+          Bird
+        </option>
+      </select>
+    </label>
+  </div>
+</div>
+`;

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -58,6 +58,9 @@ export type { QuoteCarouselProps } from './QuoteCarousel';
 export { Section, SectionHeading } from './Section';
 export type { SectionProps } from './Section';
 
+export { Select } from './Select';
+export type { SelectProps } from './Select';
+
 export { ShareButton } from './ShareButton';
 export type { ShareButtonProps } from './ShareButton';
 


### PR DESCRIPTION
# Description
The new designs for course settings require a select button (button that offers a drop down menu when clicked). Since we didn't already have a library component for it, I've made in this PR.

I've also added Storybook stories for this. 

## Issue
Can be used everywhere on the site but was immeidately needed for #571 and #572 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
<!-- If this PR results in visual changes -->

Implemented select in storybook (note that we don't have identical icon libraries installed already, which is why they look slightly different)
<img width="208" height="167" alt="image" src="https://github.com/user-attachments/assets/0bdaee17-c696-4cff-9c1c-e86f8276ad6a" />
Original designs from Figma for the cohort change select
<img width="285" height="208" alt="image" src="https://github.com/user-attachments/assets/f84b11fb-4da9-4c97-ad78-e020a2cda820" />


