### PR TITLE
[fixes] Potentially fix course page rendering issues: hooks order and DOM validation errors

### DIFF
--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -255,7 +255,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
               <div className="flex items-start gap-4">
                 <div className="flex-1">
                   {/* Resource title and link */}
-                  <P className="resource-item__title font-semibold leading-[140%] tracking-[-0.005em]">
+                  <div className="resource-item__title font-semibold leading-[140%] tracking-[-0.005em]">
                     {resource.resourceLink ? (
                       <div className="flex items-center group">
                         {/* Favicon */}
@@ -289,7 +289,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
                     ) : (
                       resource.resourceName
                     )}
-                  </P>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -255,15 +255,15 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
               <div className="flex items-start gap-4">
                 <div className="flex-1">
                   {/* Resource title and link */}
-                  <div className="resource-item__title font-semibold leading-[140%] tracking-[-0.005em]">
-                    {resource.resourceLink ? (
-                      <div className="flex items-center group">
-                        {/* Favicon */}
-                        <FaviconImage
-                          url={resource.resourceLink}
-                          displaySize={16}
-                          className="mr-2"
-                        />
+                  {resource.resourceLink ? (
+                    <div className="resource-item__title flex items-center group">
+                      {/* Favicon */}
+                      <FaviconImage
+                        url={resource.resourceLink}
+                        displaySize={16}
+                        className="mr-2"
+                      />
+                      <P className="font-semibold leading-[140%] tracking-[-0.005em]">
                         <a
                           href={resource.resourceLink}
                           target="_blank"
@@ -273,23 +273,25 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource }) 
                         >
                           {resource.resourceName}
                         </a>
-                        <a
-                          href={resource.resourceLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex group-hover:opacity-80 transition-opacity ml-2"
-                          aria-label={`Open ${resource.resourceName} in new tab`}
-                        >
-                          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                            <path d="M9.14286 2.28613H13.7143M13.7143 2.28613V6.85756M13.7143 2.28613L8 8.00042" stroke="#13132E" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                            <path d="M5.71422 3.42871H4.28564C3.18108 3.42871 2.28564 4.32414 2.28564 5.42871V11.7144C2.28564 12.819 3.18108 13.7144 4.28565 13.7144H10.5714C11.6759 13.7144 12.5714 12.819 12.5714 11.7144V10.2859" stroke="#13132E" strokeWidth="1.5" strokeLinecap="round" />
-                          </svg>
-                        </a>
-                      </div>
-                    ) : (
-                      resource.resourceName
-                    )}
-                  </div>
+                      </P>
+                      <a
+                        href={resource.resourceLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex group-hover:opacity-80 transition-opacity ml-2"
+                        aria-label={`Open ${resource.resourceName} in new tab`}
+                      >
+                        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                          <path d="M9.14286 2.28613H13.7143M13.7143 2.28613V6.85756M13.7143 2.28613L8 8.00042" stroke="#13132E" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                          <path d="M5.71422 3.42871H4.28564C3.18108 3.42871 2.28564 4.32414 2.28564 5.42871V11.7144C2.28564 12.819 3.18108 13.7144 4.28565 13.7144H10.5714C11.6759 13.7144 12.5714 12.819 12.5714 11.7144V10.2859" stroke="#13132E" strokeWidth="1.5" strokeLinecap="round" />
+                        </svg>
+                      </a>
+                    </div>
+                  ) : (
+                    <P className="resource-item__title font-semibold leading-[140%] tracking-[-0.005em]">
+                      {resource.resourceName}
+                    </P>
+                  )}
                 </div>
               </div>
             </div>

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -15,9 +15,7 @@ const CourseUnitChunkPage = () => {
     },
   } = router;
 
-  if (typeof unitNumber !== 'string') {
-    return <ProgressDots />;
-  }
+  const auth = useAuthStore((s) => s.auth);
 
   // Handle old ?chunk={n-1} format redirect
   useEffect(() => {
@@ -36,8 +34,6 @@ const CourseUnitChunkPage = () => {
       router.replace(`/courses/${courseSlug}/${unitNumber}/1`);
     }
   }, [courseSlug, unitNumber, chunkNumber, router]);
-
-  const auth = useAuthStore((s) => s.auth);
 
   let actualChunkNumber = '1';
   // [[...chunkNumber]] catch-all syntax results in `chunkNumber` being an array, parse the first element
@@ -102,6 +98,11 @@ const CourseUnitChunkPage = () => {
   const handleSetChunkIndex = (newIndex: number) => {
     router.push(`/courses/${courseSlug}/${unitNumber}/${newIndex + 1}`);
   };
+
+  // Check for valid unitNumber after all hooks
+  if (typeof unitNumber !== 'string') {
+    return <ProgressDots />;
+  }
 
   if (loading || groupDiscussionLoading) {
     return <ProgressDots />;


### PR DESCRIPTION
# Description
This PR fixes two React errors that might have been preventing the course pages from rendering correctly:

1. **React Hooks Order Violation**: The `CourseUnitChunkPage` component had a conditional return statement before `useEffect` hooks, which violates React's Rules of Hooks. All hooks must be called in the same order on every render.

2. **Invalid DOM Nesting**: The `ResourceListItem` component was rendering a `<div>` element inside a `<P>` (paragraph) tag, which is invalid HTML and was causing React warnings.

These issues were causing instability in the course pages and potentially preventing exercises from displaying correctly.

## Issue
Currently can't see exercises locally, despite prod being at the same version as development. 
