### PR TITLE
More explicit website DB error information

### DIFF
--- a/apps/website/src/pages/api/course-registrations/[courseId]/index.tsx
+++ b/apps/website/src/pages/api/course-registrations/[courseId]/index.tsx
@@ -35,7 +35,7 @@ export default makeApiRoute({
           },
         });
       } catch (error) {
-        throw new createHttpError.InternalServerError('Database error occurred');
+        throw new createHttpError.InternalServerError(`Database error occurred: ${error instanceof Error ? error.message : String(error)}`);
       }
 
       if (courseRegistration) {

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/feedback.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/feedback.ts
@@ -60,7 +60,7 @@ export default makeApiRoute(
         filter: { unitId: unit.id, userEmail: auth.email },
       });
     } catch (error) {
-      throw new createHttpError.InternalServerError('Database error occurred');
+      throw new createHttpError.InternalServerError(`Database error occurred: ${error instanceof Error ? error.message : String(error)}`);
     }
 
     if (method === 'GET') {

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/feedback.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/feedback.ts
@@ -35,8 +35,16 @@ export default makeApiRoute(
   async (body, { raw, auth }) => {
     const { courseSlug, unitNumber } = raw.req.query;
 
-    if (!auth.email || typeof courseSlug !== 'string' || typeof unitNumber !== 'string') {
-      throw new createHttpError.BadRequest();
+    if (!auth.email) {
+      throw new createHttpError.Unauthorized('Authentication required');
+    }
+
+    if (typeof courseSlug !== 'string') {
+      throw new createHttpError.BadRequest('Invalid course slug');
+    }
+
+    if (typeof unitNumber !== 'string') {
+      throw new createHttpError.BadRequest('Invalid unit number');
     }
 
     const { method } = raw.req;

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/index.ts
@@ -60,7 +60,7 @@ export default makeApiRoute({
   try {
     allChunks = await db.scan(chunkTable, { unitId: unit.id });
   } catch (error) {
-    throw new createHttpError.InternalServerError('Database error occurred');
+    throw new createHttpError.InternalServerError(`Database error occurred: ${error instanceof Error ? error.message : String(error)}`);
   }
   const activeChunks = allChunks.filter((chunk) => chunk.status === 'Active');
   const chunks = activeChunks.sort((a, b) => (a.chunkOrder || '').localeCompare(b.chunkOrder || '', undefined, { numeric: true, sensitivity: 'base' }));

--- a/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
+++ b/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
@@ -31,8 +31,12 @@ export default makeApiRoute({
 }, async (body, { raw, auth }) => {
   const { exerciseId } = raw.req.query;
 
-  if (!auth.email || typeof exerciseId !== 'string') {
-    throw new createHttpError.BadRequest();
+  if (!auth.email) {
+    throw new createHttpError.Unauthorized('Authentication required');
+  }
+
+  if (typeof exerciseId !== 'string') {
+    throw new createHttpError.BadRequest('Invalid exercise ID');
   }
 
   let exerciseResponse: ExerciseResponse | null = null;

--- a/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
+++ b/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
@@ -45,7 +45,7 @@ export default makeApiRoute({
       filter: { exerciseId, email: auth.email },
     });
   } catch (error) {
-    throw new createHttpError.InternalServerError('Database error occurred');
+    throw new createHttpError.InternalServerError(`Database error occurred: ${error instanceof Error ? error.message : String(error)}`);
   }
 
   switch (raw.req.method) {

--- a/apps/website/src/pages/api/courses/resource-completion/[unitResourceId]/index.ts
+++ b/apps/website/src/pages/api/courses/resource-completion/[unitResourceId]/index.ts
@@ -40,8 +40,12 @@ export default makeApiRoute({
 }, async (body, { raw, auth }) => {
   const { unitResourceId } = raw.req.query;
 
-  if (!auth.email || typeof unitResourceId !== 'string') {
-    throw new createHttpError.BadRequest();
+  if (!auth.email) {
+    throw new createHttpError.Unauthorized('Authentication required');
+  }
+
+  if (typeof unitResourceId !== 'string') {
+    throw new createHttpError.BadRequest('Invalid unit resource ID');
   }
 
   let resourceCompletion: ResourceCompletion | null;

--- a/apps/website/src/pages/api/users/me.ts
+++ b/apps/website/src/pages/api/users/me.ts
@@ -30,7 +30,7 @@ export default makeApiRoute({
       filter: { email: auth.email },
     });
   } catch (error) {
-    throw new createHttpError.InternalServerError('Database error occurred');
+    throw new createHttpError.InternalServerError(`Database error occurred: ${error instanceof Error ? error.message : String(error)}`);
   }
 
   switch (raw.req.method) {


### PR DESCRIPTION
# Description

When we have DB errors we just throw a generic `InternalServerError`. To provide better transparency around what went wrong we now pass the error message along too.

Also address some minor error separation between authorization errors and actual bad requests.

## Issue

Part of #1293.

