### PR TITLE
[fix] Typography changes to allign to specs

### DIFF
--- a/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -79,7 +79,7 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, c
 
   return (
     // See @utility prose in globals.css for advanced styles
-    <div className={clsx('markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] max-w-none', className)}>
+    <div className={clsx('markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none', className)}>
       {Component && <Component components={getSupportedComponents()} />}
     </div>
   );

--- a/apps/website/src/components/courses/ResourceListCourseContent.tsx
+++ b/apps/website/src/components/courses/ResourceListCourseContent.tsx
@@ -363,7 +363,7 @@ const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) => {
                           target="_blank"
                           rel="noopener noreferrer"
                           onClick={() => handleToggleComplete(true)}
-                          className="no-underline text-inherit group-hover:opacity-80 transition-opacity"
+                          className="no-underline hover:underline hover:text-[#2244BB] text-inherit transition-colors"
                           aria-label={`${resource.resourceName} (opens in new tab)`}
                         >
                           {resource.resourceName}

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -560,7 +560,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             </h1>
           </div>
           <div
-            class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] max-w-none"
+            class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none"
           >
             <p>
               Five years ago, AI systems struggled to form coherent sentences. Today, &gt;5% of the world use AI products like ChatGPT every week for help with work, studies, and creative projects. These systems extend far beyond a simple chat. They can produce art, write complex code, and control robots to do real-world tasks.

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
           Understanding LLMs
         </p>
         <div
-          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] max-w-none"
+          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none"
         >
           <p>
             Why is a language model's ability to predict 'the next word' capable of producing complex behaviors like solving maths problems?
@@ -148,7 +148,7 @@ exports[`FreeTextResponse > renders logged in as expected 1`] = `
           Understanding LLMs
         </p>
         <div
-          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] max-w-none"
+          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none"
         >
           <p>
             Why is a language model's ability to predict 'the next word' capable of producing complex behaviors like solving maths problems?
@@ -240,7 +240,7 @@ exports[`FreeTextResponse > renders with saved exercise response 1`] = `
           Understanding LLMs
         </p>
         <div
-          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] max-w-none"
+          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none"
         >
           <p>
             Why is a language model's ability to predict 'the next word' capable of producing complex behaviors like solving maths problems?

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
           Understanding LLMs
         </p>
         <div
-          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] max-w-none multiple-choice__description"
+          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none multiple-choice__description"
         >
           <p>
             Why is a language model's ability to predict 'the next word' capable of producing complex behaviors like solving maths problems?
@@ -163,7 +163,7 @@ exports[`MultipleChoice > renders logged in as expected 1`] = `
           Understanding LLMs
         </p>
         <div
-          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] max-w-none multiple-choice__description"
+          class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none multiple-choice__description"
         >
           <p>
             Why is a language model's ability to predict 'the next word' capable of producing complex behaviors like solving maths problems?
@@ -266,7 +266,6 @@ exports[`MultipleChoice > updates styles for correct option 1`] = `
                 false"
 >
   <input
-    checked=""
     class="input--radio size-6 accent-bluedot-normal rounded cursor-pointer"
     name="answer"
     type="radio"
@@ -297,7 +296,6 @@ exports[`MultipleChoice > updates styles for incorrect option 1`] = `
                 multiple-choice__option--incorrect bg-[#FF636333] border-[#FF6363]"
 >
   <input
-    checked=""
     class="input--radio size-6 accent-bluedot-normal rounded cursor-pointer"
     name="answer"
     type="radio"


### PR DESCRIPTION
# Description
Fixing the last remaining issues from #1145

## Issue

Fixes #1145

## Developer checklist
Just changing styling.

## Screenshot
Text hyperlink (not bolded anymore)
<img width="1320" height="658" alt="image" src="https://github.com/user-attachments/assets/dad39985-8a08-467f-8b41-6aacdc72b6c3" />
Resource card titles hyperlinked (blue when hovered + underline)
<img width="1320" height="658" alt="image" src="https://github.com/user-attachments/assets/b04b7e4b-3782-42f4-8613-5af6175d7ff0" />

