### PR TITLE
[bug] Remove notNull requirement for hasDroppedOut

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -735,7 +735,7 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       airtableId: 'fldqBkQC2fZLtPEZX',
     },
     hasDroppedOut: {
-      pgColumn: boolean(),
+      pgColumn: boolean().default(false),
       airtableId: 'fldygOncl6PuOxQ28',
     },
   },

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -735,7 +735,7 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       airtableId: 'fldqBkQC2fZLtPEZX',
     },
     hasDroppedOut: {
-      pgColumn: boolean().notNull(),
+      pgColumn: boolean(),
       airtableId: 'fldygOncl6PuOxQ28',
     },
   },


### PR DESCRIPTION
# Description
Inserts into course registration is failing because hasDroppedOut hasn't been added in all of the API requests that deal with the table. I've also made the default False. 