### PR TITLE
[feat]: prevent user dropout

### DIFF
--- a/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
+++ b/apps/website/src/components/courses/MarkdownExtendedRenderer.tsx
@@ -42,6 +42,26 @@ const remarkUnescapeMdxAttributes: Plugin = () => {
   };
 };
 
+// Custom link component to handle external links
+const Link = ({ href, children, ...props }: React.ComponentProps<'a'>) => {
+  const isExternal = href && (href.startsWith('http://') || href.startsWith('https://'));
+
+  if (isExternal) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return <a href={href} {...props}>{children}</a>;
+};
+
 export type MarkdownRendererProps = {
   children?: string;
   className?: string;
@@ -54,6 +74,7 @@ export const getSupportedComponents = () => ({
   Collapsible,
   Callout,
   Exercise,
+  a: Link,
 });
 
 const MarkdownExtendedRenderer: React.FC<MarkdownRendererProps> = ({ children, className }) => {


### PR DESCRIPTION
# Description
While our React resource card components correctly open links in new tabs, links rendered in markdown (used throughout our courses, including the entire FOAI course, portions of others) were opening in the same tab, causing users to navigate away from their lesson.

I updated the MarkdownExtendedRenderer to open all external links in new tabs. This prevents users from accidentally leaving their course and maintains their learning flow.

This approach aligns with industry standards (Coursera, Khan Academy, etc) to ensure external resources enhance rather than interrupt the learning experience

## Issue
Fixes #1168 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
N/A