### PR TITLE
[Fix]: `isMobile` from device detect not reset between tests

### DIFF
--- a/apps/website/src/components/about/HistorySection.test.tsx
+++ b/apps/website/src/components/about/HistorySection.test.tsx
@@ -20,6 +20,6 @@ describe('HistorySection', () => {
     const { container } = render(<HistorySection />);
     expect(container).toMatchSnapshot();
     expect(container.querySelector('.history-section__event-container--mobile')).not.toBeNull();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 });

--- a/apps/website/src/components/join-us/JobsListSection.test.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.test.tsx
@@ -67,7 +67,7 @@ describe('JobsListSection', () => {
     const jobListings = container.querySelectorAll('.jobs-list__listing');
     expect(jobListings.length).toBe(2);
 
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   test('renders empty state when no jobs are provided', () => {

--- a/apps/website/src/components/join-us/ValuesSection.test.tsx
+++ b/apps/website/src/components/join-us/ValuesSection.test.tsx
@@ -18,6 +18,6 @@ describe('ValuesSection', () => {
     vi.spyOn(deviceDetect, 'isMobile', 'get').mockReturnValue(true);
     const { container } = render(<ValuesSection />);
     expect(container).toMatchSnapshot();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 });

--- a/libraries/ui/src/SlideList.test.tsx
+++ b/libraries/ui/src/SlideList.test.tsx
@@ -1,10 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {
-  describe, it, expect,
-  vi,
-  afterAll,
-  beforeAll,
+  afterEach, describe, it, expect, vi, beforeAll,
 } from 'vitest';
 import * as deviceDetect from 'react-device-detect';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -63,9 +60,9 @@ describe('SlideList', () => {
     originalResizeObserver = window.ResizeObserver;
   });
 
-  afterAll(() => {
     vi.clearAllMocks();
     vi.resetAllMocks();
+  afterEach(() => {
     window.ResizeObserver = originalResizeObserver;
   });
 

--- a/libraries/ui/src/SlideList.test.tsx
+++ b/libraries/ui/src/SlideList.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {
-  afterEach, describe, it, expect, vi, beforeAll,
+  afterEach, beforeAll, describe, expect, it, vi,
 } from 'vitest';
 import * as deviceDetect from 'react-device-detect';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/libraries/ui/src/SlideList.test.tsx
+++ b/libraries/ui/src/SlideList.test.tsx
@@ -60,9 +60,8 @@ describe('SlideList', () => {
     originalResizeObserver = window.ResizeObserver;
   });
 
-    vi.clearAllMocks();
-    vi.resetAllMocks();
   afterEach(() => {
+    vi.restoreAllMocks();
     window.ResizeObserver = originalResizeObserver;
   });
 
@@ -90,10 +89,6 @@ describe('SlideList', () => {
       </SlideList>,
     );
     expect(screen.queryAllByLabelText(/(Previous|Next) slide/)).toHaveLength(0);
-
-    vi.clearAllMocks();
-    // TODO: clearAllMocks() doesn't actually clear this
-    vi.spyOn(deviceDetect, 'isMobile', 'get').mockReturnValue(false);
   });
 
   it('hides next/previous buttons if container is wide enough to fit all items on one row', async () => {


### PR DESCRIPTION
# Description

Two problems:

1. We were calling `afterAll`, not `afterEach`, so the call to `clearAllMocks` was needing to be directly invoked
2. Prefer `restoreAllMocks` to `clearAllMocks`. `isMobile` is not a function, which means it is treated as a property descriptor. From the [vitest docs](https://vitest.dev/api/vi.html#vi-restoreallmocks): `restoreAllMocks` will '...  restore original descriptors of spied-on objects.' This is not the case for `clearAllMocks`. I tested this by logging the value of `isMobile` within the component and validating that it is always reset to `false` unless you explicitly over-ride the mock.

## Issue

Fixes #482 

## Developer checklist

NA

## Screenshot

NA
