### PR TITLE
[fix]: responsive mobile buttons

### DIFF
--- a/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
@@ -184,13 +184,16 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
         )}
       </div>
       {!isLoggedIn && (
-        <CTALinkOrButton
-          variant="primary"
-          url={getLoginUrl(router.asPath, true)}
-          withChevron
-        >
-          Create a free account to save your answers
-        </CTALinkOrButton>
+        <div className="w-full flex">
+          <CTALinkOrButton
+            variant="primary"
+            url={getLoginUrl(router.asPath, true)}
+            withChevron
+            className="!w-auto !whitespace-normal text-center min-w-0"
+          >
+            Create a free account to save your answers
+          </CTALinkOrButton>
+        </div>
       )}
     </form>
   );

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -88,35 +88,39 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
         </div>
       </div>
     </div>
-    <a
-      class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
-      href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-path"
-      tabindex="0"
+    <div
+      class="w-full flex"
     >
-      <span
-        class="cta-button__text"
+      <a
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark !w-auto !whitespace-normal text-center min-w-0"
+        href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-path"
+        tabindex="0"
       >
-        Create a free account to save your answers
-      </span>
-      <span
-        class="cta-button__chevron ml-3"
-      >
-        <svg
-          class="cta-button__chevron-icon size-2"
-          fill="currentColor"
-          height="1em"
-          stroke="currentColor"
-          stroke-width="0"
-          viewBox="0 0 320 512"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          class="cta-button__text"
         >
-          <path
-            d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-          />
-        </svg>
-      </span>
-    </a>
+          Create a free account to save your answers
+        </span>
+        <span
+          class="cta-button__chevron ml-3"
+        >
+          <svg
+            class="cta-button__chevron-icon size-2"
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 320 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+            />
+          </svg>
+        </span>
+      </a>
+    </div>
   </form>
 </div>
 `;


### PR DESCRIPTION
# Description
Buttons for exercises (when not logged in) are now responsive on mobile.

## Issue
Fixes #1166 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Video Screenshot
![mobile-button](https://github.com/user-attachments/assets/ff339c4f-eb19-4622-80eb-88faa70f8bb1)
