### PR TITLE
[Bug]: Prevent "0" being treated as text, rather than as a truthy condition.

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -407,8 +407,8 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
           )}
 
           {/* Chunk resources and exercises - Show if there are any resources or exercises */}
-          {chunks[currentChunkIndex] && (
-            (chunks[currentChunkIndex].resources?.length || chunks[currentChunkIndex].exercises?.length) && (
+          {chunks[currentChunkIndex]
+            && (chunks[currentChunkIndex].resources?.length || chunks[currentChunkIndex].exercises?.length) ? (
               <ResourceDisplay
                 resources={chunks[currentChunkIndex].resources || []}
                 exercises={chunks[currentChunkIndex].exercises || []}
@@ -419,8 +419,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
                   (chunks[currentChunkIndex]?.chunkContent || unit.content) ? 'mt-8 md:mt-6' : 'mt-4',
                 )}
               />
-            )
-          )}
+            ) : null}
 
           {/* Keyboard navigation hint */}
           <div className="unit__keyboard-hint text-size-xs text-color-secondary mt-4">


### PR DESCRIPTION
# Description

#1234 introduced a bug into staging where if a chunk has content but no resources or exercises, React renders "0" text on the page.  

Auto-generated message: 
Refactor conditional rendering logic in UnitLayout component
Replace nested conditional statements with ternary operator for cleaner code structure when displaying chunk resources and exercises.

# Screenshot
<!-- If this PR results in visual changes -->

| Before | After |
|---------|---|
| <img width="894" height="456" alt="CleanShot 2025-08-24 at 10 37 06@2x" src="https://github.com/user-attachments/assets/2140391f-5b6b-4467-ac4b-ea54842946ef" /> | <img width="862" height="418" alt="CleanShot 2025-08-24 at 10 37 03@2x" src="https://github.com/user-attachments/assets/104cfd67-456f-40b8-9882-1f64bb009842" /> |
