### PR TITLE
Remove optional resource time calculation and display

### DIFF
--- a/apps/website/src/components/courses/ResourceDisplay.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.tsx
@@ -67,7 +67,6 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
   const coreResources = filterResourcesByType(resources, 'Core');
   const optionalResources = filterResourcesByType(resources, 'Further');
   const totalCoreResourceTime = calculateResourceTime(coreResources);
-  const totalOptionalResourceTime = calculateResourceTime(optionalResources);
 
   // Generate unique IDs for ARIA labeling
   const unitContext = unitTitle && unitNumber ? `Unit ${unitNumber}: ${unitTitle}` : '';
@@ -127,7 +126,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
       {/* Optional Resources */}
       {optionalResources.length > 0 && (
         <section className="resource-display__optional mt-8">
-          <Collapsible title={`Optional Resources${totalOptionalResourceTime > 0 ? ` (${formatResourceTime(totalOptionalResourceTime)})` : ''}`} summaryClassName="justify-start gap-2">
+          <Collapsible title="Optional Resources" summaryClassName="justify-start gap-2">
             <div className="flex flex-col gap-6" role="list" aria-label="Optional resources">
               {optionalResources.map((resource) => (
                 <ResourceListItem

--- a/apps/website/src/components/courses/ResourceListItem.test.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.test.tsx
@@ -57,6 +57,7 @@ describe('ResourceListItem - Listen to Article Feature', () => {
     avgRating: null,
     syncedAudioUrl: null,
     year: 2024,
+    autoNumberId: null,
   };
 
   it('should render metadata without Listen to article button when no audio URL', () => {


### PR DESCRIPTION
Auto-commit message: Remove totalOptionalResourceTime calculation and its display in the Collapsible title. Add missing autoNumberId field to test mock data.

# Description

The time estimate for "optional resources" is redundant, so I deleted it. 

The tests were failing in localhost, so Cline added `autoNumberId: null,` in `apps/website/src/components/courses/ResourceListItem.test.tsx` - I'm not confident this is correct.