### PR TITLE
[fix]: consistent side bar font colors

### DIFF
--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -42,7 +42,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
         className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
       >
         <summary className={clsx('sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider', unit.menuText && 'cursor-pointer')}>
-          <p className="sidebar-collapsible__title font-bold">{unit.unitNumber}. {unit.title}</p>
+          <p className="sidebar-collapsible__title font-bold text-color-secondary-text">{unit.unitNumber}. {unit.title}</p>
           <span className="sidebar-collapsible__button flex items-center">
             <FaChevronRight className="size-3 transition-transform group-open:rotate-90" />
           </span>
@@ -53,7 +53,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
             key={chunk.id}
             onClick={() => onChunkSelect(index)}
             className={clsx(
-              'sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer',
+              'sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer text-color-secondary-text',
               currentChunkIndex === index && 'border-l-4 border-color-primary bg-bluedot-lightest',
             )}
           >
@@ -64,7 +64,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
     ) : (
       <A href={addQueryParam(unit.path, 'chunk', '0')} className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text">
         <div className="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider">
-          <p className="sidebar-collapsible__title font-bold">{unit.unitNumber}. {unit.title}</p>
+          <p className="sidebar-collapsible__title font-bold text-color-secondary-text">{unit.unitNumber}. {unit.title}</p>
           <span className="sidebar-collapsible__button flex items-center">
             <FaChevronRight className="size-3" />
           </span>

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`SideBar > renders default as expected 1`] = `
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider cursor-pointer"
         >
           <p
-            class="sidebar-collapsible__title font-bold"
+            class="sidebar-collapsible__title font-bold text-color-secondary-text"
           >
             1
             . 
@@ -65,7 +65,7 @@ exports[`SideBar > renders default as expected 1`] = `
           </span>
         </summary>
         <button
-          class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer border-l-4 border-color-primary bg-bluedot-lightest"
+          class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer text-color-secondary-text border-l-4 border-color-primary bg-bluedot-lightest"
           type="button"
         >
           What can AI do today?
@@ -80,7 +80,7 @@ exports[`SideBar > renders default as expected 1`] = `
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
         >
           <p
-            class="sidebar-collapsible__title font-bold"
+            class="sidebar-collapsible__title font-bold text-color-secondary-text"
           >
             2
             . 
@@ -115,7 +115,7 @@ exports[`SideBar > renders default as expected 1`] = `
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
         >
           <p
-            class="sidebar-collapsible__title font-bold"
+            class="sidebar-collapsible__title font-bold text-color-secondary-text"
           >
             3
             . 
@@ -150,7 +150,7 @@ exports[`SideBar > renders default as expected 1`] = `
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
         >
           <p
-            class="sidebar-collapsible__title font-bold"
+            class="sidebar-collapsible__title font-bold text-color-secondary-text"
           >
             4
             . 
@@ -185,7 +185,7 @@ exports[`SideBar > renders default as expected 1`] = `
           class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
         >
           <p
-            class="sidebar-collapsible__title font-bold"
+            class="sidebar-collapsible__title font-bold text-color-secondary-text"
           >
             5
             . 

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -214,7 +214,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider cursor-pointer"
                 >
                   <p
-                    class="sidebar-collapsible__title font-bold"
+                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
                   >
                     1
                     . 
@@ -240,13 +240,13 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                   </span>
                 </summary>
                 <button
-                  class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer border-l-4 border-color-primary bg-bluedot-lightest"
+                  class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer text-color-secondary-text border-l-4 border-color-primary bg-bluedot-lightest"
                   type="button"
                 >
                   What can AI do today?
                 </button>
                 <button
-                  class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer"
+                  class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer text-color-secondary-text"
                   type="button"
                 >
                   What can AI do today?
@@ -261,7 +261,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
                 >
                   <p
-                    class="sidebar-collapsible__title font-bold"
+                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
                   >
                     2
                     . 
@@ -296,7 +296,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
                 >
                   <p
-                    class="sidebar-collapsible__title font-bold"
+                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
                   >
                     3
                     . 
@@ -331,7 +331,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
                 >
                   <p
-                    class="sidebar-collapsible__title font-bold"
+                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
                   >
                     4
                     . 
@@ -366,7 +366,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                   class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
                 >
                   <p
-                    class="sidebar-collapsible__title font-bold"
+                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
                   >
                     5
                     . 


### PR DESCRIPTION
# Description
Font colors are now consistent and aligned with the original [figma designs](https://www.figma.com/design/62YlFNK7QS6z7SkrPjrwVb/Blue-Dot?node-id=243-3969)

## Issue
Fixes #979 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
<img width="337" height="548" alt="consistent-font-color" src="https://github.com/user-attachments/assets/4b547925-6616-4225-894a-ace8122ea414" />