### PR TITLE
[Bug] Upgrade vke-cluster to the version that is actually live (1.32.1+1)

### DIFF
--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
   label: 'bluedot-prod',
   region: 'ams',
-  version: 'v1.29.2+1',
+  version: 'v1.32.1+1',
 
   // Initial node pool
   // nodePools: {


### PR DESCRIPTION
# Description

From the issue #1266 :

>The version shown in the [Vultr web UI](https://my.vultr.com/kubernetes/manage/?id=83dad468-420e-4bdb-a5da-5b5395b22bdc#subsupgrade) is actually 1.32.1+1, and running `kubectl version` locally confirms this (client/server mismatch is just a local issue):
>```
>> kubectl version
>Client Version: v1.34.0
>Kustomize Version: v5.7.1
>Server Version: v1.32.1
>Warning: version difference between client (1.34) and server (1.32) exceeds the supported minor version skew of +/-1
>```

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1266

## Developer checklist

N/A

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Steps to test

On master, running `pulumi preview --diff --show-config` should give an output that looks like this:
```
pulumi preview --diff --show-config
Previewing update (prod):
Configuration:
    infra:airtablePat: [secret]
    infra:alertsSlackBotToken: [secret]
    infra:anthropicApiKey: [secret]
    infra:backupGcsKey: [secret]
    infra:keycloakClientId: [secret]
    infra:keycloakClientSecret: [secret]
    infra:loginProxyKeycloakClientSecret: [secret]
    infra:loginProxySharedSecret: [secret]
    infra:meetZoomClientSecret: [secret]
    infra:minioRootPassword: [secret]
    infra:openaiApiKey: [secret]
    infra:prodOnlyWebhookDeletion: [secret]
    infra:roomDisplayBearerToken: [secret]
    pulumi:disable-default-providers: ["kubernetes","minio"]
    vultr:apiKey: [secret]
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:prod::infra::pulumi:pulumi:Stack::infra-prod]
    ~ vultr:index/kubernetes:Kubernetes: (update)
        [id=THE_ACTUAL_ID]
        [urn=urn:pulumi:prod::infra::vultr:index/kubernetes:Kubernetes::vke-cluster]
        [provider=urn:pulumi:prod::infra::pulumi:providers:vultr::default_2_20_1_github_/api.github.com/dirien/pulumi-vultr::ANOTHER_ACTUAL_ID]
      ~ version: "v1.32.1+1" => "v1.29.2+1"
Resources:
    ~ 1 to update
    104 unchanged
```
And on this branch:
```
pulumi preview --diff --show-config
Previewing update (prod):
Configuration:
    infra:airtablePat: [secret]
    infra:alertsSlackBotToken: [secret]
    infra:anthropicApiKey: [secret]
    infra:backupGcsKey: [secret]
    infra:keycloakClientId: [secret]
    infra:keycloakClientSecret: [secret]
    infra:loginProxyKeycloakClientSecret: [secret]
    infra:loginProxySharedSecret: [secret]
    infra:meetZoomClientSecret: [secret]
    infra:minioRootPassword: [secret]
    infra:openaiApiKey: [secret]
    infra:prodOnlyWebhookDeletion: [secret]
    infra:roomDisplayBearerToken: [secret]
    pulumi:disable-default-providers: ["kubernetes","minio"]
    vultr:apiKey: [secret]
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:prod::infra::pulumi:pulumi:Stack::infra-prod]
Resources:
    105 unchanged
```
