### PR TITLE
[feat]: Removing whitespace in the chunk pages

### DIFF
--- a/apps/website/src/components/courses/MarkdownExtendedRenderer.test.tsx
+++ b/apps/website/src/components/courses/MarkdownExtendedRenderer.test.tsx
@@ -6,7 +6,7 @@ describe('MarkdownExtendedRenderer', () => {
   test('renders nothing when children is undefined', () => {
     const { container } = render(<MarkdownExtendedRenderer />);
     const element = container.querySelector('.markdown-extended-renderer');
-    expect(element?.children.length).toBe(0);
+    expect(element).toBeNull();
   });
 
   test('renders nothing when children is empty string', () => {
@@ -17,7 +17,7 @@ describe('MarkdownExtendedRenderer', () => {
       </MarkdownExtendedRenderer>,
     );
     const element = container.querySelector('.markdown-extended-renderer');
-    expect(element?.children.length).toBe(0);
+    expect(element).toBeNull();
   });
 
   test('renders basic markdown content', async () => {

--- a/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -61,6 +61,7 @@ export const getSupportedComponents = () => ({
 
 const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, className }) => {
   const [Component, setComponent] = React.useState<MDXContent | null>(null);
+
   useEffect(() => {
     if (!children) {
       return;
@@ -76,6 +77,11 @@ const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, c
       setComponent(() => evalResult.default);
     })();
   }, [children, setComponent]);
+
+  // Return null if there's no content to avoid rendering empty containers
+  if (!children || !children.trim()) {
+    return null;
+  }
 
   return (
     // See @utility prose in globals.css for advanced styles

--- a/apps/website/src/components/courses/ResourceDisplay.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.tsx
@@ -97,7 +97,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
 
       {/* Exercises */}
       {exercises.length > 0 && (
-        <section className="mt-8">
+        <section className={`${coreResources.length > 0 || unitDescription ? 'mt-8' : ''}`}>
           <h4
             id={exercisesHeadingId}
             className="text-[20px] font-semibold leading-[140%] tracking-normal mb-6 bluedot-h4 not-prose"

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -380,16 +380,18 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
       {/* Main content section - positioned below breadcrumbs */}
       <Section className="unit__main !border-none !pt-0 !mt-0">
         <div className={clsx(
-          'unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto gap-8 md:gap-6 px-5 sm:px-spacing-x pt-6 md:pt-8',
+          'unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto px-5 sm:px-spacing-x pt-6 md:pt-8',
           !isSidebarHidden && 'md:ml-[360px]',
         )}
         >
           {groupDiscussion && (
-            <GroupDiscussionBanner
-              unit={unit}
-              groupDiscussion={groupDiscussion}
-              onClickPrepare={() => handleChunkSelect(0)}
-            />
+            <div className="mb-8 md:mb-6">
+              <GroupDiscussionBanner
+                unit={unit}
+                groupDiscussion={groupDiscussion}
+                onClickPrepare={() => handleChunkSelect(0)}
+              />
+            </div>
           )}
           <div className="unit__title-container">
             <P className="unit__course-title font-semibold text-[13px] leading-[140%] tracking-[0.04em] uppercase text-[#2244BB] mb-2">Unit {unit.unitNumber}: {unit.title}</P>
@@ -397,19 +399,27 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
               <H1 className="unit__title font-bold text-[32px] leading-[130%] tracking-[-0.015em] text-[#13132E]">{chunks[currentChunkIndex].chunkTitle}</H1>
             )}
           </div>
-          {/* chunk content → unit content if no chunks */}
-          <MarkdownExtendedRenderer>
-            {chunks[currentChunkIndex]?.chunkContent || unit.content || ''}
-          </MarkdownExtendedRenderer>
+          {/* chunk content → unit content if no chunks - Only render if there's actual content */}
+          {(chunks[currentChunkIndex]?.chunkContent || unit.content) && (
+            <MarkdownExtendedRenderer className="mt-8 md:mt-6">
+              {chunks[currentChunkIndex]?.chunkContent || unit.content || ''}
+            </MarkdownExtendedRenderer>
+          )}
 
-          {/* Chunk resources and exercises - Only displays if we used chunkContent instead of unit content to prevent resources from showing up twice */}
-          {chunks[currentChunkIndex]?.chunkContent && (
-            <ResourceDisplay
-              resources={chunks[currentChunkIndex].resources || []}
-              exercises={chunks[currentChunkIndex].exercises || []}
-              unitTitle={unit.title}
-              unitNumber={unitNumber}
-            />
+          {/* Chunk resources and exercises - Show if there are any resources or exercises */}
+          {chunks[currentChunkIndex] && (
+            (chunks[currentChunkIndex].resources?.length || chunks[currentChunkIndex].exercises?.length) && (
+              <ResourceDisplay
+                resources={chunks[currentChunkIndex].resources || []}
+                exercises={chunks[currentChunkIndex].exercises || []}
+                unitTitle={unit.title}
+                unitNumber={unitNumber}
+                className={clsx(
+                  // Add top margin only if there's content above it
+                  (chunks[currentChunkIndex]?.chunkContent || unit.content) ? 'mt-8 md:mt-6' : 'mt-4',
+                )}
+              />
+            )
           )}
 
           {/* Keyboard navigation hint */}

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -545,7 +545,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
         class="section__body"
       >
         <div
-          class="unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto gap-8 md:gap-6 px-5 sm:px-spacing-x pt-6 md:pt-8 md:ml-[360px]"
+          class="unit__content flex flex-col flex-1 max-w-full md:max-w-[680px] lg:max-w-[800px] xl:max-w-[900px] mx-auto px-5 sm:px-spacing-x pt-6 md:pt-8 md:ml-[360px]"
         >
           <div
             class="unit__title-container"
@@ -565,7 +565,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             </h1>
           </div>
           <div
-            class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none"
+            class="markdown-extended-renderer prose prose-p:text-[16px] prose-li:text-[16px] prose-p:leading-[160%] prose-li:leading-[160%] prose-p:tracking-[-0.002em] prose-li:tracking-[-0.002em] prose-p:font-normal prose-li:font-normal prose-p:font-sans prose-li:font-sans prose-strong:font-sans prose-strong:font-semibold prose-strong:text-[16px] prose-strong:leading-[160%] prose-strong:tracking-[-0.002em] prose-a:font-normal prose-a:underline max-w-none mt-8 md:mt-6"
           >
             <p>
               Five years ago, AI systems struggled to form coherent sentences. Today, &gt;5% of the world use AI products like ChatGPT every week for help with work, studies, and creative projects. These systems extend far beyond a simple chat. They can produce art, write complex code, and control robots to do real-world tasks.
@@ -576,10 +576,6 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               This unit explores how AI is evolving from simple "tools" into autonomous "agents",  capable of setting goals, making complex plans, and acting in the real world.
             </p>
           </div>
-          <section
-            aria-label="Unit 1: Basic Principles of Fish"
-            class="resource-display "
-          />
           <div
             class="unit__keyboard-hint text-size-xs text-color-secondary mt-4"
           >


### PR DESCRIPTION
# Description
If a chunk has no text, there's a big gap between the title and the "Resources" heading. Likewise if there's no text and resources, there's a big gap to the "Exercises" heading. This commit fixes this. I ran npm run build to ensure everything was working. 

Auto-generated commit message: 
Fix MarkdownExtendedRenderer to return null for empty content

- Return null instead of empty div when no content is provided
- Update tests to expect null element rather than empty container
- Improve spacing logic in ResourceDisplay and UnitLayout components
- Wrap GroupDiscussionBanner in proper margin container

## Screenshot
**Before on the left, after on the right.** 

With resources, but no content
<img width="5120" height="2880" alt="CleanShot 2025-08-23 at 22 31 44@2x" src="https://github.com/user-attachments/assets/4b207677-8ea9-4f6e-b93c-2c7a016ef3c2" />

With exercises, but no content and resources
<img width="5120" height="2880" alt="CleanShot 2025-08-23 at 22 31 35@2x" src="https://github.com/user-attachments/assets/efcfe542-74dc-4065-ae09-20cf67ce6f63" />

With content and exercises, but no resources
<img width="5120" height="2880" alt="CleanShot 2025-08-23 at 22 31 16@2x" src="https://github.com/user-attachments/assets/96bc2cf8-84c7-4672-a5e3-30b07b5a6280" />