### PR TITLE
[feat]: responsive hairline borders for high-DPI displays

### DIFF
--- a/apps/website/src/components/courses/MobileCourseModal.tsx
+++ b/apps/website/src/components/courses/MobileCourseModal.tsx
@@ -369,7 +369,7 @@ export const MobileCourseModal: React.FC<MobileCourseModalProps> = ({
               {/* Header Section with Drag Handle */}
               <div
                 className={clsx(
-                  'flex flex-col bg-[#FCFAF7] border-b-[0.5px] border-[rgba(19,19,46,0.2)] rounded-t-[24px] transition-shadow duration-300',
+                  'flex flex-col bg-[#FCFAF7] border-b-hairline border-[rgba(19,19,46,0.2)] rounded-t-[24px] transition-shadow duration-300',
                   isHeaderSticky && 'sticky top-0 z-10 shadow-[0_4px_12px_rgba(0,0,0,0.08)]',
                 )}
               >
@@ -411,7 +411,7 @@ export const MobileCourseModal: React.FC<MobileCourseModalProps> = ({
                   return (
                     <div key={unit.id} className="relative">
                       {unitIndex > 0 && (
-                        <div className="border-t border-[rgba(42,45,52,0.2)] mx-6" />
+                        <div className="border-t-hairline border-[rgba(42,45,52,0.2)] mx-6" />
                       )}
 
                       {/* Current unit - shows as non-clickable with expand/collapse toggle */}

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -58,7 +58,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   return (
     isCurrentUnit ? (
       <div className="relative">
-        <div className="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]" />
+        <div className="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]" />
         <details
           open={isCurrentUnit}
           className="sidebar-collapsible group marker:hidden [&_summary::-webkit-details-marker]:hidden"
@@ -105,7 +105,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
       </div>
     ) : (
       <div className="relative">
-        <div className="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]" />
+        <div className="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]" />
         <A href={addQueryParam(unit.path, 'chunk', '0')} className="block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors">
           <div className="flex flex-row items-center gap-[8px]">
             <p className="font-semibold text-[14px] leading-[140%] tracking-[-0.005em] text-[#13132E] flex-1">

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`SideBar > renders default as expected 1`] = `
         class="relative"
       >
         <div
-          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
         />
         <details
           class="sidebar-collapsible group marker:hidden [&_summary::-webkit-details-marker]:hidden"
@@ -130,7 +130,7 @@ exports[`SideBar > renders default as expected 1`] = `
         class="relative"
       >
         <div
-          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
         />
         <a
           class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
@@ -168,7 +168,7 @@ exports[`SideBar > renders default as expected 1`] = `
         class="relative"
       >
         <div
-          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
         />
         <a
           class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
@@ -206,7 +206,7 @@ exports[`SideBar > renders default as expected 1`] = `
         class="relative"
       >
         <div
-          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
         />
         <a
           class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
@@ -244,7 +244,7 @@ exports[`SideBar > renders default as expected 1`] = `
         class="relative"
       >
         <div
-          class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+          class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
         />
         <a
           class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="relative"
         >
           <div
-            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+            class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
           />
           <details
             class="sidebar-collapsible group marker:hidden [&_summary::-webkit-details-marker]:hidden"
@@ -274,7 +274,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="relative"
         >
           <div
-            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+            class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
           />
           <a
             class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
@@ -312,7 +312,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="relative"
         >
           <div
-            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+            class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
           />
           <a
             class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
@@ -350,7 +350,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="relative"
         >
           <div
-            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+            class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
           />
           <a
             class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"
@@ -388,7 +388,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           class="relative"
         >
           <div
-            class="absolute top-0 inset-x-[24px] border-t border-[rgba(42,45,52,0.2)]"
+            class="absolute top-0 inset-x-[24px] border-t-hairline border-[rgba(42,45,52,0.2)]"
           />
           <a
             class="bluedot-a not-prose block mx-[24px] px-[24px] md:px-[12px] py-[15px] no-underline hover:bg-[rgba(42,45,52,0.05)] hover:rounded-[10px] transition-colors"

--- a/apps/website/src/globals.css
+++ b/apps/website/src/globals.css
@@ -25,6 +25,16 @@
 :root {
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif ;
   --font-serif: var(--font-inter-display), ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif ;
+  
+  /* Hairline borders for standard displays */
+  --border-hairline: 1px;
+}
+
+/* High-DPI displays (2dppx and above) get 0.5px hairline borders */
+@media (min-resolution: 2dppx) {
+  :root {
+    --border-hairline: 0.5px;
+  }
 }
 
 /* Headers use Inter Display */
@@ -48,6 +58,8 @@
     0% { transform: translateX(0) }
     100% { transform: translateX(-100%) }
   }
+  
+  --border-width-hairline: var(--border-hairline);
 }
 
 .slide-up-fade-in {


### PR DESCRIPTION
# Description
Implements responsive hairline borders (0.5px on high-DPI displays, 1px on standard displays) for horizontal separator lines in the sidebar and mobile menu components (rq'd from @herrhaase)

## Issue
Related to #1162 and #1174 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
<img width="437" height="829" alt="Screenshot 2025-08-29 at 6 41 24 PM" src="https://github.com/user-attachments/assets/23f2bce3-bfa8-4ad7-8908-a729fcf13d02" />
<img width="377" height="677" alt="Screenshot 2025-08-29 at 6 41 45 PM" src="https://github.com/user-attachments/assets/f0edaae7-4c93-4055-a869-be5271daa916" />

