### PR TITLE
Add number key navigation for units in course layout

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website/src/components/courses/UnitLayout.test.tsx
@@ -251,7 +251,7 @@ describe('UnitLayout', () => {
 
     const hint = container.querySelector('.unit__keyboard-hint');
     expect(hint).toBeTruthy();
-    expect(hint?.textContent).toContain('Use ←/→ to navigate sections');
+    expect(hint?.textContent).toContain('Use ←/→ or 1-9 to navigate');
   });
 
   test('navigation buttons have keyboard shortcut tooltips', async () => {

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -436,7 +436,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
 
           {/* Keyboard navigation hint */}
           <div className="unit__keyboard-hint text-size-xs text-color-secondary mt-4">
-            <p>Tip: Use ←/→ or 1-9 to navigate sections, and Cmd+B (Ctrl+B on Windows/Linux) to toggle the sidebar.</p>
+            <p>Use ←/→ or 1-9 to navigate, and Cmd/Ctrl+B to toggle sidebar.</p>
           </div>
 
           {(!nextUnit && isLastChunk) ? (

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -239,6 +239,18 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
         return;
       }
 
+      // Handle number keys for unit navigation
+      if (/^[1-9]$/.test(event.key)) {
+        const targetUnitNumber = parseInt(event.key, 10);
+        const targetUnit = units.find((u) => Number(u.unitNumber) === targetUnitNumber);
+        if (targetUnit) {
+          event.preventDefault();
+          router.push(`${targetUnit.path}?chunk=0`);
+          setNavigationAnnouncement(`Navigated to Unit ${targetUnitNumber}: ${targetUnit.title}`);
+        }
+        return;
+      }
+
       switch (event.key) {
         case 'ArrowLeft':
           event.preventDefault();
@@ -424,7 +436,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
 
           {/* Keyboard navigation hint */}
           <div className="unit__keyboard-hint text-size-xs text-color-secondary mt-4">
-            <p>Tip: Use ←/→ to navigate sections, and Cmd+B (Ctrl+B on Windows/Linux) to toggle the sidebar.</p>
+            <p>Tip: Use ←/→ or 1-9 to navigate sections, and Cmd+B (Ctrl+B on Windows/Linux) to toggle the sidebar.</p>
           </div>
 
           {(!nextUnit && isLastChunk) ? (

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -580,7 +580,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             class="unit__keyboard-hint text-size-xs text-color-secondary mt-4"
           >
             <p>
-              Tip: Use ←/→ to navigate sections, and Cmd+B (Ctrl+B on Windows/Linux) to toggle the sidebar.
+              Use ←/→ or 1-9 to navigate, and Cmd/Ctrl+B to toggle sidebar.
             </p>
           </div>
           <div


### PR DESCRIPTION
# Description

- Add keyboard shortcuts 1-9 to jump directly to specific units
- Update keyboard navigation hint to include new shortcuts
- Provide accessibility announcement when navigating via number keys


I want to navigate units faster. This is the most intuitive way to do it in my mind. 

It takes the user to the first chunk of the unit number they select. E.g. if they're currently on unit 3, chunk 4, and they press the '2' key, it will take them to the first chunk in unit 2. 