### PR TITLE
[Bug] Support dynamic DNS resolution in posthog-proxy

### DIFF
--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -8,7 +8,7 @@ http {
     }
 
     server {
-        resolver 8.8.8.8 8.8.4.4 [2001:4860:4860::]:8888 [2001:4860:4860::]:8844 valid=300s;
+        resolver 8.8.8.8 8.8.4.4 [2001:4860:4860::8888] [2001:4860:4860::8844] valid=300s;
         resolver_timeout 5s;
 
         set $posthog_upstream "eu.i.posthog.com";

--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -8,6 +8,11 @@ http {
     }
 
     server {
+        resolver 8.8.8.8 8.8.4.4 [2001:4860:4860::]:8888 [2001:4860:4860::]:8844 valid=300s;
+        resolver_timeout 5s;
+
+        set $posthog_upstream "eu.i.posthog.com";
+
         listen 8080;
         add_header X-BlueDot-Version '$VERSION_TAG';
 
@@ -32,7 +37,7 @@ http {
                 return 204;
             }
 
-            proxy_set_header Host eu.i.posthog.com;
+            proxy_set_header Host $posthog_upstream;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
@@ -42,7 +47,8 @@ http {
             proxy_set_header User-Agent $http_user_agent;
 
             # Route to ingestion API
-            proxy_pass https://eu.i.posthog.com;
+            # Use variable to force proper DNS re-resolution, otherwise analytics can drop if PostHog rotates IP addresses upstream
+            proxy_pass https://$posthog_upstream;
             proxy_redirect off;
             proxy_ssl_session_reuse off;
             proxy_ssl_server_name on;


### PR DESCRIPTION
# Description

PostHog analytics dropped to zero with no obvious cause on 2025-08-25, and came back when I [upgraded Kubernetes](https://github.com/bluedotimpact/bluedot/issues/1266#issuecomment-3248563311) on 2025-09-03, which caused the pod to restart.

I looked at the [logs in Grafana at the time the problem started](https://grafana.k8s.bluedot.org/a/grafana-lokiexplore-app/explore/k8s_deployment_name/bluedot-posthog-proxy-deployment/logs?from=2025-08-25T13:00:00.000Z&to=2025-08-25T13:27:40.000Z&var-ds=fekp33muo5pfka&var-filters=k8s_deployment_name%7C%3D%7Cbluedot-posthog-proxy-deployment&patterns=%5B%5D&var-lineFormat=&var-fields=&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&timezone=browser&var-all-fields=&displayedFields=%5B%5D&urlColumns=%5B%5D&visualizationType=%22logs%22&prettifyLogMessage=false&sortOrder=%22Descending%22&wrapLogMessage=false), and we start seeing logs like this:
```
1756126890467	2025-08-25T13:01:30.467Z	2025/08/25 13:01:30 [error] 30#30: *443656 upstream timed out (110: Operation timed out) while connecting to upstream, client: 10.244.10.178, server: , request: "POST /i/v0/e/?retry_count=1&ip=1&_=1756126830540&ver=1.252.0&compression=gzip-js HTTP/1.1", upstream: "https://[2a05:d014:1776:c001:8d66:b232:8df4:611c]:443/i/v0/e/?retry_count=1&ip=1&_=1756126830540&ver=1.252.0&compression=gzip-js", host: "analytics.k8s.bluedot.org", referrer: "https://bluedot.org/"
```
Also the requests start returning 499 "Client Closed Request", which is consistent with timing out while trying to connect to the upstream PostHog server:
```
2025-08-25 14:08:18.855	
10.244.10.178 - - [25/Aug/2025:13:08:18 +0000] "POST /e/?ip=1&_=1756127238773&ver=1.252.0&beacon=1 HTTP/1.1" 499 0 "https://bluedot.org/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36"
```

Combined with the fact that restarting the pod fixed the problem, I think this is probably due to PostHog rotating the IP address of the upstream server, since [nginx resolves domain names to IPs once on startup and then caches them](https://trac.nginx.org/nginx/ticket/1064#comment:1) by default. Other evidence: the [PostHog nginx template](https://posthog.com/docs/advanced/proxy/nginx) includes the variable trick added in this PR, with the comment `# use variable to force proper DNS re-resolution`.

This trick of using a variable seems to be the standard way to handle this problem, there are a bunch of [forum answers](https://serverfault.com/a/593003) with similar problems and this as the suggested solution.

### Steps to test

Run the service locally (make sure Docker is running):
```
cd apps/posthog-proxy
npm run start
```

Send a fake analytics event:
```
curl -i -X POST http://localhost:8000/e/ \
  -H "Content-Type: application/json" \
  -H "Origin: https://bluedot.org" \
  -H "Referer: https://bluedot.org/" \
  -d '{
    "api_key": "NEXT_PUBLIC_POSTHOG_KEY from apps/website/.env.local",
    "event": "test_event",
    "properties": {"test": true},
    "distinct_id": "test_user_123"
  }'
```
It should return `{"status":"Ok"}`. I only tested that it returned Ok, not that the event makes it through to PostHog.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1175

## Developer checklist

N/A