### PR TITLE
Fix sidebar chunk alignment from start to center

### DIFF
--- a/apps/website/src/components/courses/MobileCourseModal.tsx
+++ b/apps/website/src/components/courses/MobileCourseModal.tsx
@@ -464,7 +464,7 @@ export const MobileCourseModal: React.FC<MobileCourseModalProps> = ({
                                 key={chunk.id}
                                 onClick={() => handleChunkClick(index)}
                                 className={clsx(
-                                  'flex items-start px-6 py-4 gap-3 text-left transition-colors rounded-lg',
+                                  'flex items-center px-6 py-4 gap-3 text-left transition-colors rounded-lg',
                                   isActive ? 'bg-[rgba(42,45,52,0.05)]' : 'hover:bg-[rgba(42,45,52,0.05)]',
                                 )}
                               >

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -78,7 +78,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
                   key={chunk.id}
                   onClick={() => onChunkSelect(index)}
                   className={clsx(
-                    'flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] text-left transition-colors',
+                    'flex flex-row items-center p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] text-left transition-colors',
                     isActive ? 'bg-[rgba(42,45,52,0.05)] rounded-[10px]' : 'hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px]',
                   )}
                 >

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`SideBar > renders default as expected 1`] = `
             class="flex flex-col items-start px-0 pb-[16px] gap-[4px]"
           >
             <button
-              class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
+              class="flex flex-row items-center p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
               type="button"
             >
               <svg

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
               class="flex flex-col items-start px-0 pb-[16px] gap-[4px]"
             >
               <button
-                class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
+                class="flex flex-row items-center p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] text-left transition-colors bg-[rgba(42,45,52,0.05)] rounded-[10px]"
                 type="button"
               >
                 <svg
@@ -237,7 +237,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
                 </div>
               </button>
               <button
-                class="flex flex-row items-start p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] text-left transition-colors hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px]"
+                class="flex flex-row items-center p-[16px] gap-[12px] mx-[24px] w-[calc(100%-48px)] text-left transition-colors hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px]"
                 type="button"
               >
                 <svg


### PR DESCRIPTION
# Description

Super small fix. The circle wasn't vertically centred, which bugged me. 

Changed "start" to "center" in the code. 

## Screenshot
Before on the left, after on the right. 
<img width="5120" height="2880" alt="CleanShot 2025-08-24 at 22 44 06@2x" src="https://github.com/user-attachments/assets/1558d7eb-1ad9-4b82-8714-5166d534a3d0" />