### PR TITLE
[Bug] Allow localhost origin in posthog-proxy

### DIFF
--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -1,9 +1,10 @@
 http {
-    # Define allowed origins - only production and staging
+    # Define allowed origins - only production, staging, and localhost
     map $http_origin $cors_origin {
         default "";
         "~^https://(.*\.)?bluedot\.org$" $http_origin;
         "~^https://(.*\.)?k8s\.bluedot\.org$" $http_origin;
+        "~^https?://localhost(:[0-9]+)?$" $http_origin;
     }
 
     server {


### PR DESCRIPTION
# Description
A bug introduced by #1186 is that localhost was no longer an origin allowed by posthog-proxy, which resulted in this error when running the website (and a CORS error in the console):
<img width="2042" height="1034" alt="Screenshot 2025-08-15 at 09 23 15" src="https://github.com/user-attachments/assets/fb71765e-266d-434f-9a06-c23ff28b9d48" />

## Issue
#1175

## Steps to test

### Before fix

1. Docker must be running
2. Run posthog-proxy locally:
```bash
git checkout master
cd apps/posthog-proxy
npm run start
```
3. Ping it with a curl request:
```
curl -i -X POST -H "Origin: http://localhost:8000" -H "Content-Type: application/json" -d '{"test": "data"}' http://localhost:8000/e/
```

On this branch the result should have `Access-Control-Allow-Origin: https://localhost:8000` in the response, whereas on master it won't