### PR TITLE
[fix]: course content mobile align

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -250,7 +250,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
             currentChunkIndex={currentChunkIndex}
             onChunkSelect={handleChunkSelect}
           />
-          <div className="unit__content flex flex-col flex-1 max-w-[680px] mx-auto gap-6 px-0 md:px-spacing-x md:ml-[320px]">
+          <div className="unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto gap-6 px-4 sm:px-spacing-x md:ml-[320px]">
             <div className="unit__title-container">
               <P className="unit__course-title text-size-sm mb-2">Unit {unit.unitNumber}</P>
               <H1 className="unit__title font-serif text-[32px]">{chunks[currentChunkIndex]?.chunkTitle}</H1>

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -395,7 +395,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             </div>
           </div>
           <div
-            class="unit__content flex flex-col flex-1 max-w-[680px] mx-auto gap-6 px-0 md:px-spacing-x md:ml-[320px]"
+            class="unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto gap-6 px-4 sm:px-spacing-x md:ml-[320px]"
           >
             <div
               class="unit__title-container"


### PR DESCRIPTION
# Description
Fixed course content on mobile from being cut off.

## Issue
Fixes #1144 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
<img width="490" height="716" alt="not-cut-off" src="https://github.com/user-attachments/assets/e9f9cfb7-963c-49d8-ab22-98e405f0e45e" />

