### PR TITLE
[fix]: secondary button on dark in nav

### DIFF
--- a/apps/website/src/components/Nav/_NavCta.tsx
+++ b/apps/website/src/components/Nav/_NavCta.tsx
@@ -42,7 +42,9 @@ export const NavCta: React.FC<{
       ) : (
         <>
           <CTALinkOrButton
-            className="nav-cta__secondary-cta hidden sm:block" // Hide on small screens
+            className={`nav-cta__secondary-cta hidden sm:block ${
+              isScrolled ? 'border-white text-white hover:bg-white/10' : ''
+            }`} // Hide on small screens
             variant="secondary"
             url={loginUrl}
           >

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`Nav > renders with courses 1`] = `
           class="nav-cta flex flex-row items-center gap-6"
         >
           <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter nav-cta__secondary-cta hidden sm:block"
+            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter nav-cta__secondary-cta hidden sm:block "
             href="http://localhost:3000/login?redirect_to=%2Ftest-page"
             tabindex="0"
           >


### PR DESCRIPTION
# Description
Fixed the on-scroll outline for secondary button on dark in nav (desktop)


## Issue
Fixes #591 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<img width="1512" height="301" alt="secondary-button-on-dark-in-nav" src="https://github.com/user-attachments/assets/2dc54ebc-f8cc-4b95-8083-8c5cd8f60444" />
