### PR TITLE
[Feat] Adding "year" and fixing text wrapping

### DIFF
--- a/apps/website/src/components/courses/ResourceListItem.test.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.test.tsx
@@ -45,21 +45,18 @@ vi.mock('./MarkdownExtendedRenderer', () => ({
 describe('ResourceListItem - Listen to Article Feature', () => {
   const baseResource = {
     id: 'test-resource-1',
-    resourceId: 'rec123',
-    unitId: 'unit123',
     resourceName: 'Introduction to AI Safety',
-    resourceType: 'article' as const,
-    platform: 'Medium',
+    resourceType: 'article',
+    resourceLink: 'https://example.com/article',
+    resourceGuide: 'This is a guide to the resource',
     authors: 'John Doe',
     timeFocusOnMins: 10,
-    url: 'https://example.com/article',
-    resourceGuide: 'This is a guide to the resource',
-    updatedAt: new Date('2024-01-01'),
-    createdAt: new Date('2024-01-01'),
-    deletedAt: null,
-    year: 2024,
-    unitNumber: 1,
+    coreFurtherMaybe: null,
+    readingOrder: null,
+    unitId: 'unit123',
+    avgRating: null,
     syncedAudioUrl: null,
+    year: 2024,
   };
 
   it('should render metadata without Listen to article button when no audio URL', () => {
@@ -67,8 +64,9 @@ describe('ResourceListItem - Listen to Article Feature', () => {
       <ResourceListItem resource={baseResource} />,
     );
 
-    // Should show author and time
+    // Should show author, year, and time
     expect(queryByText(/John Doe/)).toBeTruthy();
+    expect(queryByText(/2024/)).toBeTruthy();
     expect(queryByText(/10 min/)).toBeTruthy();
 
     // Should NOT show Listen to article
@@ -133,9 +131,11 @@ describe('ResourceListItem - Listen to Article Feature', () => {
     // Should show Listen to article button even when no other metadata
     expect(getByText('Listen to article')).toBeTruthy();
 
-    // Should not have separator when no other metadata
+    // Should show year and separator before audio button
     const metadata = container.querySelector('.resource-item__bottom-metadata');
-    expect(metadata?.textContent).not.toContain('·');
+    expect(metadata?.textContent).toContain('2024');
+    expect(metadata?.textContent).toContain('·');
+    expect(metadata?.textContent).toContain('Listen to article');
 
     expect(metadata).toMatchSnapshot();
   });
@@ -166,5 +166,58 @@ describe('ResourceListItem - Listen to Article Feature', () => {
       <ResourceListItem resource={timeAndAudio} />,
     );
     expect(container2.querySelector('.resource-item__bottom-metadata')).toMatchSnapshot();
+  });
+
+  it('should display year field correctly in metadata', () => {
+    const { queryByText } = render(
+      <ResourceListItem resource={baseResource} />,
+    );
+
+    // Should show year between author and time
+    expect(queryByText(/2024/)).toBeTruthy();
+  });
+
+  it('should handle metadata without year field', () => {
+    const resourceWithoutYear = {
+      ...baseResource,
+      year: null,
+    };
+
+    const { container, queryByText } = render(
+      <ResourceListItem resource={resourceWithoutYear} />,
+    );
+
+    // Should show author and time but not year
+    expect(queryByText(/John Doe/)).toBeTruthy();
+    expect(queryByText(/10 min/)).toBeTruthy();
+    expect(queryByText(/2024/)).toBeFalsy();
+
+    // Check proper separator handling without year
+    const metadata = container.querySelector('.resource-item__bottom-metadata');
+    const textContent = metadata?.textContent;
+    expect(textContent).toContain('John Doe');
+    expect(textContent).toContain('·');
+    expect(textContent).toContain('10 min');
+  });
+
+  it('should handle only year field in metadata', () => {
+    const resourceWithOnlyYear = {
+      ...baseResource,
+      authors: null,
+      timeFocusOnMins: null,
+    };
+
+    const { container, queryByText } = render(
+      <ResourceListItem resource={resourceWithOnlyYear} />,
+    );
+
+    // Should show only year
+    expect(queryByText(/2024/)).toBeTruthy();
+    expect(queryByText(/John Doe/)).toBeFalsy();
+    expect(queryByText(/10 min/)).toBeFalsy();
+
+    // Should not have separators when only year is present
+    const metadata = container.querySelector('.resource-item__bottom-metadata');
+    expect(metadata?.textContent).not.toContain('·');
   });
 });

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -324,13 +324,15 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
           )}
 
           {/* Author and time metadata */}
-          {(resource.authors || resource.timeFocusOnMins || resource.syncedAudioUrl) && (
+          {(resource.authors || resource.year || resource.timeFocusOnMins || resource.syncedAudioUrl) && (
             <div className="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2">
               <P className="text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap">
                 {resource.authors && <span>{resource.authors}</span>}
-                {resource.authors && resource.timeFocusOnMins && <span> · </span>}
+                {resource.authors && (resource.year || resource.timeFocusOnMins) && <span> · </span>}
+                {resource.year && <span>{resource.year}</span>}
+                {resource.year && resource.timeFocusOnMins && <span> · </span>}
                 {resource.timeFocusOnMins && <span>{resource.timeFocusOnMins} min</span>}
-                {resource.syncedAudioUrl && (resource.timeFocusOnMins || resource.authors) && <span> ·</span>}
+                {resource.syncedAudioUrl && (resource.timeFocusOnMins || resource.year || resource.authors) && <span> ·</span>}
               </P>
 
               {/* Listen to article button */}

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -326,7 +326,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
           {/* Author and time metadata */}
           {(resource.authors || resource.year || resource.timeFocusOnMins || resource.syncedAudioUrl) && (
             <div className="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2">
-              <P className="text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap">
+              <P className="text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]">
                 {resource.authors && <span>{resource.authors}</span>}
                 {resource.authors && (resource.year || resource.timeFocusOnMins) && <span> · </span>}
                 {resource.year && <span>{resource.year}</span>}
@@ -361,13 +361,13 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
               <div className="w-full h-0 opacity-20 border-[0.5px] border-[#13132E] my-4" />
 
               {/* Bottom action bar */}
-              <div className="flex flex-row justify-between items-center p-0 gap-2 h-[30px]">
+              <div className="flex flex-wrap items-center p-0 gap-2 min-h-[30px]">
                 {/* Complete/Completed button */}
                 {!isCompleted ? (
                   <button
                     type="button"
                     onClick={() => handleToggleComplete(true)}
-                    className="flex flex-row justify-center items-center px-2.5 py-1.5 gap-2 w-20 h-[30px] bg-[#2244BB] rounded-md border-none cursor-pointer font-medium text-[13px] leading-[140%] tracking-[-0.005em] text-white flex-shrink-0 transition-all duration-200"
+                    className="flex flex-row justify-center items-center px-2.5 py-1.5 gap-2 w-20 h-[30px] bg-[#2244BB] rounded-md border-none cursor-pointer font-medium text-[13px] leading-[140%] tracking-[-0.005em] text-white transition-all duration-200"
                     aria-label="Mark resource as complete"
                   >
                     Complete
@@ -376,7 +376,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
                   <button
                     type="button"
                     onClick={() => handleToggleComplete(false)}
-                    className="flex items-center gap-2 transition-all duration-200 hover:opacity-70 flex-shrink-0 bg-transparent border-none cursor-pointer p-0"
+                    className="flex items-center gap-2 transition-all duration-200 hover:opacity-70 bg-transparent border-none cursor-pointer p-0"
                     aria-label="Mark resource as incomplete"
                   >
                     <span className="font-medium text-[13px] leading-[140%] tracking-[-0.005em] text-[#2244BB]">
@@ -390,7 +390,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
 
                 {/* Feedback buttons (show when completed or feedback given) */}
                 {showFeedback && (
-                  <div className="flex-shrink-0">
+                  <div>
                     <FeedbackSection
                       resourceFeedback={resourceFeedback}
                       onFeedback={handleFeedback}

--- a/apps/website/src/components/courses/__snapshots__/ResourceListItem.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/ResourceListItem.test.tsx.snap
@@ -11,6 +11,12 @@ exports[`ResourceListItem - Listen to Article Feature > should handle various me
       Alice Brown
     </span>
     <span>
+       · 
+    </span>
+    <span>
+      2024
+    </span>
+    <span>
        ·
     </span>
   </p>
@@ -59,6 +65,12 @@ exports[`ResourceListItem - Listen to Article Feature > should handle various me
   <p
     class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
   >
+    <span>
+      2024
+    </span>
+    <span>
+       · 
+    </span>
     <span>
       20
        min
@@ -119,6 +131,12 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
        · 
     </span>
     <span>
+      2024
+    </span>
+    <span>
+       · 
+    </span>
+    <span>
       10
        min
     </span>
@@ -170,7 +188,14 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
 >
   <p
     class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
-  />
+  >
+    <span>
+      2024
+    </span>
+    <span>
+       ·
+    </span>
+  </p>
   <button
     aria-label="Listen to article: Introduction to AI Safety (opens in Spotify)"
     class="flex flex-row items-center gap-1.5 h-[18px] group cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
@@ -218,6 +243,12 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
   >
     <span>
       Jane Smith
+    </span>
+    <span>
+       · 
+    </span>
+    <span>
+      2024
     </span>
     <span>
        · 
@@ -277,6 +308,12 @@ exports[`ResourceListItem - Listen to Article Feature > should render metadata w
   >
     <span>
       John Doe
+    </span>
+    <span>
+       · 
+    </span>
+    <span>
+      2024
     </span>
     <span>
        · 

--- a/apps/website/src/components/courses/__snapshots__/ResourceListItem.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/ResourceListItem.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ResourceListItem - Listen to Article Feature > should handle various me
   class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
   >
     <span>
       Alice Brown
@@ -63,7 +63,7 @@ exports[`ResourceListItem - Listen to Article Feature > should handle various me
   class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
   >
     <span>
       2024
@@ -122,7 +122,7 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
   class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
   >
     <span>
       John Doe
@@ -187,7 +187,7 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
   class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
   >
     <span>
       2024
@@ -239,7 +239,7 @@ exports[`ResourceListItem - Listen to Article Feature > should render Listen to 
   class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
   >
     <span>
       Jane Smith
@@ -304,7 +304,7 @@ exports[`ResourceListItem - Listen to Article Feature > should render metadata w
   class="resource-item__bottom-metadata mt-4 flex flex-wrap items-center gap-x-1 gap-y-2"
 >
   <p
-    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em] whitespace-nowrap"
+    class="bluedot-p not-prose text-gray-600 text-[13px] font-medium leading-[140%] tracking-[-0.005em]"
   >
     <span>
       John Doe


### PR DESCRIPTION
# Description
Added the "year" to the resources, and fixed the text wrapping on mobile. 

I ran the tests to ensure it works. 

## Screenshot
<!-- If this PR results in visual changes -->

| **Before** | **After** |
|---|---|
| <img width="766" height="1078" alt="CleanShot 2025-09-02 at 21 34 51@2x" src="https://github.com/user-attachments/assets/fa48a3a3-8273-4eca-bca0-d7cd6918984d" /> | <img width="844" height="1384" alt="CleanShot 2025-09-02 at 21 34 40@2x" src="https://github.com/user-attachments/assets/5286068b-106a-4859-b473-1de7f0cb6060" /> |
<img width="3054" height="832" alt="CleanShot 2025-09-02 at 21 35 31@2x" src="https://github.com/user-attachments/assets/bf7ec19d-ac1c-4c36-af69-14520a791d2a" />

