### PR TITLE
[feat]: feedback toggle

### DIFF
--- a/apps/website/src/components/courses/ResourceListCourseContent.tsx
+++ b/apps/website/src/components/courses/ResourceListCourseContent.tsx
@@ -299,11 +299,13 @@ const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) => {
 
   // Handle like/dislike feedback
   const handleFeedback = useCallback(async (feedbackValue: typeof RESOURCE_FEEDBACK.LIKE | typeof RESOURCE_FEEDBACK.DISLIKE) => {
-    setResourceFeedback(feedbackValue);
+    // Toggle off if clicking the same feedback button
+    const newFeedback = resourceFeedback === feedbackValue ? RESOURCE_FEEDBACK.NO_RESPONSE : feedbackValue;
+    setResourceFeedback(newFeedback);
     setIsCompleted(true); // Mark as completed when feedback is given
     setShowFeedback(true); // Ensure feedback section stays visible
-    await handleSaveCompletion(true, feedbackValue);
-  }, [handleSaveCompletion]);
+    await handleSaveCompletion(true, newFeedback);
+  }, [resourceFeedback, handleSaveCompletion]);
 
   if (completionLoading && !completionData) {
     return <ProgressDots />;


### PR DESCRIPTION
# Description
The user is now able to toggle on/off their resource feedback and updates the database with that response.

## Issue
Fixes #1198 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Video Screenshot
![like-dislike-toggle](https://github.com/user-attachments/assets/de8ffc32-f8c7-4655-991f-305b3445f125)

