### PR TITLE
Pin Helm chart versions in infra

### DIFF
--- a/apps/infra/src/k8s/certManager.ts
+++ b/apps/infra/src/k8s/certManager.ts
@@ -3,6 +3,7 @@ import { provider } from './provider';
 
 export const certManager = new k8s.helm.v3.Release('cert-manager', {
   chart: 'cert-manager',
+  version: 'v1.18.2',
   repositoryOpts: {
     repo: 'https://charts.jetstack.io',
   },

--- a/apps/infra/src/k8s/ingress.ts
+++ b/apps/infra/src/k8s/ingress.ts
@@ -3,6 +3,7 @@ import { provider } from './provider';
 
 export const ingressNginx = new k8s.helm.v3.Release('ingress-nginx', {
   chart: 'ingress-nginx',
+  version: '4.13.1',
   repositoryOpts: {
     repo: 'https://kubernetes.github.io/ingress-nginx',
   },

--- a/apps/infra/src/k8s/observability.ts
+++ b/apps/infra/src/k8s/observability.ts
@@ -62,6 +62,7 @@ const grafanaService = {
 const kubePrometheus = new k8s.helm.v3.Release('kube-prometheus', {
   name: 'kube-prometheus-stack',
   chart: 'kube-prometheus-stack',
+  version: '76.4.0',
   repositoryOpts: {
     repo: 'https://prometheus-community.github.io/helm-charts',
   },
@@ -151,6 +152,7 @@ new k8s.networking.v1.Ingress(`${grafanaService.name}-ingress`, {
 new k8s.helm.v3.Release('opentelemetry-collector', {
   name: 'opentelemetry-collector',
   chart: 'opentelemetry-collector',
+  version: '0.130.2',
   repositoryOpts: {
     repo: 'https://open-telemetry.github.io/opentelemetry-helm-charts',
   },
@@ -253,6 +255,7 @@ new k8s.helm.v3.Release('opentelemetry-collector', {
 new k8s.helm.v3.Release('loki', {
   name: 'loki',
   chart: 'loki',
+  version: '6.36.1',
   repositoryOpts: {
     repo: 'https://grafana.github.io/helm-charts',
   },

--- a/apps/infra/src/k8s/postgres.ts
+++ b/apps/infra/src/k8s/postgres.ts
@@ -5,6 +5,7 @@ import { provider } from './provider';
 
 export const cloudNativePg = new k8s.helm.v3.Release('cloud-native-pg', {
   chart: 'cloudnative-pg',
+  version: '0.26.0',
   repositoryOpts: {
     repo: 'https://cloudnative-pg.github.io/charts',
   },


### PR DESCRIPTION
## Summary
Pin all Helm chart versions in infra to latest available versions to prevent automatic updates that can cause breakages.

## Why
Without pinned versions, Helm charts automatically pull the latest version during deployments, which can introduce breaking changes that require manual fixes (see #1202 and #1165 for examples).

## Changes
- ingress-nginx: 4.13.1
- cert-manager: v1.18.2  
- kube-prometheus-stack: 76.4.0
- opentelemetry-collector: 0.130.2
- loki: 6.36.1
- cloudnative-pg: 0.26.0

All versions pinned to latest available as of 2025-08-20.