### PR TITLE
[Feature] Support --initial-sync-tables flag in pg-sync-service to restrict initial sync to specific tables

### DIFF
--- a/apps/pg-sync-service/README.md
+++ b/apps/pg-sync-service/README.md
@@ -18,5 +18,5 @@ npm run start -- --initial-sync-tables course person user
 ## How it works
 
 1. **Webhooks**: Creates [Airtable webhooks](https://airtable.com/developers/web/api/webhooks-overview) for each base and polls them for changes
-2. **Initial sync**: When started with `--initial-sync`, or when no sync has occured in the last 24 hours, performs a full scan of each table to sync existing data. Use `--initial-sync-tables` to limit initial sync to specific postgres tables while keeping all webhook syncing active, this is useful for testing schema changes in development.
+2. **Initial sync**: When started with `--initial-sync`, or when no sync has occurred in the last 24 hours, performs a full scan of each table to sync existing data. Use `--initial-sync-tables` to limit initial sync to specific postgres tables while keeping all webhook syncing active, this is useful for testing schema changes in development.
 3. **Ongoing sync**: Continuously polls webhooks and replicates changes to PostgreSQL using the `@bluedot/db` library

--- a/apps/pg-sync-service/src/index.ts
+++ b/apps/pg-sync-service/src/index.ts
@@ -37,6 +37,10 @@ const start = async () => {
 
     const initialSyncTableNames = hasInitialSyncTablesFlag ? getInitialSyncTableNames(process.argv) : undefined;
 
+    if (initialSyncTableNames && initialSyncTableNames.length === 0) {
+      throw new Error('Flag --initial-sync-tables requires at least one table name. Example: --initial-sync-tables course person user');
+    }
+
     const schemaChangesDetected = await ensureSchemaUpToDate();
 
     const instance = await getInstance();

--- a/apps/pg-sync-service/src/lib/scan.ts
+++ b/apps/pg-sync-service/src/lib/scan.ts
@@ -112,7 +112,7 @@ export async function performFullSync(
 
   if (limitToTables) {
     const foundPgNames = new Set(tableFieldMappings.map((r) => r.pgTable));
-    const missingPgNames = new Set([...limitToTables].filter((x) => !foundPgNames.has(x)));
+    const missingPgNames = new Set(limitToTables.filter((x) => !foundPgNames.has(x)));
 
     if (missingPgNames.size) {
       logger.warn(`Failed to find some of the tables given by --initial-sync-tables: ${Array.from(missingPgNames).join(', ')}`);


### PR DESCRIPTION
# Description

I'm finding it useful to sync individual tables locally when iterating on schema changes, so I'm adding the ability to do this with a flag


## Issue

Prompted by #1210 

## Developer checklist

N/A

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

N/A