### PR TITLE
Remove slack alert for `pollForUpdates`

### DIFF
--- a/apps/pg-sync-service/src/lib/pg-sync.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.ts
@@ -131,7 +131,6 @@ export async function pollForUpdates(): Promise<void> {
       allUpdates.push(deduplicateActions(updates));
     } catch (err) {
       logger.error('[pollForUpdates] Failed to poll webhook:', err);
-      slackAlert(env, [`[pollForUpdates] Failed to poll webhook: ${err instanceof Error ? err.message : String(err)}`]);
     }
   }
 


### PR DESCRIPTION
# Description

This is spamming our slack channel and is a known problem: https://github.com/bluedotimpact/bluedot/issues/18

