### PR TITLE
[Bug] Increase timeout of loki deployment, attempting to fix flaky app/infra deployments

### DIFF
--- a/apps/infra/src/k8s/observability.ts
+++ b/apps/infra/src/k8s/observability.ts
@@ -257,6 +257,7 @@ new k8s.helm.v3.Release('loki', {
     repo: 'https://grafana.github.io/helm-charts',
   },
   namespace: 'monitoring',
+  timeout: 600, // 10 minutes, added as a fix for https://github.com/bluedotimpact/bluedot/issues/1170
   values: {
     loki: {
       commonConfig: {


### PR DESCRIPTION
# Description

`infra` deployments have been failing recently, with this as the apparent main error ([example](https://github.com/bluedotimpact/bluedot/actions/runs/16909987805/job/47909624064)):
```
Diagnostics:
  kubernetes:helm.sh/v3:Release (loki):
    error: 1 error occurred:
    	* Helm release "monitoring/loki" failed to initialize completely. Use Helm CLI to investigate: failed to become available within allocated timeout. Error: Helm Release monitoring/loki: context deadline exceeded
```

There is at least one example of the deployment passing since this issue started: [example](https://github.com/bluedotimpact/bluedot/actions/runs/16918610369/job/47939344927).

I haven't spent that long looking into this, so I don't have a very good understanding of how the whole system works, but I think it's quite likely this is a basic timeout issue. I've added a timeout of 10 mins to the loki release (up from the [Helm default](https://helm.sh/docs/intro/using_helm/#:~:text=%2D%2Dtimeout%20%3A%20A%20Go%20duration,This%20defaults%20to%205m0s%20.) of 5 mins. We can see if this resolves the issue, and then I can investigate further if it keeps happening.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1170
