### PR TITLE
[feat]: new sidebar

### DIFF
--- a/apps/website/src/components/courses/Embed.tsx
+++ b/apps/website/src/components/courses/Embed.tsx
@@ -81,7 +81,7 @@ const Embed: React.FC<EmbedProps> = ({
         frameBorder="0"
         allowFullScreen
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        className={clsx('embed rounded-lg', isYouTube ? 'aspect-video h-auto' : 'h-[450px]', className)}
+        className={clsx('embed rounded-lg', isYouTube ? 'aspect-video h-auto' : 'min-h-[450px]', className)}
       />
     )
   );

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -28,6 +28,24 @@ type SideBarCollapsibleProps = {
   onChunkSelect: (index: number) => void;
 };
 
+// Icon components for different chunk types, currently it's all the same but will be different in the future
+const ChunkIcon: React.FC<{ isActive?: boolean }> = ({ isActive }) => {
+  const iconClass = 'size-6 rounded-full flex items-center justify-center';
+
+  // Always show the same icon for all chunk types
+  return (
+    <div className={clsx(iconClass, isActive ? 'bg-[#13132E]' : 'bg-[#FCFBF9] border border-[rgba(106,111,122,0.3)]')}>
+      {isActive && (
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <rect x="2" y="3" width="10" height="1" fill="white" />
+          <rect x="2" y="6" width="10" height="1" fill="white" />
+          <rect x="2" y="9" width="7" height="1" fill="white" />
+        </svg>
+      )}
+    </div>
+  );
+};
+
 const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   unit,
   isCurrentUnit,
@@ -35,41 +53,65 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   currentChunkIndex,
   onChunkSelect,
 }) => {
+  // TODO add this back in once we have a way to track progress
+  const formatTime = (min: number) => (min < 60 ? `${min}min` : `${Math.floor(min / 60)}h${min % 60 ? ` ${min % 60}min` : ''}`);
+
   return (
     isCurrentUnit ? (
-      <details
-        open={isCurrentUnit}
-        className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
-      >
-        <summary className={clsx('sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider', unit.menuText && 'cursor-pointer')}>
-          <p className="sidebar-collapsible__title font-bold text-color-secondary-text">{unit.unitNumber}. {unit.title}</p>
-          <span className="sidebar-collapsible__button flex items-center">
-            <FaChevronRight className="size-3 transition-transform group-open:rotate-90" />
-          </span>
-        </summary>
-        {chunks.map((chunk, index) => (
-          <button
-            type="button"
-            key={chunk.id}
-            onClick={() => onChunkSelect(index)}
-            className={clsx(
-              'sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer text-color-secondary-text',
-              currentChunkIndex === index && 'border-l-4 border-color-primary bg-bluedot-lightest',
-            )}
-          >
-            {chunk.chunkTitle}
-          </button>
-        ))}
-      </details>
+      <div className="relative">
+        <div className="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]" />
+        <details
+          open={isCurrentUnit}
+          className="sidebar-collapsible group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+        >
+          <summary className="flex flex-row items-center mx-[24px] px-[24px] md:px-[12px] py-[15px] gap-[8px] text-left cursor-pointer hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors">
+            <p className="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1">
+              {unit.unitNumber}. {unit.title}
+            </p>
+            <FaChevronRight className="size-[14px] transition-transform group-open:rotate-90 text-[#13132E]" />
+          </summary>
+          <div className="flex flex-col items-start px-0 pb-[16px] gap-[4px]">
+            {chunks.map((chunk, index) => {
+              const isActive = currentChunkIndex === index;
+              return (
+                <button
+                  type="button"
+                  key={chunk.id}
+                  onClick={() => onChunkSelect(index)}
+                  className={clsx(
+                    'flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] h-[100px] text-left transition-colors',
+                    isActive ? 'bg-[rgba(42,45,52,0.05)] rounded-[10px]' : 'hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px]',
+                  )}
+                >
+                  <ChunkIcon isActive={isActive} />
+                  <div className="flex flex-col items-start p-0 gap-[8px] flex-1 h-[68px]">
+                    <p className="font-semibold text-[14px] leading-[150%] text-[#13132E]">
+                      {chunk.chunkTitle}
+                    </p>
+                    {chunk.estimatedTime && (
+                    <span className="text-[13px] leading-[140%] tracking-[-0.005em] font-medium text-[#13132E] opacity-60">
+                      {formatTime(chunk.estimatedTime)}
+                    </span>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </details>
+      </div>
     ) : (
-      <A href={addQueryParam(unit.path, 'chunk', '0')} className="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text">
-        <div className="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider">
-          <p className="sidebar-collapsible__title font-bold text-color-secondary-text">{unit.unitNumber}. {unit.title}</p>
-          <span className="sidebar-collapsible__button flex items-center">
-            <FaChevronRight className="size-3" />
-          </span>
-        </div>
-      </A>
+      <div className="relative">
+        <div className="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]" />
+        <A href={addQueryParam(unit.path, 'chunk', '0')} className="block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors">
+          <div className="flex flex-row items-center gap-[8px]">
+            <p className="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1">
+              {unit.unitNumber}. {unit.title}
+            </p>
+            <FaChevronRight className="size-[14px] text-[#13132E]" />
+          </div>
+        </A>
+      </div>
     )
   );
 };
@@ -88,21 +130,38 @@ const SideBar: React.FC<SideBarProps> = ({
   };
 
   return (
-    <div className={clsx('sidebar w-full md:w-[320px] flex flex-col', className)}>
-      <div className="sidebar__header-container flex flex-row gap-2 pb-6">
-        <img src="/icons/course.svg" className="size-11" alt="" />
-        <div className="sidebar__title-container flex flex-col">
-          <p className="sidebar__course-header text-size-sm text-[#999eb3]">Course</p>
-          <p className="sidebar__course-title bluedot-h4">{courseTitle}</p>
+    <div className={clsx(
+      'sidebar flex flex-col bg-color-canvas',
+      'size-full md:w-[360px]',
+      'border-r-[0.5px] border-color-divider',
+      className,
+    )}
+    >
+      {/* Header */}
+      <div className="p-[24px]">
+        <div className="flex flex-row items-start gap-[16px]">
+          <svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect width="44" height="44" rx="8" fill="#2244BB" />
+            <path d="M33.9941 23.4938L30.4941 26.9938C30.3299 27.158 30.1072 27.2502 29.875 27.2502C29.6428 27.2502 29.4201 27.158 29.2559 26.9938C29.0918 26.8296 28.9995 26.6069 28.9995 26.3747C28.9995 26.1425 29.0918 25.9198 29.2559 25.7556L31.263 23.7497H21.487L15.362 29.8747H18.5C18.7321 29.8747 18.9546 29.9669 19.1187 30.131C19.2828 30.2951 19.375 30.5176 19.375 30.7497C19.375 30.9818 19.2828 31.2043 19.1187 31.3684C18.9546 31.5325 18.7321 31.6247 18.5 31.6247H13.25C13.0179 31.6247 12.7954 31.5325 12.6313 31.3684C12.4672 31.2043 12.375 30.9818 12.375 30.7497V25.4997C12.375 25.2676 12.4672 25.0451 12.6313 24.881C12.7954 24.7169 13.0179 24.6247 13.25 24.6247C13.4821 24.6247 13.7046 24.7169 13.8687 24.881C14.0328 25.0451 14.125 25.2676 14.125 25.4997V28.6377L20.25 22.5127V12.7367L18.2441 14.7438C18.0799 14.908 17.8572 15.0002 17.625 15.0002C17.3928 15.0002 17.1701 14.908 17.0059 14.7438C16.8418 14.5796 16.7495 14.3569 16.7495 14.1247C16.7495 13.8925 16.8418 13.6698 17.0059 13.5056L20.5059 10.0056C20.5872 9.92429 20.6837 9.85976 20.7899 9.81572C20.8961 9.77169 21.01 9.74902 21.125 9.74902C21.24 9.74902 21.3538 9.77169 21.4601 9.81572C21.5663 9.85976 21.6628 9.92429 21.7441 10.0056L25.2441 13.5056C25.4082 13.6698 25.5005 13.8925 25.5005 14.1247C25.5005 14.3569 25.4082 14.5796 25.2441 14.7438C25.0799 14.908 24.8572 15.0002 24.625 15.0002C24.3928 15.0002 24.1701 14.908 24.0059 14.7438L22 12.7367V21.9997H31.263L29.2559 19.9938C29.0918 19.8296 28.9995 19.6069 28.9995 19.3747C28.9995 19.1425 29.0918 18.9198 29.2559 18.7556C29.4201 18.5915 29.6428 18.4992 29.875 18.4992C30.1072 18.4992 30.3299 18.5915 30.4941 18.7556L33.9941 22.2556C34.0754 22.3369 34.14 22.4334 34.184 22.5396C34.228 22.6459 34.2507 22.7597 34.2507 22.8747C34.2507 22.9897 34.228 23.1036 34.184 23.2098C34.14 23.316 34.0754 23.4125 33.9941 23.4938Z" fill="white" />
+          </svg>
+          <div className="flex flex-col justify-center gap-[4px] flex-1">
+            <h2 className="text-[18px] leading-[22px] font-semibold text-[#13132E]">{courseTitle}</h2>
+            {/*
+            // TODO add this back in once we have a way to track progress
+            <p className="text-[12px] leading-[17px] tracking-[-0.005em] font-medium text-[#6A6F7A]">{courseProgress}% completed</p> */}
+            <p className="text-[12px] leading-[17px] tracking-[-0.005em] font-medium text-[#6A6F7A]">Interactive Course</p>
+          </div>
         </div>
       </div>
-      <div className="sidebar__content flex flex-col container-lined bg-white">
+
+      {/* Units */}
+      <div className="flex-1 overflow-y-auto">
         {units.map((unit) => (
           <SideBarCollapsible
             key={unit.id}
             unit={unit}
             isCurrentUnit={isCurrentUnit(unit)}
-            chunks={chunks}
+            chunks={isCurrentUnit(unit) ? chunks : []}
             currentChunkIndex={currentChunkIndex}
             onChunkSelect={onChunkSelect}
           />

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -53,7 +53,6 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   currentChunkIndex,
   onChunkSelect,
 }) => {
-  // TODO add this back in once we have a way to track progress
   const formatTime = (min: number) => (min < 60 ? `${min}min` : `${Math.floor(min / 60)}h${min % 60 ? ` ${min % 60}min` : ''}`);
 
   return (
@@ -79,12 +78,12 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
                   key={chunk.id}
                   onClick={() => onChunkSelect(index)}
                   className={clsx(
-                    'flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] h-[100px] text-left transition-colors',
+                    'flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] min-h-[100px] text-left transition-colors',
                     isActive ? 'bg-[rgba(42,45,52,0.05)] rounded-[10px]' : 'hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px]',
                   )}
                 >
                   <ChunkIcon isActive={isActive} />
-                  <div className="flex flex-col items-start p-0 gap-[8px] flex-1 h-[68px]">
+                  <div className="flex flex-col items-start p-0 gap-[8px] flex-1 min-h-[68px]">
                     <p className="font-semibold text-[14px] leading-[150%] text-[#13132E]">
                       {chunk.chunkTitle}
                     </p>

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -244,7 +244,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
           </div>
 
           {/* Breadcrumbs - left aligned after hide */}
-          <nav className="flex items-center gap-[8px] flex-1 h-[18px]">
+          <nav className="flex items-center gap-[8px] flex-1 min-h-[18px]">
             <A
               href={ROUTES.courses.url}
               className="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline inline-flex items-center"
@@ -265,7 +265,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
           </nav>
 
           {/* Right section: Navigation */}
-          <div className="flex items-center gap-[20px] h-[18px]">
+          <div className="flex items-center gap-[20px] min-h-[18px]">
             <button
               type="button"
               className="flex items-center gap-1 text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#13132E] hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`SideBar > renders default as expected 1`] = `
             class="flex flex-col items-start px-0 pb-[16px] gap-[4px]"
           >
             <button
-              class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] h-[100px] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
+              class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] min-h-[100px] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
               type="button"
             >
               <div
@@ -123,7 +123,7 @@ exports[`SideBar > renders default as expected 1`] = `
                 </svg>
               </div>
               <div
-                class="flex flex-col items-start p-0 gap-[8px] flex-1 h-[68px]"
+                class="flex flex-col items-start p-0 gap-[8px] flex-1 min-h-[68px]"
               >
                 <p
                   class="font-semibold text-[14px] leading-[150%] text-[#13132E]"

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -3,94 +3,73 @@
 exports[`SideBar > renders default as expected 1`] = `
 <div>
   <div
-    class="sidebar w-full md:w-[320px] flex flex-col"
+    class="sidebar flex flex-col bg-color-canvas size-full md:w-[360px] border-r-[0.5px] border-color-divider"
   >
     <div
-      class="sidebar__header-container flex flex-row gap-2 pb-6"
+      class="p-[24px]"
     >
-      <img
-        alt=""
-        class="size-11"
-        src="/icons/course.svg"
-      />
       <div
-        class="sidebar__title-container flex flex-col"
+        class="flex flex-row items-start gap-[16px]"
       >
-        <p
-          class="sidebar__course-header text-size-sm text-[#999eb3]"
+        <svg
+          fill="none"
+          height="44"
+          viewBox="0 0 44 44"
+          width="44"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          Course
-        </p>
-        <p
-          class="sidebar__course-title bluedot-h4"
+          <rect
+            fill="#2244BB"
+            height="44"
+            rx="8"
+            width="44"
+          />
+          <path
+            d="M33.9941 23.4938L30.4941 26.9938C30.3299 27.158 30.1072 27.2502 29.875 27.2502C29.6428 27.2502 29.4201 27.158 29.2559 26.9938C29.0918 26.8296 28.9995 26.6069 28.9995 26.3747C28.9995 26.1425 29.0918 25.9198 29.2559 25.7556L31.263 23.7497H21.487L15.362 29.8747H18.5C18.7321 29.8747 18.9546 29.9669 19.1187 30.131C19.2828 30.2951 19.375 30.5176 19.375 30.7497C19.375 30.9818 19.2828 31.2043 19.1187 31.3684C18.9546 31.5325 18.7321 31.6247 18.5 31.6247H13.25C13.0179 31.6247 12.7954 31.5325 12.6313 31.3684C12.4672 31.2043 12.375 30.9818 12.375 30.7497V25.4997C12.375 25.2676 12.4672 25.0451 12.6313 24.881C12.7954 24.7169 13.0179 24.6247 13.25 24.6247C13.4821 24.6247 13.7046 24.7169 13.8687 24.881C14.0328 25.0451 14.125 25.2676 14.125 25.4997V28.6377L20.25 22.5127V12.7367L18.2441 14.7438C18.0799 14.908 17.8572 15.0002 17.625 15.0002C17.3928 15.0002 17.1701 14.908 17.0059 14.7438C16.8418 14.5796 16.7495 14.3569 16.7495 14.1247C16.7495 13.8925 16.8418 13.6698 17.0059 13.5056L20.5059 10.0056C20.5872 9.92429 20.6837 9.85976 20.7899 9.81572C20.8961 9.77169 21.01 9.74902 21.125 9.74902C21.24 9.74902 21.3538 9.77169 21.4601 9.81572C21.5663 9.85976 21.6628 9.92429 21.7441 10.0056L25.2441 13.5056C25.4082 13.6698 25.5005 13.8925 25.5005 14.1247C25.5005 14.3569 25.4082 14.5796 25.2441 14.7438C25.0799 14.908 24.8572 15.0002 24.625 15.0002C24.3928 15.0002 24.1701 14.908 24.0059 14.7438L22 12.7367V21.9997H31.263L29.2559 19.9938C29.0918 19.8296 28.9995 19.6069 28.9995 19.3747C28.9995 19.1425 29.0918 18.9198 29.2559 18.7556C29.4201 18.5915 29.6428 18.4992 29.875 18.4992C30.1072 18.4992 30.3299 18.5915 30.4941 18.7556L33.9941 22.2556C34.0754 22.3369 34.14 22.4334 34.184 22.5396C34.228 22.6459 34.2507 22.7597 34.2507 22.8747C34.2507 22.9897 34.228 23.1036 34.184 23.2098C34.14 23.316 34.0754 23.4125 33.9941 23.4938Z"
+            fill="white"
+          />
+        </svg>
+        <div
+          class="flex flex-col justify-center gap-[4px] flex-1"
         >
-          What the fish [Test Course]
-        </p>
+          <h2
+            class="text-[18px] leading-[22px] font-semibold text-[#13132E]"
+          >
+            What the fish [Test Course]
+          </h2>
+          <p
+            class="text-[12px] leading-[17px] tracking-[-0.005em] font-medium text-[#6A6F7A]"
+          >
+            Interactive Course
+          </p>
+        </div>
       </div>
     </div>
     <div
-      class="sidebar__content flex flex-col container-lined bg-white"
+      class="flex-1 overflow-y-auto"
     >
-      <details
-        class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
-        open=""
-      >
-        <summary
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider cursor-pointer"
-        >
-          <p
-            class="sidebar-collapsible__title font-bold text-color-secondary-text"
-          >
-            1
-            . 
-            Basic Principles of Fish
-          </p>
-          <span
-            class="sidebar-collapsible__button flex items-center"
-          >
-            <svg
-              class="size-3 transition-transform group-open:rotate-90"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 320 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-              />
-            </svg>
-          </span>
-        </summary>
-        <button
-          class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer text-color-secondary-text border-l-4 border-color-primary bg-bluedot-lightest"
-          type="button"
-        >
-          What can AI do today?
-        </button>
-      </details>
-      <a
-        class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-        href="http://localhost:3000/courses/test-course/2?chunk=0"
-        tabindex="0"
+      <div
+        class="relative"
       >
         <div
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
+          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+        />
+        <details
+          class="sidebar-collapsible group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+          open=""
         >
-          <p
-            class="sidebar-collapsible__title font-bold text-color-secondary-text"
+          <summary
+            class="flex flex-row items-center mx-[24px] px-[24px] md:px-[12px] py-[15px] gap-[8px] text-left cursor-pointer hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
           >
-            2
-            . 
-            What Fish Are People Catching, and Why?
-          </p>
-          <span
-            class="sidebar-collapsible__button flex items-center"
-          >
+            <p
+              class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+            >
+              1
+              . 
+              Basic Principles of Fish
+            </p>
             <svg
-              class="size-3"
+              class="size-[14px] transition-transform group-open:rotate-90 text-[#13132E]"
               fill="currentColor"
               height="1em"
               stroke="currentColor"
@@ -103,29 +82,82 @@ exports[`SideBar > renders default as expected 1`] = `
                 d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
               />
             </svg>
-          </span>
-        </div>
-      </a>
-      <a
-        class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-        href="http://localhost:3000/courses/test-course/3?chunk=0"
-        tabindex="0"
+          </summary>
+          <div
+            class="flex flex-col items-start px-0 pb-[16px] gap-[4px]"
+          >
+            <button
+              class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] h-[100px] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
+              type="button"
+            >
+              <div
+                class="size-6 rounded-full flex items-center justify-center bg-[#13132E]"
+              >
+                <svg
+                  fill="none"
+                  height="14"
+                  viewBox="0 0 14 14"
+                  width="14"
+                >
+                  <rect
+                    fill="white"
+                    height="1"
+                    width="10"
+                    x="2"
+                    y="3"
+                  />
+                  <rect
+                    fill="white"
+                    height="1"
+                    width="10"
+                    x="2"
+                    y="6"
+                  />
+                  <rect
+                    fill="white"
+                    height="1"
+                    width="7"
+                    x="2"
+                    y="9"
+                  />
+                </svg>
+              </div>
+              <div
+                class="flex flex-col items-start p-0 gap-[8px] flex-1 h-[68px]"
+              >
+                <p
+                  class="font-semibold text-[14px] leading-[150%] text-[#13132E]"
+                >
+                  What can AI do today?
+                </p>
+              </div>
+            </button>
+          </div>
+        </details>
+      </div>
+      <div
+        class="relative"
       >
         <div
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
+          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+        />
+        <a
+          class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+          href="http://localhost:3000/courses/test-course/2?chunk=0"
+          tabindex="0"
         >
-          <p
-            class="sidebar-collapsible__title font-bold text-color-secondary-text"
+          <div
+            class="flex flex-row items-center gap-[8px]"
           >
-            3
-            . 
-            The Promise of Fish
-          </p>
-          <span
-            class="sidebar-collapsible__button flex items-center"
-          >
+            <p
+              class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+            >
+              2
+              . 
+              What Fish Are People Catching, and Why?
+            </p>
             <svg
-              class="size-3"
+              class="size-[14px] text-[#13132E]"
               fill="currentColor"
               height="1em"
               stroke="currentColor"
@@ -138,29 +170,32 @@ exports[`SideBar > renders default as expected 1`] = `
                 d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
               />
             </svg>
-          </span>
-        </div>
-      </a>
-      <a
-        class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-        href="http://localhost:3000/courses/test-course/4?chunk=0"
-        tabindex="0"
+          </div>
+        </a>
+      </div>
+      <div
+        class="relative"
       >
         <div
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
+          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+        />
+        <a
+          class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+          href="http://localhost:3000/courses/test-course/3?chunk=0"
+          tabindex="0"
         >
-          <p
-            class="sidebar-collapsible__title font-bold text-color-secondary-text"
+          <div
+            class="flex flex-row items-center gap-[8px]"
           >
-            4
-            . 
-            The Risks of Fish
-          </p>
-          <span
-            class="sidebar-collapsible__button flex items-center"
-          >
+            <p
+              class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+            >
+              3
+              . 
+              The Promise of Fish
+            </p>
             <svg
-              class="size-3"
+              class="size-[14px] text-[#13132E]"
               fill="currentColor"
               height="1em"
               stroke="currentColor"
@@ -173,29 +208,32 @@ exports[`SideBar > renders default as expected 1`] = `
                 d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
               />
             </svg>
-          </span>
-        </div>
-      </a>
-      <a
-        class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-        href="http://localhost:3000/courses/test-course/5?chunk=0"
-        tabindex="0"
+          </div>
+        </a>
+      </div>
+      <div
+        class="relative"
       >
         <div
-          class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
+          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+        />
+        <a
+          class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+          href="http://localhost:3000/courses/test-course/4?chunk=0"
+          tabindex="0"
         >
-          <p
-            class="sidebar-collapsible__title font-bold text-color-secondary-text"
+          <div
+            class="flex flex-row items-center gap-[8px]"
           >
-            5
-            . 
-            Contributing to Fish Safety
-          </p>
-          <span
-            class="sidebar-collapsible__button flex items-center"
-          >
+            <p
+              class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+            >
+              4
+              . 
+              The Risks of Fish
+            </p>
             <svg
-              class="size-3"
+              class="size-[14px] text-[#13132E]"
               fill="currentColor"
               height="1em"
               stroke="currentColor"
@@ -208,9 +246,47 @@ exports[`SideBar > renders default as expected 1`] = `
                 d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
               />
             </svg>
-          </span>
-        </div>
-      </a>
+          </div>
+        </a>
+      </div>
+      <div
+        class="relative"
+      >
+        <div
+          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+        />
+        <a
+          class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+          href="http://localhost:3000/courses/test-course/5?chunk=0"
+          tabindex="0"
+        >
+          <div
+            class="flex flex-row items-center gap-[8px]"
+          >
+            <p
+              class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+            >
+              5
+              . 
+              Contributing to Fish Safety
+            </p>
+            <svg
+              class="size-[14px] text-[#13132E]"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </div>
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -10,111 +10,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
       role="status"
     />
     <div
-      class="breadcrumbs bg-color-canvas border-b border-color-divider w-full py-space-between unit__breadcrumbs hidden md:block md:sticky md:top-16 z-10"
-    >
-      <nav
-        aria-label="Breadcrumbs"
-        class="breadcrumbs__nav section-base flex flex-row justify-between"
-      >
-        <ol
-          class="breadcrumbs__list flex"
-        >
-          <li
-            class="breadcrumbs__item flex items-center"
-          >
-            <a
-              class="bluedot-a not-prose breadcrumbs__link no-underline"
-              href="/"
-              tabindex="0"
-            >
-              Home
-            </a>
-            <span
-              class="breadcrumbs__separator mx-2"
-            >
-              &gt;
-            </span>
-          </li>
-          <li
-            class="breadcrumbs__item flex items-center"
-          >
-            <a
-              class="bluedot-a not-prose breadcrumbs__link no-underline"
-              href="/courses"
-              tabindex="0"
-            >
-              Courses
-            </a>
-            <span
-              class="breadcrumbs__separator mx-2"
-            >
-              &gt;
-            </span>
-          </li>
-          <li
-            class="breadcrumbs__item flex items-center"
-          >
-            <a
-              class="bluedot-a not-prose breadcrumbs__link no-underline"
-              href="/courses/test-course"
-              tabindex="0"
-            >
-              What the fish [Test Course]
-            </a>
-          </li>
-        </ol>
-        <div
-          class="unit__breadcrumbs-cta-container flex flex-row items-center gap-6"
-        >
-          <button
-            aria-label="Previous"
-            class="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline cursor-pointer hover:text-color-primary disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-color-primary focus:ring-offset-2"
-            disabled=""
-            title="Navigate to previous section (use ← arrow key)"
-            type="button"
-          >
-            <svg
-              class="size-3"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 448 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.2 288 416 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-306.7 0L214.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
-              />
-            </svg>
-             Prev
-          </button>
-          <button
-            aria-label="Next"
-            class="unit__breadcrumbs-cta flex flex-row items-center gap-1 no-underline cursor-pointer hover:text-color-primary disabled:opacity-50 disabled:hover:text-inherit disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-color-primary focus:ring-offset-2"
-            title="Navigate to next section (use → arrow key)"
-            type="button"
-          >
-            Next 
-            <svg
-              class="size-3"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 448 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
-              />
-            </svg>
-          </button>
-        </div>
-      </nav>
-    </div>
-    <div
       class="mobile-unit-header bg-color-canvas border-b border-color-divider w-full p-3 unit__mobile-header md:hidden sticky top-16 z-10"
     >
       <nav
@@ -168,301 +63,498 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
         </button>
       </nav>
     </div>
+    <div
+      class="sidebar flex flex-col bg-color-canvas size-full md:w-[360px] border-r-[0.5px] border-color-divider hidden md:block md:fixed md:overflow-y-auto md:max-h-[calc(100vh-57px)]"
+    >
+      <div
+        class="p-[24px]"
+      >
+        <div
+          class="flex flex-row items-start gap-[16px]"
+        >
+          <svg
+            fill="none"
+            height="44"
+            viewBox="0 0 44 44"
+            width="44"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              fill="#2244BB"
+              height="44"
+              rx="8"
+              width="44"
+            />
+            <path
+              d="M33.9941 23.4938L30.4941 26.9938C30.3299 27.158 30.1072 27.2502 29.875 27.2502C29.6428 27.2502 29.4201 27.158 29.2559 26.9938C29.0918 26.8296 28.9995 26.6069 28.9995 26.3747C28.9995 26.1425 29.0918 25.9198 29.2559 25.7556L31.263 23.7497H21.487L15.362 29.8747H18.5C18.7321 29.8747 18.9546 29.9669 19.1187 30.131C19.2828 30.2951 19.375 30.5176 19.375 30.7497C19.375 30.9818 19.2828 31.2043 19.1187 31.3684C18.9546 31.5325 18.7321 31.6247 18.5 31.6247H13.25C13.0179 31.6247 12.7954 31.5325 12.6313 31.3684C12.4672 31.2043 12.375 30.9818 12.375 30.7497V25.4997C12.375 25.2676 12.4672 25.0451 12.6313 24.881C12.7954 24.7169 13.0179 24.6247 13.25 24.6247C13.4821 24.6247 13.7046 24.7169 13.8687 24.881C14.0328 25.0451 14.125 25.2676 14.125 25.4997V28.6377L20.25 22.5127V12.7367L18.2441 14.7438C18.0799 14.908 17.8572 15.0002 17.625 15.0002C17.3928 15.0002 17.1701 14.908 17.0059 14.7438C16.8418 14.5796 16.7495 14.3569 16.7495 14.1247C16.7495 13.8925 16.8418 13.6698 17.0059 13.5056L20.5059 10.0056C20.5872 9.92429 20.6837 9.85976 20.7899 9.81572C20.8961 9.77169 21.01 9.74902 21.125 9.74902C21.24 9.74902 21.3538 9.77169 21.4601 9.81572C21.5663 9.85976 21.6628 9.92429 21.7441 10.0056L25.2441 13.5056C25.4082 13.6698 25.5005 13.8925 25.5005 14.1247C25.5005 14.3569 25.4082 14.5796 25.2441 14.7438C25.0799 14.908 24.8572 15.0002 24.625 15.0002C24.3928 15.0002 24.1701 14.908 24.0059 14.7438L22 12.7367V21.9997H31.263L29.2559 19.9938C29.0918 19.8296 28.9995 19.6069 28.9995 19.3747C28.9995 19.1425 29.0918 18.9198 29.2559 18.7556C29.4201 18.5915 29.6428 18.4992 29.875 18.4992C30.1072 18.4992 30.3299 18.5915 30.4941 18.7556L33.9941 22.2556C34.0754 22.3369 34.14 22.4334 34.184 22.5396C34.228 22.6459 34.2507 22.7597 34.2507 22.8747C34.2507 22.9897 34.228 23.1036 34.184 23.2098C34.14 23.316 34.0754 23.4125 33.9941 23.4938Z"
+              fill="white"
+            />
+          </svg>
+          <div
+            class="flex flex-col justify-center gap-[4px] flex-1"
+          >
+            <h2
+              class="text-[18px] leading-[22px] font-semibold text-[#13132E]"
+            >
+              What the fish [Test Course]
+            </h2>
+            <p
+              class="text-[12px] leading-[17px] tracking-[-0.005em] font-medium text-[#6A6F7A]"
+            >
+              Interactive Course
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex-1 overflow-y-auto"
+      >
+        <div
+          class="relative"
+        >
+          <div
+            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          />
+          <details
+            class="sidebar-collapsible group marker:hidden [&_summary::-webkit-details-marker]:hidden"
+            open=""
+          >
+            <summary
+              class="flex flex-row items-center mx-[24px] px-[24px] md:px-[12px] py-[15px] gap-[8px] text-left cursor-pointer hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+            >
+              <p
+                class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+              >
+                1
+                . 
+                Basic Principles of Fish
+              </p>
+              <svg
+                class="size-[14px] transition-transform group-open:rotate-90 text-[#13132E]"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 320 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                />
+              </svg>
+            </summary>
+            <div
+              class="flex flex-col items-start px-0 pb-[16px] gap-[4px]"
+            >
+              <button
+                class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] h-[100px] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
+                type="button"
+              >
+                <div
+                  class="size-6 rounded-full flex items-center justify-center bg-[#13132E]"
+                >
+                  <svg
+                    fill="none"
+                    height="14"
+                    viewBox="0 0 14 14"
+                    width="14"
+                  >
+                    <rect
+                      fill="white"
+                      height="1"
+                      width="10"
+                      x="2"
+                      y="3"
+                    />
+                    <rect
+                      fill="white"
+                      height="1"
+                      width="10"
+                      x="2"
+                      y="6"
+                    />
+                    <rect
+                      fill="white"
+                      height="1"
+                      width="7"
+                      x="2"
+                      y="9"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="flex flex-col items-start p-0 gap-[8px] flex-1 h-[68px]"
+                >
+                  <p
+                    class="font-semibold text-[14px] leading-[150%] text-[#13132E]"
+                  >
+                    What can AI do today?
+                  </p>
+                </div>
+              </button>
+              <button
+                class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] h-[100px] text-left transition-colors hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px]"
+                type="button"
+              >
+                <div
+                  class="size-6 rounded-full flex items-center justify-center bg-[#FCFBF9] border border-[rgba(106,111,122,0.3)]"
+                />
+                <div
+                  class="flex flex-col items-start p-0 gap-[8px] flex-1 h-[68px]"
+                >
+                  <p
+                    class="font-semibold text-[14px] leading-[150%] text-[#13132E]"
+                  >
+                    What can AI do today?
+                  </p>
+                </div>
+              </button>
+            </div>
+          </details>
+        </div>
+        <div
+          class="relative"
+        >
+          <div
+            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          />
+          <a
+            class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+            href="http://localhost:3000/courses/test-course/2?chunk=0"
+            tabindex="0"
+          >
+            <div
+              class="flex flex-row items-center gap-[8px]"
+            >
+              <p
+                class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+              >
+                2
+                . 
+                What Fish Are People Catching, and Why?
+              </p>
+              <svg
+                class="size-[14px] text-[#13132E]"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 320 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                />
+              </svg>
+            </div>
+          </a>
+        </div>
+        <div
+          class="relative"
+        >
+          <div
+            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          />
+          <a
+            class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+            href="http://localhost:3000/courses/test-course/3?chunk=0"
+            tabindex="0"
+          >
+            <div
+              class="flex flex-row items-center gap-[8px]"
+            >
+              <p
+                class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+              >
+                3
+                . 
+                The Promise of Fish
+              </p>
+              <svg
+                class="size-[14px] text-[#13132E]"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 320 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                />
+              </svg>
+            </div>
+          </a>
+        </div>
+        <div
+          class="relative"
+        >
+          <div
+            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          />
+          <a
+            class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+            href="http://localhost:3000/courses/test-course/4?chunk=0"
+            tabindex="0"
+          >
+            <div
+              class="flex flex-row items-center gap-[8px]"
+            >
+              <p
+                class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+              >
+                4
+                . 
+                The Risks of Fish
+              </p>
+              <svg
+                class="size-[14px] text-[#13132E]"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 320 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                />
+              </svg>
+            </div>
+          </a>
+        </div>
+        <div
+          class="relative"
+        >
+          <div
+            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          />
+          <a
+            class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
+            href="http://localhost:3000/courses/test-course/5?chunk=0"
+            tabindex="0"
+          >
+            <div
+              class="flex flex-row items-center gap-[8px]"
+            >
+              <p
+                class="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1"
+              >
+                5
+                . 
+                Contributing to Fish Safety
+              </p>
+              <svg
+                class="size-[14px] text-[#13132E]"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 320 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                />
+              </svg>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="unit__breadcrumbs-wrapper hidden md:block md:sticky md:top-16 z-10 border-b-[0.5px] border-[rgba(19,19,46,0.2)] h-[48px] bg-color-canvas md:ml-[360px]"
+    >
+      <div
+        class="flex flex-row justify-between items-center size-full px-6 gap-2"
+      >
+        <div
+          class="flex items-center gap-[8px]"
+        >
+          <button
+            aria-label="Hide sidebar"
+            class="flex items-center gap-[8px] text-[13px] font-medium text-[#13132E] hover:opacity-80 transition-opacity"
+            type="button"
+          >
+            <svg
+              class="size-[16px]"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 448 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0 96C0 78.3 14.3 64 32 64l384 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 128C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32l384 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 288c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32L32 448c-17.7 0-32-14.3-32-32s14.3-32 32-32l384 0c17.7 0 32 14.3 32 32z"
+              />
+            </svg>
+            <span
+              class="tracking-[-0.005em]"
+            >
+              Hide
+            </span>
+          </button>
+          <span
+            class="w-px h-[18px] bg-[#6A6F7A] opacity-50"
+          />
+        </div>
+        <nav
+          class="flex items-center gap-[8px] flex-1 h-[18px]"
+        >
+          <a
+            class="bluedot-a not-prose text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline inline-flex items-center"
+            href="/courses"
+            tabindex="0"
+          >
+            Courses
+          </a>
+          <svg
+            class="size-[14px] text-[#6A6F7A] flex-shrink-0 opacity-50"
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 320 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+            />
+          </svg>
+          <a
+            class="bluedot-a not-prose text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline inline-flex items-center"
+            href="/courses/test-course"
+            tabindex="0"
+          >
+            What the fish [Test Course]
+          </a>
+          <svg
+            class="size-[14px] text-[#6A6F7A] flex-shrink-0 opacity-50"
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 320 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+            />
+          </svg>
+          <span
+            class="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#13132E] inline-flex items-center"
+          >
+            1
+            . 
+            Basic Principles of Fish
+          </span>
+        </nav>
+        <div
+          class="flex items-center gap-[20px] h-[18px]"
+        >
+          <button
+            aria-label="Previous"
+            class="flex items-center gap-1 text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#13132E] hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled=""
+            title="Navigate to previous section (use ← arrow key)"
+            type="button"
+          >
+            ← Prev
+          </button>
+          <button
+            aria-label="Next"
+            class="flex items-center gap-1 text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#13132E] hover:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Navigate to next section (use → arrow key)"
+            type="button"
+          >
+            Next →
+          </button>
+        </div>
+      </div>
+    </div>
     <section
-      class="section section-body unit__main !border-none"
+      class="section section-body unit__main !border-none !pt-0 !mt-0"
     >
       <div
         class="section__body"
       >
         <div
-          class="unit__content-container flex flex-col md:flex-row"
+          class="unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto gap-6 px-4 sm:px-spacing-x pt-6 md:ml-[360px]"
         >
           <div
-            class="sidebar w-full md:w-[320px] flex flex-col hidden md:block md:fixed md:overflow-y-auto md:max-h-[calc(100vh-57px-65px-42px)]"
+            class="unit__title-container"
           >
-            <div
-              class="sidebar__header-container flex flex-row gap-2 pb-6"
+            <p
+              class="bluedot-p not-prose unit__course-title text-size-sm mb-2"
             >
-              <img
-                alt=""
-                class="size-11"
-                src="/icons/course.svg"
-              />
-              <div
-                class="sidebar__title-container flex flex-col"
-              >
-                <p
-                  class="sidebar__course-header text-size-sm text-[#999eb3]"
-                >
-                  Course
-                </p>
-                <p
-                  class="sidebar__course-title bluedot-h4"
-                >
-                  What the fish [Test Course]
-                </p>
-              </div>
-            </div>
-            <div
-              class="sidebar__content flex flex-col container-lined bg-white"
+              Unit 
+              1
+            </p>
+            <h1
+              class="bluedot-h1 not-prose unit__title font-serif text-[32px]"
             >
-              <details
-                class="sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden"
-                open=""
-              >
-                <summary
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left group-open:border-b border-color-divider cursor-pointer"
-                >
-                  <p
-                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
-                  >
-                    1
-                    . 
-                    Basic Principles of Fish
-                  </p>
-                  <span
-                    class="sidebar-collapsible__button flex items-center"
-                  >
-                    <svg
-                      class="size-3 transition-transform group-open:rotate-90"
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      stroke-width="0"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                      />
-                    </svg>
-                  </span>
-                </summary>
-                <button
-                  class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer text-color-secondary-text border-l-4 border-color-primary bg-bluedot-lightest"
-                  type="button"
-                >
-                  What can AI do today?
-                </button>
-                <button
-                  class="sidebar-collapsible__content block w-full text-left p-4 hover:bg-bluedot-lightest cursor-pointer text-color-secondary-text"
-                  type="button"
-                >
-                  What can AI do today?
-                </button>
-              </details>
-              <a
-                class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-                href="http://localhost:3000/courses/test-course/2?chunk=0"
-                tabindex="0"
-              >
-                <div
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
-                >
-                  <p
-                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
-                  >
-                    2
-                    . 
-                    What Fish Are People Catching, and Why?
-                  </p>
-                  <span
-                    class="sidebar-collapsible__button flex items-center"
-                  >
-                    <svg
-                      class="size-3"
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      stroke-width="0"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                      />
-                    </svg>
-                  </span>
-                </div>
-              </a>
-              <a
-                class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-                href="http://localhost:3000/courses/test-course/3?chunk=0"
-                tabindex="0"
-              >
-                <div
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
-                >
-                  <p
-                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
-                  >
-                    3
-                    . 
-                    The Promise of Fish
-                  </p>
-                  <span
-                    class="sidebar-collapsible__button flex items-center"
-                  >
-                    <svg
-                      class="size-3"
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      stroke-width="0"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                      />
-                    </svg>
-                  </span>
-                </div>
-              </a>
-              <a
-                class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-                href="http://localhost:3000/courses/test-course/4?chunk=0"
-                tabindex="0"
-              >
-                <div
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
-                >
-                  <p
-                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
-                  >
-                    4
-                    . 
-                    The Risks of Fish
-                  </p>
-                  <span
-                    class="sidebar-collapsible__button flex items-center"
-                  >
-                    <svg
-                      class="size-3"
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      stroke-width="0"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                      />
-                    </svg>
-                  </span>
-                </div>
-              </a>
-              <a
-                class="bluedot-a not-prose sidebar-collapsible max-w-max-width border-b border-color-divider last:border-b-0 no-underline hover:text-color-secondary-text"
-                href="http://localhost:3000/courses/test-course/5?chunk=0"
-                tabindex="0"
-              >
-                <div
-                  class="sidebar-collapsible__header flex justify-between w-full p-4 text-left border-color-divider"
-                >
-                  <p
-                    class="sidebar-collapsible__title font-bold text-color-secondary-text"
-                  >
-                    5
-                    . 
-                    Contributing to Fish Safety
-                  </p>
-                  <span
-                    class="sidebar-collapsible__button flex items-center"
-                  >
-                    <svg
-                      class="size-3"
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      stroke-width="0"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                      />
-                    </svg>
-                  </span>
-                </div>
-              </a>
-            </div>
+              What can AI do today?
+            </h1>
           </div>
           <div
-            class="unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto gap-6 px-4 sm:px-spacing-x md:ml-[320px]"
+            class="markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal prose-li:leading-normal max-w-none"
           >
-            <div
-              class="unit__title-container"
-            >
-              <p
-                class="bluedot-p not-prose unit__course-title text-size-sm mb-2"
-              >
-                Unit 
-                1
-              </p>
-              <h1
-                class="bluedot-h1 not-prose unit__title font-serif text-[32px]"
-              >
-                What can AI do today?
-              </h1>
-            </div>
-            <div
-              class="markdown-extended-renderer prose prose-p:text-size-md prose-li:text-size-md prose-p:leading-normal prose-li:leading-normal max-w-none"
-            >
-              <p>
-                Five years ago, AI systems struggled to form coherent sentences. Today, &gt;5% of the world use AI products like ChatGPT every week for help with work, studies, and creative projects. These systems extend far beyond a simple chat. They can produce art, write complex code, and control robots to do real-world tasks.
-              </p>
-              
+            <p>
+              Five years ago, AI systems struggled to form coherent sentences. Today, &gt;5% of the world use AI products like ChatGPT every week for help with work, studies, and creative projects. These systems extend far beyond a simple chat. They can produce art, write complex code, and control robots to do real-world tasks.
+            </p>
+            
 
-              <p>
-                This unit explores how AI is evolving from simple "tools" into autonomous "agents",  capable of setting goals, making complex plans, and acting in the real world.
-              </p>
-            </div>
-            <div
-              class="unit__keyboard-hint text-size-xs text-color-secondary mt-4"
+            <p>
+              This unit explores how AI is evolving from simple "tools" into autonomous "agents",  capable of setting goals, making complex plans, and acting in the real world.
+            </p>
+          </div>
+          <div
+            class="unit__keyboard-hint text-size-xs text-color-secondary mt-4"
+          >
+            <p>
+              Tip: Use arrow keys (← →) to navigate between sections
+            </p>
+          </div>
+          <div
+            class="unit__cta-container flex flex-row justify-between mt-6 mx-1 mb-14 sm:mb-0"
+          >
+            <button
+              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
+              type="button"
             >
-              <p>
-                Tip: Use arrow keys (← →) to navigate between sections
-              </p>
-            </div>
-            <div
-              class="unit__cta-container flex flex-row justify-between mt-6 mx-1 mb-14 sm:mb-0"
-            >
-              <button
-                class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
-                type="button"
+              <span
+                class="cta-button__text"
               >
-                <span
-                  class="cta-button__text"
+                Continue
+              </span>
+              <span
+                class="cta-button__chevron ml-3"
+              >
+                <svg
+                  class="cta-button__chevron-icon size-2"
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Continue
-                </span>
-                <span
-                  class="cta-button__chevron ml-3"
-                >
-                  <svg
-                    class="cta-button__chevron-icon size-2"
-                    fill="currentColor"
-                    height="1em"
-                    stroke="currentColor"
-                    stroke-width="0"
-                    viewBox="0 0 320 512"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
+                  <path
+                    d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
       </div>

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               class="flex flex-col items-start px-0 pb-[16px] gap-[4px]"
             >
               <button
-                class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] h-[100px] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
+                class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] min-h-[100px] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
                 type="button"
               >
                 <div
@@ -184,7 +184,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                   </svg>
                 </div>
                 <div
-                  class="flex flex-col items-start p-0 gap-[8px] flex-1 h-[68px]"
+                  class="flex flex-col items-start p-0 gap-[8px] flex-1 min-h-[68px]"
                 >
                   <p
                     class="font-semibold text-[14px] leading-[150%] text-[#13132E]"
@@ -194,14 +194,14 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 </div>
               </button>
               <button
-                class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] h-[100px] text-left transition-colors hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px]"
+                class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] min-h-[100px] text-left transition-colors hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px]"
                 type="button"
               >
                 <div
                   class="size-6 rounded-full flex items-center justify-center bg-[#FCFBF9] border border-[rgba(106,111,122,0.3)]"
                 />
                 <div
-                  class="flex flex-col items-start p-0 gap-[8px] flex-1 h-[68px]"
+                  class="flex flex-col items-start p-0 gap-[8px] flex-1 min-h-[68px]"
                 >
                   <p
                     class="font-semibold text-[14px] leading-[150%] text-[#13132E]"
@@ -406,7 +406,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           />
         </div>
         <nav
-          class="flex items-center gap-[8px] flex-1 h-[18px]"
+          class="flex items-center gap-[8px] flex-1 min-h-[18px]"
         >
           <a
             class="bluedot-a not-prose text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline inline-flex items-center"
@@ -459,7 +459,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           </span>
         </nav>
         <div
-          class="flex items-center gap-[20px] h-[18px]"
+          class="flex items-center gap-[20px] min-h-[18px]"
         >
           <button
             aria-label="Previous"

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -500,7 +500,6 @@ export const chunkTable = pgAirtable('chunk', {
       pgColumn: text().notNull(),
       airtableId: 'fldiv4wuePLO9UtHr',
     },
-    // TODO, needed for issue #1149
     estimatedTime: {
       pgColumn: numeric({ mode: 'number' }).default(0),
       airtableId: 'fldvzUryETzU5Yn64',


### PR DESCRIPTION
# Description
Implements the new sidebar + link breadcrumb design.

**Out of scope (separate features):**
- **Progress tracking**: In this PR, time/chunk estimates and completion hidden when unavailable
- **Content type icons**: In this PR, all items use the same icon until text/exercise/reflection fields are added to the chunk table in the database
- **Exercise type headers**: In this PR, headers display only chunk names until introduction/exercise/reflection is added as a field to the chunk table in the database

## Issue
Fixes #1149 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Video Screenshot
![new-sidebar](https://github.com/user-attachments/assets/3ee3828f-7f3b-4d6a-961f-f6cab42aef59)
