### PR TITLE
[feat + fix]: quote module enhancements - timer reset and hover pause

### DIFF
--- a/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Quote } from '@bluedot/ui';
 
 type QuoteWithUrl = Quote & {
@@ -69,17 +69,54 @@ const getFontSizeForQuote = (quote: string): string => {
 
 const QuoteSection = () => {
   const [activeIndex, setActiveIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const autorotateTiming = 11000;
 
-  useEffect(() => {
-    const interval = setInterval(() => {
+  // Start timer function
+  const startTimer = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    intervalRef.current = setInterval(() => {
       setActiveIndex((prevIndex) => (prevIndex + 1) % testimonialQuotes.length);
     }, autorotateTiming);
-    return () => clearInterval(interval);
-  }, []);
+  };
+
+  // Timer management effect
+  useEffect(() => {
+    if (!isPaused) {
+      startTimer();
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [isPaused]);
 
   const handleIndicatorClick = (index: number) => {
     setActiveIndex(index);
+    // Always clear the timer to reset it, but only restart if not paused
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    if (!isPaused) {
+      startTimer();
+    }
+  };
+
+  const handleMouseEnter = () => {
+    setIsPaused(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsPaused(false);
   };
 
   const activeQuote = testimonialQuotes[activeIndex];
@@ -92,6 +129,8 @@ const QuoteSection = () => {
     <section
       className="flex flex-col items-center w-full py-6 px-5 lg:p-12"
       style={{ backgroundColor: COLORS.background }}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       {/* Main content container - Mobile: 350px, Desktop: 1120px */}
       <div className="flex flex-col items-center gap-8 w-full max-w-[350px] lg:max-w-[1120px] mx-auto">

--- a/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
@@ -73,42 +73,24 @@ const QuoteSection = () => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const autorotateTiming = 11000;
 
-  // Start timer function
-  const startTimer = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-    intervalRef.current = setInterval(() => {
-      setActiveIndex((prevIndex) => (prevIndex + 1) % testimonialQuotes.length);
-    }, autorotateTiming);
-  };
-
-  // Timer management effect
+  // Single effect that handles all timer logic
   useEffect(() => {
     if (!isPaused) {
-      startTimer();
-    } else if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
+      intervalRef.current = setInterval(() => {
+        setActiveIndex((prevIndex) => (prevIndex + 1) % testimonialQuotes.length);
+      }, autorotateTiming);
     }
 
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
     };
-  }, [isPaused]);
+  }, [activeIndex, isPaused]); // Restart timer when activeIndex changes
 
   const handleIndicatorClick = (index: number) => {
-    setActiveIndex(index);
-    // Always clear the timer to reset it, but only restart if not paused
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-    if (!isPaused) {
-      startTimer();
-    }
+    setActiveIndex(index); // Timer will restart automatically via useEffect
   };
 
   const handleMouseEnter = () => {


### PR DESCRIPTION
# Description
The AGI strategy lander quote carousel had two UX issues:
1. **Jumpy transitions** - Clicking a tab didn't reset the auto-rotation timer, potentially causing quotes to switch immediately after user interaction (e.g., click a tab, then 1 second later it auto-advances)
2. **Interrupts reading** - Timer continued running while users hovered over quotes, potentially switching content while they were actively reading

Improved logic:
  - Resets the 11-second timer whenever a user clicks a tab indicator
  - Pauses auto-rotation when hovering over the quote section
  - Resumes auto-rotation when mouse leaves the section

## Issue
Implements #1344, leaving issue open pending potential additional design updates cc @dewierwan @herrhaase 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories
