### PR TITLE
[fix] Allow for prod to delete webhooks during sync

### DIFF
--- a/apps/infra/Pulumi.prod.yaml
+++ b/apps/infra/Pulumi.prod.yaml
@@ -26,3 +26,5 @@ config:
     secure: v1:PqgjbLHibVf6zb24:lhA4auDR6YRHTBRGMT148rL4sOpf5VmSW/vZx3dzig==
   infra:keycloakClientSecret:
     secure: v1:xFifyNHW/RrW9Nu2:El+89xjeyp8EiGmgtvyscw129C+CinAwLde1sd6k6xgiorWDbUEaCdvq5jY7xewv
+  infra:prodOnlyWebhookDeletion:
+    secure: v1:9v9u5E5OOc+3SDxJ:V7AxNmgk9GmkCYegen7P9IEIZyQ=

--- a/apps/infra/src/k8s/secrets.ts
+++ b/apps/infra/src/k8s/secrets.ts
@@ -16,6 +16,7 @@ const toK8s = [
   'minioRootPassword',
   'keycloakClientId',
   'keycloakClientSecret',
+  'prodOnlyWebhookDeletion',
 ] as const;
 
 export const envVarSources = toK8s.reduce((obj, key) => {

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -251,6 +251,7 @@ export const services: ServiceDefinition[] = [
           { name: 'PG_URL', valueFrom: getConnectionDetails(airtableSyncPg).uri },
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: 'C04SAGM4FN1' /* #tech-prod-alerts */ },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
+          { name: 'PROD_ONLY_WEBHOOK_DELETION', valueFrom: envVarSources.prodOnlyWebhookDeletion },
         ],
       }],
     },

--- a/apps/pg-sync-service/src/env.ts
+++ b/apps/pg-sync-service/src/env.ts
@@ -10,6 +10,7 @@ const env = validateEnv({
   ],
   optional: [
     'PORT',
+    'PROD_ONLY_WEBHOOK_DELETION',
   ],
 });
 

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -390,7 +390,7 @@ export class AirtableWebhook {
   private async cleanupOldWebhooks(): Promise<void> {
     // Only run cleanup if explicitly enabled via env var
     if (env.PROD_ONLY_WEBHOOK_DELETION !== 'TRUE') {
-      logger.info('[WEBHOOK] Webhook cleanup disabled (PROD_ONLY_WEBHOOK_DELETION != "TRUE"). You will not be able to recieve webhook events for this base.');
+      logger.info('[WEBHOOK] Webhook cleanup disabled (PROD_ONLY_WEBHOOK_DELETION != "TRUE"). You will not be able to receive webhook events for this base.');
       return;
     }
 

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -84,6 +84,9 @@ export class AirtableWebhook {
   }
 
   public static async getOrCreate(baseId: string, fieldIds: string[], rateLimiter: RateLimiter): Promise<AirtableWebhook> {
+    const cleanupEnabled = env.PROD_ONLY_WEBHOOK_DELETION === 'TRUE';
+    logger.info(`[WEBHOOK] PROD_ONLY_WEBHOOK_DELETION=${env.PROD_ONLY_WEBHOOK_DELETION || 'undefined'} (cleanup ${cleanupEnabled ? 'ENABLED' : 'DISABLED'})`);
+    logger.info(`[WEBHOOK] Creating/retrieving webhook for base ${baseId} with ${fieldIds.length} field filters`);
     const webhook = new AirtableWebhook(baseId, fieldIds, rateLimiter);
     await webhook.ensureInitialized();
     return webhook;
@@ -290,6 +293,15 @@ export class AirtableWebhook {
         await this.createWebhook();
         return; // Success
       } catch (error) {
+        // Check if we hit the webhook limit
+        const errorResponse = error as { response?: { data?: { error?: { type?: string } } } };
+        if (errorResponse?.response?.data?.error?.type === 'TOO_MANY_WEBHOOKS_IN_BASE') {
+          logger.warn(`[WEBHOOK] Hit webhook limit for base ${this.baseId}, attempting cleanup...`);
+          // eslint-disable-next-line no-await-in-loop
+          await this.cleanupOldWebhooks();
+          // Continue to retry after cleanup
+        }
+
         if (attempt === maxRetries) {
           logger.error(`[WEBHOOK] Failed to create webhook after ${maxRetries} attempts for base ${this.baseId}`, error);
           throw new Error(`Failed to create webhook after ${maxRetries} attempts: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -367,5 +379,48 @@ export class AirtableWebhook {
 
     // Create new webhook with filtered fields, using retry logic
     await this.createWebhookWithRetry();
+  }
+
+  /**
+   * Clean up ALL existing webhooks when hitting the limit.
+   * Only runs if PROD_ONLY_WEBHOOK_DELETION environment variable is set to "TRUE"
+   * This ensures production always has room to create its webhooks and never has the live
+   * webhooks deleted accidently
+   */
+  private async cleanupOldWebhooks(): Promise<void> {
+    // Only run cleanup if explicitly enabled via env var
+    if (env.PROD_ONLY_WEBHOOK_DELETION !== 'TRUE') {
+      logger.info('[WEBHOOK] Webhook cleanup disabled (PROD_ONLY_WEBHOOK_DELETION != "TRUE"). You will not be able to recieve webhook events for this base.');
+      return;
+    }
+
+    try {
+      await this.rateLimiter.acquire();
+      const response = await this.axiosInstance.get<ListWebhooksApiResponse>(
+        `/bases/${this.baseId}/webhooks`,
+      );
+      const { webhooks } = response.data;
+
+      logger.warn(`[WEBHOOK] PROD cleanup mode: Found ${webhooks.length} existing webhooks for base ${this.baseId}, deleting ALL to make room...`);
+
+      // Delete ALL existing webhooks
+      let deletedCount = 0;
+      for (const webhook of webhooks) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await this.rateLimiter.acquire();
+          // eslint-disable-next-line no-await-in-loop
+          await this.axiosInstance.delete(`/bases/${this.baseId}/webhooks/${webhook.id}`);
+          logger.info(`[WEBHOOK] Deleted webhook ${webhook.id} for base ${this.baseId}`);
+          deletedCount += 1;
+        } catch (deleteError) {
+          logger.error(`[WEBHOOK] Failed to delete webhook ${webhook.id}:`, deleteError);
+        }
+      }
+
+      logger.info(`[WEBHOOK] PROD cleanup complete: Deleted ${deletedCount} webhooks for base ${this.baseId}`);
+    } catch (error) {
+      logger.error('[WEBHOOK] Failed to clean up webhooks:', error);
+    }
   }
 }

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -859,7 +859,7 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       pgColumn: text(),
       airtableId: 'fldPkqPbeoIhERqSY',
     },
-    // Note: This is the id of the course in the COURSE_BUILDER base, not in the APPLICATIONS base
+    // Note: This is the id of the course in the COURSE_BUILDER base and not in the APPLICATIONS base
     courseId: {
       pgColumn: text().notNull(),
       airtableId: 'fldFTXtevzOc29Qte',


### PR DESCRIPTION
## Issue
We encountered a `TOO_MANY_WEBHOOKS_IN_BASE` Airtable error that was causing the production pg-sync-service to get stuck creating webhooks.

## Solution
Airtable has a maximum limit of 10 webhooks per base. I've added a new environment variable to k8s: `PROD_ONLY_WEBHOOK_DELETION="TRUE"`. This is configured for prod only

This setting allows the production server to delete old webhooks when needed, so it stays in sync with Airtable. By restricting webhook deletion to production only, we prevent developers syncing locally from accidentally deleting the production webhook and breaking prod sync.

## Testing
I've tested this locally and confirmed the code successfully:
- Catches the Airtable `TOO_MANY_WEBHOOKS_IN_BASE` error response
- Initiates deletion of old webhooks when the env variable is set to `TRUE`