### PR TITLE
Slack notifications for `pg-sync-service` errors

### DIFF
--- a/apps/pg-sync-service/src/lib/cron.ts
+++ b/apps/pg-sync-service/src/lib/cron.ts
@@ -28,18 +28,6 @@ cron.schedule(`*/${POLLING_INTERVAL_SECONDS} * * * * *`, cronJob);
 
 export const startCronJobs = async () => {
   logger.info('Starting cron jobs...');
-  try {
-    await initializeWebhooks();
-    cronJob();
-  } catch (error) {
-    const errorDetails = {
-      operation: 'initializing webhooks on startup',
-      errorType: error instanceof Error ? error.name : 'Unknown',
-      errorMessage: error instanceof Error ? error.message : String(error),
-      feedbackMessage: 'Webhook initialization failed - real-time sync will not work. Check database connection and Airtable credentials.',
-    };
-    const initError = `[startCronJobs] Critical webhook initialization failure: ${JSON.stringify(errorDetails)}`;
-    logger.error(initError);
-    await slackAlert(env, [initError]);
-  }
+  await initializeWebhooks();
+  cronJob();
 };

--- a/apps/pg-sync-service/src/lib/cron.ts
+++ b/apps/pg-sync-service/src/lib/cron.ts
@@ -1,8 +1,6 @@
 import cron from 'node-cron';
 import { logger } from '@bluedot/ui/src/api';
-import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import { initializeWebhooks, pollForUpdates, processUpdateQueue } from './pg-sync';
-import env from '../env';
 
 const POLLING_INTERVAL_SECONDS = 5;
 let isProcessing = false;

--- a/apps/pg-sync-service/src/lib/pg-sync.test.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.test.ts
@@ -12,6 +12,7 @@ import {
   getQueueStatus,
   deduplicateActions,
   clearQueues,
+  MAX_RETRIES,
 } from './pg-sync';
 import type { AirtableAction } from './webhook';
 
@@ -283,7 +284,7 @@ describe('pg-sync priority queue', () => {
     expect(vi.mocked(slackAlert)).toHaveBeenCalledWith(
       expect.any(Object),
       expect.arrayContaining([
-        expect.stringContaining('Update failed after 3 attempts, giving up: base1/table1/fail1'),
+        expect.stringContaining(`Update failed after ${MAX_RETRIES} attempts, giving up: base1/table1/fail1`),
       ]),
     );
   });

--- a/apps/pg-sync-service/src/lib/pg-sync.test.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.test.ts
@@ -30,6 +30,10 @@ vi.mock('./db', () => ({
   },
 }));
 
+vi.mock('@bluedot/utils/src/slackNotifications', () => ({
+  slackAlert: vi.fn(),
+}));
+
 // Mock the @bluedot/db module
 vi.mock('@bluedot/db', () => ({
   eq: vi.fn(),

--- a/apps/pg-sync-service/src/lib/pg-sync.test.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.test.ts
@@ -5,6 +5,7 @@ import {
   beforeEach,
   vi,
 } from 'vitest';
+import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import {
   addToQueue,
   processUpdateQueue,
@@ -276,5 +277,14 @@ describe('pg-sync priority queue', () => {
     const finalStatus = getQueueStatus();
     expect(finalStatus.high).toBe(0);
     expect(finalStatus.low).toBe(0);
+
+    // Slack alert should be called once for final failure
+    expect(vi.mocked(slackAlert)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(slackAlert)).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.arrayContaining([
+        expect.stringContaining('Update failed after 3 attempts, giving up: base1/table1/fail1'),
+      ]),
+    );
   });
 });

--- a/apps/pg-sync-service/src/lib/pg-sync.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.ts
@@ -244,13 +244,7 @@ export async function processUpdateQueue(processor: UpdateProcessor = processSin
         logger.info(`[processUpdateQueue] Update failed (attempt ${currentRetries + 1}/${MAX_RETRIES}), retrying: ${update.baseId}/${update.tableId}/${update.recordId}`);
         addToQueue([update], 'low');
       } else {
-        const errorDetails = {
-          baseId: update.baseId,
-          tableId: update.tableId,
-          recordId: update.recordId,
-          isDelete: update.isDelete,
-        };
-        const finalFailure = `[processUpdateQueue] Update failed after ${MAX_RETRIES} attempts, giving up: ${JSON.stringify(errorDetails)}`;
+        const finalFailure = `[processUpdateQueue] Update failed after ${MAX_RETRIES} attempts, giving up: ${update.baseId}/${update.tableId}/${update.recordId}`;
         logger.error(finalFailure);
         slackAlert(env, [finalFailure]);
         retryCountMap.delete(retryKey);

--- a/apps/pg-sync-service/src/lib/pg-sync.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.ts
@@ -237,7 +237,13 @@ export async function processUpdateQueue(processor: UpdateProcessor = processSin
         logger.info(`[processUpdateQueue] Update failed (attempt ${currentRetries + 1}/${MAX_RETRIES}), retrying: ${update.baseId}/${update.tableId}/${update.recordId}`);
         addToQueue([update], 'low');
       } else {
-        const finalFailure = `[processUpdateQueue] Update failed after ${MAX_RETRIES} attempts, giving up: ${update.baseId}/${update.tableId}/${update.recordId}`;
+        const errorDetails = {
+          baseId: update.baseId,
+          tableId: update.tableId,
+          recordId: update.recordId,
+          isDelete: update.isDelete,
+        };
+        const finalFailure = `[processUpdateQueue] Update failed after ${MAX_RETRIES} attempts, giving up: ${JSON.stringify(errorDetails)}`;
         logger.error(finalFailure);
         slackAlert(env, [finalFailure]);
         retryCountMap.delete(retryKey);

--- a/apps/pg-sync-service/src/lib/pg-sync.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.ts
@@ -77,11 +77,7 @@ export async function initializeWebhooks(): Promise<void> {
 
     logger.info(`[initializeWebhooks] Initialized ${Object.keys(webhookInstances).length} webhooks with field-level filtering`);
   } catch (error) {
-    const errorDetails = {
-      name: error instanceof Error ? error.name : 'UnknownError',
-      message: error instanceof Error ? error.message : String(error),
-    };
-    const initError = `[initializeWebhooks] Critical webhook initialization failure: ${JSON.stringify(errorDetails)}`;
+    const initError = `[initializeWebhooks] Critical webhook initialization failure: ${error instanceof Error ? error.message : String(error)}`;
     logger.error(initError);
     await slackAlert(env, [initError]);
     throw error;

--- a/apps/pg-sync-service/src/lib/pg-sync.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.ts
@@ -10,7 +10,7 @@ import { RateLimiter } from './rate-limiter';
 import { syncManager } from './sync-manager';
 import env from '../env';
 
-const MAX_RETRIES = 3;
+export const MAX_RETRIES = 3;
 const highPriorityQueue: AirtableAction[] = [];
 const lowPriorityQueue: AirtableAction[] = [];
 const rateLimiter = new RateLimiter(5);

--- a/apps/pg-sync-service/src/lib/scan.test.ts
+++ b/apps/pg-sync-service/src/lib/scan.test.ts
@@ -15,6 +15,10 @@ vi.mock('./db', () => ({
   },
 }));
 
+vi.mock('@bluedot/utils/src/slackNotifications', () => ({
+  slackAlert: vi.fn(),
+}));
+
 describe('processTableForInitialSync', () => {
   let mockAddToQueue: ReturnType<typeof vi.fn>;
   let mockPgAirtable: { airtable: { name: string; baseId: string; tableId: string; schema: Record<string, string>; mappings: Record<string, string> } };

--- a/apps/pg-sync-service/src/lib/scan.ts
+++ b/apps/pg-sync-service/src/lib/scan.ts
@@ -50,7 +50,15 @@ export async function processTableForInitialSync(
     }
 
     if (!records) {
-      throw new Error(lastError?.message || 'Failed to scan records after retries');
+      const errorDetails = {
+        baseId,
+        tableId,
+        fieldIds,
+        maxRetries,
+        lastErrorType: lastError?.name || 'Unknown',
+        lastErrorMessage: lastError?.message || 'No error details available',
+      };
+      throw new Error(`Failed to scan records after ${maxRetries} retries: ${JSON.stringify(errorDetails)}`);
     }
 
     const duration = Date.now() - startTime;

--- a/apps/pg-sync-service/src/lib/scan.ts
+++ b/apps/pg-sync-service/src/lib/scan.ts
@@ -43,8 +43,6 @@ export async function processTableForInitialSync(
           await new Promise((resolve) => {
             setTimeout(resolve, retryDelay);
           });
-        } else {
-          throw error;
         }
       }
     }

--- a/apps/pg-sync-service/src/lib/schema-sync.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.ts
@@ -161,7 +161,7 @@ export async function ensureSchemaUpToDate(): Promise<boolean> {
   } catch (error) {
     const schemaError = `[schema-sync] ❌ Failed to update database schema: ${error instanceof Error ? error.message : String(error)}`;
     logger.error(schemaError);
-    slackAlert(env, [schemaError]);
+    await slackAlert(env, [schemaError]);
     throw error;
   }
 }

--- a/apps/pg-sync-service/src/lib/schema-sync.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.ts
@@ -6,7 +6,9 @@ import {
 } from '@bluedot/db';
 import * as schema from '@bluedot/db/src/schema';
 import { pushSchema } from 'drizzle-kit/api';
+import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import { db } from './db';
+import env from '../env';
 
 /**
  * Cleans up columns that exist in the database but are no longer in the schema definition.
@@ -157,7 +159,9 @@ export async function ensureSchemaUpToDate(): Promise<boolean> {
     logger.info(`[schema-sync] ✅ Schema is now up to date. ${schemaChangesDetected ? 'Changes applied.' : 'No changes needed.'}`);
     return schemaChangesDetected;
   } catch (error) {
-    logger.error('[schema-sync] ❌ Failed to update database schema:', error);
+    const schemaError = `[schema-sync] ❌ Failed to update database schema: ${error instanceof Error ? error.message : String(error)}`;
+    logger.error(schemaError);
+    slackAlert(env, [schemaError]);
     throw error;
   }
 }

--- a/apps/pg-sync-service/src/lib/sync-manager.ts
+++ b/apps/pg-sync-service/src/lib/sync-manager.ts
@@ -115,7 +115,6 @@ class SyncManager {
         .where(eq(syncMetadataTable.id, 'singleton'));
 
       logger.info('[SyncManager] Marked sync as started');
-      await slackAlert(env, ['[SyncManager] Sync starting...']);
     } catch (error) {
       logger.error('[SyncManager] Error marking sync as started:', error);
       throw error;
@@ -140,7 +139,6 @@ class SyncManager {
         .where(eq(syncMetadataTable.id, 'singleton'));
 
       logger.info('[SyncManager] Marked sync as completed successfully');
-      await slackAlert(env, ['[SyncManager] Sync completed successfully']);
     } catch (error) {
       logger.error('[SyncManager] Error marking sync as completed:', error);
       throw error;

--- a/apps/pg-sync-service/src/lib/sync-manager.ts
+++ b/apps/pg-sync-service/src/lib/sync-manager.ts
@@ -1,6 +1,8 @@
 import { logger } from '@bluedot/ui/src/api';
 import { syncMetadataTable, eq } from '@bluedot/db';
+import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import { db } from './db';
+import env from '../env';
 
 const DEFAULT_SYNC_THRESHOLD_HOURS = 24;
 
@@ -113,6 +115,7 @@ class SyncManager {
         .where(eq(syncMetadataTable.id, 'singleton'));
 
       logger.info('[SyncManager] Marked sync as started');
+      await slackAlert(env, ['[SyncManager] Sync starting...']);
     } catch (error) {
       logger.error('[SyncManager] Error marking sync as started:', error);
       throw error;
@@ -137,6 +140,7 @@ class SyncManager {
         .where(eq(syncMetadataTable.id, 'singleton'));
 
       logger.info('[SyncManager] Marked sync as completed successfully');
+      await slackAlert(env, ['[SyncManager] Sync completed successfully']);
     } catch (error) {
       logger.error('[SyncManager] Error marking sync as completed:', error);
       throw error;
@@ -158,6 +162,7 @@ class SyncManager {
         .where(eq(syncMetadataTable.id, 'singleton'));
 
       logger.error(`[SyncManager] Marked sync as failed: ${error}`);
+      await slackAlert(env, [`[SyncManager] Sync failed: ${error}`]);
     } catch (updateError) {
       logger.error('[SyncManager] Error marking sync as failed:', updateError);
       throw updateError;

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -298,7 +298,7 @@ export class AirtableWebhook {
         return; // Success
       } catch (error) {
         // Check if we hit the webhook limit
-        if (isAxiosError(error) && error?.response?.data?.error?.type === 'TOO_MANY_WEBHOOKS_IN_BASE') {
+        if (isAxiosError(error) && error.response?.data?.error?.type === 'TOO_MANY_WEBHOOKS_IN_BASE') {
           logger.warn(`[WEBHOOK] Hit webhook limit for base ${this.baseId}, attempting cleanup...`);
           // eslint-disable-next-line no-await-in-loop
           await this.cleanupOldWebhooks();
@@ -311,9 +311,9 @@ export class AirtableWebhook {
             const errorDetails = {
               baseId: this.baseId,
               fieldIds: this.fieldIds,
-              statusCode: error?.response?.status,
-              errorType: error?.response?.data?.error?.type,
-              errorMessage: error?.response?.data?.error?.message,
+              statusCode: error.response?.status,
+              errorType: error.response?.data?.error?.type,
+              errorMessage: error.response?.data?.error?.message,
             };
             logger.error(`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`);
             slackAlert(env, [`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`]);

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -314,7 +314,16 @@ export class AirtableWebhook {
               statusCode: error.response?.status,
               errorType: error.response?.data?.error?.type,
               errorMessage: error.response?.data?.error?.message,
+              feedbackMessage: '',
             };
+
+            if (error.response?.status === 422) {
+              errorDetails.feedbackMessage = 'This may mean one of the field IDs has been deleted in Airtable. Additionally, check that the base exists and that you have access.';
+            } else if (error.response?.status === 403) {
+              errorDetails.feedbackMessage = 'Check that your Airtable PAT has the webhook:manage scope';
+            } else if (error.response?.status === 401) {
+              errorDetails.feedbackMessage = 'Check that your Airtable PAT is valid and has not expired';
+            }
             logger.error(`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`);
             slackAlert(env, [`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`]);
             throw error;

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -317,12 +317,12 @@ export class AirtableWebhook {
               feedbackMessage: '',
             };
 
-            if (error.response?.status === 422) {
-              errorDetails.feedbackMessage = 'This may mean one of the field IDs has been deleted in Airtable. Additionally, check that the base exists and that you have access.';
+            if (error.response?.status === 401) {
+              errorDetails.feedbackMessage = 'Check that your Airtable PAT is valid and has not expired';
             } else if (error.response?.status === 403) {
               errorDetails.feedbackMessage = 'Check that your Airtable PAT has the webhook:manage scope';
-            } else if (error.response?.status === 401) {
-              errorDetails.feedbackMessage = 'Check that your Airtable PAT is valid and has not expired';
+            } else if (error.response?.status === 422) {
+              errorDetails.feedbackMessage = 'This may mean one of the field IDs has been deleted in Airtable. Additionally, check that the base exists and that you have access.';
             }
             logger.error(`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`);
             slackAlert(env, [`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`]);

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -108,7 +108,7 @@ export class AirtableWebhook {
           statusCode: error.response?.status,
           errorType: error.response?.data?.error?.type,
           errorMessage: error.response?.data?.error?.message,
-          feedbackMessage: getAirtableFeedbackMessage(error.response?.status),
+          feedbackMessage: `*${getAirtableFeedbackMessage(error.response?.status)}*`,
         };
 
         logger.error(`[WEBHOOK] ${webhookListError}: ${JSON.stringify(errorDetails)}`);
@@ -329,7 +329,7 @@ export class AirtableWebhook {
               statusCode: error.response?.status,
               errorType: error.response?.data?.error?.type,
               errorMessage: error.response?.data?.error?.message,
-              feedbackMessage: getAirtableFeedbackMessage(error.response?.status),
+              feedbackMessage: `*${getAirtableFeedbackMessage(error.response?.status)}*`,
             };
 
             logger.error(`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`);

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -112,7 +112,7 @@ export class AirtableWebhook {
         };
 
         logger.error(`[WEBHOOK] ${webhookListError}: ${JSON.stringify(errorDetails)}`);
-        await slackAlert(env, [`[WEBHOOK] ${webhookListError}: ${JSON.stringify(errorDetails)}`]);
+        await slackAlert(env, [`[WEBHOOK] ${webhookListError}: ${formatForSlack(errorDetails)}`]);
         throw error;
       } else {
         const e = new Error(`${webhookListError}. Check your Airtable PAT has webhook:manage permissions.`, { cause: error });
@@ -333,7 +333,7 @@ export class AirtableWebhook {
             };
 
             logger.error(`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`);
-            slackAlert(env, [`[WEBHOOK] ${webhookCreationError} ${JSON.stringify(errorDetails)}`]);
+            slackAlert(env, [`[WEBHOOK] ${webhookCreationError} ${formatForSlack(errorDetails)}`]);
             throw error;
           } else {
             throw new Error(webhookCreationError, { cause: error });
@@ -481,4 +481,18 @@ const getAirtableFeedbackMessage = (statusCode: number | undefined): string => {
     default:
       return 'Unknown error';
   }
+};
+
+/**
+ * Formats an object into a readable string for Slack, with each key-value pair on a new line.
+ */
+const formatForSlack = (obj: Record<string, unknown>): string => {
+  return Object.entries(obj)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return `${key}: [${value.join(', ')}]`;
+      }
+      return `${key}: ${value}`;
+    })
+    .join('\n');
 };

--- a/libraries/ui/README.md
+++ b/libraries/ui/README.md
@@ -173,7 +173,7 @@ const MyComponent: React.FC<MyComponentProps> = ({ error }) => {
 ### Slack Alerting
 
 ```typescript
-import { slackAlert } from '@bluedot/ui/src/api';
+import { slackAlert } from '@bluedot/ui/utils/src/slackNotifications';
 import env from './env';
 
 // Send alerts to Slack for monitoring

--- a/libraries/ui/README.md
+++ b/libraries/ui/README.md
@@ -173,7 +173,7 @@ const MyComponent: React.FC<MyComponentProps> = ({ error }) => {
 ### Slack Alerting
 
 ```typescript
-import { slackAlert } from '@bluedot/ui/utils/src/slackNotifications';
+import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import env from './env';
 
 // Send alerts to Slack for monitoring

--- a/libraries/ui/src/api.ts
+++ b/libraries/ui/src/api.ts
@@ -3,4 +3,3 @@ export { logger } from './utils/logger';
 export {
   makeMakeApiRoute, StreamingResponseSchema, type Handler, type MakeMakeApiRouteEnv, type RouteOptions,
 } from './utils/makeMakeApiRoute';
-export { slackAlert } from './utils/slackAlert';

--- a/libraries/ui/src/utils/makeMakeApiRoute.ts
+++ b/libraries/ui/src/utils/makeMakeApiRoute.ts
@@ -5,7 +5,7 @@ import {
   trace, metrics,
   SpanStatusCode,
 } from '@opentelemetry/api';
-import { slackAlert } from './slackAlert';
+import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import { logger } from './logger';
 
 export type RouteOptions<ReqZT extends ZodType, ResZT extends ZodType, RequiresAuth extends boolean> = {

--- a/libraries/utils/src/slackNotifications.ts
+++ b/libraries/utils/src/slackNotifications.ts
@@ -6,10 +6,16 @@ type SlackAlertEnv = {
 
 export const slackAlert = async (env: SlackAlertEnv, messages: string[]): Promise<void> => {
   if (messages.length === 0) return;
-  const res = await sendSingleSlackMessage(env, messages[0]!);
-  for (let i = 1; i < messages.length; i++) {
-    // eslint-disable-next-line no-await-in-loop
-    await sendSingleSlackMessage(env, messages[i]!, res.ts);
+
+  try {
+    const res = await sendSingleSlackMessage(env, messages[0]!);
+    for (let i = 1; i < messages.length; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await sendSingleSlackMessage(env, messages[i]!, res.ts);
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error sending Slack alert:', error);
   }
 };
 


### PR DESCRIPTION
# Description

Implements direct Slack calling to notify us when critical errors occur in our `pg-sync-service`.

We have two Slack channels for notifications. For the new `slackAlert` calls we rely on the env variable `ALERTS_SLACK_CHANNEL_ID`, which is used for critical error handling.

For informational messages (e.g. sync started/completed) it would be better if we send to our non-critical Slack channel. I'm not sure of the best way to handle multiple channel IDs without cluttering the env. For now I've added a Grafana alert that is linked to a new Slack contact point which will send a message to this 'informational' channel. Going forward it would be nice to include this in our `observability.ts` so that we have deterministic setup. 

## Issue

Fixes #1293.




