### PR TITLE
[Bug] Fix duplicate header issue in posthog-proxy

### DIFF
--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -31,25 +31,31 @@ http {
                 return 204;
             }
 
-            # Add CORS headers to all responses
-            add_header 'Access-Control-Allow-Origin' '$cors_origin' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
-            add_header 'Access-Control-Allow-Credentials' 'true' always;
-
-            # PostHog requires these headers - route to ingestion API
-            proxy_pass https://eu.i.posthog.com;
-            proxy_redirect off;
-            proxy_ssl_session_reuse off;
-            proxy_ssl_server_name on;
             proxy_set_header Host eu.i.posthog.com;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
-            
+
             # Pass through important headers
             proxy_set_header Referer $http_referer;
             proxy_set_header User-Agent $http_user_agent;
+
+            # Route to ingestion API
+            proxy_pass https://eu.i.posthog.com;
+            proxy_redirect off;
+            proxy_ssl_session_reuse off;
+            proxy_ssl_server_name on;
+
+            # Hide upstream CORS headers to prevent duplicates, then add our own
+            proxy_hide_header Access-Control-Allow-Origin;
+            proxy_hide_header Access-Control-Allow-Methods;
+            proxy_hide_header Access-Control-Allow-Headers;
+            proxy_hide_header Access-Control-Allow-Credentials;
+            proxy_hide_header Access-Control-Max-Age;
+            add_header 'Access-Control-Allow-Origin' '$cors_origin' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
+            add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
     }
 }


### PR DESCRIPTION
# Description

Both our reverse proxy, and the upstream PostHog server were setting Access-Control-Allow-Origin and Access-Control-Allow-Credentials headers. This resulted in 'header contains multiple values' CORS errors.

Here's an example error from the console:
```
Access to fetch at 'https://analytics.k8s.bluedot.org/e/?ip=1&_=1755023983200&ver=1.252.0&compression=gzip-js' from origin 'https://bluedot.org' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values 'https://bluedot.org, https://bluedot.org', but only one is allowed. Have the server send the header with a valid value.
```

This PR adds proxy_hide_header to remove the headers returned from the upstream server.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1175

## Steps to test

### Before fix

1. Docker must be running
2. Run posthog-proxy locally:
```bash
git checkout master
cd apps/posthog-proxy
npm run start
```
3. Ping it with a curl request:
```
curl -i -X POST -H "Origin: https://bluedot.org" -H "Content-Type: application/json" -d '{"test": "data"}' http://localhost:8000/e/
```

The result should look like this, with duplicate access-control-allow-credentials, access-control-allow-origin header (it returns a 400 because the data is invalid, which is fine):
```
wh$ curl -i -X POST -H "Origin: https://bluedot.org" -H "Content-Type: application/json" -d '{"test": "data"}' http://localhost:8000/e/
HTTP/1.1 400 Bad Request
Server: nginx/1.26.2
Date: Tue, 12 Aug 2025 19:31:14 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 86
Connection: keep-alive
vary: origin, access-control-request-method, access-control-request-headers, Accept-Encoding
access-control-allow-origin: https://bluedot.org
access-control-allow-credentials: true
x-envoy-upstream-service-time: 0
Strict-Transport-Security: max-age=31536000; includeSubDomains
Access-Control-Allow-Origin: https://bluedot.org
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization
Access-Control-Allow-Credentials: true
```

### After fix

Run the same steps as above on this branch, the result of the curl request should now be like this:
```
wh$ curl -i -X POST -H "Origin: https://bluedot.org" -H "Content-Type: application/json" -d '{"test": "data"}' http://localhost:8000/e/
HTTP/1.1 400 Bad Request
Server: nginx/1.26.2
Date: Tue, 12 Aug 2025 19:31:52 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 86
Connection: keep-alive
vary: origin, access-control-request-method, access-control-request-headers, Accept-Encoding
x-envoy-upstream-service-time: 0
Strict-Transport-Security: max-age=31536000; includeSubDomains
Access-Control-Allow-Origin: https://bluedot.org
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization
Access-Control-Allow-Credentials: true
```

