### PR TITLE
UI/UX improvements and code cleanup for course resources

### DIFF
--- a/apps/website/src/components/courses/ResourceListCourseContent.tsx
+++ b/apps/website/src/components/courses/ResourceListCourseContent.tsx
@@ -258,11 +258,8 @@ const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) => {
       const feedback = completionData.resourceCompletion.resourceFeedback || RESOURCE_FEEDBACK.NO_RESPONSE;
       setResourceFeedback(feedback);
 
-      // Show feedback box if resource is completed OR if feedback has been given
-      const hasFeedback = feedback === RESOURCE_FEEDBACK.LIKE || feedback === RESOURCE_FEEDBACK.DISLIKE;
-      if (completionData.resourceCompletion.isCompleted || hasFeedback) {
-        setShowFeedback(true);
-      }
+      // Show feedback box only if resource is completed
+      setShowFeedback(completionData.resourceCompletion.isCompleted || false);
     }
   }, [completionData, hasCompletionLoaded]);
 
@@ -292,11 +289,10 @@ const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) => {
   // Handle marking resource as complete
   const handleToggleComplete = useCallback(async (newIsCompleted = !isCompleted) => {
     setIsCompleted(newIsCompleted);
-    // Keep feedback visible if user has already provided feedback
-    const hasFeedback = resourceFeedback === RESOURCE_FEEDBACK.LIKE || resourceFeedback === RESOURCE_FEEDBACK.DISLIKE;
-    setShowFeedback(newIsCompleted || hasFeedback);
+    // Show feedback only when resource is completed
+    setShowFeedback(newIsCompleted);
     await handleSaveCompletion(newIsCompleted);
-  }, [isCompleted, resourceFeedback, handleSaveCompletion]);
+  }, [isCompleted, handleSaveCompletion]);
 
   // Handle like/dislike feedback
   const handleFeedback = useCallback(async (feedbackValue: typeof RESOURCE_FEEDBACK.LIKE | typeof RESOURCE_FEEDBACK.DISLIKE) => {

--- a/apps/website/src/components/courses/ResourceListCourseContent.tsx
+++ b/apps/website/src/components/courses/ResourceListCourseContent.tsx
@@ -381,7 +381,6 @@ const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) => {
                           href={resource.resourceLink}
                           target="_blank"
                           rel="noopener noreferrer"
-                          onClick={() => handleToggleComplete(true)}
                           className="no-underline hover:underline hover:text-[#2244BB] text-inherit transition-colors"
                           aria-label={`${resource.resourceName} (opens in new tab)`}
                         >

--- a/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { CTALinkOrButton, Tag } from '@bluedot/ui';
+import { CTALinkOrButton } from '@bluedot/ui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';
@@ -130,9 +130,6 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={clsx('container-lined bg-white p-8 flex flex-col gap-6', className)}>
       <div className="flex flex-col gap-4">
-        <Tag variant="secondary" className="uppercase">
-          Think it through
-        </Tag>
         <div className="flex flex-col gap-2">
           <p className="bluedot-h4 not-prose">{title}</p>
           <MarkdownExtendedRenderer>{description}</MarkdownExtendedRenderer>

--- a/apps/website/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website/src/components/courses/exercises/MultipleChoice.tsx
@@ -1,7 +1,6 @@
 import {
   CTALinkOrButton,
   Input,
-  Tag,
 } from '@bluedot/ui';
 import clsx from 'clsx';
 import React, { useCallback, useEffect } from 'react';
@@ -90,9 +89,6 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={clsx('multiple-choice container-lined bg-white p-8 flex flex-col gap-6', className)}>
       <div className="multiple-choice__header flex flex-col gap-4">
-        <Tag variant="secondary" className="uppercase">
-          Quiz
-        </Tag>
         <div className="multiple-choice__header-content flex flex-col gap-2">
           <p className="multiple-choice__title bluedot-h4 not-prose">{title}</p>
           <MarkdownExtendedRenderer className="multiple-choice__description">{description}</MarkdownExtendedRenderer>

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -8,12 +8,6 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
     <div
       class="flex flex-col gap-4"
     >
-      <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
-        role="status"
-      >
-        Think it through
-      </span>
       <div
         class="flex flex-col gap-2"
       >
@@ -133,12 +127,6 @@ exports[`FreeTextResponse > renders logged in as expected 1`] = `
     <div
       class="flex flex-col gap-4"
     >
-      <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
-        role="status"
-      >
-        Think it through
-      </span>
       <div
         class="flex flex-col gap-2"
       >
@@ -225,12 +213,6 @@ exports[`FreeTextResponse > renders with saved exercise response 1`] = `
     <div
       class="flex flex-col gap-4"
     >
-      <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
-        role="status"
-      >
-        Think it through
-      </span>
       <div
         class="flex flex-col gap-2"
       >

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -8,12 +8,6 @@ exports[`MultipleChoice > renders default as expected 1`] = `
     <div
       class="multiple-choice__header flex flex-col gap-4"
     >
-      <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
-        role="status"
-      >
-        Quiz
-      </span>
       <div
         class="multiple-choice__header-content flex flex-col gap-2"
       >
@@ -148,12 +142,6 @@ exports[`MultipleChoice > renders logged in as expected 1`] = `
     <div
       class="multiple-choice__header flex flex-col gap-4"
     >
-      <span
-        class="tag inline-flex items-center px-4 py-2 text-xs font-semibold w-fit !text-bluedot-normal bg-[#E5EDFE] rounded-sm uppercase"
-        role="status"
-      >
-        Quiz
-      </span>
       <div
         class="multiple-choice__header-content flex flex-col gap-2"
       >

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -46,6 +46,11 @@ exports[`CourseSection > renders as expected 1`] = `
                 >
                   Featured Course
                 </h3>
+                <p
+                  class="course-card__subtitle overflow-hidden text-bluedot-black text-ellipsis mb-6 bluedot-p"
+                >
+                  Short description
+                </p>
                 <button
                   class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
                   type="button"
@@ -56,11 +61,6 @@ exports[`CourseSection > renders as expected 1`] = `
                     Start learning for free
                   </span>
                 </button>
-                <p
-                  class="course-card__subtitle overflow-hidden text-bluedot-black text-ellipsis mb-6 bluedot-p"
-                >
-                  Short description
-                </p>
               </div>
               <div
                 class="course-card__image-container shrink-0 md:max-w-[60%] w-fit mb-6"

--- a/libraries/ui/src/CourseCard.tsx
+++ b/libraries/ui/src/CourseCard.tsx
@@ -51,6 +51,11 @@ const FeaturedCourseCard: React.FC<CourseCardProps> = ({
           <h3 className="course-card__title mb-6 bluedot-h3">
             {title}
           </h3>
+          {description && (
+            <p className="course-card__subtitle overflow-hidden text-bluedot-black text-ellipsis mb-6 bluedot-p">
+              {description}
+            </p>
+          )}
           <CTALinkOrButton
             className="course-card__cta mb-6 px-6"
             variant="primary"
@@ -58,11 +63,6 @@ const FeaturedCourseCard: React.FC<CourseCardProps> = ({
           >
             {applyByText(applicationDeadline)}
           </CTALinkOrButton>
-          {description && (
-            <p className="course-card__subtitle overflow-hidden text-bluedot-black text-ellipsis mb-6 bluedot-p">
-              {description}
-            </p>
-          )}
         </div>
         {imageSrc && (
         <div className={clsx('course-card__image-container shrink-0 md:max-w-[60%] w-fit mb-6', imageClassName)}>

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -18,6 +18,11 @@ exports[`CourseCard > renders Featured as expected 1`] = `
         >
           Title
         </h3>
+        <p
+          class="course-card__subtitle overflow-hidden text-bluedot-black text-ellipsis mb-6 bluedot-p"
+        >
+          Description
+        </p>
         <button
           class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
           type="button"
@@ -28,11 +33,6 @@ exports[`CourseCard > renders Featured as expected 1`] = `
             Start learning for free
           </span>
         </button>
-        <p
-          class="course-card__subtitle overflow-hidden text-bluedot-black text-ellipsis mb-6 bluedot-p"
-        >
-          Description
-        </p>
       </div>
       <div
         class="course-card__image-container shrink-0 md:max-w-[60%] w-fit mb-6"


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

This PR consolidates several UI/UX improvements and code cleanup tasks focused on the course resource experience:

- **Visual hierarchy improvements**: Moved course descriptions above CTA buttons in CourseCard components for better information flow
- **UI cleanup**: Removed redundant "Think it through" and "Quiz" tags from exercise components to reduce visual clutter
- **User control enhancement**: Removed automatic completion marking when clicking external resource links, giving users explicit control over their progress tracking
- **Logic simplification**: Streamlined feedback visibility to only show when resources are actually completed, eliminating edge cases where feedback could persist incorrectly. When a user clicks "complete", then clicks "Like", then clicks "uncomplete", the Like/Dislike buttons will now disappear instead of staying around. 

The changes collectively improve user experience by providing clearer information hierarchy, more predictable behaviour, and a cleaner interface whilst simplifying the underlying code.

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

|**Before**|**After**|
|---------|---|
| <img width="1346" height="1250" alt="CleanShot 2025-08-20 at 19 37 52@2x" src="https://github.com/user-attachments/assets/3d771a24-bf81-4165-be67-e7f28e7ad6de" /> | <img width="1552" height="1358" alt="CleanShot 2025-08-20 at 19 38 20@2x" src="https://github.com/user-attachments/assets/eade7837-db98-42dc-8361-ae5a41feb72f" /> |
| <img width="642" height="514" alt="CleanShot 2025-08-20 at 19 40 35@2x" src="https://github.com/user-attachments/assets/a0b0e379-26a5-4e5a-9dd9-d6726a01b118" /> | <img width="608" height="576" alt="CleanShot 2025-08-20 at 19 41 00@2x" src="https://github.com/user-attachments/assets/bc53c292-264f-4cad-96cd-e12e0c6fc839" />| 