### PR TITLE
Add tag component to card title to show featured tag.

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -212,11 +212,15 @@ exports[`AboutPage > should render correctly 1`] = `
                     <div
                       class="card__text"
                     >
-                      <p
-                        class="card__title bluedot-h4 mb-2"
+                      <div
+                        class="flex flex-row gap-4 items-center mb-2"
                       >
-                        AGI could arrive soon, and society is dangerously unprepared
-                      </p>
+                        <p
+                          class="card__title bluedot-h4"
+                        >
+                          AGI could arrive soon, and society is dangerously unprepared
+                        </p>
+                      </div>
                       <p
                         class="card__subtitle bluedot-p "
                       >
@@ -249,11 +253,15 @@ exports[`AboutPage > should render correctly 1`] = `
                     <div
                       class="card__text"
                     >
-                      <p
-                        class="card__title bluedot-h4 mb-2"
+                      <div
+                        class="flex flex-row gap-4 items-center mb-2"
                       >
-                        What we do now matters
-                      </p>
+                        <p
+                          class="card__title bluedot-h4"
+                        >
+                          What we do now matters
+                        </p>
+                      </div>
                       <p
                         class="card__subtitle bluedot-p "
                       >
@@ -286,11 +294,15 @@ exports[`AboutPage > should render correctly 1`] = `
                     <div
                       class="card__text"
                     >
-                      <p
-                        class="card__title bluedot-h4 mb-2"
+                      <div
+                        class="flex flex-row gap-4 items-center mb-2"
                       >
-                        People at key moments rewrite history
-                      </p>
+                        <p
+                          class="card__title bluedot-h4"
+                        >
+                          People at key moments rewrite history
+                        </p>
+                      </div>
                       <p
                         class="card__subtitle bluedot-p "
                       >
@@ -323,11 +335,15 @@ exports[`AboutPage > should render correctly 1`] = `
                     <div
                       class="card__text"
                     >
-                      <p
-                        class="card__title bluedot-h4 mb-2"
+                      <div
+                        class="flex flex-row gap-4 items-center mb-2"
                       >
-                        We need urgency, wisdom and optimism
-                      </p>
+                        <p
+                          class="card__title bluedot-h4"
+                        >
+                          We need urgency, wisdom and optimism
+                        </p>
+                      </div>
                       <p
                         class="card__subtitle bluedot-p "
                       >

--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                    class="card__content flex gap-6 w-full flex-1 flex-col"
                   >
                     <div
                       class="card__text"
@@ -248,7 +248,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                    class="card__content flex gap-6 w-full flex-1 flex-col"
                   >
                     <div
                       class="card__text"
@@ -289,7 +289,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                    class="card__content flex gap-6 w-full flex-1 flex-col"
                   >
                     <div
                       class="card__text"
@@ -330,7 +330,7 @@ exports[`AboutPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                    class="card__content flex gap-6 w-full flex-1 flex-col"
                   >
                     <div
                       class="card__text"

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -259,7 +259,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                    class="card__content flex gap-6 w-full flex-1 flex-col"
                   >
                     <div
                       class="card__text"
@@ -300,7 +300,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                    class="card__content flex gap-6 w-full flex-1 flex-col"
                   >
                     <div
                       class="card__text"
@@ -341,7 +341,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     />
                   </div>
                   <div
-                    class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                    class="card__content flex gap-6 w-full flex-1 flex-col"
                   >
                     <div
                       class="card__text"

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -264,11 +264,15 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     <div
                       class="card__text"
                     >
-                      <p
-                        class="card__title bluedot-h4 mb-2"
+                      <div
+                        class="flex flex-row gap-4 items-center mb-2"
                       >
-                        Own the mission
-                      </p>
+                        <p
+                          class="card__title bluedot-h4"
+                        >
+                          Own the mission
+                        </p>
+                      </div>
                       <p
                         class="card__subtitle bluedot-p "
                       >
@@ -301,11 +305,15 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     <div
                       class="card__text"
                     >
-                      <p
-                        class="card__title bluedot-h4 mb-2"
+                      <div
+                        class="flex flex-row gap-4 items-center mb-2"
                       >
-                        Find the fastest, best way to do everything
-                      </p>
+                        <p
+                          class="card__title bluedot-h4"
+                        >
+                          Find the fastest, best way to do everything
+                        </p>
+                      </div>
                       <p
                         class="card__subtitle bluedot-p "
                       >
@@ -338,11 +346,15 @@ exports[`JoinUsPage > should render correctly 1`] = `
                     <div
                       class="card__text"
                     >
-                      <p
-                        class="card__title bluedot-h4 mb-2"
+                      <div
+                        class="flex flex-row gap-4 items-center mb-2"
                       >
-                        Say the uncomfortable truth
-                      </p>
+                        <p
+                          class="card__title bluedot-h4"
+                        >
+                          Say the uncomfortable truth
+                        </p>
+                      </div>
                       <p
                         class="card__subtitle bluedot-p "
                       >

--- a/apps/website/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"
@@ -97,7 +97,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"
@@ -138,7 +138,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"
@@ -179,7 +179,7 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"

--- a/apps/website/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
+++ b/apps/website/src/components/about/__snapshots__/BeliefsSection.test.tsx.snap
@@ -61,11 +61,15 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      AGI could arrive soon, and society is dangerously unprepared
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        AGI could arrive soon, and society is dangerously unprepared
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p "
                     >
@@ -98,11 +102,15 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      What we do now matters
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        What we do now matters
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p "
                     >
@@ -135,11 +143,15 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      People at key moments rewrite history
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        People at key moments rewrite history
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p "
                     >
@@ -172,11 +184,15 @@ exports[`BeliefsSection > renders default as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      We need urgency, wisdom and optimism
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        We need urgency, wisdom and optimism
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p "
                     >

--- a/apps/website/src/components/blog/BlogListSection.tsx
+++ b/apps/website/src/components/blog/BlogListSection.tsx
@@ -1,5 +1,5 @@
 import {
-  Card, CTALinkOrButton, ErrorSection, ProgressDots, Section, Tag,
+  Card, CTALinkOrButton, ErrorSection, ProgressDots, Section,
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import { blogTable, InferSelectModel } from '@bluedot/db';
@@ -72,7 +72,7 @@ export const BlogListItem = ({ blog }: {
         isFullWidth
         subtitle={`${blog.authorName || 'Unknown author'} • ${formattedDate}`}
         title={blog.title || 'Untitled'}
-        subtitleBadge={blog.isFeatured ? <Tag variant="secondary">FEATURED</Tag> : null}
+        subtitleBadge={blog.isFeatured ? 'FEATURED' : undefined}
       />
     </div>
   );

--- a/apps/website/src/components/blog/BlogListSection.tsx
+++ b/apps/website/src/components/blog/BlogListSection.tsx
@@ -1,7 +1,6 @@
 import {
   Card, CTALinkOrButton, ErrorSection, ProgressDots, Section, Tag,
 } from '@bluedot/ui';
-import { isMobile } from 'react-device-detect';
 import useAxios from 'axios-hooks';
 import { blogTable, InferSelectModel } from '@bluedot/db';
 import { P } from '../Text';
@@ -69,11 +68,11 @@ export const BlogListItem = ({ blog }: {
         className="blog-list__card container-lined hover:container-elevated p-8"
         ctaText="Read more"
         ctaUrl={url}
-        isEntireCardClickable={!isMobile}
-        isFullWidth={!isMobile}
+        isEntireCardClickable
+        isFullWidth
         subtitle={`${blog.authorName || 'Unknown author'} • ${formattedDate}`}
         title={blog.title || 'Untitled'}
-        subtitleBadge={blog.isFeatured && <Tag variant="secondary">FEATURED</Tag>}
+        subtitleBadge={blog.isFeatured ? <Tag variant="secondary">FEATURED</Tag> : null}
       />
     </div>
   );

--- a/apps/website/src/components/blog/BlogListSection.tsx
+++ b/apps/website/src/components/blog/BlogListSection.tsx
@@ -19,16 +19,18 @@ const BlogListSection = ({ maxItems }: BlogListSectionProps) => {
     url: '/api/cms/blogs',
   });
 
+  const title = 'Latest articles';
+
   if (error) {
     return <ErrorSection error={error} />;
   }
 
   if (loading) {
-    return <Section><ProgressDots /></Section>;
+    return <Section title={title}><ProgressDots /></Section>;
   }
 
   return (
-    <Section className="blog-list-section">
+    <Section className="blog-list-section" title={title}>
       <div id="blog-articles-anchor" className="invisible relative bottom-48" />
       {data?.blogs.length === 0 ? (
         <P>

--- a/apps/website/src/components/blog/BlogListSection.tsx
+++ b/apps/website/src/components/blog/BlogListSection.tsx
@@ -1,5 +1,5 @@
 import {
-  Card, CTALinkOrButton, ErrorSection, ProgressDots, Section,
+  Card, CTALinkOrButton, ErrorSection, ProgressDots, Section, Tag,
 } from '@bluedot/ui';
 import { isMobile } from 'react-device-detect';
 import useAxios from 'axios-hooks';
@@ -19,18 +19,17 @@ const BlogListSection = ({ maxItems }: BlogListSectionProps) => {
     method: 'get',
     url: '/api/cms/blogs',
   });
-  const title = 'Latest articles';
 
   if (error) {
     return <ErrorSection error={error} />;
   }
 
   if (loading) {
-    return <Section title={title}><ProgressDots /></Section>;
+    return <Section><ProgressDots /></Section>;
   }
 
   return (
-    <Section className="blog-list-section" title={title}>
+    <Section className="blog-list-section">
       <div id="blog-articles-anchor" className="invisible relative bottom-48" />
       {data?.blogs.length === 0 ? (
         <P>
@@ -74,6 +73,7 @@ export const BlogListItem = ({ blog }: {
         isFullWidth={!isMobile}
         subtitle={`${blog.authorName || 'Unknown author'} • ${formattedDate}`}
         title={blog.title || 'Untitled'}
+        subtitleBadge={blog.isFeatured && <Tag variant="secondary">FEATURED</Tag>}
       />
     </div>
   );

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                class="card__content flex gap-6 w-full flex-1 flex-col"
               >
                 <div
                   class="card__text"
@@ -89,7 +89,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                class="card__content flex gap-6 w-full flex-1 flex-col"
               >
                 <div
                   class="card__text"
@@ -125,7 +125,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                class="card__content flex gap-6 w-full flex-1 flex-col"
               >
                 <div
                   class="card__text"
@@ -161,7 +161,7 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                class="card__content flex gap-6 w-full flex-1 flex-col"
               >
                 <div
                   class="card__text"

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/CommunityValuesSection.test.tsx.snap
@@ -58,11 +58,15 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 <div
                   class="card__text"
                 >
-                  <p
-                    class="card__title bluedot-h4 mb-2"
+                  <div
+                    class="flex flex-row gap-4 items-center mb-2"
                   >
-                    Our online community brings together 4,500+ professionals across 100+ countries
-                  </p>
+                    <p
+                      class="card__title bluedot-h4"
+                    >
+                      Our online community brings together 4,500+ professionals across 100+ countries
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -90,11 +94,15 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 <div
                   class="card__text"
                 >
-                  <p
-                    class="card__title bluedot-h4 mb-2"
+                  <div
+                    class="flex flex-row gap-4 items-center mb-2"
                   >
-                    Diverse expertise, from engineers and entrepreneurs to policymakers and philosophers
-                  </p>
+                    <p
+                      class="card__title bluedot-h4"
+                    >
+                      Diverse expertise, from engineers and entrepreneurs to policymakers and philosophers
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -122,11 +130,15 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 <div
                   class="card__text"
                 >
-                  <p
-                    class="card__title bluedot-h4 mb-2"
+                  <div
+                    class="flex flex-row gap-4 items-center mb-2"
                   >
-                    40+ independent study groups worldwide have used our materials to run their own courses
-                  </p>
+                    <p
+                      class="card__title bluedot-h4"
+                    >
+                      40+ independent study groups worldwide have used our materials to run their own courses
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -154,11 +166,15 @@ exports[`CommunityValuesSection > renders as expected 1`] = `
                 <div
                   class="card__text"
                 >
-                  <p
-                    class="card__title bluedot-h4 mb-2"
+                  <div
+                    class="flex flex-row gap-4 items-center mb-2"
                   >
-                    We run regular in-person events across the world, turning online connections into lasting relationships
-                  </p>
+                    <p
+                      class="card__title bluedot-h4"
+                    >
+                      We run regular in-person events across the world, turning online connections into lasting relationships
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"
@@ -104,7 +104,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"
@@ -146,7 +146,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"
@@ -188,7 +188,7 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ProjectsSubSection.test.tsx.snap
@@ -67,11 +67,15 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      Contextual Constitutional AI
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        Contextual Constitutional AI
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p text-base"
                     >
@@ -105,11 +109,15 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      Safety Haven: Justifying and exploring an antitrust safe haven for AI safety research collaboration
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        Safety Haven: Justifying and exploring an antitrust safe haven for AI safety research collaboration
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p text-base"
                     >
@@ -143,11 +151,15 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      Societal Adaptation to AI Human-Labor Automation
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        Societal Adaptation to AI Human-Labor Automation
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p text-base"
                     >
@@ -181,11 +193,15 @@ exports[`ProjectsSubSection > renders as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      Are you secretly training AI? Methods for uncovering covert AI training: A framework for feasibility and future research
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        Are you secretly training AI? Methods for uncovering covert AI training: A framework for feasibility and future research
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p text-base"
                     >

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
@@ -58,11 +58,15 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 <div
                   class="card__text"
                 >
-                  <p
-                    class="card__title bluedot-h4 mb-2"
+                  <div
+                    class="flex flex-row gap-4 items-center mb-2"
                   >
-                    Our online community brings together 4,500+ professionals across 100+ countries
-                  </p>
+                    <p
+                      class="card__title bluedot-h4"
+                    >
+                      Our online community brings together 4,500+ professionals across 100+ countries
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -90,11 +94,15 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 <div
                   class="card__text"
                 >
-                  <p
-                    class="card__title bluedot-h4 mb-2"
+                  <div
+                    class="flex flex-row gap-4 items-center mb-2"
                   >
-                    Diverse expertise, from engineers and entrepreneurs to policymakers and philosophers
-                  </p>
+                    <p
+                      class="card__title bluedot-h4"
+                    >
+                      Diverse expertise, from engineers and entrepreneurs to policymakers and philosophers
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -122,11 +130,15 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 <div
                   class="card__text"
                 >
-                  <p
-                    class="card__title bluedot-h4 mb-2"
+                  <div
+                    class="flex flex-row gap-4 items-center mb-2"
                   >
-                    40+ independent study groups worldwide have used our materials to run their own courses
-                  </p>
+                    <p
+                      class="card__title bluedot-h4"
+                    >
+                      40+ independent study groups worldwide have used our materials to run their own courses
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -154,11 +166,15 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 <div
                   class="card__text"
                 >
-                  <p
-                    class="card__title bluedot-h4 mb-2"
+                  <div
+                    class="flex flex-row gap-4 items-center mb-2"
                   >
-                    We run regular in-person events across the world, turning online connections into lasting relationships
-                  </p>
+                    <p
+                      class="card__title bluedot-h4"
+                    >
+                      We run regular in-person events across the world, turning online connections into lasting relationships
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/website/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/CommunitySection/__snapshots__/ValuesSection.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                class="card__content flex gap-6 w-full flex-1 flex-col"
               >
                 <div
                   class="card__text"
@@ -89,7 +89,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                class="card__content flex gap-6 w-full flex-1 flex-col"
               >
                 <div
                   class="card__text"
@@ -125,7 +125,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                class="card__content flex gap-6 w-full flex-1 flex-col"
               >
                 <div
                   class="card__text"
@@ -161,7 +161,7 @@ exports[`CommunityValuesSection > renders default as expected 1`] = `
                 />
               </div>
               <div
-                class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                class="card__content flex gap-6 w-full flex-1 flex-col"
               >
                 <div
                   class="card__text"

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`CourseSection > renders as expected 1`] = `
                         />
                       </div>
                       <div
-                        class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                        class="card__content flex gap-6 w-full flex-1 flex-col"
                       >
                         <div
                           class="card__text"
@@ -158,7 +158,7 @@ exports[`CourseSection > renders as expected 1`] = `
                         />
                       </div>
                       <div
-                        class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                        class="card__content flex gap-6 w-full flex-1 flex-col"
                       >
                         <div
                           class="card__text"

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -115,11 +115,15 @@ exports[`CourseSection > renders as expected 1`] = `
                         <div
                           class="card__text"
                         >
-                          <p
-                            class="card__title bluedot-h4 mb-2"
+                          <div
+                            class="flex flex-row gap-4 items-center mb-2"
                           >
-                            New Course
-                          </p>
+                            <p
+                              class="card__title bluedot-h4"
+                            >
+                              New Course
+                            </p>
+                          </div>
                           <p
                             class="card__subtitle bluedot-p grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >
@@ -159,11 +163,15 @@ exports[`CourseSection > renders as expected 1`] = `
                         <div
                           class="card__text"
                         >
-                          <p
-                            class="card__title bluedot-h4 mb-2"
+                          <div
+                            class="flex flex-row gap-4 items-center mb-2"
                           >
-                            Another Course
-                          </p>
+                            <p
+                              class="card__title bluedot-h4"
+                            >
+                              Another Course
+                            </p>
+                          </div>
                           <p
                             class="card__subtitle bluedot-p grow overflow-hidden text-ellipsis line-clamp-4 max-h-[96px]"
                           >

--- a/apps/website/src/components/join-us/JobsListSection.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.tsx
@@ -1,5 +1,4 @@
 import { Card, Section } from '@bluedot/ui';
-import { isMobile } from 'react-device-detect';
 import { jobPostingTable, InferSelectModel } from '@bluedot/db';
 import { P } from '../Text';
 import { ROUTES } from '../../lib/routes';
@@ -62,8 +61,8 @@ const JobListItem = ({ job }: {
         className="jobs-list__card container-lined hover:container-elevated p-8"
         ctaText="Learn more"
         ctaUrl={url}
-        isEntireCardClickable={!isMobile}
-        isFullWidth={!isMobile}
+        isEntireCardClickable
+        isFullWidth
         subtitle={job.location}
         title={job.title}
       />

--- a/apps/website/src/components/join-us/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/ValuesSection.test.tsx.snap
@@ -61,11 +61,15 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      Own the mission
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        Own the mission
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p "
                     >
@@ -98,11 +102,15 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      Find the fastest, best way to do everything
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        Find the fastest, best way to do everything
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p "
                     >
@@ -135,11 +143,15 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   <div
                     class="card__text"
                   >
-                    <p
-                      class="card__title bluedot-h4 mb-2"
+                    <div
+                      class="flex flex-row gap-4 items-center mb-2"
                     >
-                      Say the uncomfortable truth
-                    </p>
+                      <p
+                        class="card__title bluedot-h4"
+                      >
+                        Say the uncomfortable truth
+                      </p>
+                    </div>
                     <p
                       class="card__subtitle bluedot-p "
                     >

--- a/apps/website/src/components/join-us/__snapshots__/ValuesSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/ValuesSection.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"
@@ -97,7 +97,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"
@@ -138,7 +138,7 @@ exports[`ValuesSection > renders default as expected 1`] = `
                   />
                 </div>
                 <div
-                  class="card__content flex gap-6 w-full flex-1 justify-between flex-col"
+                  class="card__content flex gap-6 w-full flex-1 flex-col"
                 >
                   <div
                     class="card__text"

--- a/apps/website/src/pages/api/cms/blogs/index.ts
+++ b/apps/website/src/pages/api/cms/blogs/index.ts
@@ -23,7 +23,12 @@ export default makeApiRoute({
 
   // Sort by publishedAt descending and remove the body field from each blog to make the response lighter
   const blogSummaries = allBlogs
-    .sort((a, b) => (b.publishedAt || 0) - (a.publishedAt || 0))
+    .sort((a, b) => {
+      if (a.isFeatured !== b.isFeatured) {
+        return b.isFeatured ? 1 : -1;
+      }
+      return (b.publishedAt || 0) - (a.publishedAt || 0);
+    })
     .map(({ body, ...rest }) => rest);
 
   return {

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import { CTALinkOrButton } from './CTALinkOrButton';
+import { Tag } from './Tag';
 
 export type CardProps = {
   // Required
@@ -16,7 +17,7 @@ export type CardProps = {
   isFullWidth?: boolean;
   subtitle?: string;
   subtitleClassName?: string;
-  subtitleBadge?: React.ReactNode;
+  subtitleBadge?: string;
 };
 
 export const Card: React.FC<CardProps> = ({
@@ -71,7 +72,7 @@ export const Card: React.FC<CardProps> = ({
         <div className="card__text">
           <div className="flex flex-row gap-4 items-center mb-2">
             <p className="card__title bluedot-h4">{title}</p>
-            {subtitleBadge && (subtitleBadge)}
+            {subtitleBadge && <Tag variant="secondary">{subtitleBadge}</Tag>}
           </div>
           {subtitle && (<p className={`card__subtitle bluedot-p ${subtitleClassName}`}>{subtitle}</p>)}
           {/* For non-fullWidth cards, show CTA and children inline */}

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -38,7 +38,8 @@ export const Card: React.FC<CardProps> = ({
   const Wrapper = isEntireCardClickable ? 'a' : 'div';
   const wrapperClassName = clsx(
     'card flex items-start transition-transform duration-200',
-    isFullWidth ? 'flex-row w-full' : 'flex-col',
+    // Mobile: column layout, Desktop (md and up): row layout when isFullWidth is true
+    isFullWidth ? 'flex-col md:flex-row w-full' : 'flex-col',
     isEntireCardClickable && 'hover:scale-[1.01]',
     className,
   );
@@ -62,8 +63,9 @@ export const Card: React.FC<CardProps> = ({
       )}
       <div
         className={clsx(
-          'card__content flex gap-6 w-full flex-1 justify-between',
-          isFullWidth ? 'flex-row w-full' : 'flex-col',
+          'card__content flex gap-6 w-full flex-1',
+          // Mobile: column layout, Desktop (md and up): row layout when isFullWidth is true
+          isFullWidth ? 'flex-col md:flex-row md:justify-between' : 'flex-col',
         )}
       >
         <div className="card__text">
@@ -72,13 +74,29 @@ export const Card: React.FC<CardProps> = ({
             {subtitleBadge && (subtitleBadge)}
           </div>
           {subtitle && (<p className={`card__subtitle bluedot-p ${subtitleClassName}`}>{subtitle}</p>)}
+          {/* For non-fullWidth cards, show CTA and children inline */}
+          {!isFullWidth && showCTA && (
+            <CTALinkOrButton
+              className="card__cta mt-4"
+              url={isEntireCardClickable ? undefined : ctaUrl}
+              variant="secondary"
+              withChevron
+            >
+              {ctaText}
+            </CTALinkOrButton>
+          )}
+          {!isFullWidth && children && (
+            <div className="card__footer flex items-center justify-between w-full mt-4">
+              {children}
+            </div>
+          )}
         </div>
-        {/* When isEntireCardClickable is true, the CTALinkOrButton does not render a URL because nested URLs are invalid HTML. */}
-        {showBottomSection && (
+        {/* For isFullWidth cards, show CTA and children in a separate section */}
+        {isFullWidth && showBottomSection && (
           <div className="card__bottom-section flex flex-col gap-space-between">
             {showCTA && (
               <CTALinkOrButton
-                className="card__cta"
+                className="card__cta mt-4 md:mt-0"
                 url={isEntireCardClickable ? undefined : ctaUrl}
                 variant="secondary"
                 withChevron
@@ -87,7 +105,7 @@ export const Card: React.FC<CardProps> = ({
               </CTALinkOrButton>
             )}
             {children && (
-              <div className="card__footer flex items-center justify-between w-full">
+              <div className="card__footer flex items-center justify-between w-full mt-4 md:mt-0">
                 {children}
               </div>
             )}

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -94,10 +94,10 @@ export const Card: React.FC<CardProps> = ({
         </div>
         {/* For isFullWidth cards, show CTA and children in a separate section */}
         {isFullWidth && showBottomSection && (
-          <div className="card__bottom-section flex flex-col gap-space-between">
+          <div className="card__bottom-section flex flex-col gap-space-between justify-center">
             {showCTA && (
               <CTALinkOrButton
-                className="card__cta mt-4 md:mt-0"
+                className="card__cta"
                 url={isEntireCardClickable ? undefined : ctaUrl}
                 variant="secondary"
                 withChevron

--- a/libraries/ui/src/Card.tsx
+++ b/libraries/ui/src/Card.tsx
@@ -16,6 +16,7 @@ export type CardProps = {
   isFullWidth?: boolean;
   subtitle?: string;
   subtitleClassName?: string;
+  subtitleBadge?: React.ReactNode;
 };
 
 export const Card: React.FC<CardProps> = ({
@@ -32,6 +33,7 @@ export const Card: React.FC<CardProps> = ({
   isFullWidth = false,
   subtitle,
   subtitleClassName = '',
+  subtitleBadge,
 }) => {
   const Wrapper = isEntireCardClickable ? 'a' : 'div';
   const wrapperClassName = clsx(
@@ -65,7 +67,10 @@ export const Card: React.FC<CardProps> = ({
         )}
       >
         <div className="card__text">
-          <p className="card__title bluedot-h4 mb-2">{title}</p>
+          <div className="flex flex-row gap-4 items-center mb-2">
+            <p className="card__title bluedot-h4">{title}</p>
+            {subtitleBadge && (subtitleBadge)}
+          </div>
           {subtitle && (<p className={`card__subtitle bluedot-p ${subtitleClassName}`}>{subtitle}</p>)}
         </div>
         {/* When isEntireCardClickable is true, the CTALinkOrButton does not render a URL because nested URLs are invalid HTML. */}


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->
- Sort blog posts by featured status and then by publish date. 
- Updated tests and snapshots.
- Made the cards responsive to screen size rather than relying on React isMobile 

There's some hydration issue for the Join Us page, but I don't think this has to do with the changes I made.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1316 

## Developer checklist

- [ x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ x] Considered having snapshot tests and/or happy path functional tests
- [ x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 |  |
|---------|---|
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
<img width="382" height="842" alt="CleanShot 2025-09-10 at 15 26 56@2x" src="https://github.com/user-attachments/assets/5960f8f0-9a01-47f8-9b12-9be0c9c086bd" />
<img width="380" height="842" alt="CleanShot 2025-09-10 at 15 27 13@2x" src="https://github.com/user-attachments/assets/d535ed3f-7221-4c80-8744-9182258ee7b7" />
<img width="382" height="838" alt="CleanShot 2025-09-10 at 15 31 19@2x" src="https://github.com/user-attachments/assets/6c8edfbe-0549-41fb-b2a0-6ed1dd43dbcf" />


| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |


<img width="2318" height="1580" alt="CleanShot 2025-09-10 at 15 29 52@2x" src="https://github.com/user-attachments/assets/7183f14d-596c-43a9-9575-e2ccbf0f4316" />


<img width="3750" height="1770" alt="CleanShot 2025-09-10 at 14 56 23@2x" src="https://github.com/user-attachments/assets/e8565129-4e74-46b0-b828-4b516f0f286d" />

<img width="2318" height="1640" alt="CleanShot 2025-09-10 at 15 30 27@2x" src="https://github.com/user-attachments/assets/e7bf62e4-7a32-452e-8b72-257301d338a0" />

