### PR TITLE
[bug] Fix to allow users to see certificate even if they had duplicate course registrations

### DIFF
--- a/apps/website/src/pages/api/certificates/request.ts
+++ b/apps/website/src/pages/api/certificates/request.ts
@@ -31,13 +31,11 @@ export default makeApiRoute({
     case 'POST': {
       // KNOWN ISSUE: Due to race conditions and Airtable limitations, multiple course registrations
       // can be created for the same user/course combination. The course registration creation endpoint
-      // has duplicate prevention logic, but concurrent requests can slip through. Airtable doesn't support unqiue IDs
+      // has duplicate prevention logic, but concurrent requests can slip through. Airtable doesn't support unqiue and solving this would have been trivial if we just were using a traditional DB
       //
       // WORKAROUND: Instead of using db.get() which expects exactly one record, we use db.scan()
       // to find all matching registrations and select the first one based on a stable sort by ID.
       // This ensures consistent behavior even when duplicates exist.
-      //
-      //
 
       const courseRegistrations = await db.scan(courseRegistrationTable, {
         email: auth.email,


### PR DESCRIPTION
# Description
 Fix to allow users to see certificate even if they had duplicate course registrations. The issue is caused by a race condition in course registration causing them to have multiele rows in Airtable.
 
 This doesn't fix the root cause, but at least should let them see their certificates. The fix for the root cause is actually relatively difficult because Airtable doesn't support a unique columns.


## Issue
Fixes #1142

## Developer checklist

Not relevant. 

## Screenshot
None
