### PR TITLE
[Fix] warnings about missing keys when looping over components

### DIFF
--- a/apps/website/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website/src/components/courses/exercises/MultipleChoice.tsx
@@ -97,6 +97,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
       <div className="multiple-choice__options flex flex-col gap-2">
         {formattedOptions.map((option) => (
           <Input
+            key={option}
             {...register('answer')}
             labelClassName={`
               multiple-choice__option flex items-center gap-2 p-4 hover:cursor-pointer

--- a/libraries/ui/src/QuoteCarousel.tsx
+++ b/libraries/ui/src/QuoteCarousel.tsx
@@ -49,6 +49,7 @@ export const QuoteCarousel: React.FC<QuoteCarouselProps> = ({
       <div className="relative quote-carousel__image-section h-28 flex justify-center mb-4">
         {quotes.map((quote, index) => (
           <div
+            key={quote.name}
             className={clsx(
               'quote-carousel__image-container flex flex-col items-center justify-center transition-all duration-700 ease-[cubic-bezier(0.68,-0.3,0.32,1)]',
               active === index
@@ -77,6 +78,7 @@ export const QuoteCarousel: React.FC<QuoteCarouselProps> = ({
       <div className="quote-carousel__quote-section flex flex-col mb-9 transition-all delay-300 duration-150 ease-in-out">
         {quotes.map((quote, index) => (
           <div
+            key={quote.name}
             className={clsx(
               'quote-carousel__quote-block w-full transition-all duration-500',
               active === index
@@ -96,6 +98,7 @@ export const QuoteCarousel: React.FC<QuoteCarouselProps> = ({
         <div className="quote-carousel__btn-section mt-4 flex flex-row gap-2 justify-center">
           {quotes.map((quote, index) => (
             <button
+              key={quote.name}
               type="button"
               className={clsx(
                 'size-3 rounded-full transition-all duration-150 hover:cursor-pointer',


### PR DESCRIPTION
# Description

When rendering lists React expects a unique key for each entry in the list: https://react.dev/learn/rendering-lists

We are currently getting warnings about the `QuoteCarousel` and `MarkdownExtendedRenderer` (which I believe is rendering the `MultipleChoice` component).

By adding a unique key to each entry in the list we can alleviate the warnings.