### PR TITLE
[Bug] Upgrade vke-cluster to latest version (v1.33.0+3)

### DIFF
--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
   label: 'bluedot-prod',
   region: 'ams',
-  version: 'v1.32.1+1',
+  version: 'v1.33.0+1',
 
   // Initial node pool
   // nodePools: {

--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
   label: 'bluedot-prod',
   region: 'ams',
-  version: 'v1.33.0+1',
+  version: 'v1.33.0+3',
 
   // Initial node pool
   // nodePools: {


### PR DESCRIPTION
# Description

I won't merge this until after [Upgrade vke-cluster to the version that is actually live (1.32.1+1)](https://github.com/bluedotimpact/bluedot/pull/1267) is deployed. There is some risk with this PR of the load balancer IP changing (this is the main entry point into the website and production database), copying [this comment](https://github.com/bluedotimpact/bluedot/issues/1266#issuecomment-3241563281) from the issue regarding that:

> An alternative would be to first update the load balancer to definitely use a static IP, and then proceed with the upgrade. The reasons I think it not worth doing it this way are:
>
>1. I think it's very unlikely that the load balancer IP will change. Reasoning:
>  a. It is an external resource created by the 'ingress-nginx' service, not a Kubernetes node itself, so it shouldn't be recreated during an upgrade
>  b. The fact that we are currently on v1.32.1+1 and not v1.29.2+1 means that Vultr has probably forced an upgrade itself, and this didn't cause problems
>2. Switching to a static IP would require first provisioning a new [reserved IP](https://docs.vultr.com/products/network/reserved-ips/provisioning), then updating the load balancer to use that, then doing the Kubernetes upgrade. This would itself require switching DNS settings and come with some risk of downtime


## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1266

## Developer checklist

N/A
