### PR TITLE
[feat]: resource favicons

### DIFF
--- a/apps/website/src/components/courses/FaviconImage.tsx
+++ b/apps/website/src/components/courses/FaviconImage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 type FaviconImageProps = {
   url: string;
-  displaySize?: number;  // Size in pixels for displaying the favicon (default: 16px)
+  displaySize?: number; // Size in pixels for displaying the favicon (default: 16px)
   className?: string;
   alt?: string;
 };
@@ -13,12 +13,12 @@ type FaviconImageProps = {
  */
 export const FaviconImage: React.FC<FaviconImageProps> = ({
   url,
-  displaySize = 16,  // How large the favicon appears on screen
+  displaySize = 16, // How large the favicon appears on screen
   className = '',
   alt,
 }) => {
   const [hasError, setHasError] = useState(false);
-  
+
   // Extract domain from URL
   let domain: string;
   try {
@@ -34,8 +34,8 @@ export const FaviconImage: React.FC<FaviconImageProps> = ({
   }
 
   // API Configuration
-  const API_FAVICON_SIZE = 256;  // Size requested from Google's API (higher res for quality)
-  
+  const API_FAVICON_SIZE = 256; // Size requested from Google's API (higher res for quality)
+
   // Request high-resolution favicon from Google's API
   // We fetch at 256px for quality, then scale down to displaySize for crisp rendering
   const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=${API_FAVICON_SIZE}`;
@@ -44,8 +44,8 @@ export const FaviconImage: React.FC<FaviconImageProps> = ({
     <img
       src={faviconUrl}
       alt={alt || `${domain} favicon`}
-      width={displaySize}    // Display dimensions (e.g., 16x16)
-      height={displaySize}   // Browser scales down the high-res image
+      width={displaySize} // Display dimensions (e.g., 16x16)
+      height={displaySize} // Browser scales down the high-res image
       className={`inline-block flex-shrink-0 ${className}`}
       onError={() => setHasError(true)}
       loading="lazy"

--- a/apps/website/src/components/courses/FaviconImage.tsx
+++ b/apps/website/src/components/courses/FaviconImage.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+
+type FaviconImageProps = {
+  url: string;
+  displaySize?: number;  // Size in pixels for displaying the favicon (default: 16px)
+  className?: string;
+  alt?: string;
+};
+
+/**
+ * Component that displays a favicon for a given URL using Google's favicon API
+ * Falls back gracefully if the favicon fails to load
+ */
+export const FaviconImage: React.FC<FaviconImageProps> = ({
+  url,
+  displaySize = 16,  // How large the favicon appears on screen
+  className = '',
+  alt,
+}) => {
+  const [hasError, setHasError] = useState(false);
+  
+  // Extract domain from URL
+  let domain: string;
+  try {
+    const urlObject = new URL(url);
+    domain = urlObject.hostname;
+  } catch {
+    return null;
+  }
+
+  // Don't render if there was an error loading the favicon
+  if (hasError) {
+    return null;
+  }
+
+  // API Configuration
+  const API_FAVICON_SIZE = 256;  // Size requested from Google's API (higher res for quality)
+  
+  // Request high-resolution favicon from Google's API
+  // We fetch at 256px for quality, then scale down to displaySize for crisp rendering
+  const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=${API_FAVICON_SIZE}`;
+
+  return (
+    <img
+      src={faviconUrl}
+      alt={alt || `${domain} favicon`}
+      width={displaySize}    // Display dimensions (e.g., 16x16)
+      height={displaySize}   // Browser scales down the high-res image
+      className={`inline-block flex-shrink-0 ${className}`}
+      onError={() => setHasError(true)}
+      loading="lazy"
+    />
+  );
+};
+
+export default FaviconImage;

--- a/apps/website/src/components/courses/ResourceListCourseContent.tsx
+++ b/apps/website/src/components/courses/ResourceListCourseContent.tsx
@@ -24,6 +24,7 @@ import Callout from './Callout';
 import Exercise from './exercises/Exercise';
 import { GetUnitResponse } from '../../pages/api/courses/[courseSlug]/[unitNumber]';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
+import { FaviconImage } from './FaviconImage';
 
 type UnitResource = InferSelectModel<typeof unitResourceTable.pg>;
 
@@ -369,7 +370,13 @@ const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) => {
                   {/* Resource title and link */}
                   <P className="resource-item__title font-semibold leading-[140%] tracking-[-0.005em]">
                     {resource.resourceLink ? (
-                      <div className="flex items-center gap-2 group">
+                      <div className="flex items-center group">
+                        {/* Favicon */}
+                        <FaviconImage
+                          url={resource.resourceLink}
+                          displaySize={16}
+                          className="mr-2"
+                        />
                         <a
                           href={resource.resourceLink}
                           target="_blank"
@@ -384,7 +391,7 @@ const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) => {
                           href={resource.resourceLink}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="inline-flex group-hover:opacity-80 transition-opacity"
+                          className="inline-flex group-hover:opacity-80 transition-opacity ml-2"
                           aria-label={`Open ${resource.resourceName} in new tab`}
                         >
                           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">


### PR DESCRIPTION
# Description
Implemented favicons from resource websites for all resource cards. "As a user I want to see the thumbnails of the websites hosting a resource, so that I can quickly get a better feeling for where I am landing."

Note that this new component requests favicons at render time, so there's no need for extraction of full-page thumbnails, SVGs or storage.

## Issue
Fixes #1157 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Video Screenshot
![extracted-favicons](https://github.com/user-attachments/assets/88ba0ef0-19fc-44f8-8bc9-676e316ff375)
## Screenshot
<img width="942" height="601" alt="resource-favicons" src="https://github.com/user-attachments/assets/7fa4f0b9-ca37-444c-a9dd-4efa3786d1be" />
