### PR TITLE
feat: only count new customer sign ups

### DIFF
--- a/apps/website/src/pages/api/users/me.ts
+++ b/apps/website/src/pages/api/users/me.ts
@@ -10,6 +10,7 @@ type User = InferSelectModel<typeof userTable.pg>;
 export type GetUserResponse = {
   type: 'success';
   user: User;
+  isNewUser: boolean;
 };
 
 export type PatchUserBody = {
@@ -23,6 +24,7 @@ export default makeApiRoute({
   responseBody: z.object({
     type: z.literal('success'),
     user: z.any(),
+    isNewUser: z.boolean(),
   }).optional(),
 }, async (body, { auth, raw }) => {
   // Try to get existing user
@@ -36,6 +38,7 @@ export default makeApiRoute({
   switch (raw.req.method) {
     case 'GET': {
       let user: User;
+      const isNewUser = !existingUser;
       if (!existingUser) {
         // Create user if doesn't exist
         user = await db.insert(userTable, {
@@ -53,6 +56,7 @@ export default makeApiRoute({
       return {
         type: 'success' as const,
         user,
+        isNewUser, // Include in response
       };
     }
 
@@ -80,6 +84,7 @@ export default makeApiRoute({
       return {
         type: 'success' as const,
         user: updatedUser,
+        isNewUser: false,
       };
     }
 

--- a/apps/website/src/pages/login/oauth-callback.tsx
+++ b/apps/website/src/pages/login/oauth-callback.tsx
@@ -6,12 +6,18 @@ export default () => (
   <LoginOauthCallbackPage
     loginPreset={loginPresets.keycloak}
     onLoginComplete={async (auth) => {
-      // This ensures the user is created
-      await axios.get<GetUserResponse>('/api/users/me', {
+      const response = await axios.get<GetUserResponse>('/api/users/me', {
         headers: {
           Authorization: `Bearer ${auth.token}`,
         },
       });
+
+      if (typeof window !== 'undefined' && window.dataLayer) {
+        window.dataLayer.push({
+          event: 'CompletedSignup',
+          new_customer: response.data.isNewUser,
+        });
+      }
     }}
   />
 );


### PR DESCRIPTION
# Description
This fires a new google tag that includes whether the user is a new customer. we will use this to optimize for new users only.

```
{
  event: "CompletedSignup",
  gtm: {uniqueEventId: 28, start: 1753360059289},
  new_customer: true
}
```


## Issue

Fixes https://github.com/bluedotimpact/bluedot/issues/1105

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->
