### PR TITLE
`cn` class merge utility

### DIFF
--- a/libraries/ui/package.json
+++ b/libraries/ui/package.json
@@ -31,6 +31,7 @@
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
     "react-icons": "^4.3.1",
+    "tailwind-merge": "^3.3.1",
     "winston": "^3.17.0",
     "winston-console-format": "^1.0.8",
     "zod": "^3.24.2",

--- a/libraries/ui/src/CTALinkOrButton.stories.tsx
+++ b/libraries/ui/src/CTALinkOrButton.stories.tsx
@@ -178,3 +178,11 @@ export const DisabledLink: Story = {
     disabled: true,
   },
 };
+
+export const CustomStyles: Story = {
+  args: {
+    children: 'Custom Styles',
+    variant: 'primary',
+    className: 'bg-[#2244BB] hover:bg-[color-mix(in_oklab,#2244BB,#000_30%)] text-white hover:text-white',
+  },
+};

--- a/libraries/ui/src/CTALinkOrButton.tsx
+++ b/libraries/ui/src/CTALinkOrButton.tsx
@@ -1,7 +1,7 @@
-import clsx from 'clsx';
 import React from 'react';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 import { ClickTarget, ClickTargetProps } from './ClickTarget';
+import { cn } from './utils';
 
 export type CTALinkOrButtonProps = {
   variant?: 'primary' | 'secondary' | 'black' | 'outline-black';
@@ -36,7 +36,7 @@ export const CTALinkOrButton: React.FC<CTALinkOrButtonProps> = ({
 }) => {
   return (
     <ClickTarget
-      className={clsx(
+      className={cn(
         CTA_BASE_STYLES,
         CTA_SIZE_STYLES[size],
         CTA_VARIANT_STYLES[variant],

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -86,6 +86,7 @@ export type { BugReportModalProps } from './BugReportModal';
 
 export { addQueryParam } from './utils/addQueryParam';
 export { maybePlural } from './utils';
+export { cn } from './utils';
 export { asError } from './utils/asError';
 export { useAuthStore, withAuth, type Auth } from './utils/auth';
 export * as constants from './constants';

--- a/libraries/ui/src/utils/index.ts
+++ b/libraries/ui/src/utils/index.ts
@@ -1,3 +1,22 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
 export const maybePlural = (count: number, base: string, pluralEnding = 's'): string => {
   return `${count} ${base}${count === 1 ? '' : pluralEnding}`;
 };
+
+/**
+ * Merges Tailwind CSS classes with proper conflict resolution. Later classes always take precedence over earlier ones.
+ *
+ * @example
+ * ```ts
+ * // Without cn:
+ * clsx('rounded-sm', 'rounded-md') // No guarantee which class will be applied
+ *
+ * // With cn:
+ * cn('rounded-sm', 'rounded-md') // Always 'rounded-md'
+ * ```
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -805,6 +805,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "dotenv": "^16.4.5",
         "eslint": "^8.57.0",
+        "tailwind-merge": "^3.3.1",
         "typescript": "^5.8.3",
         "vitest": "^3.2.3"
       }
@@ -32462,6 +32463,17 @@
       "integrity": "sha512-HYkOQ/8ha113ln/Vp48wiDTPtbB59AWOdU44AXjhLyJLJjWWfn2kjnXUcyWLQepwbixA/mEeo1iW2Z9OwaBClQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.1.10",


### PR DESCRIPTION
# Description

We don't have a way to ensure that overriding styles we pass via `className` are respected.

Consider the `CTALinkOrButton`, which has a 'primary' `bg-bluedot-normal`. If a caller passes a `bg-[#mycustomcolor]` via the `className` prop both classes are present in the DOM. Since Tailwind generates CSS with similar specificity for these background utilities, the order they appear in  the compiled stylesheet (not the order in your className string) determines which one actually applies - leading to unpredictable results. This means that callers need to [use the `!important` specifier,](https://github.com/bluedotimpact/bluedot/pull/1269/files#diff-9991d16143d4292f8d7d0ab1980bdfb984bca5a612ef6c4e21e26b12c42b950eR144) which is not ideal.

This `cn()` utility solves this by detecting conflicting Tailwind classes and ensuring only the last one (your custom colour override) is included in the final output. This a fairly common pattern -[ ShadCN uses it extensively.](https://ui.shadcn.com/docs/installation/manual#add-a-cn-helper)

