### PR TITLE
Remove year so that Drizzle doesn't attempt to alter the existing year data but rather drop it and re-add it as a different type

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -770,10 +770,6 @@ export const unitResourceTable = pgAirtable('unit_resource', {
       pgColumn: text().default(''), // For future github issue #1148
       airtableId: 'fldIqUoLYILUmMgY0',
     },
-    year: {
-      pgColumn: text(),
-      airtableId: 'fldtl37ZOF2Qx4Ui8',
-    },
   },
 });
 


### PR DESCRIPTION
# Description
PG has already set year as a text column, which is making drizzle use an alter table command (which ends up failing) instead of dropping the column and adding it back.

I'll follow this up with another schema change to make year numeric. I've tested this all locally and can confirm that this was the issue


Fixes #
https://github.com/bluedotimpact/bluedot/commit/5e419368c56fbe5d05df09ea582826f504c03e9b
