### PR TITLE
Override loki anti-affinity rules to allow it to deploy

### DIFF
--- a/apps/infra/src/k8s/observability.ts
+++ b/apps/infra/src/k8s/observability.ts
@@ -257,7 +257,6 @@ new k8s.helm.v3.Release('loki', {
     repo: 'https://grafana.github.io/helm-charts',
   },
   namespace: 'monitoring',
-  timeout: 600, // 10 minutes, added as a fix for https://github.com/bluedotimpact/bluedot/issues/1170
   values: {
     loki: {
       commonConfig: {
@@ -304,6 +303,12 @@ new k8s.helm.v3.Release('loki', {
     deploymentMode: 'SingleBinary',
     singleBinary: {
       replicas: 1,
+    },
+    gateway: {
+      // Partial fix for https://github.com/bluedotimpact/bluedot/issues/1170 , the default anti-affinity
+      // rules were preventing deployment on our single node cluster (because pods can't be scheduled on
+      // separate nodes)
+      affinity: {},
     },
     // Disable things we don't need
     selfMonitoring: {

--- a/apps/infra/src/k8s/observability.ts
+++ b/apps/infra/src/k8s/observability.ts
@@ -308,7 +308,20 @@ new k8s.helm.v3.Release('loki', {
       // Partial fix for https://github.com/bluedotimpact/bluedot/issues/1170 , the default anti-affinity
       // rules were preventing deployment on our single node cluster (because pods can't be scheduled on
       // separate nodes)
-      affinity: {},
+      affinity: {
+        podAntiAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution: [
+            {
+              labelSelector: {
+                matchLabels: {
+                  'app.kubernetes.io/component': 'not-read',
+                },
+              },
+              topologyKey: 'kubernetes.io/hostname',
+            },
+          ],
+        },
+      },
     },
     // Disable things we don't need
     selfMonitoring: {


### PR DESCRIPTION
# Description

Loki is currently failing to deploy due to a timeout error, I previously tried [raising the timeout](https://github.com/bluedotimpact/bluedot/pull/1187) but it still fails.

After investigating in Kubernetes, it seems that it's failing to deploy due to anti-affinity rules:
```
> kubectl get events -n monitoring --sort-by=.metadata.creationTimestamp | tail -10
LAST SEEN   TYPE      REASON              OBJECT                              MESSAGE
40m         Warning   FailedScheduling    pod/loki-gateway-b6855b66d-27jtq    0/1 nodes are available: 1 node(s) didn't match pod anti-affinity rules. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.
```

(This is after killing the Pending pod once, before that it had been pending for 20h):
```
wh@whcea infra % kubectl get pods -n monitoring
NAME                                                        READY   STATUS      RESTARTS       AGE
...
loki-0                                                      2/2     Running     0              9d
loki-chunks-cache-0                                         2/2     Running     0              9d
loki-gateway-64d7c7768b-xt8ff                               1/1     Running     0              84d
loki-gateway-b6855b66d-v8ch8                                0/1     Pending     0              13m
loki-results-cache-0                                        2/2     Running     0              9d
...
```

We have a single node cluster, so if there are anti-affinity rules trying to schedule pods on different nodes, this explains why it fails. The current rules must be defaults inside Loki, this PR now adds an explicitly empty `affinity` block

### Edit 2025-08-16

It turned out to be tricky to override the affinity settings, because values are merged rather than being fully overridden, so if you provide an empty `affinity` object it will keep using the previous defaults. I found [this workaround](https://github.com/grafana/helm-charts/issues/2709#issuecomment-2839130975) and deployed locally to test that it works, so prod is not already on this new version.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1170 , this should fix most of the failing deployments we see, but there is a remaining [problem with the Kubernetes version](https://github.com/bluedotimpact/bluedot/pull/1189) that I expect will cause some deployments to still fail (planning to fix that too)

