### PR TITLE
[fix]: cleaned up nested reduce logic in resource time calculations

### DIFF
--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -266,6 +266,7 @@ exports[`MultipleChoice > updates styles for correct option 1`] = `
                 false"
 >
   <input
+    checked=""
     class="input--radio size-6 accent-bluedot-normal rounded cursor-pointer"
     name="answer"
     type="radio"
@@ -296,6 +297,7 @@ exports[`MultipleChoice > updates styles for incorrect option 1`] = `
                 multiple-choice__option--incorrect bg-[#FF636333] border-[#FF6363]"
 >
   <input
+    checked=""
     class="input--radio size-6 accent-bluedot-normal rounded cursor-pointer"
     name="answer"
     type="radio"


### PR DESCRIPTION
# Description
Simplified and cleaned up nested reduce logic introduced in #1192 + for readability

## Issue
Related to #1192

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
N/A
