### PR TITLE
Make zsh default shell inside devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,15 @@
         "bradlc.vscode-tailwindcss",
         "figma.figma-vscode-extension",
         "yzhang.markdown-all-in-one"
-      ]
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

I think most of us prefer zsh so it should probably be the default!