### PR TITLE
[Feat] Add claude code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,94 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Allow Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Allow Claude to run common development commands for this monorepo
+          allowed_tools: |
+            Bash(npm install)
+            Bash(npm run build)
+            Bash(npm run test)
+            Bash(npm run test:*)
+            Bash(npm run lint)
+            Bash(npm run lint:fix)
+            Bash(turbo run *)
+            Bash(npm run start --workspace=*)
+
+          # Custom instructions tailored to this monorepo
+          custom_instructions: |
+            This is a TypeScript monorepo using Turbo for build orchestration and npm workspaces.
+            
+            Project Structure:
+            - apps/: Contains multiple applications (Next.js apps, backend services, etc.)
+            - libraries/: Shared libraries and packages
+            - Uses Turbo for efficient builds and task running
+            - Node.js 22 and npm 10.7.0
+            - AGPL-3.0 license
+            
+            Development Guidelines:
+            - Follow the existing TypeScript and ESLint configuration
+            - Use the turbo commands for building and testing across workspaces
+            - When making changes, consider the impact on other packages in the monorepo
+            - Run tests and linting before suggesting changes
+            - Respect the workspace structure and dependencies
+            - Use npm workspaces syntax when working with specific apps/libraries
+            
+            Common Commands:
+            - `npm run build` - Build all packages
+            - `npm run test` - Run all tests
+            - `npm run lint` - Lint all packages
+            - `turbo run <command>` - Run commands across workspaces efficiently
+            
+            When implementing changes:
+            1. Understand the monorepo structure and affected packages
+            2. Run appropriate tests and linting
+            3. Consider cross-package dependencies
+            4. Follow existing code patterns and conventions
+
+          # Environment variables for development
+          claude_env: |
+            NODE_ENV: development
+            TURBO_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
# Description
I saw Anthropic staff doing @claude in their repos, which seemed awesome. See [this PR](https://github.com/modelcontextprotocol/registry/pull/289) from Adam. I thought I'd copy it. 

Learn more about this functionality [here](https://github.com/marketplace/actions/claude-code-action-official).

I've added the Anthropic API key as a secret to the repo. 

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories