### PR TITLE
[bug] Webhooks broken because specific field didn't exist anymore

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -57,7 +57,7 @@ export const courseTable = pgAirtable('course', {
     },
     detailsUrl: {
       pgColumn: text().notNull(),
-      airtableId: 'fldblKROooVG5p9UW',
+      airtableId: 'fldlnWDzZZPZHP6S1',
     },
     displayOnCourseHubIndex: {
       pgColumn: boolean().notNull(),


### PR DESCRIPTION
**TL;DR:** Webhook syncing broke when a field was removed from an Airtable base/table. The webhook appeared healthy but was actually in an "INVALID_HOOK" state and stopped receiving updates. I attempted to make webhooks more resilient by: 1) detecting INVALID_HOOK payloads and recreating webhooks without broken fields, and 2) identifying incorrect fields when starting pg-sync-service. However, I'm still blocked by #1190 since the data shape from Airtable differs from our schema, causing unrecoverable errors. So for now, I just deleted & updated the field so that the existing pg-sync-code would work again.

---

# Description

Syncing broke for a base/table because an existing webhook expected a field to exist that had been removed. This caused our code to incorrectly think the webhook was healthy and re-use it, when in reality, if we'd looked at the last payload the broken hook received, it would have shown:

```json
{
  "timestamp": "2025-08-12T13:05:03.376Z",
  "baseTransactionNumber": 2980403,
  "actionMetadata": {
    "source": "client",
    "sourceMetadata": {
      "user": {
        "id": "usr1nltjajeySYx2f",
        "email": "dewi@bluedot.org",
        "permissionLevel": "create",
        "name": "Dewi Erwan",
        "profilePicUrl": "https://dl.airtable.com/.profilePics/6a391f7694d330935207364cd0ccd51a/6da1503b"
      }
    }
  },
  "changedTablesById": {
    "tbl6nq5AVLKINBJ73": {
      "destroyedFieldIds": [
        "fldblKROooVG5p9UW"
      ]
    }
  },
  "payloadFormat": "v0",
  "error": true,
  "code": "INVALID_HOOK"
}
```

When a hook is in an "INVALID_HOOK" state, it actually stops receiving updates despite our code currently treating it as healthy.

At first, I did some work to make webhooks more resilient to fields being removed. This consisted of two things:
1. We need to make sure our code recognizes when it receives an INVALID_HOOK payload and recreates the webhook. It also needs to recreate the webhook and remove the broken field from the fields to watch.
2. When starting the pg-sync-service, if there isn't an existing working webhook, we need to figure out what fields are incorrect so we can create a new one (I believe we can do this because we get a separate error during scanning Airtable). Scanning Airtable with an incorrect field will result in the Airtable API telling us which field is missing/incorrect.

Unfortunately, even if I implemented both, I'm still stuck being blocked by #1190 because the shape of the data we'd be getting from Airtable would be different from our schema and cause unrecoverable errors.

## Issue
Fixes #1196 until we delete another field without changing the codebase again.

## Developer checklist
Not applicable