### PR TITLE
Simplify sidebar margin logic in UnitLayout component

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -351,7 +351,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
       <Section className="unit__main !border-none !pt-0 !mt-0">
         <div className={clsx(
           'unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto gap-8 md:gap-6 px-5 sm:px-spacing-x pt-6 md:pt-24',
-          isSidebarHidden ? 'md:ml-0' : 'md:ml-[360px]',
+          !isSidebarHidden && 'md:ml-[360px]',
         )}
         >
           <div className="unit__title-container">


### PR DESCRIPTION
Remove redundant conditional logic by using logical AND operator instead of ternary operator for cleaner code readability.

# Description
Content spacing was off when the side bar was hidden. 

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
Before: 
<img width="5120" height="2880" alt="CleanShot 2025-08-13 at 12 28 39@2x" src="https://github.com/user-attachments/assets/83b07079-c367-4d6d-b5e0-6bc6cf2ecaf3" />

After:
<img width="5120" height="2880" alt="CleanShot 2025-08-13 at 12 29 17@2x" src="https://github.com/user-attachments/assets/e9a35d03-c33b-4bce-997f-8275bca965f0" />


| 📸 |  |
|---------|---|
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
