### PR TITLE
[Feature] Display error when group discussion fails to load

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import {
   Section,
   CTALinkOrButton,
+  ErrorSection,
 } from '@bluedot/ui';
 import {
   FaBars, FaChevronRight, FaChevronDown,
@@ -54,6 +55,7 @@ type UnitLayoutProps = {
   setChunkIndex: (index: number) => void;
   // Optional
   groupDiscussion?: GroupDiscussion;
+  groupDiscussionError?: Error | null;
 };
 
 type MobileHeaderProps = {
@@ -143,6 +145,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
   chunkIndex,
   setChunkIndex,
   groupDiscussion,
+  groupDiscussionError,
 }) => {
   const router = useRouter();
   const [navigationAnnouncement, setNavigationAnnouncement] = useState('');
@@ -392,6 +395,9 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
           !isSidebarHidden && 'md:ml-[360px]',
         )}
         >
+          {groupDiscussionError && (
+            <ErrorSection error={groupDiscussionError} />
+          )}
           {groupDiscussion && (
             <div className="mb-8 md:mb-6">
               <GroupDiscussionBanner

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -111,12 +111,6 @@ const CourseUnitChunkPage = () => {
     return <ErrorSection error={error ?? new Error('Missing data from API')} />;
   }
 
-  // Workaround for auth issue, but likely better to keep it this way in the long run
-  if (groupDiscussionError) {
-    // eslint-disable-next-line no-console
-    console.error(groupDiscussionError ?? new Error('Missing data from API'));
-  }
-
   if (chunkIndex < 0 || chunkIndex >= data.chunks.length) {
     return <ProgressDots />;
   }
@@ -129,7 +123,8 @@ const CourseUnitChunkPage = () => {
       unitNumber={parseInt(unitNumber)}
       chunkIndex={chunkIndex}
       setChunkIndex={handleSetChunkIndex}
-      groupDiscussion={groupDiscussionData?.groupDiscussion || undefined}
+      groupDiscussion={groupDiscussionData?.groupDiscussion}
+      groupDiscussionError={groupDiscussionError}
     />
   );
 };


### PR DESCRIPTION
# Description

Cleaning up a quick change (#1306) made during an outage earlier. Still allow the page to load if there is an error loading the group discussion, but show a banner so users can report this.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1309 

## Developer checklist

N/A

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 |  |
|---------|---|
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <img width="3014" height="1640" alt="Screenshot 2025-09-09 at 22 43 22" src="https://github.com/user-attachments/assets/659de9f4-edb5-4a65-929b-1f6e76f674c3" /> |
