### PR TITLE
[Bug] Upgrade Kubernetes from v1.29.2+1 to v1.31.8+1

### DIFF
--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
   label: 'bluedot-prod',
   region: 'ams',
-  version: 'v1.29.2+1',
+  version: 'v1.31.8+1',
 
   // Initial node pool
   // nodePools: {


### PR DESCRIPTION
# Description

`infra` deployments are sometimes failing with this error:

```
  vultr:index:Kubernetes (vke-cluster):
    error: 1 error occurred:
    	* updating urn:pulumi:prod::infra::vultr:index/kubernetes:Kubernetes::vke-cluster: 1 error occurred:
    	* error upgrading VKE cluster 83dad468-420e-4bdb-a5da-5b5395b22bdc : gave up after 4 attempts, last error: "{\"error\":\"VKE server error: Cluster upgrade failed: invalid upgrade version\",\"status\":500}"
```

According to https://docs.vultr.com/products/kubernetes/changelog , the version we are using (v1.29.2+1) is now archived, which is sufficient to explain the above error (although not why it sometimes tries and fails to update the version, and sometimes just passes). This PR upgrades to a version that is shown as being supported.

Note that this error was seen independently of the "[loki timeout error](https://github.com/bluedotimpact/bluedot/pull/1187)". Here is an [example before](https://github.com/bluedotimpact/bluedot/actions/runs/16914901475/job/47926361326) the fix for that was merged, and an [example after](https://github.com/bluedotimpact/bluedot/actions/runs/16929666194/job/47972182482).

I haven't tested this, and I'm not sure exactly how to go about testing it. I don't think the version change is very likely to cause issues, but given the high downside risk (there could be bugs due to the new version, and we couldn't roll back to the previous version) it would be worthwhile to test. @marn-in-prod do you have thoughts on this?

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1170 
