### PR TITLE
[fix]: removing chunk types on desktop and mobile

### DIFF
--- a/apps/website/src/components/courses/MobileCourseModal.tsx
+++ b/apps/website/src/components/courses/MobileCourseModal.tsx
@@ -471,10 +471,6 @@ export const MobileCourseModal: React.FC<MobileCourseModalProps> = ({
                                 <div className="flex flex-col flex-1 min-h-[44px]">
                                   {/* Chunk content wrapper with proper spacing */}
                                   <div className="flex flex-col gap-[6px]">
-                                    {/* Chunk Type */}
-                                    <p className="font-semibold text-[14px] leading-[150%] text-[#13132E]">
-                                      {chunk.chunkType}:
-                                    </p>
                                     {/* Chunk Title */}
                                     <p className="font-normal text-[14px] leading-[150%] text-[#13132E]">
                                       {chunk.chunkTitle}

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -86,10 +86,6 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
                   <div className="flex flex-col items-start p-0 flex-1 min-h-[68px]">
                     {/* Chunk content wrapper with proper spacing */}
                     <div className="flex flex-col items-start gap-[6px]">
-                      {/* Chunk Type */}
-                      <p className="font-semibold text-[14px] leading-[150%] text-[#13132E]">
-                        {chunk.chunkType}:
-                      </p>
                       {/* Chunk Title */}
                       <p className="font-normal text-[14px] leading-[150%] text-[#13132E]">
                         {chunk.chunkTitle}

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -129,12 +129,6 @@ exports[`SideBar > renders default as expected 1`] = `
                   class="flex flex-col items-start gap-[6px]"
                 >
                   <p
-                    class="font-semibold text-[14px] leading-[150%] text-[#13132E]"
-                  >
-                    Reading
-                    :
-                  </p>
-                  <p
                     class="font-normal text-[14px] leading-[150%] text-[#13132E]"
                   >
                     What can AI do today?

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -242,12 +242,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                     class="flex flex-col items-start gap-[6px]"
                   >
                     <p
-                      class="font-semibold text-[14px] leading-[150%] text-[#13132E]"
-                    >
-                      Reading
-                      :
-                    </p>
-                    <p
                       class="font-normal text-[14px] leading-[150%] text-[#13132E]"
                     >
                       What can AI do today?
@@ -268,12 +262,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                   <div
                     class="flex flex-col items-start gap-[6px]"
                   >
-                    <p
-                      class="font-semibold text-[14px] leading-[150%] text-[#13132E]"
-                    >
-                      Reading
-                      :
-                    </p>
                     <p
                       class="font-normal text-[14px] leading-[150%] text-[#13132E]"
                     >


### PR DESCRIPTION
# Description
Implementing part of Issue #1215: Removing chunk types on desktop and mobile. Will follow up with another PR for icons pending:

> "Alex will propose a new design which more clearly describes the "completed" state for a specific chunk."


## Issue
Implementing part of #1215 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
### Desktop
<img width="356" height="758" alt="chunk-type-removal-desktop" src="https://github.com/user-attachments/assets/e4c91b95-6c08-46b5-9b0c-b5ab7431dff2" />

### Mobile
<img width="385" height="654" alt="chunk-type-removal-mobile" src="https://github.com/user-attachments/assets/8ecfb0ab-baff-49fa-bf93-7d72a0bebd13" />

