### PR TITLE
[Feat] Simplifying the keyboard shortcut popup

### DIFF
--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/website/src/components/courses/KeyboardNavMenu.test.tsx
+++ b/apps/website/src/components/courses/KeyboardNavMenu.test.tsx
@@ -20,19 +20,16 @@ describe('KeyboardNavMenu', () => {
     const button = getByRole('button', { name: 'Keyboard shortcuts' });
 
     // Initially, the popover content should not be visible
-    expect(queryByText('Inside courses')).toBeNull();
+    expect(queryByText('Toggle sidebar')).toBeNull();
 
     // Click the button to open the popover
     await user.click(button);
 
-    expect(getByRole('dialog', { name: 'Inside courses' })).toBeTruthy();
+    expect(getByRole('dialog', { name: 'Keyboard shortcuts' })).toBeTruthy();
 
-    // Now the popover content should be visible
-    expect(getByText('Inside courses')).toBeTruthy();
+    // Now the popover content should be visible (no title, just shortcuts)
+    expect(getByText('Navigate sections')).toBeTruthy();
     expect(getByText('Toggle sidebar')).toBeTruthy();
-    expect(getByText('Go to unit 1-9')).toBeTruthy();
-    expect(getByText('Next chunk or unit')).toBeTruthy();
-    expect(getByText('Previous chunk or unit')).toBeTruthy();
 
     // Check that keyboard shortcuts are displayed
     expect(getByText('1-9')).toBeTruthy();

--- a/apps/website/src/components/courses/KeyboardNavMenu.tsx
+++ b/apps/website/src/components/courses/KeyboardNavMenu.tsx
@@ -4,10 +4,8 @@ import {
 import { FiCommand } from 'react-icons/fi';
 
 const DEFAULT_SHORTCUTS = [
-  { action: 'Go to unit 1-9', keys: ['1-9'] },
+  { action: 'Navigate sections', keys: ['←', '→', '1-9'] },
   { action: 'Toggle sidebar', keys: ['Ctrl/Cmd', 'B'] },
-  { action: 'Next chunk or unit', keys: ['→'] },
-  { action: 'Previous chunk or unit', keys: ['←'] },
 ] as const;
 
 type Shortcut = {
@@ -21,7 +19,7 @@ type KeyboardNavMenuProps = {
 };
 
 const KeyboardNavMenu = ({
-  popoverTitle = 'Inside courses',
+  popoverTitle = '',
   shortcuts = DEFAULT_SHORTCUTS,
 }: KeyboardNavMenuProps) => {
   return (
@@ -35,12 +33,14 @@ const KeyboardNavMenu = ({
       </Button>
       <Popover placement="top start">
         <Dialog
-          aria-labelledby="keyboard-shortcuts-title"
+          aria-label={popoverTitle || 'Keyboard shortcuts'}
           className="w-fit rounded-lg border border-gray-300 bg-white p-4 shadow-sm"
         >
-          <h3 id="keyboard-shortcuts-title" className="mb-3 font-semibold">
-            {popoverTitle}
-          </h3>
+          {popoverTitle && (
+            <h3 id="keyboard-shortcuts-title" className="mb-3 font-semibold">
+              {popoverTitle}
+            </h3>
+          )}
           <ul className="space-y-2">
             {shortcuts.map(({ action, keys }) => (
               <li key={action} className="flex items-center justify-between gap-4">

--- a/apps/website/src/components/courses/KeyboardNavMenu.tsx
+++ b/apps/website/src/components/courses/KeyboardNavMenu.tsx
@@ -37,7 +37,7 @@ const KeyboardNavMenu = ({
           className="w-fit rounded-lg border border-gray-300 bg-white p-4 shadow-sm"
         >
           {popoverTitle && (
-            <h3 id="keyboard-shortcuts-title" className="mb-3 font-semibold">
+            <h3 className="mb-3 font-semibold">
               {popoverTitle}
             </h3>
           )}

--- a/apps/website/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website/src/components/courses/UnitLayout.test.tsx
@@ -255,7 +255,7 @@ describe('UnitLayout', () => {
     const keyboardNavMenu = getByRole('button', { name: 'Keyboard shortcuts' });
     expect(keyboardNavMenu).toBeTruthy();
     await user.click(keyboardNavMenu);
-    expect(getByRole('dialog', { name: 'Inside courses' })).toBeTruthy();
+    expect(getByRole('dialog', { name: 'Keyboard shortcuts' })).toBeTruthy();
   });
 
   test('navigation buttons have keyboard shortcut tooltips', async () => {


### PR DESCRIPTION
# Code updates
- Consolidate navigation shortcuts into single "Navigate sections" entry
- Remove popover title by default for cleaner UI
- Update dialog aria-label for better accessibility
- Fix test assertions to match new menu structure

# Description
I felt the new keyboard shortcuts design was wordy, so I've simplified it. 

Users don't know what "Units" and "Chunks" are, so I don't think we should use these words publicly. Sections is more intuitive imo.

"Inside course" doesn't mean anything to me, so I deleted it too. 

# Screenshot
| **Old** | **New** |
| --- | ---- | 
| <img width="1274" height="680" alt="CleanShot 2025-08-30 at 14 29 27@2x" src="https://github.com/user-attachments/assets/6fe61487-39f2-4296-8316-0e7cd842ac04" /> | <img width="1188" height="424" alt="CleanShot 2025-08-30 at 14 29 03@2x" src="https://github.com/user-attachments/assets/37660b95-f1d7-4753-985e-78293798c82f" /> |