### PR TITLE
Fix ingress-nginx path validation for cert-manager compatibility

### DIFF
--- a/apps/infra/src/k8s/ingress.ts
+++ b/apps/infra/src/k8s/ingress.ts
@@ -19,6 +19,11 @@ export const ingressNginx = new k8s.helm.v3.Release('ingress-nginx', {
 
         // Allow large file uploads
         'proxy-body-size': '100m',
+
+        // Disable strict path validation, to work around a bug in ingress-nginx
+        // https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes
+        // https://github.com/kubernetes/ingress-nginx/issues/11176
+        'strict-validate-path-type': false,
       },
       ingressClassResource: {
         default: 'true',


### PR DESCRIPTION
## Summary
- Disable strict path validation in ingress-nginx configuration
- Resolves compatibility issues with cert-manager ACME HTTP01 challenges
- References upstream issues and documentation for context

## References
- https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes
- https://github.com/kubernetes/ingress-nginx/issues/11176