### PR TITLE
[Bug] Fix type of unitNumber in groupDiscussionTable

### DIFF
--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion.ts
@@ -38,7 +38,7 @@ export default makeApiRoute({
       and(
         sql`${groupDiscussionTable.pg.participantEmailsExpected} @> ARRAY[${auth.email}]`,
         sql`${groupDiscussionTable.pg.courseSite} ~ ${`${courseSlug}/?$`}`,
-        eq(groupDiscussionTable.pg.unitNumber, unitNumber),
+        eq(groupDiscussionTable.pg.unitNumber, parseInt(unitNumber, 10)),
         sql`${groupDiscussionTable.pg.endDateTime} > ${cutoffTimeSeconds}`,
       ),
     )

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -313,7 +313,7 @@ export const groupDiscussionTable = pgAirtable('group_discussion', {
       airtableId: 'fldRV2aVcMiNZMViJ',
     },
     unitNumber: {
-      pgColumn: text(),
+      pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldbNYACt7S5J2QlU',
     },
     zoomLink: {


### PR DESCRIPTION
# Description

Reverts [one commit](https://github.com/bluedotimpact/bluedot/pull/1220/commits/f8ef104af184a33676f20f08f81825b223b16ec4) from #1220 which I added to make the type of `unitNumber` consistent across tables. It turns out the type is actually different in the "Course runner" base vs "Course builder", and this is causing the syncing of `group_discussion` to fail.

By default, deploying this PR will cause an error like "Failed to update database schema: column "unitNumber" cannot be cast automatically to type numeric" when deployed. I'll manually drop and re-add the column in the db just before deploying to work around this (I could do two deployments to drop and re-add the column, but given the syncing is already failing I think it's best to get this out as quick as possible).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1209 