### PR TITLE
[Feature] Allow announcement banners to be dismissed

### DIFF
--- a/apps/website/src/components/AnnouncementBanner.test.tsx
+++ b/apps/website/src/components/AnnouncementBanner.test.tsx
@@ -6,7 +6,7 @@ import {
   test,
 } from 'vitest';
 import { useAnnouncementBannerStore } from '../stores/announcementBanner';
-import { AnnouncementBanner } from './AnnouncementBanner';
+import { AnnouncementBanner, getAnnouncementBannerKey } from './AnnouncementBanner';
 
 describe('AnnouncementBanner', () => {
   beforeEach(() => {
@@ -123,16 +123,15 @@ describe('AnnouncementBanner', () => {
   });
 
   test('does not render when banner has been dismissed', () => {
-    const ctaText = 'Learn more';
-    const ctaUrl = 'https://example.com';
-    const bannerKey = `${ctaText}-${ctaUrl}`;
+    const textContent = 'Test Announcement';
+    const bannerKey = getAnnouncementBannerKey(textContent);
 
     // Set up dismissed banner state
     useAnnouncementBannerStore.setState({ dismissedBanners: { [bannerKey]: true } });
 
     const { container } = render(
-      <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
-        Test Announcement
+      <AnnouncementBanner>
+        {textContent}
       </AnnouncementBanner>,
     );
 
@@ -144,7 +143,7 @@ describe('AnnouncementBanner', () => {
   test('renders when banner has not been dismissed', () => {
     // Initial state has no dismissed banners (set in beforeEach)
     render(
-      <AnnouncementBanner ctaText="Learn more" ctaUrl="https://example.com">
+      <AnnouncementBanner>
         Test Announcement
       </AnnouncementBanner>,
     );
@@ -155,23 +154,36 @@ describe('AnnouncementBanner', () => {
   });
 
   test('calls dismissBanner when close button is clicked', () => {
-    const ctaText = 'Click Here';
-    const ctaUrl = 'https://example.com';
-    const bannerKey = `${ctaText}-${ctaUrl}`;
+    const textContent = 'Test Announcement';
+    const bannerKey = getAnnouncementBannerKey(textContent);
 
     render(
-      <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
-        Test Announcement
+      <AnnouncementBanner>
+        {textContent}
       </AnnouncementBanner>,
     );
+
+    // Banner is initially shown
+    const banner = document.querySelector('.announcement-banner');
+    expect(banner).toBeDefined();
 
     const closeButton = screen.getByRole('button', { name: 'Close announcement' });
     fireEvent.click(closeButton);
 
     expect(useAnnouncementBannerStore.getState().dismissedBanners).toEqual({ [bannerKey]: true });
 
-    // Banner should not be rendered
-    const banner = document.querySelector('.announcement-banner');
-    expect(banner).toBeNull();
+    // Re-query the banner after dismiss
+    const bannerAfterDismiss = document.querySelector('.announcement-banner');
+    // Banner should be closed
+    expect(bannerAfterDismiss).toBeNull();
+  });
+
+  test('getAnnouncementBannerKey produces consistent keys', () => {
+    const key1 = getAnnouncementBannerKey('Sample Announcement');
+    const key2 = getAnnouncementBannerKey('Sample Announcement');
+    const key3 = getAnnouncementBannerKey('Different Announcement');
+
+    expect(key1).toBe(key2);
+    expect(key1).not.toBe(key3);
   });
 });

--- a/apps/website/src/components/AnnouncementBanner.test.tsx
+++ b/apps/website/src/components/AnnouncementBanner.test.tsx
@@ -157,6 +157,7 @@ describe('AnnouncementBanner', () => {
   test('calls dismissBanner when close button is clicked', () => {
     const ctaText = 'Click Here';
     const ctaUrl = 'https://example.com';
+    const bannerKey = `${ctaText}-${ctaUrl}`;
 
     render(
       <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
@@ -167,7 +168,6 @@ describe('AnnouncementBanner', () => {
     const closeButton = screen.getByRole('button', { name: 'Close announcement' });
     fireEvent.click(closeButton);
 
-    const bannerKey = `${ctaText}-${ctaUrl}`;
     expect(useAnnouncementBannerStore.getState().dismissedBanners).toEqual({[bannerKey]: true });
   });
 });

--- a/apps/website/src/components/AnnouncementBanner.test.tsx
+++ b/apps/website/src/components/AnnouncementBanner.test.tsx
@@ -164,5 +164,9 @@ describe('AnnouncementBanner', () => {
     fireEvent.click(closeButton);
 
     expect(useAnnouncementBannerStore.getState().dismissedBanners).toEqual({ [bannerKey]: true });
+
+    // Banner should not be rendered
+    const banner = document.querySelector('.announcement-banner');
+    expect(banner).toBeNull();
   });
 });

--- a/apps/website/src/components/AnnouncementBanner.test.tsx
+++ b/apps/website/src/components/AnnouncementBanner.test.tsx
@@ -1,10 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import {
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from 'vitest';
+import { beforeEach, describe, expect, test } from 'vitest';
 import { useAnnouncementBannerStore } from '../stores/announcementBanner';
 import { AnnouncementBanner } from './AnnouncementBanner';
 
@@ -133,7 +128,7 @@ describe('AnnouncementBanner', () => {
     const { container } = render(
       <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
         Test Announcement
-      </AnnouncementBanner>,
+      </AnnouncementBanner>
     );
 
     // Banner should not be rendered
@@ -144,9 +139,9 @@ describe('AnnouncementBanner', () => {
   test('renders when banner has not been dismissed', () => {
     // Initial state has no dismissed banners (set in beforeEach)
     render(
-      <AnnouncementBanner ctaText= 'Learn more' ctaUrl= 'https://example.com'>
+      <AnnouncementBanner ctaText="Learn more" ctaUrl="https://example.com">
         Test Announcement
-      </AnnouncementBanner>,
+      </AnnouncementBanner>
     );
 
     // Banner should be rendered
@@ -162,12 +157,12 @@ describe('AnnouncementBanner', () => {
     render(
       <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
         Test Announcement
-      </AnnouncementBanner>,
+      </AnnouncementBanner>
     );
 
     const closeButton = screen.getByRole('button', { name: 'Close announcement' });
     fireEvent.click(closeButton);
 
-    expect(useAnnouncementBannerStore.getState().dismissedBanners).toEqual({[bannerKey]: true });
+    expect(useAnnouncementBannerStore.getState().dismissedBanners).toEqual({ [bannerKey]: true });
   });
 });

--- a/apps/website/src/components/AnnouncementBanner.test.tsx
+++ b/apps/website/src/components/AnnouncementBanner.test.tsx
@@ -1,8 +1,18 @@
-import { describe, expect, test } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'vitest';
+import { useAnnouncementBannerStore } from '../stores/announcementBanner';
 import { AnnouncementBanner } from './AnnouncementBanner';
 
 describe('AnnouncementBanner', () => {
+  beforeEach(() => {
+    useAnnouncementBannerStore.setState({ dismissedBanners: {} });
+  });
+
   test('renders the banner with content', () => {
     render(<AnnouncementBanner>Test Announcement</AnnouncementBanner>);
 
@@ -110,5 +120,56 @@ describe('AnnouncementBanner', () => {
     // Banner should be rendered
     const banner = document.querySelector('.announcement-banner');
     expect(banner).toBeDefined();
+  });
+
+  test('does not render when banner has been dismissed', () => {
+    const ctaText = 'Learn more';
+    const ctaUrl = 'https://example.com';
+    const bannerKey = `${ctaText}-${ctaUrl}`;
+
+    // Set up dismissed banner state
+    useAnnouncementBannerStore.setState({ dismissedBanners: { [bannerKey]: true } });
+
+    const { container } = render(
+      <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
+        Test Announcement
+      </AnnouncementBanner>,
+    );
+
+    // Banner should not be rendered
+    const banner = container.querySelector('.announcement-banner');
+    expect(banner).toBeNull();
+  });
+
+  test('renders when banner has not been dismissed', () => {
+    const ctaText = 'Learn more';
+    const ctaUrl = 'https://example.com';
+
+    render(
+      <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
+        Test Announcement
+      </AnnouncementBanner>,
+    );
+
+    // Banner should be rendered
+    const banner = document.querySelector('.announcement-banner');
+    expect(banner).toBeDefined();
+  });
+
+  test('calls dismissBanner when close button is clicked', () => {
+    const ctaText = 'Click Here';
+    const ctaUrl = 'https://example.com';
+
+    render(
+      <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
+        Test Announcement
+      </AnnouncementBanner>,
+    );
+
+    const closeButton = screen.getByRole('button', { name: 'Close announcement' });
+    fireEvent.click(closeButton);
+
+    const bannerKey = `${ctaText}-${ctaUrl}`;
+    expect(useAnnouncementBannerStore.getState().dismissedBanners).toEqual({[bannerKey]: true });
   });
 });

--- a/apps/website/src/components/AnnouncementBanner.test.tsx
+++ b/apps/website/src/components/AnnouncementBanner.test.tsx
@@ -1,5 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, test } from 'vitest';
+import {
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'vitest';
 import { useAnnouncementBannerStore } from '../stores/announcementBanner';
 import { AnnouncementBanner } from './AnnouncementBanner';
 
@@ -128,7 +133,7 @@ describe('AnnouncementBanner', () => {
     const { container } = render(
       <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
         Test Announcement
-      </AnnouncementBanner>
+      </AnnouncementBanner>,
     );
 
     // Banner should not be rendered
@@ -141,7 +146,7 @@ describe('AnnouncementBanner', () => {
     render(
       <AnnouncementBanner ctaText="Learn more" ctaUrl="https://example.com">
         Test Announcement
-      </AnnouncementBanner>
+      </AnnouncementBanner>,
     );
 
     // Banner should be rendered
@@ -157,7 +162,7 @@ describe('AnnouncementBanner', () => {
     render(
       <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
         Test Announcement
-      </AnnouncementBanner>
+      </AnnouncementBanner>,
     );
 
     const closeButton = screen.getByRole('button', { name: 'Close announcement' });

--- a/apps/website/src/components/AnnouncementBanner.test.tsx
+++ b/apps/website/src/components/AnnouncementBanner.test.tsx
@@ -142,11 +142,9 @@ describe('AnnouncementBanner', () => {
   });
 
   test('renders when banner has not been dismissed', () => {
-    const ctaText = 'Learn more';
-    const ctaUrl = 'https://example.com';
-
+    // Initial state has no dismissed banners (set in beforeEach)
     render(
-      <AnnouncementBanner ctaText={ctaText} ctaUrl={ctaUrl}>
+      <AnnouncementBanner ctaText= 'Learn more' ctaUrl= 'https://example.com'>
         Test Announcement
       </AnnouncementBanner>,
     );

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -45,8 +45,8 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
     <div className={clsx('announcement-banner w-full py-4 bg-bluedot-lighter', className)}>
       <div className="announcement-banner__container section-base flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6">
         <P className="announcement-banner__content text-center sm:text-left">{children}</P>
-        {ctaUrl && (
-          <div className="flex gap-2">
+        <div className="flex gap-2">
+          {ctaUrl && (
             <CTALinkOrButton
               className="announcement-banner__cta"
               variant="black"
@@ -55,16 +55,16 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
             >
               {ctaText}
             </CTALinkOrButton>
-            <CTALinkOrButton
-              className="announcement-banner__close"
-              variant="outline-black"
-              aria-label="Close announcement"
-              onClick={() => dismissBanner(bannerKey)}
-            >
-              x
-            </CTALinkOrButton>
-          </div>
-        )}
+          )}
+          <CTALinkOrButton
+            className="announcement-banner__close"
+            variant="outline-black"
+            aria-label="Close announcement"
+            onClick={() => dismissBanner(bannerKey)}
+          >
+            x
+          </CTALinkOrButton>
+        </div>
       </div>
     </div>
   );

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import React from 'react';
-import clsx from 'clsx';
 import { CTALinkOrButton } from '@bluedot/ui/src/CTALinkOrButton';
-import { P } from './Text';
+import clsx from 'clsx';
+import React from 'react';
 import { useAnnouncementBannerStore } from '../stores/announcementBanner';
+import { P } from './Text';
 
 export type AnnouncementBannerProps = React.PropsWithChildren<{
   className?: string;

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { CTALinkOrButton } from '@bluedot/ui/src/CTALinkOrButton';
 import { P } from './Text';
+import { useAnnouncementBannerStore } from '../stores/announcementBanner';
 
 export type AnnouncementBannerProps = React.PropsWithChildren<{
   className?: string;
@@ -22,6 +23,8 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
   hideUntil,
   hideAfter,
 }) => {
+  const dismissBanner = useAnnouncementBannerStore((state) => state.dismissBanner);
+  const bannerKey = `${ctaText}-${ctaUrl}`;
   if (hideUntil && Date.now() < hideUntil.getTime()) {
     return null;
   }
@@ -39,13 +42,19 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
       <div className="announcement-banner__container section-base flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6">
         <P className="announcement-banner__content text-center sm:text-left">{children}</P>
         {ctaUrl && (
-          <CTALinkOrButton
-            className="announcement-banner__cta"
-            variant="secondary"
-            url={ctaUrl}
-          >
-            {ctaText}
-          </CTALinkOrButton>
+          <div className="flex gap-2">
+            <CTALinkOrButton
+              className="announcement-banner__cta"
+              variant="black"
+              aria-label={ctaText}
+              url={ctaUrl}
+            >
+              {ctaText}
+            </CTALinkOrButton>
+            <CTALinkOrButton className="announcement-banner__close" variant="outline-black" aria-label="close" onClick={() => dismissBanner(bannerKey)}>
+              x
+            </CTALinkOrButton>
+          </div>
         )}
       </div>
     </div>

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -59,7 +59,7 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
             <CTALinkOrButton
               className="announcement-banner__close"
               variant="outline-black"
-              aria-label="close"
+              aria-label="Close announcement"
               onClick={() => dismissBanner(bannerKey)}
             >
               x

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -15,7 +15,15 @@ import { P } from './Text';
  * @returns A base-36 encoded hash string that uniquely identifies the content
  */
 export const getAnnouncementBannerKey = (children: React.ReactNode) => {
-  const str = String(children);
+  const textFromNode = (node: React.ReactNode): string => {
+    if (node == null || typeof node === 'boolean') return '';
+    if (typeof node === 'string' || typeof node === 'number') return String(node);
+    if (Array.isArray(node)) return node.map(textFromNode).join(' ');
+    if (React.isValidElement(node)) return textFromNode(node.props?.children);
+    return '';
+  };
+
+  const str = textFromNode(children).trim();
   let hash = 5381;
 
   for (let i = 0; i < str.length; i++) {

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -30,7 +30,8 @@ export const getAnnouncementBannerKey = (children: React.ReactNode) => {
     hash = hash * 33 + str.charCodeAt(i);
   }
 
-  return Math.abs(hash).toString(36);
+  // Convert to a positive number and then to base-36 string, taking first 8 characters
+  return Math.abs(hash).toString(36).slice(0, 8);
 };
 
 export type AnnouncementBannerProps = React.PropsWithChildren<{

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -78,7 +78,6 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
             <CTALinkOrButton
               className="announcement-banner__cta"
               variant="black"
-              aria-label={ctaText}
               url={ctaUrl}
             >
               {ctaText}

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -12,7 +12,7 @@ import { P } from './Text';
  * Source: https://stackoverflow.com/questions/7666509/hash-function-for-string/7666577#7666577
  *
  * @param children - The React children (content) of the banner
- * @returns A base-36 encoded hash string that uniquely identifies the content
+ * @returns An 8 character base-36 encoded hash string that uniquely identifies the content
  */
 export const getAnnouncementBannerKey = (children: React.ReactNode) => {
   const textFromNode = (node: React.ReactNode): string => {

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -28,8 +28,8 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
   const bannerKey = `${ctaText}-${ctaUrl}`;
   const dismissBanner = useAnnouncementBannerStore((state) => state.dismissBanner);
   // If this banner has been dismissed (now or in the past) don't show it
-  const dismissedBanners = useAnnouncementBannerStore((state) => state.dismissedBanners);
-  if (Boolean(dismissedBanners[bannerKey])) {
+  const isDismissed = useAnnouncementBannerStore((s) => Boolean(s.dismissedBanners[bannerKey]));
+  if (isDismissed) {
     return null;
   }
 

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -43,11 +43,7 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
   }
 
   return (
-    <div className={clsx(
-      'announcement-banner w-full py-4 bg-bluedot-lighter',
-      className,
-    )}
-    >
+    <div className={clsx('announcement-banner w-full py-4 bg-bluedot-lighter', className)}>
       <div className="announcement-banner__container section-base flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6">
         <P className="announcement-banner__content text-center sm:text-left">{children}</P>
         {ctaUrl && (
@@ -60,7 +56,12 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
             >
               {ctaText}
             </CTALinkOrButton>
-            <CTALinkOrButton className="announcement-banner__close" variant="outline-black" aria-label="close" onClick={() => dismissBanner(bannerKey)}>
+            <CTALinkOrButton
+              className="announcement-banner__close"
+              variant="outline-black"
+              aria-label="close"
+              onClick={() => dismissBanner(bannerKey)}
+            >
               x
             </CTALinkOrButton>
           </div>

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -6,6 +6,25 @@ import React from 'react';
 import { useAnnouncementBannerStore } from '../stores/announcementBanner';
 import { P } from './Text';
 
+/**
+ * Generates a unique key for an announcement banner based on its content.
+ * Uses a djb2 hash algorithm to create a stable, short identifier.
+ * Source: https://stackoverflow.com/questions/7666509/hash-function-for-string/7666577#7666577
+ *
+ * @param children - The React children (content) of the banner
+ * @returns A base-36 encoded hash string that uniquely identifies the content
+ */
+export const getAnnouncementBannerKey = (children: React.ReactNode) => {
+  const str = String(children);
+  let hash = 5381;
+
+  for (let i = 0; i < str.length; i++) {
+    hash = hash * 33 + str.charCodeAt(i);
+  }
+
+  return Math.abs(hash).toString(36);
+};
+
 export type AnnouncementBannerProps = React.PropsWithChildren<{
   className?: string;
   ctaText?: string;
@@ -25,7 +44,7 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
   hideUntil,
   hideAfter,
 }) => {
-  const bannerKey = `${ctaText}-${ctaUrl}`;
+  const bannerKey = getAnnouncementBannerKey(children);
   const dismissBanner = useAnnouncementBannerStore((state) => state.dismissBanner);
   // If this banner has been dismissed (now or in the past) don't show it
   const isDismissed = useAnnouncementBannerStore((s) => Boolean(s.dismissedBanners[bannerKey]));

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -89,7 +89,7 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
             aria-label="Close announcement"
             onClick={() => dismissBanner(bannerKey)}
           >
-            x
+            <span aria-hidden="true">&times;</span>
           </CTALinkOrButton>
         </div>
       </div>

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import clsx from 'clsx';
 import { CTALinkOrButton } from '@bluedot/ui/src/CTALinkOrButton';
@@ -25,6 +27,13 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
 }) => {
   const dismissBanner = useAnnouncementBannerStore((state) => state.dismissBanner);
   const bannerKey = `${ctaText}-${ctaUrl}`;
+
+  // If this banner has been dismissed (now or in the past) don't show it
+  const dismissedBanners = useAnnouncementBannerStore((state) => state.dismissedBanners);
+  if (Boolean(dismissedBanners[bannerKey])) {
+    return null;
+  }
+
   if (hideUntil && Date.now() < hideUntil.getTime()) {
     return null;
   }

--- a/apps/website/src/components/AnnouncementBanner.tsx
+++ b/apps/website/src/components/AnnouncementBanner.tsx
@@ -25,9 +25,8 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
   hideUntil,
   hideAfter,
 }) => {
-  const dismissBanner = useAnnouncementBannerStore((state) => state.dismissBanner);
   const bannerKey = `${ctaText}-${ctaUrl}`;
-
+  const dismissBanner = useAnnouncementBannerStore((state) => state.dismissBanner);
   // If this banner has been dismissed (now or in the past) don't show it
   const dismissedBanners = useAnnouncementBannerStore((state) => state.dismissedBanners);
   if (Boolean(dismissedBanners[bannerKey])) {

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { Footer } from '@bluedot/ui';
 import { useRouter } from 'next/router';
+import dynamic from 'next/dynamic';
 import { GoogleTagManager } from '../components/analytics/GoogleTagManager';
 import { PostHogProvider } from '../components/analytics/PostHogProvider';
 import { Nav } from '../components/Nav/Nav';
@@ -11,7 +12,7 @@ import { CookieBanner } from '../components/CookieBanner';
 import { CircleWidget } from '../components/community/CircleWidget';
 import { useCourses } from '../lib/hooks/useCourses';
 import { inter } from '../lib/fonts';
-import dynamic from 'next/dynamic'
+
 const AnnouncementBanner = dynamic(() => import('../components/AnnouncementBanner'), { ssr: false });
 
 const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -7,11 +7,12 @@ import { useRouter } from 'next/router';
 import { GoogleTagManager } from '../components/analytics/GoogleTagManager';
 import { PostHogProvider } from '../components/analytics/PostHogProvider';
 import { Nav } from '../components/Nav/Nav';
-import { AnnouncementBanner } from '../components/AnnouncementBanner';
 import { CookieBanner } from '../components/CookieBanner';
 import { CircleWidget } from '../components/community/CircleWidget';
 import { useCourses } from '../lib/hooks/useCourses';
 import { inter } from '../lib/fonts';
+import dynamic from 'next/dynamic'
+const AnnouncementBanner = dynamic(() => import('../components/AnnouncementBanner'), { ssr: false });
 
 const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
   const fromSiteParam = useRouter().query.from_site as string;

--- a/apps/website/src/stores/announcementBanner.ts
+++ b/apps/website/src/stores/announcementBanner.ts
@@ -6,7 +6,7 @@ export const useAnnouncementBannerStore = create<{
   dismissBanner: (key: string) => void;
 }>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       dismissedBanners: {},
       dismissBanner: (key: string) =>
         set((state) => ({

--- a/apps/website/src/stores/announcementBanner.ts
+++ b/apps/website/src/stores/announcementBanner.ts
@@ -3,19 +3,18 @@ import { persist } from 'zustand/middleware';
 
 export const useAnnouncementBannerStore = create<{
   dismissedBanners: Record<string, boolean>;
-  dismissBanner: (key: string) => void;
+  dismissBanner:(key: string) => void;
 }>()(
   persist(
     (set) => ({
       dismissedBanners: {},
-      dismissBanner: (key: string) =>
-        set((state) => ({
-          dismissedBanners: { ...state.dismissedBanners, [key]: true },
-        })),
+      dismissBanner: (key: string) => set((state) => ({
+        dismissedBanners: { ...state.dismissedBanners, [key]: true },
+      })),
     }),
     {
       name: 'bluedot_announcement_banners',
       version: 20250826,
-    }
-  )
+    },
+  ),
 );

--- a/apps/website/src/stores/announcementBanner.ts
+++ b/apps/website/src/stores/announcementBanner.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const useAnnouncementBannerStore = create<{
+  dismissedBanners: Record<string, boolean>;
+  dismissBanner: (key: string) => void;
+}>()(
+  persist(
+    (set, get) => ({
+      dismissedBanners: {},
+      dismissBanner: (key: string) =>
+        set((state) => ({
+          dismissedBanners: { ...state.dismissedBanners, [key]: true },
+        })),
+    }),
+    {
+      name: 'bluedot_announcement_banners',
+      version: 20250826,
+    }
+  )
+);


### PR DESCRIPTION
# Description

Closes #731.

1. Creates a new Zustand store for tracking which announcement banners have been dismissed. Although the original issue mentions `localStorage` we already use Zustand for cookie consent - I copied that pattern.
2. Adds a new '×' (close) button for closing a currently open announcement -> this updates the store.
3. Make `AnnouncementBanner` a pure client component by explicitly removing it from SSR using `dynamic`. This is needed because reading/writing to `localStorage` (what Zustand does under the hood) can only be done on pure client components.
4. Introduce `getAnnouncementBannerKey` which will hash the banner children to produce a unique key for the banner (used for tracking dismissal). A little more dev effort now but future authors won't need to think of a new ID for each new banner.
5. Update `AnnouncementBanner` tests to accommodate new functionality.

You can check the functionality by creating a new `AnnouncementBanner` and/or removing the `hideAfter` attribute of the current banner (side note: if `hideAfter` has passed we should likely remove the banner from our codebase). After clicking the close button you can either open again in an incognito window or clear the local storage key `bluedot_announcement_banners`.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📱  | <img width="379" height="171" alt="image" src="https://github.com/user-attachments/assets/0b688d0e-7ccd-45be-a6e2-f43c13575088" />
| 🖥️ | <img width="1203" height="79" alt="image" src="https://github.com/user-attachments/assets/f48637c8-e42f-4d3a-b2e3-8f51e13b7532" />
