### PR TITLE
[Bug] Use course registration table for determine course drop outs

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -118,10 +118,6 @@ export const courseTable = pgAirtable('course', {
       pgColumn: boolean().notNull(),
       airtableId: 'fldDXwQyHpHtUspFY',
     },
-    hasDroppedOut: {
-      pgColumn: boolean().notNull(),
-      airtableId: 'fldygOncl6PuOxQ28',
-    },
   },
 });
 
@@ -737,6 +733,10 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
     lastVisitedChunkIndex: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldqBkQC2fZLtPEZX',
+    },
+    hasDroppedOut: {
+      pgColumn: boolean().notNull(),
+      airtableId: 'fldygOncl6PuOxQ28',
     },
   },
 });


### PR DESCRIPTION
# Description
I should have used Course Registration table instead course table for course dropouts. 

## Issue
Working towards #571 and #572

## Developer checklist
N/A

## Screenshot
N/A
