### PR TITLE
[feat]: next discussion implementation

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -389,7 +389,14 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
               <GroupDiscussionBanner
                 unit={unit}
                 groupDiscussion={groupDiscussion}
-                onClickPrepare={() => handleChunkSelect(0)}
+                onClickPrepare={() => {
+                  const discussionUnit = units.find((u) => u.unitNumber === String(groupDiscussion.unitNumber));
+                  if (discussionUnit) {
+                    router.push(`/courses/${unit.courseSlug}/${discussionUnit.unitNumber}?chunk=0`);
+                  } else {
+                    handleChunkSelect(0); // fallback to current unit
+                  }
+                }}
                 units={units}
               />
             </div>

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber].tsx
@@ -7,8 +7,6 @@ import { GetUnitResponse } from '../../api/courses/[courseSlug]/[unitNumber]';
 import { GetGroupDiscussionResponse } from '../../api/courses/[courseSlug]/[unitNumber]/groupDiscussion';
 import { GetCourseRegistrationResponse } from '../../api/course-registrations/[courseId]';
 
-const isGroupDiscussionUIEnabled = process.env.NEXT_PUBLIC_FF_GROUP_DISCUSSION_UI === 'true';
-
 const CourseUnitPage = () => {
   const { query: { courseSlug, unitNumber } } = useRouter();
 
@@ -30,7 +28,7 @@ const CourseUnitPage = () => {
       Authorization: `Bearer ${auth?.token}`,
     },
   }, {
-    manual: !auth || !isGroupDiscussionUIEnabled,
+    manual: !auth,
   });
 
   // Track visits to Unit 1 of Future of AI course


### PR DESCRIPTION
# Description
Implementing Next Discussion Info modal and logic.

### Display Priority:
- Shows the soonest upcoming group discussion by default
- Overrides to show current/ending discussions if one is happening now or ended within 15 minutes

### Time Display Rules:
- Days: When discussion is ≥1 day away
- Hours (+ optional minutes): When <1 day but ≥1 hour away
- Minutes only: When <1 hour away

### Interactive Elements:
- "Prepare for discussion" → Links to first chunk in discussion unit
- Slack link → Opens user's specific Slack channel in web (prompts for account confirmation)
- Documentation link → Opens relevant Google Doc

**Notes:** Feature flag blocking this functionality has been removed. For testing, I modified the endpoints and can confirm it works on the frontend, but we should confirm that it works live since we don't currently have access to real test users in live courses.

## Issue
Fixes #1209

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
<img width="877" height="246" alt="next-discussion-info" src="https://github.com/user-attachments/assets/ba82a46b-7793-469b-87a3-5b3a1c55ac7a" />

### Desktop
![next-discussion-info-desktop](https://github.com/user-attachments/assets/cc874bb3-8b39-495b-91c4-4ab4a7a598ec)

### Mobile
![next-discussion-info-mobile](https://github.com/user-attachments/assets/032ff80d-3530-4f2b-b175-1dbae88dadbc)