### PR TITLE
feat: update AGI strategy course application deadline to 21st Sep

### DIFF
--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -455,7 +455,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                   <span
                     class="font-semibold"
                   >
-                    19th Sep
+                    21st Sep
                   </span>
                 </p>
               </div>

--- a/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.test.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.test.tsx
@@ -39,6 +39,6 @@ describe('CourseDetailsSection', () => {
     expect(getByText(/facilitated by an AI safety expert/)).toBeDefined();
     expect(getByText(/pay-what-you-want/)).toBeDefined();
     expect(getByText('29th Sep')).toBeDefined();
-    expect(getByText('19th Sep')).toBeDefined();
+    expect(getByText('21st Sep')).toBeDefined();
   });
 });

--- a/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.tsx
@@ -52,7 +52,7 @@ const CourseDetailsSection = () => {
         <>
           New cohorts start every month:
           <br />
-          Next round <span className="font-semibold">29th Sep</span>, application deadline <span className="font-semibold">19th Sep</span>
+          Next round <span className="font-semibold">29th Sep</span>, application deadline <span className="font-semibold">21st Sep</span>
         </>
       ),
     },

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/CourseDetailsSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/CourseDetailsSection.test.tsx.snap
@@ -253,7 +253,7 @@ exports[`CourseDetailsSection > renders correctly 1`] = `
               <span
                 class="font-semibold"
               >
-                19th Sep
+                21st Sep
               </span>
             </p>
           </div>


### PR DESCRIPTION
Update application deadline from 19th Sep to 21st Sep for the AGI strategy course cohort starting 29th Sep. This change affects the course details section, related tests, and snapshots to reflect the extended deadline.
