### PR TITLE
[feat]: FAQ section + small ui changes

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -11,6 +11,7 @@ import WhyTakeThisCourseSection from './agi-strategy/WhyTakeThisCourseSection';
 import HeroSection from './agi-strategy/HeroSection';
 import QuoteSection from './agi-strategy/QuoteSection';
 import CourseDetailsSection from './agi-strategy/CourseDetailsSection';
+import FAQSection from './agi-strategy/FAQSection';
 
 const AgiStrategyBanner = ({ title, ctaUrl }: { title: string, ctaUrl: string }) => {
   return (
@@ -123,10 +124,13 @@ const AgiStrategyLander = () => {
       <QuoteSection />
 
       {/* Community Members Section - What learners are saying */}
-      <Section className="py-16">
+      <Section className="py-16 bg-[#FAFAF7]">
         <H2 className="text-[36px] text-center font-semibold leading-tight mb-16">Some of our graduates</H2>
         <CommunityMembersSubSection members={communityMembers} />
       </Section>
+
+      {/* FAQ Section */}
+      <FAQSection />
 
       {/* Banner */}
       <AgiStrategyBanner

--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -124,10 +124,12 @@ const AgiStrategyLander = () => {
       <QuoteSection />
 
       {/* Community Members Section - What learners are saying */}
-      <Section className="py-16 bg-[#FAFAF7]">
-        <H2 className="text-[36px] text-center font-semibold leading-tight mb-16">Some of our graduates</H2>
-        <CommunityMembersSubSection members={communityMembers} />
-      </Section>
+      <div className="w-full bg-[#FAFAF7]">
+        <Section className="py-16">
+          <H2 className="text-[36px] text-center font-semibold leading-tight mb-16">Some of our graduates</H2>
+          <CommunityMembersSubSection members={communityMembers} />
+        </Section>
+      </div>
 
       {/* FAQ Section */}
       <FAQSection />

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -570,27 +570,31 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
         </div>
       </div>
     </section>
-    <section
-      class="section section-body py-16 bg-[#FAFAF7]"
+    <div
+      class="w-full bg-[#FAFAF7]"
     >
-      <div
-        class="section__body"
+      <section
+        class="section section-body py-16"
       >
-        <h2
-          class="bluedot-h2 not-prose text-[36px] text-center font-semibold leading-tight mb-16"
-        >
-          Some of our graduates
-        </h2>
         <div
-          data-testid="community-members-section"
+          class="section__body"
         >
-          <span>
-            Members: 
-            6
-          </span>
+          <h2
+            class="bluedot-h2 not-prose text-[36px] text-center font-semibold leading-tight mb-16"
+          >
+            Some of our graduates
+          </h2>
+          <div
+            data-testid="community-members-section"
+          >
+            <span>
+              Members: 
+              6
+            </span>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
     <section
       class="section section-body bg-white py-16 px-5 md:px-12 lg:px-44"
     >

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -571,7 +571,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       </div>
     </section>
     <section
-      class="section section-body py-16"
+      class="section section-body py-16 bg-[#FAFAF7]"
     >
       <div
         class="section__body"
@@ -588,6 +588,87 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             Members: 
             6
           </span>
+        </div>
+      </div>
+    </section>
+    <section
+      class="section section-body bg-white py-16 px-5 md:px-12 lg:px-44"
+    >
+      <div
+        class="section__body"
+      >
+        <div
+          class="max-w-[928px] mx-auto flex flex-col gap-16"
+        >
+          <h2
+            class="text-[28px] lg:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center"
+          >
+            Frequently Asked Questions
+          </h2>
+          <div
+            class="flex flex-col gap-6"
+          >
+            <div
+              class="border border-[rgba(19,19,46,0.1)] bg-white rounded-xl overflow-hidden"
+            >
+              <button
+                aria-controls="faq-answer-funding"
+                aria-expanded="false"
+                class="w-full flex items-center justify-between text-left py-6 px-8 transition-colors hover:bg-gray-50"
+                type="button"
+              >
+                <span
+                  class="text-[18px] font-semibold leading-[125%] text-[#13132E] pr-4"
+                >
+                  Can I just apply for funding?
+                </span>
+                <svg
+                  class="size-4 text-[#13132E] flex-shrink-0"
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 448 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              class="border border-[rgba(19,19,46,0.1)] bg-white rounded-xl overflow-hidden"
+            >
+              <button
+                aria-controls="faq-answer-bluedot"
+                aria-expanded="false"
+                class="w-full flex items-center justify-between text-left py-6 px-8 transition-colors hover:bg-gray-50"
+                type="button"
+              >
+                <span
+                  class="text-[18px] font-semibold leading-[125%] text-[#13132E] pr-4"
+                >
+                  Who is BlueDot Impact?
+                </span>
+                <svg
+                  class="size-4 text-[#13132E] flex-shrink-0"
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 448 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/apps/website/src/components/lander/agi-strategy/FAQSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/FAQSection.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Section } from '@bluedot/ui';
+import { FaPlus, FaTimes } from 'react-icons/fa';
+
+const FAQSection = () => {
+  const [openQuestion, setOpenQuestion] = useState<string | null>(null);
+
+  const faqData = [
+    {
+      id: 'funding',
+      question: 'Can I just apply for funding?',
+      answer: 'Funding is only available for graduates of the course.',
+    },
+    {
+      id: 'bluedot',
+      question: 'Who is BlueDot Impact?',
+      answer: (
+        <>
+          We're a London-based startup. Since 2022, we've trained 5,000 people, with ~1,000 now working on making AI go well.
+          <br /><br />
+          Our courses are the main entry point into the AI safety field.
+          <br /><br />
+          We're an intense 4-person team. We've raised $35M in total, including $25M in 2025.
+        </>
+      ),
+    },
+  ];
+
+  const handleToggle = (id: string) => {
+    setOpenQuestion(openQuestion === id ? null : id);
+  };
+
+  return (
+    <Section className="bg-white py-16 px-5 md:px-12 lg:px-44">
+      <div className="max-w-[928px] mx-auto flex flex-col gap-16">
+        <h2 className="text-[28px] lg:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center">
+          Frequently Asked Questions
+        </h2>
+
+        <div className="flex flex-col gap-6">
+          {faqData.map((item) => {
+            const isOpen = openQuestion === item.id;
+
+            return (
+              <div
+                key={item.id}
+                className="border border-[rgba(19,19,46,0.1)] bg-white rounded-xl overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() => handleToggle(item.id)}
+                  className={`w-full flex items-center justify-between text-left py-6 px-8 transition-colors ${
+                    !isOpen ? 'hover:bg-gray-50' : ''
+                  }`}
+                  aria-expanded={isOpen}
+                  aria-controls={`faq-answer-${item.id}`}
+                >
+                  <span className="text-[18px] font-semibold leading-[125%] text-[#13132E] pr-4">
+                    {item.question}
+                  </span>
+                  {isOpen ? (
+                    <FaTimes className="size-4 text-[#13132E] flex-shrink-0" />
+                  ) : (
+                    <FaPlus className="size-4 text-[#13132E] flex-shrink-0" />
+                  )}
+                </button>
+
+                {isOpen && (
+                  <div id={`faq-answer-${item.id}`} className="px-8 pb-6 -mt-2">
+                    <div className="text-[18px] font-normal leading-[160%] text-[#13132E] opacity-80">
+                      {item.answer}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Section>
+  );
+};
+
+export default FAQSection;


### PR DESCRIPTION
# Description
Implementing an FAQ section for the AGI strategy lander. I decided to isolate the component into a separate FAQsection within the directory instead of implementing directly in the lander. I also updated the section background color of the graduates section.

## Issue
Implements part of #1334 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Desktop
![FAQ-desktop](https://github.com/user-attachments/assets/0987048b-db7e-4e89-949d-d5df697f5df1)

### Mobile
![FAQ-mobile](https://github.com/user-attachments/assets/a71d5019-3f76-424d-9475-1975eed10253)
