### PR TITLE
[feat]: course benefits section update, various mobile updates

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -126,7 +126,7 @@ const AgiStrategyLander = () => {
       {/* Community Members Section - What learners are saying */}
       <div className="w-full bg-[#FAFAF7]">
         <Section className="py-16">
-          <H2 className="text-[36px] text-center font-semibold leading-tight mb-16">Some of our graduates</H2>
+          <H2 className="text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] mb-16 tracking-[-0.01em]">Some of our graduates</H2>
           <CommunityMembersSubSection members={communityMembers} />
         </Section>
       </div>

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -83,9 +83,9 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
         class="max-w-max-width mx-auto px-spacing-x py-16"
       >
         <h2
-          class="bluedot-h2 not-prose text-[36px] font-semibold leading-tight text-[#13132E] text-center mb-16"
+          class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]"
         >
-          How will this course benefit you?
+          How this course will benefit you
         </h2>
         <div
           class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"
@@ -94,56 +94,20 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             class="flex flex-col gap-6"
           >
             <div
-              class="size-11 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+              class="size-14 bg-[#ECF0FF] rounded-lg flex items-center justify-center flex-shrink-0"
             >
               <svg
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21M23 21V19C22.9993 18.1137 22.7044 17.2528 22.1614 16.5523C21.6184 15.8519 20.8581 15.3516 20 15.13M16 3.13C16.8604 3.35031 17.623 3.85071 18.1676 4.55232C18.7122 5.25392 19.0078 6.11683 19.0078 7.005C19.0078 7.89317 18.7122 8.75608 18.1676 9.45768C17.623 10.1593 16.8604 10.6597 16 10.88M13 7C13 9.20914 11.2091 11 9 11C6.79086 11 5 9.20914 5 7C5 4.79086 6.79086 3 9 3C11.2091 3 13 4.79086 13 7Z"
-                  fill="none"
-                  stroke="white"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <div
-              class="space-y-2"
-            >
-              <h3
-                class="bluedot-h3 not-prose text-[18px] font-semibold leading-tight text-[#13132E]"
-              >
-                Join a network of builders
-              </h3>
-              <p
-                class="bluedot-p not-prose text-size-sm leading-[1.6] text-[#13132E] opacity-80"
-              >
-                This course isn't for everyone. We're building a community of people who are energised to take ambitious actions to make AI go well, including starting new companies, policy entrepreneurship, and high-impact research bets. Completing this course will give you access to this community.
-              </p>
-            </div>
-          </div>
-          <div
-            class="flex flex-col gap-6"
-          >
-            <div
-              class="size-11 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
-            >
-              <svg
-                fill="none"
+                class="text-black"
+                fill="currentColor"
                 height="28"
-                viewBox="0 0 28 28"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 256 256"
                 width="28"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M25.9941 15.4938L22.4941 18.9938C22.3299 19.158 22.1072 19.2502 21.875 19.2502C21.6428 19.2502 21.4201 19.158 21.2559 18.9938C21.0918 18.8296 20.9995 18.6069 20.9995 18.3747C20.9995 18.1425 21.0918 17.9198 21.2559 17.7556L23.263 15.7497H13.487L7.36203 21.8747H10.5C10.7321 21.8747 10.9546 21.9669 11.1187 22.131C11.2828 22.2951 11.375 22.5176 11.375 22.7497C11.375 22.9818 11.2828 23.2043 11.1187 23.3684C10.9546 23.5325 10.7321 23.6247 10.5 23.6247H5.25C5.01794 23.6247 4.79538 23.5325 4.63128 23.3684C4.46719 23.2043 4.375 22.9818 4.375 22.7497V17.4997C4.375 17.2676 4.46719 17.0451 4.63128 16.881C4.79538 16.7169 5.01794 16.6247 5.25 16.6247C5.48206 16.6247 5.70462 16.7169 5.86872 16.881C6.03281 17.0451 6.125 17.2676 6.125 17.4997V20.6377L12.25 14.5127V4.73674L10.2441 6.74377C10.0799 6.90796 9.85719 7.0002 9.625 7.0002C9.39281 7.0002 9.17012 6.90796 9.00594 6.74377C8.84175 6.57959 8.74951 6.3569 8.74951 6.12471C8.74951 5.89252 8.84175 5.66983 9.00594 5.50565L12.5059 2.00565C12.5872 1.92429 12.6837 1.85976 12.7899 1.81572C12.8961 1.77169 13.01 1.74902 13.125 1.74902C13.24 1.74902 13.3538 1.77169 13.4601 1.81572C13.5663 1.85976 13.6628 1.92429 13.7441 2.00565L17.2441 5.50565C17.4082 5.66983 17.5005 5.89252 17.5005 6.12471C17.5005 6.3569 17.4082 6.57959 17.2441 6.74377C17.0799 6.90796 16.8572 7.0002 16.625 7.0002C16.3928 7.0002 16.1701 6.90796 16.0059 6.74377L14 4.73674V13.9997H23.263L21.2559 11.9938C21.0918 11.8296 20.9995 11.6069 20.9995 11.3747C20.9995 11.1425 21.0918 10.9198 21.2559 10.7556C21.4201 10.5915 21.6428 10.4992 21.875 10.4992C22.1072 10.4992 22.3299 10.5915 22.4941 10.7556L25.9941 14.2556C26.0754 14.3369 26.14 14.4334 26.184 14.5396C26.228 14.6459 26.2507 14.7597 26.2507 14.8747C26.2507 14.9897 26.228 15.1036 26.184 15.2098C26.14 15.316 26.0754 15.4125 25.9941 15.4938Z"
-                  fill="white"
+                  d="M223.85,47.12a16,16,0,0,0-15-15c-12.58-.75-44.73.4-71.41,27.07L132.69,64H74.36A15.91,15.91,0,0,0,63,68.68L28.7,103a16,16,0,0,0,9.07,27.16l38.47,5.37,44.21,44.21,5.37,38.49a15.94,15.94,0,0,0,10.78,12.92,16.11,16.11,0,0,0,5.1.83A15.91,15.91,0,0,0,153,227.3L187.32,193A15.91,15.91,0,0,0,192,181.64V123.31l4.77-4.77C223.45,91.86,224.6,59.71,223.85,47.12ZM74.36,80h42.33L77.16,119.52,40,114.34Zm74.41-9.45a76.65,76.65,0,0,1,59.11-22.47,76.46,76.46,0,0,1-22.42,59.16L128,164.68,91.32,128ZM176,181.64,141.67,216l-5.19-37.17L176,139.31Zm-74.16,9.5C97.34,201,82.29,224,40,224a8,8,0,0,1-8-8c0-42.29,23-57.34,32.86-61.85a8,8,0,0,1,6.64,14.56c-6.43,2.93-20.62,12.36-23.12,38.91,26.55-2.5,36-16.69,38.91-23.12a8,8,0,1,1,14.56,6.64Z"
                 />
               </svg>
             </div>
@@ -166,22 +130,56 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             class="flex flex-col gap-6"
           >
             <div
-              class="size-11 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+              class="size-14 bg-[#ECF0FF] rounded-lg flex items-center justify-center flex-shrink-0"
             >
               <svg
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
+                class="text-black"
+                fill="currentColor"
+                height="28"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 256 256"
+                width="28"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M9 11H15M9 15H15M17 21H7C5.89543 21 5 20.1046 5 19V5C5 3.89543 5.89543 3 7 3H12.5858C12.851 3 13.1054 3.10536 13.2929 3.29289L18.7071 8.70711C18.8946 8.89464 19 9.149 19 9.41421V19C19 20.1046 18.1046 21 17 21Z"
-                  fill="none"
-                  stroke="white"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
+                  d="M244.8,150.4a8,8,0,0,1-11.2-1.6A51.6,51.6,0,0,0,192,128a8,8,0,0,1-7.37-4.89,8,8,0,0,1,0-6.22A8,8,0,0,1,192,112a24,24,0,1,0-23.24-30,8,8,0,1,1-15.5-4A40,40,0,1,1,219,117.51a67.94,67.94,0,0,1,27.43,21.68A8,8,0,0,1,244.8,150.4ZM190.92,212a8,8,0,1,1-13.84,8,57,57,0,0,0-98.16,0,8,8,0,1,1-13.84-8,72.06,72.06,0,0,1,33.74-29.92,48,48,0,1,1,58.36,0A72.06,72.06,0,0,1,190.92,212ZM128,176a32,32,0,1,0-32-32A32,32,0,0,0,128,176ZM72,120a8,8,0,0,0-8-8A24,24,0,1,1,87.24,82a8,8,0,1,0,15.5-4A40,40,0,1,0,37,117.51,67.94,67.94,0,0,0,9.6,139.19a8,8,0,1,0,12.8,9.61A51.6,51.6,0,0,1,64,128,8,8,0,0,0,72,120Z"
+                />
+              </svg>
+            </div>
+            <div
+              class="space-y-2"
+            >
+              <h3
+                class="bluedot-h3 not-prose text-[18px] font-semibold leading-tight text-[#13132E]"
+              >
+                Join a network of builders
+              </h3>
+              <p
+                class="bluedot-p not-prose text-size-sm leading-[1.6] text-[#13132E] opacity-80"
+              >
+                This course isn't for everyone. We're building a community of people who are energised to take ambitious actions to make AI go well, including starting new companies, policy entrepreneurship, and high-impact research bets. Completing this course will give you access to this community.
+              </p>
+            </div>
+          </div>
+          <div
+            class="flex flex-col gap-6"
+          >
+            <div
+              class="size-14 bg-[#ECF0FF] rounded-lg flex items-center justify-center flex-shrink-0"
+            >
+              <svg
+                class="text-black"
+                fill="currentColor"
+                height="28"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 256 256"
+                width="28"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M230.33,141.06a24.43,24.43,0,0,0-21.24-4.23l-41.84,9.62A28,28,0,0,0,140,112H89.94a31.82,31.82,0,0,0-22.63,9.37L44.69,144H16A16,16,0,0,0,0,160v40a16,16,0,0,0,16,16H120a7.93,7.93,0,0,0,1.94-.24l64-16a6.94,6.94,0,0,0,1.19-.4L226,182.82l.44-.2a24.6,24.6,0,0,0,3.93-41.56ZM16,160H40v40H16Zm203.43,8.21-38,16.18L119,200H56V155.31l22.63-22.62A15.86,15.86,0,0,1,89.94,128H140a12,12,0,0,1,0,24H112a8,8,0,0,0,0,16h32a8.32,8.32,0,0,0,1.79-.2l67-15.41.31-.08a8.6,8.6,0,0,1,6.3,15.9ZM164,96a36,36,0,0,0,5.9-.48,36,36,0,1,0,28.22-47A36,36,0,1,0,164,96Zm60-12a20,20,0,1,1-20-20A20,20,0,0,1,224,84ZM164,40a20,20,0,0,1,19.25,14.61,36,36,0,0,0-15,24.93A20.42,20.42,0,0,1,164,80a20,20,0,0,1,0-40Z"
                 />
               </svg>
             </div>
@@ -580,7 +578,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
           class="section__body"
         >
           <h2
-            class="bluedot-h2 not-prose text-[36px] text-center font-semibold leading-tight mb-16"
+            class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] mb-16 tracking-[-0.01em]"
           >
             Some of our graduates
           </h2>

--- a/apps/website/src/components/lander/agi-strategy/WhyTakeThisCourseSection.test.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhyTakeThisCourseSection.test.tsx
@@ -8,11 +8,6 @@ describe('WhyTakeThisCourseSection', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders the section title', () => {
-    const { getByText } = render(<WhyTakeThisCourseSection />);
-    expect(getByText('How will this course benefit you?')).toBeDefined();
-  });
-
   it('renders all three value cards', () => {
     const { getByText } = render(<WhyTakeThisCourseSection />);
 

--- a/apps/website/src/components/lander/agi-strategy/WhyTakeThisCourseSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhyTakeThisCourseSection.tsx
@@ -1,32 +1,21 @@
 import { NewText } from '@bluedot/ui';
+import { PiRocketLaunch, PiUsersThree, PiHandCoins } from 'react-icons/pi';
 
 const { H2, H3, P } = NewText;
 
 const valueCards = [
   {
-    icon: (
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21M23 21V19C22.9993 18.1137 22.7044 17.2528 22.1614 16.5523C21.6184 15.8519 20.8581 15.3516 20 15.13M16 3.13C16.8604 3.35031 17.623 3.85071 18.1676 4.55232C18.7122 5.25392 19.0078 6.11683 19.0078 7.005C19.0078 7.89317 18.7122 8.75608 18.1676 9.45768C17.623 10.1593 16.8604 10.6597 16 10.88M13 7C13 9.20914 11.2091 11 9 11C6.79086 11 5 9.20914 5 7C5 4.79086 6.79086 3 9 3C11.2091 3 13 4.79086 13 7Z" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    ),
-    title: 'Join a network of builders',
-    description: "This course isn't for everyone. We're building a community of people who are energised to take ambitious actions to make AI go well, including starting new companies, policy entrepreneurship, and high-impact research bets. Completing this course will give you access to this community.",
-  },
-  {
-    icon: (
-      <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M25.9941 15.4938L22.4941 18.9938C22.3299 19.158 22.1072 19.2502 21.875 19.2502C21.6428 19.2502 21.4201 19.158 21.2559 18.9938C21.0918 18.8296 20.9995 18.6069 20.9995 18.3747C20.9995 18.1425 21.0918 17.9198 21.2559 17.7556L23.263 15.7497H13.487L7.36203 21.8747H10.5C10.7321 21.8747 10.9546 21.9669 11.1187 22.131C11.2828 22.2951 11.375 22.5176 11.375 22.7497C11.375 22.9818 11.2828 23.2043 11.1187 23.3684C10.9546 23.5325 10.7321 23.6247 10.5 23.6247H5.25C5.01794 23.6247 4.79538 23.5325 4.63128 23.3684C4.46719 23.2043 4.375 22.9818 4.375 22.7497V17.4997C4.375 17.2676 4.46719 17.0451 4.63128 16.881C4.79538 16.7169 5.01794 16.6247 5.25 16.6247C5.48206 16.6247 5.70462 16.7169 5.86872 16.881C6.03281 17.0451 6.125 17.2676 6.125 17.4997V20.6377L12.25 14.5127V4.73674L10.2441 6.74377C10.0799 6.90796 9.85719 7.0002 9.625 7.0002C9.39281 7.0002 9.17012 6.90796 9.00594 6.74377C8.84175 6.57959 8.74951 6.3569 8.74951 6.12471C8.74951 5.89252 8.84175 5.66983 9.00594 5.50565L12.5059 2.00565C12.5872 1.92429 12.6837 1.85976 12.7899 1.81572C12.8961 1.77169 13.01 1.74902 13.125 1.74902C13.24 1.74902 13.3538 1.77169 13.4601 1.81572C13.5663 1.85976 13.6628 1.92429 13.7441 2.00565L17.2441 5.50565C17.4082 5.66983 17.5005 5.89252 17.5005 6.12471C17.5005 6.3569 17.4082 6.57959 17.2441 6.74377C17.0799 6.90796 16.8572 7.0002 16.625 7.0002C16.3928 7.0002 16.1701 6.90796 16.0059 6.74377L14 4.73674V13.9997H23.263L21.2559 11.9938C21.0918 11.8296 20.9995 11.6069 20.9995 11.3747C20.9995 11.1425 21.0918 10.9198 21.2559 10.7556C21.4201 10.5915 21.6428 10.4992 21.875 10.4992C22.1072 10.4992 22.3299 10.5915 22.4941 10.7556L25.9941 14.2556C26.0754 14.3369 26.14 14.4334 26.184 14.5396C26.228 14.6459 26.2507 14.7597 26.2507 14.8747C26.2507 14.9897 26.228 15.1036 26.184 15.2098C26.14 15.316 26.0754 15.4125 25.9941 15.4938Z" fill="white" />
-      </svg>
-    ),
+    icon: <PiRocketLaunch className="text-black" size={28} />,
     title: 'Take action in less than 30 hours',
     description: "You don't need another degree. This AGI Strategy course replaces years of self-study with three frameworks: incentive mapping to understand the AGI race, kill chains to analyse AI threats, and defence-in-depth to design interventions that counter them. You'll finish with a fundable plan.",
   },
   {
-    icon: (
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M9 11H15M9 15H15M17 21H7C5.89543 21 5 20.1046 5 19V5C5 3.89543 5.89543 3 7 3H12.5858C12.851 3 13.1054 3.10536 13.2929 3.29289L18.7071 8.70711C18.8946 8.89464 19 9.149 19 9.41421V19C19 20.1046 18.1046 21 17 21Z" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    ),
+    icon: <PiUsersThree className="text-black" size={28} />,
+    title: 'Join a network of builders',
+    description: "This course isn't for everyone. We're building a community of people who are energised to take ambitious actions to make AI go well, including starting new companies, policy entrepreneurship, and high-impact research bets. Completing this course will give you access to this community.",
+  },
+  {
+    icon: <PiHandCoins className="text-black" size={28} />,
     title: 'Get funded to accelerate your impact',
     description: "If your final course proposal is strong, you'll receive $10-50k to kickstart your transition into impactful work, and you'll be invited to co-work with us in London for 1-2 weeks. We'll do whatever it takes to accelerate your journey.",
   },
@@ -36,13 +25,13 @@ const WhyTakeThisCourseSection = () => {
   return (
     <section className="w-full border-t-[0.5px] border-color-divider bg-white">
       <div className="max-w-max-width mx-auto px-spacing-x py-16">
-        <H2 className="text-[36px] font-semibold leading-tight text-[#13132E] text-center mb-16">
-          How will this course benefit you?
+        <H2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]">
+          How this course will benefit you
         </H2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {valueCards.map(({ icon, title, description }) => (
             <div key={title} className="flex flex-col gap-6">
-              <div className="size-11 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0">
+              <div className="size-14 bg-[#ECF0FF] rounded-lg flex items-center justify-center flex-shrink-0">
                 {icon}
               </div>
               <div className="space-y-2">

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhyTakeThisCourseSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhyTakeThisCourseSection.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`WhyTakeThisCourseSection > renders correctly 1`] = `
     class="max-w-max-width mx-auto px-spacing-x py-16"
   >
     <h2
-      class="bluedot-h2 not-prose text-[36px] font-semibold leading-tight text-[#13132E] text-center mb-16"
+      class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]"
     >
-      How will this course benefit you?
+      How this course will benefit you
     </h2>
     <div
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"
@@ -19,56 +19,20 @@ exports[`WhyTakeThisCourseSection > renders correctly 1`] = `
         class="flex flex-col gap-6"
       >
         <div
-          class="size-11 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+          class="size-14 bg-[#ECF0FF] rounded-lg flex items-center justify-center flex-shrink-0"
         >
           <svg
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21M23 21V19C22.9993 18.1137 22.7044 17.2528 22.1614 16.5523C21.6184 15.8519 20.8581 15.3516 20 15.13M16 3.13C16.8604 3.35031 17.623 3.85071 18.1676 4.55232C18.7122 5.25392 19.0078 6.11683 19.0078 7.005C19.0078 7.89317 18.7122 8.75608 18.1676 9.45768C17.623 10.1593 16.8604 10.6597 16 10.88M13 7C13 9.20914 11.2091 11 9 11C6.79086 11 5 9.20914 5 7C5 4.79086 6.79086 3 9 3C11.2091 3 13 4.79086 13 7Z"
-              fill="none"
-              stroke="white"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </div>
-        <div
-          class="space-y-2"
-        >
-          <h3
-            class="bluedot-h3 not-prose text-[18px] font-semibold leading-tight text-[#13132E]"
-          >
-            Join a network of builders
-          </h3>
-          <p
-            class="bluedot-p not-prose text-size-sm leading-[1.6] text-[#13132E] opacity-80"
-          >
-            This course isn't for everyone. We're building a community of people who are energised to take ambitious actions to make AI go well, including starting new companies, policy entrepreneurship, and high-impact research bets. Completing this course will give you access to this community.
-          </p>
-        </div>
-      </div>
-      <div
-        class="flex flex-col gap-6"
-      >
-        <div
-          class="size-11 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
-        >
-          <svg
-            fill="none"
+            class="text-black"
+            fill="currentColor"
             height="28"
-            viewBox="0 0 28 28"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 256 256"
             width="28"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M25.9941 15.4938L22.4941 18.9938C22.3299 19.158 22.1072 19.2502 21.875 19.2502C21.6428 19.2502 21.4201 19.158 21.2559 18.9938C21.0918 18.8296 20.9995 18.6069 20.9995 18.3747C20.9995 18.1425 21.0918 17.9198 21.2559 17.7556L23.263 15.7497H13.487L7.36203 21.8747H10.5C10.7321 21.8747 10.9546 21.9669 11.1187 22.131C11.2828 22.2951 11.375 22.5176 11.375 22.7497C11.375 22.9818 11.2828 23.2043 11.1187 23.3684C10.9546 23.5325 10.7321 23.6247 10.5 23.6247H5.25C5.01794 23.6247 4.79538 23.5325 4.63128 23.3684C4.46719 23.2043 4.375 22.9818 4.375 22.7497V17.4997C4.375 17.2676 4.46719 17.0451 4.63128 16.881C4.79538 16.7169 5.01794 16.6247 5.25 16.6247C5.48206 16.6247 5.70462 16.7169 5.86872 16.881C6.03281 17.0451 6.125 17.2676 6.125 17.4997V20.6377L12.25 14.5127V4.73674L10.2441 6.74377C10.0799 6.90796 9.85719 7.0002 9.625 7.0002C9.39281 7.0002 9.17012 6.90796 9.00594 6.74377C8.84175 6.57959 8.74951 6.3569 8.74951 6.12471C8.74951 5.89252 8.84175 5.66983 9.00594 5.50565L12.5059 2.00565C12.5872 1.92429 12.6837 1.85976 12.7899 1.81572C12.8961 1.77169 13.01 1.74902 13.125 1.74902C13.24 1.74902 13.3538 1.77169 13.4601 1.81572C13.5663 1.85976 13.6628 1.92429 13.7441 2.00565L17.2441 5.50565C17.4082 5.66983 17.5005 5.89252 17.5005 6.12471C17.5005 6.3569 17.4082 6.57959 17.2441 6.74377C17.0799 6.90796 16.8572 7.0002 16.625 7.0002C16.3928 7.0002 16.1701 6.90796 16.0059 6.74377L14 4.73674V13.9997H23.263L21.2559 11.9938C21.0918 11.8296 20.9995 11.6069 20.9995 11.3747C20.9995 11.1425 21.0918 10.9198 21.2559 10.7556C21.4201 10.5915 21.6428 10.4992 21.875 10.4992C22.1072 10.4992 22.3299 10.5915 22.4941 10.7556L25.9941 14.2556C26.0754 14.3369 26.14 14.4334 26.184 14.5396C26.228 14.6459 26.2507 14.7597 26.2507 14.8747C26.2507 14.9897 26.228 15.1036 26.184 15.2098C26.14 15.316 26.0754 15.4125 25.9941 15.4938Z"
-              fill="white"
+              d="M223.85,47.12a16,16,0,0,0-15-15c-12.58-.75-44.73.4-71.41,27.07L132.69,64H74.36A15.91,15.91,0,0,0,63,68.68L28.7,103a16,16,0,0,0,9.07,27.16l38.47,5.37,44.21,44.21,5.37,38.49a15.94,15.94,0,0,0,10.78,12.92,16.11,16.11,0,0,0,5.1.83A15.91,15.91,0,0,0,153,227.3L187.32,193A15.91,15.91,0,0,0,192,181.64V123.31l4.77-4.77C223.45,91.86,224.6,59.71,223.85,47.12ZM74.36,80h42.33L77.16,119.52,40,114.34Zm74.41-9.45a76.65,76.65,0,0,1,59.11-22.47,76.46,76.46,0,0,1-22.42,59.16L128,164.68,91.32,128ZM176,181.64,141.67,216l-5.19-37.17L176,139.31Zm-74.16,9.5C97.34,201,82.29,224,40,224a8,8,0,0,1-8-8c0-42.29,23-57.34,32.86-61.85a8,8,0,0,1,6.64,14.56c-6.43,2.93-20.62,12.36-23.12,38.91,26.55-2.5,36-16.69,38.91-23.12a8,8,0,1,1,14.56,6.64Z"
             />
           </svg>
         </div>
@@ -91,22 +55,56 @@ exports[`WhyTakeThisCourseSection > renders correctly 1`] = `
         class="flex flex-col gap-6"
       >
         <div
-          class="size-11 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+          class="size-14 bg-[#ECF0FF] rounded-lg flex items-center justify-center flex-shrink-0"
         >
           <svg
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
+            class="text-black"
+            fill="currentColor"
+            height="28"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 256 256"
+            width="28"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M9 11H15M9 15H15M17 21H7C5.89543 21 5 20.1046 5 19V5C5 3.89543 5.89543 3 7 3H12.5858C12.851 3 13.1054 3.10536 13.2929 3.29289L18.7071 8.70711C18.8946 8.89464 19 9.149 19 9.41421V19C19 20.1046 18.1046 21 17 21Z"
-              fill="none"
-              stroke="white"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
+              d="M244.8,150.4a8,8,0,0,1-11.2-1.6A51.6,51.6,0,0,0,192,128a8,8,0,0,1-7.37-4.89,8,8,0,0,1,0-6.22A8,8,0,0,1,192,112a24,24,0,1,0-23.24-30,8,8,0,1,1-15.5-4A40,40,0,1,1,219,117.51a67.94,67.94,0,0,1,27.43,21.68A8,8,0,0,1,244.8,150.4ZM190.92,212a8,8,0,1,1-13.84,8,57,57,0,0,0-98.16,0,8,8,0,1,1-13.84-8,72.06,72.06,0,0,1,33.74-29.92,48,48,0,1,1,58.36,0A72.06,72.06,0,0,1,190.92,212ZM128,176a32,32,0,1,0-32-32A32,32,0,0,0,128,176ZM72,120a8,8,0,0,0-8-8A24,24,0,1,1,87.24,82a8,8,0,1,0,15.5-4A40,40,0,1,0,37,117.51,67.94,67.94,0,0,0,9.6,139.19a8,8,0,1,0,12.8,9.61A51.6,51.6,0,0,1,64,128,8,8,0,0,0,72,120Z"
+            />
+          </svg>
+        </div>
+        <div
+          class="space-y-2"
+        >
+          <h3
+            class="bluedot-h3 not-prose text-[18px] font-semibold leading-tight text-[#13132E]"
+          >
+            Join a network of builders
+          </h3>
+          <p
+            class="bluedot-p not-prose text-size-sm leading-[1.6] text-[#13132E] opacity-80"
+          >
+            This course isn't for everyone. We're building a community of people who are energised to take ambitious actions to make AI go well, including starting new companies, policy entrepreneurship, and high-impact research bets. Completing this course will give you access to this community.
+          </p>
+        </div>
+      </div>
+      <div
+        class="flex flex-col gap-6"
+      >
+        <div
+          class="size-14 bg-[#ECF0FF] rounded-lg flex items-center justify-center flex-shrink-0"
+        >
+          <svg
+            class="text-black"
+            fill="currentColor"
+            height="28"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 256 256"
+            width="28"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M230.33,141.06a24.43,24.43,0,0,0-21.24-4.23l-41.84,9.62A28,28,0,0,0,140,112H89.94a31.82,31.82,0,0,0-22.63,9.37L44.69,144H16A16,16,0,0,0,0,160v40a16,16,0,0,0,16,16H120a7.93,7.93,0,0,0,1.94-.24l64-16a6.94,6.94,0,0,0,1.19-.4L226,182.82l.44-.2a24.6,24.6,0,0,0,3.93-41.56ZM16,160H40v40H16Zm203.43,8.21-38,16.18L119,200H56V155.31l22.63-22.62A15.86,15.86,0,0,1,89.94,128H140a12,12,0,0,1,0,24H112a8,8,0,0,0,0,16h32a8.32,8.32,0,0,0,1.79-.2l67-15.41.31-.08a8.6,8.6,0,0,1,6.3,15.9ZM164,96a36,36,0,0,0,5.9-.48,36,36,0,1,0,28.22-47A36,36,0,1,0,164,96Zm60-12a20,20,0,1,1-20-20A20,20,0,0,1,224,84ZM164,40a20,20,0,0,1,19.25,14.61,36,36,0,0,0-15,24.93A20.42,20.42,0,0,1,164,80a20,20,0,0,1,0-40Z"
             />
           </svg>
         </div>


### PR DESCRIPTION
# Description
Updated WhyTakeThisCourseSection in the AGI strategy landing page to align with the [design](https://www.figma.com/design/62YlFNK7QS6z7SkrPjrwVb/Blue-Dot?node-id=1740-1919&t=4ngufKEmeIcvrJH9-0).

Also added mobile responsiveness for headline text in WhyTakeThisCourseSection and the "Some of Our Graduates" section in AgiStrategyLander so that it's consistent with the sizing of other headlines in previously-implemented sections

## Issue
Implements some of #1334 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Desktop
<img width="1512" height="621" alt="course-benefits-desktop" src="https://github.com/user-attachments/assets/09d1681e-27dc-43f1-a9db-75db845a2007" />

### Mobile
![course-benefits-mobile](https://github.com/user-attachments/assets/687624a6-a124-4ce3-87a9-0c1d7829f43d)

<img width="390" height="624" alt="some-of-our-graduates-mobile-header-update" src="https://github.com/user-attachments/assets/ef34fb59-503b-448b-94d8-53727400b95c" />