### PR TITLE
[Feature] 'Optional resources' design update

### DIFF
--- a/apps/website/src/components/courses/ResourceDisplay.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { unitResourceTable, exerciseTable, InferSelectModel } from '@bluedot/db';
+import { Collapsible } from '@bluedot/ui';
 import { ResourceListItem } from './ResourceListItem';
 import Exercise from './exercises/Exercise';
-import Callout from './Callout';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
 
 type UnitResource = InferSelectModel<typeof unitResourceTable.pg>;
@@ -117,7 +117,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
       {/* Optional Resources */}
       {optionalResources.length > 0 && (
         <section className="resource-display__optional mt-8">
-          <Callout title="Optional resources">
+          <Collapsible title="Optional resources">
             <div className="flex flex-col gap-6" role="list" aria-label="Optional resources">
               {optionalResources.map((resource) => (
                 <ResourceListItem
@@ -126,7 +126,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
                 />
               ))}
             </div>
-          </Callout>
+          </Collapsible>
         </section>
       )}
     </section>

--- a/apps/website/src/components/courses/ResourceDisplay.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.tsx
@@ -58,6 +58,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
   const coreResources = filterResourcesByType(resources, 'Core');
   const optionalResources = filterResourcesByType(resources, 'Further');
   const totalCoreResourceTime = calculateResourceTime(coreResources);
+  const totalOptionalResourceTime = calculateResourceTime(optionalResources);
 
   // Generate unique IDs for ARIA labeling
   const unitContext = unitTitle && unitNumber ? `Unit ${unitNumber}: ${unitTitle}` : '';
@@ -117,7 +118,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
       {/* Optional Resources */}
       {optionalResources.length > 0 && (
         <section className="resource-display__optional mt-8">
-          <Collapsible title="Optional resources">
+          <Collapsible title={`Optional Resources (${formatResourceTime(totalOptionalResourceTime)})`}>
             <div className="flex flex-col gap-6" role="list" aria-label="Optional resources">
               {optionalResources.map((resource) => (
                 <ResourceListItem

--- a/apps/website/src/components/courses/ResourceDisplay.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.tsx
@@ -118,7 +118,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
       {/* Optional Resources */}
       {optionalResources.length > 0 && (
         <section className="resource-display__optional mt-8">
-          <Collapsible title={`Optional Resources (${formatResourceTime(totalOptionalResourceTime)})`}>
+          <Collapsible title={`Optional Resources (${formatResourceTime(totalOptionalResourceTime)})`} summaryClassName="justify-start gap-2">
             <div className="flex flex-col gap-6" role="list" aria-label="Optional resources">
               {optionalResources.map((resource) => (
                 <ResourceListItem

--- a/libraries/ui/src/Collapsible.tsx
+++ b/libraries/ui/src/Collapsible.tsx
@@ -6,15 +6,16 @@ export type CollapsibleProps = React.PropsWithChildren<{
   title: string,
   // Optional
   className?: string,
+  summaryClassName?: string,
   children?: React.ReactNode;
 }>;
 
 export const Collapsible: React.FC<CollapsibleProps> = ({
-  children, className, title,
+  children, className, summaryClassName, title,
 }) => {
   return (
     <details className={clsx('collapsible max-w-max-width border-b border-color-divider py-4 last:border-b-0 group marker:hidden [&_summary::-webkit-details-marker]:hidden', className)}>
-      <summary className="collapsible__header flex justify-between w-full cursor-pointer py-6 text-left">
+      <summary className={clsx('collapsible__header flex justify-between w-full cursor-pointer py-6 text-left', summaryClassName)}>
         <span className="collapsible__title bluedot-h4">{title}</span>
         <span className="collapsible__button flex items-center">
           <svg


### PR DESCRIPTION
# Description

Closes #1273.

1. Replaces "Optional resources" `Callout` with `Collapsible`
2. Allows over-riding `Collapsible` summary styles - use this to position the chevron directly next to the text

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [] Considered adding Storybook stories

## Screenshot

| 📸 |  |
|---------|---|
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
