### PR TITLE
[Fix] Disabled CTA button styling

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`AboutPage > should render correctly 1`] = `
           class="flex justify-center mt-8"
         >
           <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
             href="/join-us"
             tabindex="0"
           >
@@ -864,7 +864,7 @@ exports[`AboutPage > should render correctly 1`] = `
           Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
         </h3>
         <a
-          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
+          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
           href="/join-us"
           tabindex="0"
         >
@@ -919,7 +919,7 @@ exports[`AboutPage > should render correctly 1`] = `
           We love hearing from people, and are keen for people to reach out to us with any questions or feedback!
         </p>
         <a
-          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter mt-5"
+          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter mt-5"
           href="/contact"
           tabindex="0"
         >

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
           class="flex justify-center mt-8"
         >
           <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
             href="#open-roles-anchor"
             tabindex="0"
           >

--- a/apps/website/src/__tests__/pages/settings/__snapshots__/account.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/settings/__snapshots__/account.test.tsx.snap
@@ -232,7 +232,7 @@ exports[`AccountSettingsPage > should render account settings page correctly 1`]
                 </p>
                 <button
                   aria-label="Change password"
-                  class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
+                  class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
                   type="button"
                 >
                   <span

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`Nav > renders with courses 1`] = `
           class="nav-cta flex flex-row items-center gap-6"
         >
           <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter nav-cta__secondary-cta hidden sm:block "
+            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter nav-cta__secondary-cta hidden sm:block "
             href="http://localhost:3000/login?redirect_to=%2Ftest-page"
             tabindex="0"
           >
@@ -351,7 +351,7 @@ exports[`Nav > renders with courses 1`] = `
             </span>
           </a>
           <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav-cta__primary-cta min-[370px]:flex hidden"
+            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav-cta__primary-cta min-[370px]:flex hidden"
             href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-page"
             tabindex="0"
           >

--- a/apps/website/src/components/__snapshots__/CookieBanner.test.tsx.snap
+++ b/apps/website/src/components/__snapshots__/CookieBanner.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`CookieBanner > renders as expected 1`] = `
       class="cookie-banner__buttons flex flex-wrap gap-space-between justify-center"
     >
       <button
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--accept"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--accept"
         type="button"
       >
         <span
@@ -33,7 +33,7 @@ exports[`CookieBanner > renders as expected 1`] = `
         </span>
       </button>
       <button
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--reject"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--reject"
         type="button"
       >
         <span

--- a/apps/website/src/components/about/__snapshots__/JoinUsCta.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/JoinUsCta.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`JoinUsCta > renders default as expected 1`] = `
         Join us in our mission to ensure humanity safely navigates the transition to transformative AI.
       </h3>
       <a
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark join-us-cta__cta-button"
         href="/join-us"
         tabindex="0"
       >

--- a/apps/website/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/Congratulations.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Congratulations > renders FoAI course with special component 1`] = `
       class="mt-4 flex justify-start"
     >
       <a
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
         href="https://community.bluedot.org"
         tabindex="0"
         target="_blank"

--- a/apps/website/src/components/courses/__snapshots__/FoAICongratulations.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/FoAICongratulations.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`FoAICongratulations > renders default as expected 1`] = `
       class="mt-4 flex justify-start"
     >
       <a
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
         href="https://community.bluedot.org"
         tabindex="0"
         target="_blank"
@@ -74,7 +74,7 @@ exports[`FoAICongratulations > renders with custom className 1`] = `
       class="mt-4 flex justify-start"
     >
       <a
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
         href="https://community.bluedot.org"
         tabindex="0"
         target="_blank"

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -587,7 +587,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             class="unit__cta-container flex flex-row justify-between mt-6 mx-1 mb-14 sm:mb-0"
           >
             <button
-              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
+              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
               type="button"
             >
               <span
@@ -624,7 +624,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
 
 exports[`UnitLayout > renders previous and next unit buttons for middle unit 1`] = `
 <button
-  class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
+  class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark unit__cta-link ml-auto"
   type="button"
 >
   <span

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
       class="w-full flex"
     >
       <a
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark !w-auto !whitespace-normal text-center min-w-0"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark !w-auto !whitespace-normal text-center min-w-0"
         href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-path"
         tabindex="0"
       >

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
       </label>
     </div>
     <a
-      class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark multiple-choice__login-cta"
+      class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark multiple-choice__login-cta"
       href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-path"
       tabindex="0"
     >
@@ -232,7 +232,7 @@ exports[`MultipleChoice > renders logged in as expected 1`] = `
       </label>
     </div>
     <button
-      class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark multiple-choice__submit"
+      class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark multiple-choice__submit"
       type="button"
     >
       <span

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
@@ -253,7 +253,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
         </div>
       </div>
       <a
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter projects__link h-fit py-3"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter projects__link h-fit py-3"
         href="/projects"
         tabindex="0"
       >

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`CourseSection > renders as expected 1`] = `
                   Short description
                 </p>
                 <button
-                  class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
+                  class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
                   type="button"
                 >
                   <span

--- a/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`StorySection > renders default as expected 1`] = `
             Working closely with leading organisations, we rapidly develop new courses to address emerging challenges and help talented people find roles where they can have the greatest impact.
           </p>
           <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
+            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
             href="/about"
             tabindex="0"
           >

--- a/apps/website/src/components/lander/__snapshots__/FutureOfAiLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/FutureOfAiLander.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
             class="flex flex-col sm:flex-row justify-center items-center gap-3"
           >
             <a
-              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
               href="/courses/test-course/1"
               tabindex="0"
             >
@@ -139,7 +139,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
               </span>
             </a>
             <a
-              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
               href="https://community.bluedot.org"
               tabindex="0"
               target="_blank"
@@ -386,7 +386,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
               class="flex flex-row gap-4"
             >
               <a
-                class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+                class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
                 href="/courses/test-course/1"
                 tabindex="0"
               >
@@ -415,7 +415,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
                 </span>
               </a>
               <a
-                class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+                class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
                 href="https://community.bluedot.org"
                 tabindex="0"
                 target="_blank"
@@ -843,7 +843,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
               Cover the fundamentals in just 2 hours. Go at your own pace, learn when it suits you, and finish feeling confident and informed– all for free.
             </p>
             <a
-              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__feature-cta mt-4"
+              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__feature-cta mt-4"
               href="/courses/test-course/1"
               tabindex="0"
             >
@@ -901,7 +901,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
               Get hands-on with the AI tools making headlines. Interactive demos let you experience the future of AI– not just read about it.
             </p>
             <a
-              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__feature-cta mt-4"
+              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__feature-cta mt-4"
               href="/courses/test-course/1"
               tabindex="0"
             >
@@ -959,7 +959,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
               Earn an industry-recognized certificate that shows you’re engaged with the future of AI and helps you stand out in roles focused on AI, policy, or the public good.
             </p>
             <a
-              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__feature-cta mt-4"
+              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__feature-cta mt-4"
               href="/courses/test-course/1"
               tabindex="0"
             >
@@ -1017,7 +1017,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
               Join a community of thousands of people who care about AI’s impact and are working together to share knowledge and opportunities.
             </p>
             <a
-              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__feature-cta mt-4"
+              class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__feature-cta mt-4"
               href="/courses/test-course/1"
               tabindex="0"
             >
@@ -1413,7 +1413,7 @@ exports[`FutureOfAiLander > renders as expected 1`] = `
       Understand AI today – and be ready to engage in what’s coming next.
     </h3>
     <a
-      class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__banner-cta"
+      class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark future-of-ai-lander__banner-cta"
       href="/courses/test-course/1"
       tabindex="0"
     >

--- a/libraries/ui/src/CTALinkOrButton.stories.tsx
+++ b/libraries/ui/src/CTALinkOrButton.stories.tsx
@@ -161,3 +161,20 @@ export const SmallWithChevron: Story = {
     withChevron: true,
   },
 };
+
+export const DisabledButton: Story = {
+  args: {
+    children: 'Disabled Button',
+    variant: 'primary',
+    disabled: true,
+  },
+};
+
+export const DisabledLink: Story = {
+  args: {
+    children: 'Disabled Link',
+    variant: 'primary',
+    url: 'https://www.google.com',
+    disabled: true,
+  },
+};

--- a/libraries/ui/src/CTALinkOrButton.tsx
+++ b/libraries/ui/src/CTALinkOrButton.tsx
@@ -10,7 +10,8 @@ export type CTALinkOrButtonProps = {
   withBackChevron?: boolean;
 } & ClickTargetProps;
 
-const CTA_BASE_STYLES = 'cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose';
+// `disabled:` attributes apply to buttons, `aria-disabled:` to links
+const CTA_BASE_STYLES = 'cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none';
 
 const CTA_SIZE_STYLES = {
   small: 'text-[13px] px-3 py-2.5 h-9 rounded-md font-semibold',

--- a/libraries/ui/src/ClickTarget.tsx
+++ b/libraries/ui/src/ClickTarget.tsx
@@ -44,7 +44,6 @@ export const ClickTarget = ({
         target={target}
         aria-disabled={disabled ? 'true' : undefined}
         aria-label={ariaLabel}
-        style={disabled ? { pointerEvents: 'none', opacity: 0.5 } : undefined}
         tabIndex={disabled ? -1 : 0}
       >
         {children}

--- a/libraries/ui/src/__snapshots__/Banner.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Banner.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Banner > renders with input and button 1`] = `
         value=""
       />
       <button
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark banner__submit-btn"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark banner__submit-btn"
         type="button"
       >
         <span

--- a/libraries/ui/src/__snapshots__/CTALinkOrButton.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CTALinkOrButton.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`CTALinkOrButton > renders chevron when withChevron is true 1`] = `
 
 exports[`CTALinkOrButton > renders with primary variant by default as a button 1`] = `
 <button
-  class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+  class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
   type="button"
 >
   <span

--- a/libraries/ui/src/__snapshots__/Card.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Card.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Card > renders default as expected 1`] = `
         class="card__bottom-section flex flex-col gap-space-between"
       >
         <a
-          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
           href="https://linkedin.com/in/johndoe"
           tabindex="0"
         >
@@ -105,7 +105,7 @@ exports[`Card > renders with isEntireCardClickable as expected 1`] = `
         class="card__bottom-section flex flex-col gap-space-between"
       >
         <button
-          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
+          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter card__cta"
           type="button"
         >
           <span

--- a/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/CourseCard.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`CourseCard > renders Featured as expected 1`] = `
           Description
         </p>
         <button
-          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
+          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark course-card__cta mb-6 px-6"
           type="button"
         >
           <span

--- a/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/HeroSection.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`HeroSection > renders with buttons 1`] = `
         class="flex justify-center mt-8"
       >
         <a
-          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
+          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
           href="https://example.com"
           tabindex="0"
         >


### PR DESCRIPTION
# Description

Currently if you set the `disabled` attribute on a `CTALinkOrButton` that is a button there is no UI to indicate that the button is disabled. For consistency with how we disable links, we should (1) reduce opacity to 50% and (2) disallow pointer events.

1. Introduce `disabled:opacity-50` and `disabled:pointer-events-none` base CTA styles (this only affects buttons).
2. Introduce `aria-disabled:opacity-50` and `aria-disabled:pointer-events-none` base CTA styles (this only affects links). Additionally remove the currently over-riding `styles={}` attribute that does the same thing.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

<img width="192" height="358" alt="image" src="https://github.com/user-attachments/assets/262a738e-efdb-470b-8573-05053c57e76a" />
