### PR TITLE
[fix] Make year numeric after having it removed completely

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -770,6 +770,10 @@ export const unitResourceTable = pgAirtable('unit_resource', {
       pgColumn: text().default(''), // For future github issue #1148
       airtableId: 'fldIqUoLYILUmMgY0',
     },
+    year: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldtl37ZOF2Qx4Ui8',
+    },
   },
 });
 


### PR DESCRIPTION
# Description
Fixes how prod originally have year as a text, and couldn't directly alter the column from text to number automatically.

https://github.com/bluedotimpact/bluedot/pull/1277


## Issue
Fixes 
https://github.com/bluedotimpact/bluedot/commit/5e419368c56fbe5d05df09ea582826f504c03e9b

Will only merge this after prod changes the schema to remove year.