### PR TITLE
[feat]: who is this course for section

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -8,6 +8,7 @@ import { H2, H3 } from '../Text';
 import CommunityMembersSubSection, { CommunityMember } from './agi-strategy/CommunityMembersSubSection';
 import GraduateSection from './agi-strategy/GraduateSection';
 import WhyTakeThisCourseSection from './agi-strategy/WhyTakeThisCourseSection';
+import WhoIsThisForSection from './agi-strategy/WhoIsThisForSection';
 import HeroSection from './agi-strategy/HeroSection';
 import QuoteSection from './agi-strategy/QuoteSection';
 import CourseDetailsSection from './agi-strategy/CourseDetailsSection';
@@ -113,6 +114,9 @@ const AgiStrategyLander = () => {
 
       {/* Divider */}
       <div className="border-t-hairline border-color-divider" />
+
+      {/* Who is this course for section */}
+      <WhoIsThisForSection />
 
       {/* Why take this course section */}
       <WhyTakeThisCourseSection />

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -77,6 +77,125 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="border-t-hairline border-color-divider"
     />
     <section
+      class="w-full bg-[#FAFAF7]"
+    >
+      <div
+        class="max-w-max-width mx-auto px-spacing-x py-12 md:py-16"
+      >
+        <h2
+          class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
+        >
+          Who is this course for?
+        </h2>
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"
+        >
+          <div
+            class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+          >
+            <div
+              class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+            >
+              <svg
+                class="text-white"
+                fill="currentColor"
+                height="28"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 256 256"
+                width="28"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M216,56H176V48a24,24,0,0,0-24-24H104A24,24,0,0,0,80,48v8H40A16,16,0,0,0,24,72V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V72A16,16,0,0,0,216,56ZM96,48a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96ZM216,72v41.61A184,184,0,0,1,128,136a184.07,184.07,0,0,1-88-22.38V72Zm0,128H40V131.64A200.19,200.19,0,0,0,128,152a200.25,200.25,0,0,0,88-20.37V200ZM104,112a8,8,0,0,1,8-8h32a8,8,0,0,1,0,16H112A8,8,0,0,1,104,112Z"
+                />
+              </svg>
+            </div>
+            <p
+              class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+            >
+              <span
+                class="font-semibold"
+              >
+                For entrepreneurs and operators
+              </span>
+              <span>
+                 who want to build solutions that protect humanity.
+              </span>
+            </p>
+          </div>
+          <div
+            class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+          >
+            <div
+              class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+            >
+              <svg
+                class="text-white"
+                fill="currentColor"
+                height="28"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 256 256"
+                width="28"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216ZM172.42,72.84l-64,32a8.05,8.05,0,0,0-3.58,3.58l-32,64A8,8,0,0,0,80,184a8.1,8.1,0,0,0,3.58-.84l64-32a8.05,8.05,0,0,0,3.58-3.58l32-64a8,8,0,0,0-10.74-10.74ZM138,138,97.89,158.11,118,118l40.15-20.07Z"
+                />
+              </svg>
+            </div>
+            <p
+              class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+            >
+              <span
+                class="font-semibold"
+              >
+                For leaders
+              </span>
+              <span>
+                 who want to steer AI's trajectory towards beneficial outcomes for humanity.
+              </span>
+            </p>
+          </div>
+          <div
+            class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+          >
+            <div
+              class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+            >
+              <svg
+                class="text-white"
+                fill="currentColor"
+                height="28"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 256 256"
+                width="28"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M221.69,199.77,160,96.92V40h8a8,8,0,0,0,0-16H88a8,8,0,0,0,0,16h8V96.92L34.31,199.77A16,16,0,0,0,48,224H208a16,16,0,0,0,13.72-24.23ZM110.86,103.25A7.93,7.93,0,0,0,112,99.14V40h32V99.14a7.93,7.93,0,0,0,1.14,4.11L183.36,167c-12,2.37-29.07,1.37-51.75-10.11-15.91-8.05-31.05-12.32-45.22-12.81ZM48,208l28.54-47.58c14.25-1.74,30.31,1.85,47.82,10.72,19,9.61,35,12.88,48,12.88a69.89,69.89,0,0,0,19.55-2.7L208,208Z"
+                />
+              </svg>
+            </div>
+            <p
+              class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+            >
+              <span
+                class="font-semibold"
+              >
+                For researchers
+              </span>
+              <span>
+                 who want to take big bets on the most impactful research ideas.
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
       class="w-full border-t-[0.5px] border-color-divider bg-white"
     >
       <div

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-[#FAFAF7]"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x py-12 md:py-16"
+        class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
       >
         <h2
           class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
@@ -196,7 +196,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       </div>
     </section>
     <section
-      class="w-full border-t-[0.5px] border-color-divider bg-white"
+      class="w-full bg-white"
     >
       <div
         class="max-w-max-width mx-auto px-spacing-x py-16"

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.test.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import WhoIsThisForSection from './WhoIsThisForSection';
+
+describe('WhoIsThisForSection', () => {
+  it('renders correctly', () => {
+    const { container } = render(<WhoIsThisForSection />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders the section title', () => {
+    const { getByText } = render(<WhoIsThisForSection />);
+    expect(getByText('Who is this course for?')).toBeDefined();
+  });
+
+  it('renders all three target audience cards', () => {
+    const { getByText } = render(<WhoIsThisForSection />);
+
+    // Check all card titles are rendered
+    expect(getByText('For entrepreneurs and operators')).toBeDefined();
+    expect(getByText('For leaders')).toBeDefined();
+    expect(getByText('For researchers')).toBeDefined();
+  });
+
+  it('renders target audience descriptions', () => {
+    const { getByText } = render(<WhoIsThisForSection />);
+
+    // Check card descriptions - text is now in spans
+    expect(getByText('who want to build solutions that protect humanity.')).toBeDefined();
+    expect(getByText('who want to steer AI\'s trajectory towards beneficial outcomes for humanity.')).toBeDefined();
+    expect(getByText('who want to take big bets on the most impactful research ideas.')).toBeDefined();
+  });
+});

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
@@ -1,0 +1,49 @@
+import { NewText } from '@bluedot/ui';
+import { PiBriefcase, PiCompass, PiFlask } from 'react-icons/pi';
+
+const { H2, P } = NewText;
+
+const targetAudiences = [
+  {
+    icon: <PiBriefcase className="text-white" size={28} />,
+    boldText: 'For entrepreneurs and operators',
+    normalText: ' who want to build solutions that protect humanity.',
+  },
+  {
+    icon: <PiCompass className="text-white" size={28} />,
+    boldText: 'For leaders',
+    normalText: ' who want to steer AI\'s trajectory towards beneficial outcomes for humanity.',
+  },
+  {
+    icon: <PiFlask className="text-white" size={28} />,
+    boldText: 'For researchers',
+    normalText: ' who want to take big bets on the most impactful research ideas.',
+  },
+];
+
+const WhoIsThisForSection = () => {
+  return (
+    <section className="w-full bg-[#FAFAF7]">
+      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:py-16">
+        <H2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]">
+          Who is this course for?
+        </H2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
+          {targetAudiences.map(({ icon, boldText, normalText }) => (
+            <div key={boldText} className="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none">
+              <div className="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0">
+                {icon}
+              </div>
+              <P className="text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left">
+                <span className="font-semibold">{boldText}</span>
+                <span>{normalText}</span>
+              </P>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WhoIsThisForSection;

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
@@ -24,7 +24,7 @@ const targetAudiences = [
 const WhoIsThisForSection = () => {
   return (
     <section className="w-full bg-[#FAFAF7]">
-      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:py-16">
+      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
         <H2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]">
           Who is this course for?
         </H2>

--- a/apps/website/src/components/lander/agi-strategy/WhyTakeThisCourseSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhyTakeThisCourseSection.tsx
@@ -23,7 +23,7 @@ const valueCards = [
 
 const WhyTakeThisCourseSection = () => {
   return (
-    <section className="w-full border-t-[0.5px] border-color-divider bg-white">
+    <section className="w-full bg-white">
       <div className="max-w-max-width mx-auto px-spacing-x py-16">
         <H2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]">
           How this course will benefit you

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
   class="w-full bg-[#FAFAF7]"
 >
   <div
-    class="max-w-max-width mx-auto px-spacing-x py-12 md:py-16"
+    class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
   >
     <h2
       class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
@@ -1,0 +1,123 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`WhoIsThisForSection > renders correctly 1`] = `
+<section
+  class="w-full bg-[#FAFAF7]"
+>
+  <div
+    class="max-w-max-width mx-auto px-spacing-x py-12 md:py-16"
+  >
+    <h2
+      class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
+    >
+      Who is this course for?
+    </h2>
+    <div
+      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"
+    >
+      <div
+        class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+      >
+        <div
+          class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+        >
+          <svg
+            class="text-white"
+            fill="currentColor"
+            height="28"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 256 256"
+            width="28"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M216,56H176V48a24,24,0,0,0-24-24H104A24,24,0,0,0,80,48v8H40A16,16,0,0,0,24,72V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V72A16,16,0,0,0,216,56ZM96,48a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96ZM216,72v41.61A184,184,0,0,1,128,136a184.07,184.07,0,0,1-88-22.38V72Zm0,128H40V131.64A200.19,200.19,0,0,0,128,152a200.25,200.25,0,0,0,88-20.37V200ZM104,112a8,8,0,0,1,8-8h32a8,8,0,0,1,0,16H112A8,8,0,0,1,104,112Z"
+            />
+          </svg>
+        </div>
+        <p
+          class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+        >
+          <span
+            class="font-semibold"
+          >
+            For entrepreneurs and operators
+          </span>
+          <span>
+             who want to build solutions that protect humanity.
+          </span>
+        </p>
+      </div>
+      <div
+        class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+      >
+        <div
+          class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+        >
+          <svg
+            class="text-white"
+            fill="currentColor"
+            height="28"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 256 256"
+            width="28"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216ZM172.42,72.84l-64,32a8.05,8.05,0,0,0-3.58,3.58l-32,64A8,8,0,0,0,80,184a8.1,8.1,0,0,0,3.58-.84l64-32a8.05,8.05,0,0,0,3.58-3.58l32-64a8,8,0,0,0-10.74-10.74ZM138,138,97.89,158.11,118,118l40.15-20.07Z"
+            />
+          </svg>
+        </div>
+        <p
+          class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+        >
+          <span
+            class="font-semibold"
+          >
+            For leaders
+          </span>
+          <span>
+             who want to steer AI's trajectory towards beneficial outcomes for humanity.
+          </span>
+        </p>
+      </div>
+      <div
+        class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+      >
+        <div
+          class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+        >
+          <svg
+            class="text-white"
+            fill="currentColor"
+            height="28"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 256 256"
+            width="28"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M221.69,199.77,160,96.92V40h8a8,8,0,0,0,0-16H88a8,8,0,0,0,0,16h8V96.92L34.31,199.77A16,16,0,0,0,48,224H208a16,16,0,0,0,13.72-24.23ZM110.86,103.25A7.93,7.93,0,0,0,112,99.14V40h32V99.14a7.93,7.93,0,0,0,1.14,4.11L183.36,167c-12,2.37-29.07,1.37-51.75-10.11-15.91-8.05-31.05-12.32-45.22-12.81ZM48,208l28.54-47.58c14.25-1.74,30.31,1.85,47.82,10.72,19,9.61,35,12.88,48,12.88a69.89,69.89,0,0,0,19.55-2.7L208,208Z"
+            />
+          </svg>
+        </div>
+        <p
+          class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+        >
+          <span
+            class="font-semibold"
+          >
+            For researchers
+          </span>
+          <span>
+             who want to take big bets on the most impactful research ideas.
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhyTakeThisCourseSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhyTakeThisCourseSection.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`WhyTakeThisCourseSection > renders correctly 1`] = `
 <section
-  class="w-full border-t-[0.5px] border-color-divider bg-white"
+  class="w-full bg-white"
 >
   <div
     class="max-w-max-width mx-auto px-spacing-x py-16"


### PR DESCRIPTION
# Description
Adding "Who is this course for" section for the AGI Strategy lander. 

I updated icons based on new copy - @herrhaase / @dewierwan feel free to let me know if you'd prefer other icons instead.

## Issue
Implements part of #1334 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Desktop
<img width="1512" height="552" alt="who-is-this-for-desktop" src="https://github.com/user-attachments/assets/73f80125-6207-48f1-9396-0f7273c6b1ea" />

### Mobile
![who-is-this-for-mobile](https://github.com/user-attachments/assets/cf057c77-0c4e-43e4-b043-cb04a8dd863c)
