### PR TITLE
[feat]: listen to article

### DIFF
--- a/apps/website/src/components/courses/ListenToArticleButton.test.tsx
+++ b/apps/website/src/components/courses/ListenToArticleButton.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import ListenToArticleButton from './ListenToArticleButton';
+
+describe('ListenToArticleButton', () => {
+  const mockAudioUrl = 'https://open.spotify.com/episode/test123';
+  const mockResourceTitle = 'Introduction to AI Safety';
+
+  it('should render correctly', () => {
+    const { container } = render(
+      <ListenToArticleButton
+        audioUrl={mockAudioUrl}
+        resourceTitle={mockResourceTitle}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should render with proper aria-label', () => {
+    const { getByRole } = render(
+      <ListenToArticleButton
+        audioUrl={mockAudioUrl}
+        resourceTitle={mockResourceTitle}
+      />
+    );
+    const button = getByRole('button');
+    expect(button.getAttribute('aria-label')).toBe(
+      'Listen to article: Introduction to AI Safety (opens in Spotify)'
+    );
+  });
+
+  it('should open audio URL in new tab when clicked', async () => {
+    const user = userEvent.setup();
+    const mockOpen = vi.fn();
+    const originalOpen = window.open;
+    window.open = mockOpen;
+
+    const { getByRole } = render(
+      <ListenToArticleButton
+        audioUrl={mockAudioUrl}
+        resourceTitle={mockResourceTitle}
+      />
+    );
+
+    const button = getByRole('button');
+    await user.click(button);
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      mockAudioUrl,
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    window.open = originalOpen;
+  });
+
+  it('should render with different resource titles', () => {
+    const { container, rerender } = render(
+      <ListenToArticleButton
+        audioUrl={mockAudioUrl}
+        resourceTitle="First Article"
+      />
+    );
+    const firstRender = container.innerHTML;
+
+    rerender(
+      <ListenToArticleButton
+        audioUrl={mockAudioUrl}
+        resourceTitle="Second Article with a Much Longer Title"
+      />
+    );
+    const secondRender = container.innerHTML;
+
+    expect(firstRender).not.toEqual(secondRender);
+  });
+});

--- a/apps/website/src/components/courses/ListenToArticleButton.test.tsx
+++ b/apps/website/src/components/courses/ListenToArticleButton.test.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import {
+  describe, expect, it, vi,
+} from 'vitest';
 import ListenToArticleButton from './ListenToArticleButton';
 
 describe('ListenToArticleButton', () => {
@@ -13,7 +15,7 @@ describe('ListenToArticleButton', () => {
       <ListenToArticleButton
         audioUrl={mockAudioUrl}
         resourceTitle={mockResourceTitle}
-      />
+      />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -23,11 +25,11 @@ describe('ListenToArticleButton', () => {
       <ListenToArticleButton
         audioUrl={mockAudioUrl}
         resourceTitle={mockResourceTitle}
-      />
+      />,
     );
     const button = getByRole('button');
     expect(button.getAttribute('aria-label')).toBe(
-      'Listen to article: Introduction to AI Safety (opens in Spotify)'
+      'Listen to article: Introduction to AI Safety (opens in Spotify)',
     );
   });
 
@@ -41,7 +43,7 @@ describe('ListenToArticleButton', () => {
       <ListenToArticleButton
         audioUrl={mockAudioUrl}
         resourceTitle={mockResourceTitle}
-      />
+      />,
     );
 
     const button = getByRole('button');
@@ -50,7 +52,7 @@ describe('ListenToArticleButton', () => {
     expect(mockOpen).toHaveBeenCalledWith(
       mockAudioUrl,
       '_blank',
-      'noopener,noreferrer'
+      'noopener,noreferrer',
     );
 
     window.open = originalOpen;
@@ -61,7 +63,7 @@ describe('ListenToArticleButton', () => {
       <ListenToArticleButton
         audioUrl={mockAudioUrl}
         resourceTitle="First Article"
-      />
+      />,
     );
     const firstRender = container.innerHTML;
 
@@ -69,7 +71,7 @@ describe('ListenToArticleButton', () => {
       <ListenToArticleButton
         audioUrl={mockAudioUrl}
         resourceTitle="Second Article with a Much Longer Title"
-      />
+      />,
     );
     const secondRender = container.innerHTML;
 

--- a/apps/website/src/components/courses/ListenToArticleButton.tsx
+++ b/apps/website/src/components/courses/ListenToArticleButton.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+type ListenToArticleButtonProps = {
+  audioUrl: string;
+  resourceTitle: string;
+};
+
+const ListenToArticleButton: React.FC<ListenToArticleButtonProps> = ({ audioUrl, resourceTitle }) => {
+  const handleClick = () => {
+    // Open Spotify URL in new tab
+    window.open(audioUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="flex flex-row items-center gap-1.5 h-[18px] group cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+      aria-label={`Listen to article: ${resourceTitle} (opens in Spotify)`}
+      type="button"
+    >
+      {/* Play icon */}
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <rect
+          x="0.625"
+          y="0.625"
+          width="14.75"
+          height="14.75"
+          rx="7.375"
+          stroke="#6A6F7A"
+          strokeWidth="1.25"
+          className="group-hover:stroke-[#13132E] transition-colors duration-200"
+        />
+        <path
+          d="M6 10.4839V5.51675C6 5.13551 6.40956 4.89452 6.74282 5.07967L11.2133 7.56325C11.5562 7.75375 11.5562 8.2469 11.2133 8.4374L6.74282 10.921C6.40956 11.1061 6 10.8651 6 10.4839Z"
+          fill="#6A6F7A"
+          className="group-hover:fill-[#13132E] transition-colors duration-200"
+        />
+      </svg>
+
+      {/* Text */}
+      <span className="text-[13px] font-medium leading-[140%] tracking-[-0.005em] text-[#6A6F7A] group-hover:text-[#13132E] transition-colors duration-200">
+        Listen to article
+      </span>
+    </button>
+  );
+};
+
+export default ListenToArticleButton;

--- a/apps/website/src/components/courses/ResourceListItem.test.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import {
+  describe, expect, it, vi,
+} from 'vitest';
 import { ResourceListItem } from './ResourceListItem';
 
 // Mock next-auth
@@ -37,11 +39,10 @@ vi.mock('./FaviconImage', () => ({
 vi.mock('./MarkdownExtendedRenderer', () => ({
   default: function MarkdownExtendedRenderer({ children, className }: { children: React.ReactNode; className?: string }) {
     return <div className={className}>{children}</div>;
-  }
+  },
 }));
 
 describe('ResourceListItem - Listen to Article Feature', () => {
-
   const baseResource = {
     id: 'test-resource-1',
     resourceId: 'rec123',
@@ -63,16 +64,16 @@ describe('ResourceListItem - Listen to Article Feature', () => {
 
   it('should render metadata without Listen to article button when no audio URL', () => {
     const { container, queryByText } = render(
-      <ResourceListItem resource={baseResource} />
+      <ResourceListItem resource={baseResource} />,
     );
 
     // Should show author and time
     expect(queryByText(/John Doe/)).toBeTruthy();
     expect(queryByText(/10 min/)).toBeTruthy();
-    
+
     // Should NOT show Listen to article
     expect(queryByText('Listen to article')).toBeFalsy();
-    
+
     expect(container.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
   });
 
@@ -83,14 +84,14 @@ describe('ResourceListItem - Listen to Article Feature', () => {
     };
 
     const { container, getByText } = render(
-      <ResourceListItem resource={resourceWithAudio} />
+      <ResourceListItem resource={resourceWithAudio} />,
     );
 
     // Should show author, time, and Listen to article
     expect(getByText(/John Doe/)).toBeTruthy();
     expect(getByText(/10 min/)).toBeTruthy();
     expect(getByText('Listen to article')).toBeTruthy();
-    
+
     expect(container.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
   });
 
@@ -103,12 +104,12 @@ describe('ResourceListItem - Listen to Article Feature', () => {
     };
 
     const { container } = render(
-      <ResourceListItem resource={resourceWithAudio} />
+      <ResourceListItem resource={resourceWithAudio} />,
     );
 
     const metadata = container.querySelector('.resource-item__bottom-metadata');
     expect(metadata).toMatchSnapshot();
-    
+
     // Check that separators are rendered
     const textContent = metadata?.textContent;
     expect(textContent).toContain('Jane Smith');
@@ -126,16 +127,16 @@ describe('ResourceListItem - Listen to Article Feature', () => {
     };
 
     const { container, getByText } = render(
-      <ResourceListItem resource={resourceWithOnlyAudio} />
+      <ResourceListItem resource={resourceWithOnlyAudio} />,
     );
 
     // Should show Listen to article button even when no other metadata
     expect(getByText('Listen to article')).toBeTruthy();
-    
+
     // Should not have separator when no other metadata
     const metadata = container.querySelector('.resource-item__bottom-metadata');
     expect(metadata?.textContent).not.toContain('·');
-    
+
     expect(metadata).toMatchSnapshot();
   });
 
@@ -149,7 +150,7 @@ describe('ResourceListItem - Listen to Article Feature', () => {
     };
 
     const { container: container1 } = render(
-      <ResourceListItem resource={authorAndAudio} />
+      <ResourceListItem resource={authorAndAudio} />,
     );
     expect(container1.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
 
@@ -162,7 +163,7 @@ describe('ResourceListItem - Listen to Article Feature', () => {
     };
 
     const { container: container2 } = render(
-      <ResourceListItem resource={timeAndAudio} />
+      <ResourceListItem resource={timeAndAudio} />,
     );
     expect(container2.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
   });

--- a/apps/website/src/components/courses/ResourceListItem.test.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ResourceListItem } from './ResourceListItem';
+
+// Mock next-auth
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: {
+      user: {
+        email: 'test@example.com',
+        name: 'Test User',
+      },
+    },
+    status: 'authenticated',
+  }),
+}));
+
+// Mock next/router
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: { courseSlug: 'test-course', unitNumber: '1' },
+    pathname: '/courses/[courseSlug]/units/[unitNumber]',
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+// Mock FaviconImage component
+vi.mock('./FaviconImage', () => ({
+  FaviconImage: ({ url, alt }: { url: string; alt: string }) => (
+    <img src={url} alt={alt} />
+  ),
+}));
+
+// Mock MarkdownExtendedRenderer
+vi.mock('./MarkdownExtendedRenderer', () => ({
+  default: function MarkdownExtendedRenderer({ children, className }: { children: React.ReactNode; className?: string }) {
+    return <div className={className}>{children}</div>;
+  }
+}));
+
+describe('ResourceListItem - Listen to Article Feature', () => {
+
+  const baseResource = {
+    id: 'test-resource-1',
+    resourceId: 'rec123',
+    unitId: 'unit123',
+    resourceName: 'Introduction to AI Safety',
+    resourceType: 'article' as const,
+    platform: 'Medium',
+    authors: 'John Doe',
+    timeFocusOnMins: 10,
+    url: 'https://example.com/article',
+    resourceGuide: 'This is a guide to the resource',
+    updatedAt: new Date('2024-01-01'),
+    createdAt: new Date('2024-01-01'),
+    deletedAt: null,
+    year: 2024,
+    unitNumber: 1,
+    syncedAudioUrl: null,
+  };
+
+  it('should render metadata without Listen to article button when no audio URL', () => {
+    const { container, queryByText } = render(
+      <ResourceListItem resource={baseResource} />
+    );
+
+    // Should show author and time
+    expect(queryByText(/John Doe/)).toBeTruthy();
+    expect(queryByText(/10 min/)).toBeTruthy();
+    
+    // Should NOT show Listen to article
+    expect(queryByText('Listen to article')).toBeFalsy();
+    
+    expect(container.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
+  });
+
+  it('should render Listen to article button when audio URL is provided', () => {
+    const resourceWithAudio = {
+      ...baseResource,
+      syncedAudioUrl: 'https://open.spotify.com/episode/abc123',
+    };
+
+    const { container, getByText } = render(
+      <ResourceListItem resource={resourceWithAudio} />
+    );
+
+    // Should show author, time, and Listen to article
+    expect(getByText(/John Doe/)).toBeTruthy();
+    expect(getByText(/10 min/)).toBeTruthy();
+    expect(getByText('Listen to article')).toBeTruthy();
+    
+    expect(container.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
+  });
+
+  it('should render Listen to article with proper separator when metadata exists', () => {
+    const resourceWithAudio = {
+      ...baseResource,
+      authors: 'Jane Smith',
+      timeFocusOnMins: 15,
+      syncedAudioUrl: 'https://open.spotify.com/episode/xyz789',
+    };
+
+    const { container } = render(
+      <ResourceListItem resource={resourceWithAudio} />
+    );
+
+    const metadata = container.querySelector('.resource-item__bottom-metadata');
+    expect(metadata).toMatchSnapshot();
+    
+    // Check that separators are rendered
+    const textContent = metadata?.textContent;
+    expect(textContent).toContain('Jane Smith');
+    expect(textContent).toContain('·');
+    expect(textContent).toContain('15 min');
+    expect(textContent).toContain('Listen to article');
+  });
+
+  it('should render Listen to article even without other metadata', () => {
+    const resourceWithOnlyAudio = {
+      ...baseResource,
+      authors: null,
+      timeFocusOnMins: null,
+      syncedAudioUrl: 'https://open.spotify.com/episode/solo123',
+    };
+
+    const { container, getByText } = render(
+      <ResourceListItem resource={resourceWithOnlyAudio} />
+    );
+
+    // Should show Listen to article button even when no other metadata
+    expect(getByText('Listen to article')).toBeTruthy();
+    
+    // Should not have separator when no other metadata
+    const metadata = container.querySelector('.resource-item__bottom-metadata');
+    expect(metadata?.textContent).not.toContain('·');
+    
+    expect(metadata).toMatchSnapshot();
+  });
+
+  it('should handle various metadata combinations with audio URL', () => {
+    // Only author and audio
+    const authorAndAudio = {
+      ...baseResource,
+      authors: 'Alice Brown',
+      timeFocusOnMins: null,
+      syncedAudioUrl: 'https://open.spotify.com/episode/author123',
+    };
+
+    const { container: container1 } = render(
+      <ResourceListItem resource={authorAndAudio} />
+    );
+    expect(container1.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
+
+    // Only time and audio
+    const timeAndAudio = {
+      ...baseResource,
+      authors: null,
+      timeFocusOnMins: 20,
+      syncedAudioUrl: 'https://open.spotify.com/episode/time123',
+    };
+
+    const { container: container2 } = render(
+      <ResourceListItem resource={timeAndAudio} />
+    );
+    expect(container2.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
+  });
+});

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -325,8 +325,8 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
 
           {/* Author and time metadata */}
           {(resource.authors || resource.timeFocusOnMins || resource.syncedAudioUrl) && (
-            <div className="resource-item__bottom-metadata mt-4 flex items-center gap-1">
-              <P className="text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]">
+            <div className="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2">
+              <P className="text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap">
                 {resource.authors && <span>{resource.authors}</span>}
                 {resource.authors && resource.timeFocusOnMins && <span> · </span>}
                 {resource.timeFocusOnMins && <span>{resource.timeFocusOnMins} min</span>}

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -20,6 +20,7 @@ import {
 import { ROUTES } from '../../lib/routes';
 import { FaviconImage } from './FaviconImage';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
+import ListenToArticleButton from './ListenToArticleButton';
 
 type UnitResource = InferSelectModel<typeof unitResourceTable.pg>;
 
@@ -323,13 +324,22 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
           )}
 
           {/* Author and time metadata */}
-          {(resource.authors || resource.timeFocusOnMins) && (
-            <div className="resource-item__bottom-metadata mt-4">
+          {(resource.authors || resource.timeFocusOnMins || resource.syncedAudioUrl) && (
+            <div className="resource-item__bottom-metadata mt-4 flex items-center gap-1">
               <P className="text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]">
                 {resource.authors && <span>{resource.authors}</span>}
                 {resource.authors && resource.timeFocusOnMins && <span> · </span>}
                 {resource.timeFocusOnMins && <span>{resource.timeFocusOnMins} min</span>}
+                {resource.syncedAudioUrl && (resource.timeFocusOnMins || resource.authors) && <span> ·</span>}
               </P>
+
+              {/* Listen to article button */}
+              {resource.syncedAudioUrl && (
+                <ListenToArticleButton
+                  audioUrl={resource.syncedAudioUrl}
+                  resourceTitle={resource.resourceName}
+                />
+              )}
             </div>
           )}
 

--- a/apps/website/src/components/courses/__snapshots__/ListenToArticleButton.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/ListenToArticleButton.test.tsx.snap
@@ -1,0 +1,39 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ListenToArticleButton > should render correctly 1`] = `
+<button
+  aria-label="Listen to article: Introduction to AI Safety (opens in Spotify)"
+  class="flex flex-row items-center gap-1.5 h-[18px] group cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+  type="button"
+>
+  <svg
+    aria-hidden="true"
+    fill="none"
+    height="16"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      class="group-hover:stroke-[#13132E] transition-colors duration-200"
+      height="14.75"
+      rx="7.375"
+      stroke="#6A6F7A"
+      stroke-width="1.25"
+      width="14.75"
+      x="0.625"
+      y="0.625"
+    />
+    <path
+      class="group-hover:fill-[#13132E] transition-colors duration-200"
+      d="M6 10.4839V5.51675C6 5.13551 6.40956 4.89452 6.74282 5.07967L11.2133 7.56325C11.5562 7.75375 11.5562 8.2469 11.2133 8.4374L6.74282 10.921C6.40956 11.1061 6 10.8651 6 10.4839Z"
+      fill="#6A6F7A"
+    />
+  </svg>
+  <span
+    class="text-[13px] font-medium leading-[140%] tracking-[-0.005em] text-[#6A6F7A] group-hover:text-[#13132E] transition-colors duration-200"
+  >
+    Listen to article
+  </span>
+</button>
+`;

--- a/apps/website/src/components/courses/__snapshots__/ResourceListItem.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/ResourceListItem.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`ResourceListItem - Listen to Article Feature > should handle various metadata combinations with audio URL 1`] = `
 <div
-  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+  class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
   >
     <span>
       Alice Brown
@@ -54,10 +54,10 @@ exports[`ResourceListItem - Listen to Article Feature > should handle various me
 
 exports[`ResourceListItem - Listen to Article Feature > should handle various metadata combinations with audio URL 2`] = `
 <div
-  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+  class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
   >
     <span>
       20
@@ -107,10 +107,10 @@ exports[`ResourceListItem - Listen to Article Feature > should handle various me
 
 exports[`ResourceListItem - Listen to Article Feature > should render Listen to article button when audio URL is provided 1`] = `
 <div
-  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+  class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
   >
     <span>
       John Doe
@@ -166,10 +166,10 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
 
 exports[`ResourceListItem - Listen to Article Feature > should render Listen to article even without other metadata 1`] = `
 <div
-  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+  class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
   />
   <button
     aria-label="Listen to article: Introduction to AI Safety (opens in Spotify)"
@@ -211,10 +211,10 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
 
 exports[`ResourceListItem - Listen to Article Feature > should render Listen to article with proper separator when metadata exists 1`] = `
 <div
-  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+  class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
   >
     <span>
       Jane Smith
@@ -270,10 +270,10 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
 
 exports[`ResourceListItem - Listen to Article Feature > should render metadata without Listen to article button when no audio URL 1`] = `
 <div
-  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+  class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
   >
     <span>
       John Doe

--- a/apps/website/src/components/courses/__snapshots__/ResourceListItem.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/ResourceListItem.test.tsx.snap
@@ -1,0 +1,290 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ResourceListItem - Listen to Article Feature > should handle various metadata combinations with audio URL 1`] = `
+<div
+  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+>
+  <p
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+  >
+    <span>
+      Alice Brown
+    </span>
+    <span>
+       ·
+    </span>
+  </p>
+  <button
+    aria-label="Listen to article: Introduction to AI Safety (opens in Spotify)"
+    class="flex flex-row items-center gap-1.5 h-[18px] group cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        class="group-hover:stroke-[#13132E] transition-colors duration-200"
+        height="14.75"
+        rx="7.375"
+        stroke="#6A6F7A"
+        stroke-width="1.25"
+        width="14.75"
+        x="0.625"
+        y="0.625"
+      />
+      <path
+        class="group-hover:fill-[#13132E] transition-colors duration-200"
+        d="M6 10.4839V5.51675C6 5.13551 6.40956 4.89452 6.74282 5.07967L11.2133 7.56325C11.5562 7.75375 11.5562 8.2469 11.2133 8.4374L6.74282 10.921C6.40956 11.1061 6 10.8651 6 10.4839Z"
+        fill="#6A6F7A"
+      />
+    </svg>
+    <span
+      class="text-[13px] font-medium leading-[140%] tracking-[-0.005em] text-[#6A6F7A] group-hover:text-[#13132E] transition-colors duration-200"
+    >
+      Listen to article
+    </span>
+  </button>
+</div>
+`;
+
+exports[`ResourceListItem - Listen to Article Feature > should handle various metadata combinations with audio URL 2`] = `
+<div
+  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+>
+  <p
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+  >
+    <span>
+      20
+       min
+    </span>
+    <span>
+       ·
+    </span>
+  </p>
+  <button
+    aria-label="Listen to article: Introduction to AI Safety (opens in Spotify)"
+    class="flex flex-row items-center gap-1.5 h-[18px] group cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        class="group-hover:stroke-[#13132E] transition-colors duration-200"
+        height="14.75"
+        rx="7.375"
+        stroke="#6A6F7A"
+        stroke-width="1.25"
+        width="14.75"
+        x="0.625"
+        y="0.625"
+      />
+      <path
+        class="group-hover:fill-[#13132E] transition-colors duration-200"
+        d="M6 10.4839V5.51675C6 5.13551 6.40956 4.89452 6.74282 5.07967L11.2133 7.56325C11.5562 7.75375 11.5562 8.2469 11.2133 8.4374L6.74282 10.921C6.40956 11.1061 6 10.8651 6 10.4839Z"
+        fill="#6A6F7A"
+      />
+    </svg>
+    <span
+      class="text-[13px] font-medium leading-[140%] tracking-[-0.005em] text-[#6A6F7A] group-hover:text-[#13132E] transition-colors duration-200"
+    >
+      Listen to article
+    </span>
+  </button>
+</div>
+`;
+
+exports[`ResourceListItem - Listen to Article Feature > should render Listen to article button when audio URL is provided 1`] = `
+<div
+  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+>
+  <p
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+  >
+    <span>
+      John Doe
+    </span>
+    <span>
+       · 
+    </span>
+    <span>
+      10
+       min
+    </span>
+    <span>
+       ·
+    </span>
+  </p>
+  <button
+    aria-label="Listen to article: Introduction to AI Safety (opens in Spotify)"
+    class="flex flex-row items-center gap-1.5 h-[18px] group cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        class="group-hover:stroke-[#13132E] transition-colors duration-200"
+        height="14.75"
+        rx="7.375"
+        stroke="#6A6F7A"
+        stroke-width="1.25"
+        width="14.75"
+        x="0.625"
+        y="0.625"
+      />
+      <path
+        class="group-hover:fill-[#13132E] transition-colors duration-200"
+        d="M6 10.4839V5.51675C6 5.13551 6.40956 4.89452 6.74282 5.07967L11.2133 7.56325C11.5562 7.75375 11.5562 8.2469 11.2133 8.4374L6.74282 10.921C6.40956 11.1061 6 10.8651 6 10.4839Z"
+        fill="#6A6F7A"
+      />
+    </svg>
+    <span
+      class="text-[13px] font-medium leading-[140%] tracking-[-0.005em] text-[#6A6F7A] group-hover:text-[#13132E] transition-colors duration-200"
+    >
+      Listen to article
+    </span>
+  </button>
+</div>
+`;
+
+exports[`ResourceListItem - Listen to Article Feature > should render Listen to article even without other metadata 1`] = `
+<div
+  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+>
+  <p
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+  />
+  <button
+    aria-label="Listen to article: Introduction to AI Safety (opens in Spotify)"
+    class="flex flex-row items-center gap-1.5 h-[18px] group cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        class="group-hover:stroke-[#13132E] transition-colors duration-200"
+        height="14.75"
+        rx="7.375"
+        stroke="#6A6F7A"
+        stroke-width="1.25"
+        width="14.75"
+        x="0.625"
+        y="0.625"
+      />
+      <path
+        class="group-hover:fill-[#13132E] transition-colors duration-200"
+        d="M6 10.4839V5.51675C6 5.13551 6.40956 4.89452 6.74282 5.07967L11.2133 7.56325C11.5562 7.75375 11.5562 8.2469 11.2133 8.4374L6.74282 10.921C6.40956 11.1061 6 10.8651 6 10.4839Z"
+        fill="#6A6F7A"
+      />
+    </svg>
+    <span
+      class="text-[13px] font-medium leading-[140%] tracking-[-0.005em] text-[#6A6F7A] group-hover:text-[#13132E] transition-colors duration-200"
+    >
+      Listen to article
+    </span>
+  </button>
+</div>
+`;
+
+exports[`ResourceListItem - Listen to Article Feature > should render Listen to article with proper separator when metadata exists 1`] = `
+<div
+  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+>
+  <p
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+  >
+    <span>
+      Jane Smith
+    </span>
+    <span>
+       · 
+    </span>
+    <span>
+      15
+       min
+    </span>
+    <span>
+       ·
+    </span>
+  </p>
+  <button
+    aria-label="Listen to article: Introduction to AI Safety (opens in Spotify)"
+    class="flex flex-row items-center gap-1.5 h-[18px] group cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        class="group-hover:stroke-[#13132E] transition-colors duration-200"
+        height="14.75"
+        rx="7.375"
+        stroke="#6A6F7A"
+        stroke-width="1.25"
+        width="14.75"
+        x="0.625"
+        y="0.625"
+      />
+      <path
+        class="group-hover:fill-[#13132E] transition-colors duration-200"
+        d="M6 10.4839V5.51675C6 5.13551 6.40956 4.89452 6.74282 5.07967L11.2133 7.56325C11.5562 7.75375 11.5562 8.2469 11.2133 8.4374L6.74282 10.921C6.40956 11.1061 6 10.8651 6 10.4839Z"
+        fill="#6A6F7A"
+      />
+    </svg>
+    <span
+      class="text-[13px] font-medium leading-[140%] tracking-[-0.005em] text-[#6A6F7A] group-hover:text-[#13132E] transition-colors duration-200"
+    >
+      Listen to article
+    </span>
+  </button>
+</div>
+`;
+
+exports[`ResourceListItem - Listen to Article Feature > should render metadata without Listen to article button when no audio URL 1`] = `
+<div
+  class="resource-item__bottom-metadata mt-4 flex items-center gap-1"
+>
+  <p
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
+  >
+    <span>
+      John Doe
+    </span>
+    <span>
+       · 
+    </span>
+    <span>
+      10
+       min
+    </span>
+  </p>
+</div>
+`;


### PR DESCRIPTION
# Description
Adds a "Listen to Article" feature that allows users to listen to audio versions of course resources via Spotify. The button is displayed in resource cards when available and is responsive on mobile. Added new snapshot tests accordingly.

As discussed in #1148, native media player would be separated into a future issue if it is decided that it should be prioritized.

## Issue
Fixes #1148 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Video Screenshots
### Desktop
![listen-to-article-desktop](https://github.com/user-attachments/assets/77ccf0bc-931a-431f-9bbe-65f6fdcb9912)

### Mobile
![listen-to-article-mobile](https://github.com/user-attachments/assets/aad234e3-647f-43b7-a5c2-869fc65dfe50)


