### PR TITLE
[feat]: agi strategy testimonial section

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.test.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.test.tsx
@@ -15,7 +15,7 @@ vi.mock('./agi-strategy/GraduateSection', () => ({
   default: () => <div data-testid="graduate-section">Graduate Section</div>,
 }));
 
-vi.mock('../homepage/CommunitySection/TestimonialSubSection', () => ({
+vi.mock('./agi-strategy/TestimonialSubSection', () => ({
   default: ({ testimonials, title }: { testimonials?: unknown[]; title: string }) => (
     <div data-testid="testimonial-section">
       <h2>{title}</h2>
@@ -79,7 +79,7 @@ describe('AgiStrategyLander', () => {
 
     const testimonialSection = screen.getByTestId('testimonial-section');
     expect(testimonialSection).toBeInTheDocument();
-    expect(screen.getByText('What people say about us')).toBeInTheDocument();
+    expect(screen.getByText('What learners are saying')).toBeInTheDocument();
     expect(screen.getByText('Testimonials: 3')).toBeInTheDocument();
   });
 

--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -155,12 +155,10 @@ We're funded by philanthropic grants, not venture capital. Our incentive is impa
       <div className="border-t-[0.5px] border-color-divider" />
 
       {/* Testimonials Section */}
-      <div className="py-16 px-12">
-        <div className="max-w-[1120px] mx-auto">
-          <H2 className="text-[36px] text-center font-semibold leading-tight mb-16">What learners are saying</H2>
-          <AgiStrategyTestimonialSubSection testimonials={testimonials1} />
-        </div>
-      </div>
+      <Section className="py-16">
+        <H2 className="text-[36px] text-center font-semibold leading-tight mb-16">What learners are saying</H2>
+        <AgiStrategyTestimonialSubSection testimonials={testimonials1} />
+      </Section>
 
       {/* Banner */}
       <AgiStrategyBanner

--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -10,7 +10,7 @@ import { FaCalendarAlt, FaUserFriends, FaLaptop } from 'react-icons/fa';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { H1, H2, H3 } from '../Text';
-import TestimonialSubSection, { Testimonial } from '../homepage/CommunitySection/TestimonialSubSection';
+import AgiStrategyTestimonialSubSection, { Testimonial } from './agi-strategy/TestimonialSubSection';
 import GraduateSection from './agi-strategy/GraduateSection';
 import MarkdownExtendedRenderer from '../courses/MarkdownExtendedRenderer';
 import HeroSection from './agi-strategy/HeroSection';
@@ -97,7 +97,7 @@ const AgiStrategyLander = () => {
       {/* Divider */}
       <div className="border-t-hairline border-color-divider" />
 
-      <Section>
+      <Section className="!border-b-0">
         <div className="prose prose-lg max-w-none">
           <MarkdownExtendedRenderer>
             {`
@@ -129,8 +129,8 @@ We're funded by philanthropic grants, not venture capital. Our incentive is impa
 
 **How the course works**
 
-- You’ll join a small group of ~8 peers, and you’ll meet with them online to discuss readings and complete learning activities
-- Before each live discussion, you’ll do 2-3 hours of reading and writing
+- You'll join a small group of ~8 peers, and you'll meet with them online to discuss readings and complete learning activities
+- Before each live discussion, you'll do 2-3 hours of reading and writing
 - Each discussion lasts 2 hours
 - Your discussions are facilitated by an AI safety expert
 - Participation is free for everyone, and the course is virtual so anyone on earth can join
@@ -151,10 +151,16 @@ We're funded by philanthropic grants, not venture capital. Our incentive is impa
         </div>
       </Section>
 
-      <Section className="mt-8">
-        {/* Testimonials */}
-        <TestimonialSubSection testimonials={testimonials1} title="What people say about us" />
-      </Section>
+      {/* Divider */}
+      <div className="border-t-[0.5px] border-color-divider" />
+
+      {/* Testimonials Section */}
+      <div className="py-16 px-12">
+        <div className="max-w-[1120px] mx-auto">
+          <H2 className="text-[36px] text-center font-semibold leading-tight mb-16">What learners are saying</H2>
+          <AgiStrategyTestimonialSubSection testimonials={testimonials1} />
+        </div>
+      </div>
 
       {/* Banner */}
       <AgiStrategyBanner

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="border-t-hairline border-color-divider"
     />
     <section
-      class="section section-body"
+      class="section section-body !border-b-0"
     >
       <div
         class="section__body"
@@ -190,8 +190,8 @@ We're funded by philanthropic grants, not venture capital. Our incentive is impa
 
 **How the course works**
 
-- You’ll join a small group of ~8 peers, and you’ll meet with them online to discuss readings and complete learning activities
-- Before each live discussion, you’ll do 2-3 hours of reading and writing
+- You'll join a small group of ~8 peers, and you'll meet with them online to discuss readings and complete learning activities
+- Before each live discussion, you'll do 2-3 hours of reading and writing
 - Each discussion lasts 2 hours
 - Your discussions are facilitated by an AI safety expert
 - Participation is free for everyone, and the course is virtual so anyone on earth can join
@@ -212,25 +212,31 @@ We're funded by philanthropic grants, not venture capital. Our incentive is impa
         </div>
       </div>
     </section>
-    <section
-      class="section section-body mt-8"
+    <div
+      class="border-t-[0.5px] border-color-divider"
+    />
+    <div
+      class="py-16 px-12"
     >
       <div
-        class="section__body"
+        class="max-w-[1120px] mx-auto"
       >
+        <h2
+          class="bluedot-h2 not-prose text-[36px] text-center font-semibold leading-tight mb-16"
+        >
+          What learners are saying
+        </h2>
         <div
           data-testid="testimonial-section"
         >
-          <h2>
-            What people say about us
-          </h2>
+          <h2 />
           <span>
             Testimonials: 
             3
           </span>
         </div>
       </div>
-    </section>
+    </div>
     <div
       class="agi-strategy-lander__banner flex flex-col items-center justify-center w-full py-16 px-12 gap-8 text-center bg-gradient-to-b from-white to-[#ECF0FF] -mt-px"
     >

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -215,11 +215,11 @@ We're funded by philanthropic grants, not venture capital. Our incentive is impa
     <div
       class="border-t-[0.5px] border-color-divider"
     />
-    <div
-      class="py-16 px-12"
+    <section
+      class="section section-body py-16"
     >
       <div
-        class="max-w-[1120px] mx-auto"
+        class="section__body"
       >
         <h2
           class="bluedot-h2 not-prose text-[36px] text-center font-semibold leading-tight mb-16"
@@ -236,7 +236,7 @@ We're funded by philanthropic grants, not venture capital. Our incentive is impa
           </span>
         </div>
       </div>
-    </div>
+    </section>
     <div
       class="agi-strategy-lander__banner flex flex-col items-center justify-center w-full py-16 px-12 gap-8 text-center bg-gradient-to-b from-white to-[#ECF0FF] -mt-px"
     >

--- a/apps/website/src/components/lander/agi-strategy/TestimonialSubSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/TestimonialSubSection.tsx
@@ -1,0 +1,54 @@
+import { Quote, SectionHeading } from '@bluedot/ui';
+
+export type Testimonial = Quote;
+
+type TestimonialSubSectionProps = {
+  testimonials: Testimonial[],
+  title?: string,
+};
+
+// Testimonial Card Component
+const TestimonialCard = ({ testimonial }: { testimonial: Testimonial }) => (
+  <div className="testimonial flex flex-col h-full border border-[#E7E5E4] rounded-lg p-8 bg-white gap-6">
+    <blockquote className="testimonial__quote flex-grow text-size-sm leading-[1.6] text-[#13132E] opacity-80">
+      "{testimonial.quote}"
+    </blockquote>
+    <div className="testimonial__footer flex items-center gap-4">
+      <div className="testimonial__avatar size-12 rounded-full overflow-hidden flex-shrink-0">
+        <img
+          src={testimonial.imageSrc}
+          alt={testimonial.name}
+          className="size-full object-cover"
+        />
+      </div>
+      <div className="testimonial__info flex flex-col">
+        <div className="testimonial__name font-semibold text-size-sm leading-normal text-[#13132E]">
+          {testimonial.name}
+        </div>
+        <div className="testimonial__role text-size-xs leading-[20px] text-[#13132E] opacity-80">
+          {testimonial.role}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+const AgiStrategyTestimonialSubSection = ({
+  testimonials,
+  title,
+}: TestimonialSubSectionProps) => {
+  return (
+    <div className="testimonial-section w-full" data-testid="testimonial-section">
+      {title && <SectionHeading title={title} titleLevel="h3" className="testimonial-section__heading" />}
+
+      {/* Responsive Grid Layout */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {testimonials.map((testimonial) => (
+          <TestimonialCard key={testimonial.name} testimonial={testimonial} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AgiStrategyTestimonialSubSection;


### PR DESCRIPTION
# Description
Implementing the new agi strategy lander testimonial section in #1287 for desktop and mobile. Removed SlideList and implemented stacking instead as per the [design](https://www.figma.com/design/62YlFNK7QS6z7SkrPjrwVb/Blue-Dot?node-id=1275-11437&p=f&t=ZAGEMhZsZOFuQvbC-0).

**Special notes:**
- **Component isolation:** Implemented in a dedicated agi-strategy dir rather than modifying the shared library, allowing for gradual adoption across other landing pages when needed (we currently need to maintain UI library styles in other pages)
- This PR is part of a series of updates to implement portions of the full AGI Strategy Lander design in https://github.com/bluedotimpact/bluedot/issues/1287 so that changes can be shipped faster (+ while waiting for final copy/icons necessary for other sections in the design)

## Issue
Implements part of #1287 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Video Screenshots
### Desktop
<img width="1512" height="699" alt="Screenshot 2025-09-09 at 2 25 26 PM" src="https://github.com/user-attachments/assets/e1d38064-c041-4bb0-9490-aca7ec29a150" />

![testimonials-desktop](https://github.com/user-attachments/assets/c8754e13-b32c-48c5-a40b-9df7736b3f6f)

### Mobile
![testimonials-mobile](https://github.com/user-attachments/assets/ed9d343e-1d6c-45ef-b456-9b2d848c9814)