### PR TITLE
[Feature] Schema changes to support group discussion and group switching UI

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -313,7 +313,7 @@ export const groupDiscussionTable = pgAirtable('group_discussion', {
       airtableId: 'fldRV2aVcMiNZMViJ',
     },
     unitNumber: {
-      pgColumn: numeric({ mode: 'number' }),
+      pgColumn: text(),
       airtableId: 'fldbNYACt7S5J2QlU',
     },
     zoomLink: {

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -336,7 +336,7 @@ export const groupSwitchingTable = pgAirtable('group_switching', {
   tableId: 'tblGCHwcMcDrl57OY',
   columns: {
     participant: {
-      pgColumn: text().notNull(),
+      pgColumn: text(),
       airtableId: 'fldMb4VAcZUtgX8bw',
     },
     requestStatus: {
@@ -360,11 +360,11 @@ export const groupSwitchingTable = pgAirtable('group_switching', {
       airtableId: 'fldl3oYgHUrigqv1s',
     },
     newDiscussion: {
-      pgColumn: text(),
+      pgColumn: text().array().notNull(),
       airtableId: 'fldJBqQyf7b0zR6v0',
     },
     oldDiscussion: {
-      pgColumn: text(),
+      pgColumn: text().array().notNull(),
       airtableId: 'fldqHnismQINb0lsw',
     },
     unit: {

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -284,6 +284,10 @@ export const groupDiscussionTable = pgAirtable('group_discussion', {
       pgColumn: text().array().notNull(),
       airtableId: 'fldEKYwcacAa6nBEE',
     },
+    participantEmailsExpected: {
+      pgColumn: text().array().notNull(),
+      airtableId: 'fldlxiqFYcDGKqJt4',
+    },
     attendees: {
       pgColumn: text().array().notNull(),
       airtableId: 'fldo0xEi6vJKSJlFN',
@@ -303,6 +307,73 @@ export const groupDiscussionTable = pgAirtable('group_discussion', {
     zoomAccount: {
       pgColumn: text(),
       airtableId: 'fldH0pKnEELPI65Qs',
+    },
+    courseSite: {
+      pgColumn: text(),
+      airtableId: 'fldRV2aVcMiNZMViJ',
+    },
+    unitNumber: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldbNYACt7S5J2QlU',
+    },
+    zoomLink: {
+      pgColumn: text(),
+      airtableId: 'fld5H5CNHA0B0EnYF',
+    },
+    activityDoc: {
+      pgColumn: text(),
+      airtableId: 'fldR74MrOB3EvDnmw',
+    },
+    slackChannelId: {
+      pgColumn: text(),
+      airtableId: 'fldYFQwPDKdzIAy93',
+    },
+  },
+});
+
+export const groupSwitchingTable = pgAirtable('group_switching', {
+  baseId: COURSE_RUNNER_BASE_ID,
+  tableId: 'tblGCHwcMcDrl57OY',
+  columns: {
+    participant: {
+      pgColumn: text().notNull(),
+      airtableId: 'fldMb4VAcZUtgX8bw',
+    },
+    requestStatus: {
+      pgColumn: text().notNull(),
+      airtableId: 'flddokGe6ZjpmXXgu',
+    },
+    switchType: {
+      pgColumn: text().notNull(),
+      airtableId: 'fldmQas5lXJw7cIvS',
+    },
+    notesFromParticipant: {
+      pgColumn: text(),
+      airtableId: 'fldnLvbwwrFdzqGez',
+    },
+    oldGroup: {
+      pgColumn: text(),
+      airtableId: 'fld01AHEGhcNGqBx4',
+    },
+    newGroup: {
+      pgColumn: text(),
+      airtableId: 'fldl3oYgHUrigqv1s',
+    },
+    newDiscussion: {
+      pgColumn: text(),
+      airtableId: 'fldJBqQyf7b0zR6v0',
+    },
+    oldDiscussion: {
+      pgColumn: text(),
+      airtableId: 'fldqHnismQINb0lsw',
+    },
+    unit: {
+      pgColumn: text(),
+      airtableId: 'fldkBE6yK6PS84qKv',
+    },
+    manualRequest: {
+      pgColumn: boolean(),
+      airtableId: 'fldiXRWPVR1sCH17y',
     },
   },
 });


### PR DESCRIPTION
# Description

These are all the schema changes that I believe are required for adding [Next discussion info](https://github.com/bluedotimpact/bluedot/issues/1209) and [Group switching](https://github.com/bluedotimpact/bluedot/issues/1210). I'm putting these out now so they are ready to use in development.

I'll shortly put up another PR which sets up the scaffolding for displaying group discussions, and then we should be able to work on individual features (buttons in [this Figma](https://www.figma.com/design/6PJJZThivMuDTZ9xcoWvBs/Group-switching-UI?node-id=3037-441&t=s6zDvjAAKGInxNQz-0)) in parallel.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1209, #1210

## Testing

I have tested this on a local instance of Postgres + pg-sync-service, the fields do come through and I was able to select on them in #1221


