### PR TITLE
Filter courses by status instead of displayOnCourseHubIndex in the API endpoint

### DIFF
--- a/apps/website/src/components/courses/CourseDirectory.stories.tsx
+++ b/apps/website/src/components/courses/CourseDirectory.stories.tsx
@@ -38,6 +38,7 @@ export const Default: Story = {
         publicLastUpdated: null,
         isNew: true,
         isFeatured: false,
+        status: 'Active',
       },
       {
         id: '2',
@@ -60,6 +61,7 @@ export const Default: Story = {
         publicLastUpdated: null,
         isNew: false,
         isFeatured: true,
+        status: 'Active',
       },
       {
         id: '3',
@@ -82,6 +84,7 @@ export const Default: Story = {
         publicLastUpdated: null,
         isNew: false,
         isFeatured: false,
+        status: 'Active',
       },
     ] satisfies GetCoursesResponse['courses'],
     loading: false,

--- a/apps/website/src/lib/hooks/useCourses.ts
+++ b/apps/website/src/lib/hooks/useCourses.ts
@@ -7,8 +7,11 @@ export const useCourses = () => {
     method: 'POST',
   });
 
+  // Filter for courses that should be displayed on the course hub index
+  const filteredCourses = (data?.courses ?? []).filter((course) => course.displayOnCourseHubIndex);
+
   // Sort courses: featured first, then new, then alphabetically by title
-  const sortedCourses = [...(data?.courses ?? [])].sort((a, b) => {
+  const sortedCourses = [...filteredCourses].sort((a, b) => {
     // Featured courses come first
     if (a.isFeatured && !b.isFeatured) return -1;
     if (!a.isFeatured && b.isFeatured) return 1;

--- a/apps/website/src/pages/api/courses/index.ts
+++ b/apps/website/src/pages/api/courses/index.ts
@@ -47,8 +47,8 @@ export default makeApiRoute({
     courses: z.array(z.any()),
   }),
 }, async () => {
-  // For now, just get all courses that should be displayed on the course hub
-  const courses = await db.scan(courseTable, { displayOnCourseHubIndex: true });
+  // Filter for active courses
+  const courses = await db.scan(courseTable, { status: 'Active' });
 
   return {
     type: 'success' as const,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -119,6 +119,10 @@ export const courseTable = pgAirtable('course', {
       pgColumn: boolean().notNull(),
       airtableId: 'fldDXwQyHpHtUspFY',
     },
+    status: {
+      pgColumn: text(),
+      airtableId: 'fldaEypOAkLCFfYBQ',
+    },
   },
 });
 


### PR DESCRIPTION
- Add status field to course table schema
- Update API to filter courses by 'Active' status
- Move displayOnCourseHubIndex filtering to frontend hook

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->
This endpoint is shared by the profile page so the filter shouldn't be hardcoded here. This is blocking me from testing #1217 .


## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

Can confirm it filters properly!

<img width="2320" height="1686" alt="CleanShot 2025-08-26 at 15 59 00@2x" src="https://github.com/user-attachments/assets/709687b9-af03-4f23-a0de-71a1bf07c5fd" />
<img width="2290" height="1688" alt="CleanShot 2025-08-26 at 15 59 45@2x" src="https://github.com/user-attachments/assets/5d768eb4-eb2d-4546-8db9-ed3ec75f49fa" />

| 📸 |  |
|---------|---|
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
