### PR TITLE
[feat + fix]: course curriculum section + various larger-screen-sizes cleanup

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import {
   CTALinkOrButton,
-  Section,
 } from '@bluedot/ui';
 
 import { H2, H3 } from '../Text';
@@ -12,6 +11,7 @@ import WhoIsThisForSection from './agi-strategy/WhoIsThisForSection';
 import HeroSection from './agi-strategy/HeroSection';
 import QuoteSection from './agi-strategy/QuoteSection';
 import CourseDetailsSection from './agi-strategy/CourseDetailsSection';
+import CourseCurriculumSection from './agi-strategy/CourseCurriculumSection';
 import FAQSection from './agi-strategy/FAQSection';
 
 const AgiStrategyBanner = ({ title, ctaUrl }: { title: string, ctaUrl: string }) => {
@@ -118,6 +118,9 @@ const AgiStrategyLander = () => {
       {/* Who is this course for section */}
       <WhoIsThisForSection />
 
+      {/* Course Curriculum Section */}
+      <CourseCurriculumSection />
+
       {/* Why take this course section */}
       <WhyTakeThisCourseSection />
 
@@ -128,12 +131,12 @@ const AgiStrategyLander = () => {
       <QuoteSection />
 
       {/* Community Members Section - What learners are saying */}
-      <div className="w-full bg-[#FAFAF7]">
-        <Section className="py-16">
-          <H2 className="text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] mb-16 tracking-[-0.01em]">Some of our graduates</H2>
+      <section className="w-full bg-[#FAFAF7]">
+        <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
+          <H2 className="text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] mb-12 md:mb-16 tracking-[-0.01em]">Some of our graduates</H2>
           <CommunityMembersSubSection members={communityMembers} />
-        </Section>
-      </div>
+        </div>
+      </section>
 
       {/* FAQ Section */}
       <FAQSection />

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
         <h2
           class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
         >
-          Who is this course for?
+          Who is this course for
         </h2>
         <div
           class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -199,7 +199,40 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-white"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x py-16"
+        class="max-w-max-width mx-auto px-spacing-x pt-12 pb-8 md:pt-20 md:pb-12 lg:pt-24 lg:pb-16"
+      >
+        <h2
+          class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
+        >
+          Curriculum Overview
+        </h2>
+        <div
+          class="flex justify-center"
+        >
+          <div
+            class="progress-dots flex justify-center space-x-2 my-6"
+          >
+            <span
+              class="size-2 bg-bluedot-normal rounded-full animate-bounce"
+              style="animation-delay: 0ms;"
+            />
+            <span
+              class="size-2 bg-bluedot-normal rounded-full animate-bounce"
+              style="animation-delay: 150ms;"
+            />
+            <span
+              class="size-2 bg-bluedot-normal rounded-full animate-bounce"
+              style="animation-delay: 300ms;"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      class="w-full bg-white"
+    >
+      <div
+        class="max-w-max-width mx-auto px-spacing-x pt-12 pb-16"
       >
         <h2
           class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]"
@@ -321,10 +354,10 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       </div>
     </section>
     <section
-      class="py-16 bg-[#FAFAF7]"
+      class="w-full bg-[#FAFAF7]"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x flex flex-col items-center gap-16"
+        class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16"
       >
         <h2
           class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] text-[#13132E] tracking-[-0.01em]"
@@ -687,42 +720,38 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
         </div>
       </div>
     </section>
-    <div
+    <section
       class="w-full bg-[#FAFAF7]"
     >
-      <section
-        class="section section-body py-16"
+      <div
+        class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
       >
-        <div
-          class="section__body"
+        <h2
+          class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] mb-12 md:mb-16 tracking-[-0.01em]"
         >
-          <h2
-            class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] mb-16 tracking-[-0.01em]"
-          >
-            Some of our graduates
-          </h2>
-          <div
-            data-testid="community-members-section"
-          >
-            <span>
-              Members: 
-              6
-            </span>
-          </div>
+          Some of our graduates
+        </h2>
+        <div
+          data-testid="community-members-section"
+        >
+          <span>
+            Members: 
+            6
+          </span>
         </div>
-      </section>
-    </div>
+      </div>
+    </section>
     <section
-      class="section section-body bg-white py-16 px-5 md:px-12 lg:px-44"
+      class="w-full bg-white"
     >
       <div
-        class="section__body"
+        class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
       >
         <div
-          class="max-w-[928px] mx-auto flex flex-col gap-16"
+          class="max-w-[928px] mx-auto flex flex-col gap-12 md:gap-16"
         >
           <h2
-            class="text-[28px] lg:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center"
+            class="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center"
           >
             Frequently Asked Questions
           </h2>

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -52,13 +52,7 @@ const CourseCurriculumSection = () => {
   return (
     <SectionWrapper>
       <div className="max-w-[928px] mx-auto">
-        <div
-          className="max-h-[400px] overflow-y-auto scrollbar-curriculum"
-          style={{
-            scrollbarWidth: 'thin',
-            scrollbarColor: 'rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.2)',
-          }}
-        >
+        <div className="max-h-[400px] overflow-y-auto scrollbar-curriculum">
           <div className="pb-[120px]">
             {data.units
               .sort((a, b) => {

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -60,9 +60,11 @@ const CourseCurriculumSection = () => {
           }}
         >
           <div className="pb-[120px]">
-            {data.units.map((unit) => (
-              <CurriculumUnit key={unit.id} unit={unit} />
-            ))}
+            {data.units
+              .sort((a, b) => (a.unitNumber || 0) - (b.unitNumber || 0))
+              .map((unit) => (
+                <CurriculumUnit key={unit.id} unit={unit} />
+              ))}
           </div>
           {/* Fade gradient at bottom */}
           <div className="sticky bottom-0 h-[102px] bg-gradient-to-t from-white via-white/[0.93] to-transparent pointer-events-none -mt-[102px]" />

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -5,11 +5,9 @@ import {
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import { FaChevronDown } from 'react-icons/fa';
-import { unitTable, InferSelectModel } from '@bluedot/db';
+import type { Unit } from '@bluedot/db';
 import { H2, P } from '../../Text';
 import { GetCourseResponse } from '../../../pages/api/courses/[courseSlug]';
-
-type Unit = InferSelectModel<typeof unitTable.pg>;
 
 /* Common Section Wrapper */
 const SectionWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -63,7 +61,7 @@ const CourseCurriculumSection = () => {
         >
           <div className="pb-[120px]">
             {data.units.map((unit) => (
-              <CurriculumUnit key={unit.id} unit={unit} defaultExpanded />
+              <CurriculumUnit key={unit.id} unit={unit} />
             ))}
           </div>
           {/* Fade gradient at bottom */}

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import {
+  ErrorSection,
+  ProgressDots,
+} from '@bluedot/ui';
+import useAxios from 'axios-hooks';
+import { FaChevronDown } from 'react-icons/fa';
+import { unitTable, InferSelectModel } from '@bluedot/db';
+import { H2, P } from '../../Text';
+import { GetCourseResponse } from '../../../pages/api/courses/[courseSlug]';
+
+type Unit = InferSelectModel<typeof unitTable.pg>;
+
+/* Common Section Wrapper */
+const SectionWrapper = ({ children }: { children: React.ReactNode }) => (
+  <section className="w-full bg-white">
+    <div className="max-w-max-width mx-auto px-spacing-x pt-12 pb-8 md:pt-20 md:pb-12 lg:pt-24 lg:pb-16">
+      <H2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]">
+        Curriculum Overview
+      </H2>
+      {children}
+    </div>
+  </section>
+);
+
+const CourseCurriculumSection = () => {
+  const [{ data, loading, error }] = useAxios<GetCourseResponse>({
+    method: 'get',
+    url: '/api/courses/agi-strategy',
+  });
+
+  if (error) {
+    return <ErrorSection error={error} />;
+  }
+
+  if (loading) {
+    return (
+      <SectionWrapper>
+        <div className="flex justify-center">
+          <ProgressDots />
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  if (!data?.units || data.units.length === 0) {
+    return (
+      <SectionWrapper>
+        <P className="text-center">Curriculum information will be available soon.</P>
+      </SectionWrapper>
+    );
+  }
+
+  return (
+    <SectionWrapper>
+      <div className="max-w-[928px] mx-auto">
+        <div
+          className="max-h-[400px] overflow-y-auto scrollbar-curriculum"
+          style={{
+            scrollbarWidth: 'thin',
+            scrollbarColor: 'rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.2)',
+          }}
+        >
+          <div className="pb-[120px]">
+            {data.units.map((unit) => (
+              <CurriculumUnit key={unit.id} unit={unit} defaultExpanded />
+            ))}
+          </div>
+          {/* Fade gradient at bottom */}
+          <div className="sticky bottom-0 h-[102px] bg-gradient-to-t from-white via-white/[0.93] to-transparent pointer-events-none -mt-[102px]" />
+        </div>
+      </div>
+    </SectionWrapper>
+  );
+};
+
+/* Curriculum Unit Component */
+const CurriculumUnit = ({ unit, defaultExpanded = false }: { unit: Unit; defaultExpanded?: boolean }) => {
+  const [isOpen, setIsOpen] = useState(defaultExpanded);
+
+  const unitTitle = (unit.courseUnit || unit.title || `Unit ${unit.unitNumber}`)
+    .replace(/^AGI Strategy\s*-\s*/i, '');
+  const description = unit.menuText || unit.description;
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="w-full">
+      {isOpen ? (
+        /* Expanded Unit */
+        <div className="bg-white">
+          <div className="py-[18px] px-3 flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-[16px] md:text-[18px] font-semibold leading-[125%] text-[#13132E] flex-1">
+                {unitTitle}
+              </h3>
+              <button
+                type="button"
+                onClick={handleToggle}
+                className="size-5 flex items-center justify-center"
+                aria-expanded={isOpen}
+                aria-controls={`curriculum-unit-${unit.id}`}
+              >
+                <FaChevronDown className="size-3 text-[#13132E]" />
+              </button>
+            </div>
+            {description && (
+              <div className="pl-6">
+                <div className="text-[16px] font-normal leading-[160%] text-[#13132E] opacity-80">
+                  {description}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        /* Collapsed Unit */
+        <div className="border-t-[0.5px] border-[rgba(19,19,46,0.2)] bg-white">
+          <button
+            type="button"
+            onClick={handleToggle}
+            className="w-full py-[18px] px-3 flex items-center gap-2 hover:bg-gray-50 transition-colors"
+            aria-expanded={isOpen}
+            aria-controls={`curriculum-unit-${unit.id}`}
+          >
+            <h3 className="text-[16px] md:text-[18px] font-semibold leading-[125%] text-[#13132E] flex-1 text-left">
+              {unitTitle}
+            </h3>
+            <div className="size-5 flex items-center justify-center">
+              <FaChevronDown className="size-3 text-[#13132E] -rotate-90 transition-transform duration-200" />
+            </div>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CourseCurriculumSection;

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -52,7 +52,7 @@ const CourseCurriculumSection = () => {
   return (
     <SectionWrapper>
       <div className="max-w-[928px] mx-auto">
-        <div className="max-h-[400px] overflow-y-auto scrollbar-curriculum">
+        <div className="max-h-[400px] overflow-y-auto scrollbar-curriculum pr-3">
           <div className="pb-[120px]">
             {[...data.units]
               .sort((a, b) => {
@@ -60,8 +60,8 @@ const CourseCurriculumSection = () => {
                 const bNum = parseInt(b.unitNumber || '0', 10);
                 return aNum - bNum;
               })
-              .map((unit) => (
-                <CurriculumUnit key={unit.id} unit={unit} />
+              .map((unit, index) => (
+                <CurriculumUnit key={unit.id} unit={unit} defaultExpanded={index === 0} />
               ))}
           </div>
           {/* Fade gradient at bottom */}

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -51,6 +51,7 @@ const CourseCurriculumSection = () => {
 
   return (
     <>
+      {/* eslint-disable-next-line react/no-unknown-property */}
       <style jsx>{`
         .scrollbar-curriculum {
           /* Firefox */
@@ -71,23 +72,24 @@ const CourseCurriculumSection = () => {
         .scrollbar-curriculum::-webkit-scrollbar-thumb:hover {
           background: rgba(0, 0, 0, 0.2);
         }
-      `}</style>
+      `}
+      </style>
       <SectionWrapper>
         <div className="max-w-[928px] mx-auto">
           <div className="max-h-[400px] overflow-y-auto scrollbar-curriculum pr-3">
-          <div className="pb-[120px]">
-            {[...data.units]
-              .sort((a, b) => {
-                const aNum = parseInt(a.unitNumber || '0', 10);
-                const bNum = parseInt(b.unitNumber || '0', 10);
-                return aNum - bNum;
-              })
-              .map((unit, index) => (
-                <CurriculumUnit key={unit.id} unit={unit} defaultExpanded={index === 0} />
-              ))}
-          </div>
-          {/* Fade gradient at bottom */}
-          <div className="sticky bottom-0 h-[102px] bg-gradient-to-t from-white via-white/[0.93] to-transparent pointer-events-none -mt-[102px]" />
+            <div className="pb-[120px]">
+              {[...data.units]
+                .sort((a, b) => {
+                  const aNum = parseInt(a.unitNumber || '0', 10);
+                  const bNum = parseInt(b.unitNumber || '0', 10);
+                  return aNum - bNum;
+                })
+                .map((unit, index) => (
+                  <CurriculumUnit key={unit.id} unit={unit} defaultExpanded={index === 0} />
+                ))}
+            </div>
+            {/* Fade gradient at bottom */}
+            <div className="sticky bottom-0 h-[102px] bg-gradient-to-t from-white via-white/[0.93] to-transparent pointer-events-none -mt-[102px]" />
           </div>
         </div>
       </SectionWrapper>

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -61,7 +61,11 @@ const CourseCurriculumSection = () => {
         >
           <div className="pb-[120px]">
             {data.units
-              .sort((a, b) => (a.unitNumber || 0) - (b.unitNumber || 0))
+              .sort((a, b) => {
+                const aNum = parseInt(a.unitNumber || '0', 10);
+                const bNum = parseInt(b.unitNumber || '0', 10);
+                return aNum - bNum;
+              })
               .map((unit) => (
                 <CurriculumUnit key={unit.id} unit={unit} />
               ))}

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -50,9 +50,31 @@ const CourseCurriculumSection = () => {
   }
 
   return (
-    <SectionWrapper>
-      <div className="max-w-[928px] mx-auto">
-        <div className="max-h-[400px] overflow-y-auto scrollbar-curriculum pr-3">
+    <>
+      <style jsx>{`
+        .scrollbar-curriculum {
+          /* Firefox */
+          scrollbar-width: thin;
+          scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+        }
+        .scrollbar-curriculum::-webkit-scrollbar {
+          width: 4px;
+        }
+        .scrollbar-curriculum::-webkit-scrollbar-track {
+          background: transparent;
+        }
+        .scrollbar-curriculum::-webkit-scrollbar-thumb {
+          background: rgba(0, 0, 0, 0.2);
+          border-radius: 4px;
+          min-height: 30px;
+        }
+        .scrollbar-curriculum::-webkit-scrollbar-thumb:hover {
+          background: rgba(0, 0, 0, 0.2);
+        }
+      `}</style>
+      <SectionWrapper>
+        <div className="max-w-[928px] mx-auto">
+          <div className="max-h-[400px] overflow-y-auto scrollbar-curriculum pr-3">
           <div className="pb-[120px]">
             {[...data.units]
               .sort((a, b) => {
@@ -66,9 +88,10 @@ const CourseCurriculumSection = () => {
           </div>
           {/* Fade gradient at bottom */}
           <div className="sticky bottom-0 h-[102px] bg-gradient-to-t from-white via-white/[0.93] to-transparent pointer-events-none -mt-[102px]" />
+          </div>
         </div>
-      </div>
-    </SectionWrapper>
+      </SectionWrapper>
+    </>
   );
 };
 

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -7,7 +7,7 @@ import useAxios from 'axios-hooks';
 import { FaChevronDown } from 'react-icons/fa';
 import type { Unit } from '@bluedot/db';
 import { H2, P } from '../../Text';
-import { GetCourseResponse } from '../../../pages/api/courses/[courseSlug]';
+import type { GetCourseResponse } from '../../../pages/api/courses/[courseSlug]';
 
 /* Common Section Wrapper */
 const SectionWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -54,7 +54,7 @@ const CourseCurriculumSection = () => {
       <div className="max-w-[928px] mx-auto">
         <div className="max-h-[400px] overflow-y-auto scrollbar-curriculum">
           <div className="pb-[120px]">
-            {data.units
+            {[...data.units]
               .sort((a, b) => {
                 const aNum = parseInt(a.unitNumber || '0', 10);
                 const bNum = parseInt(b.unitNumber || '0', 10);
@@ -77,7 +77,8 @@ const CurriculumUnit = ({ unit, defaultExpanded = false }: { unit: Unit; default
   const [isOpen, setIsOpen] = useState(defaultExpanded);
 
   const unitTitle = (unit.courseUnit || unit.title || `Unit ${unit.unitNumber}`)
-    .replace(/^AGI Strategy\s*-\s*/i, '');
+    .replace(/^AGI Strategy\s*-\s*/i, '')
+    .trim();
   const description = unit.menuText || unit.description;
 
   const handleToggle = () => {
@@ -97,16 +98,16 @@ const CurriculumUnit = ({ unit, defaultExpanded = false }: { unit: Unit; default
               <button
                 type="button"
                 onClick={handleToggle}
-                className="size-5 flex items-center justify-center"
+                className="size-5 flex items-center justify-center rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2244BB]"
                 aria-expanded={isOpen}
                 aria-controls={`curriculum-unit-${unit.id}`}
               >
-                <FaChevronDown className="size-3 text-[#13132E]" />
+                <FaChevronDown className="size-3 text-[#13132E] transition-transform duration-200" />
               </button>
             </div>
             {description && (
               <div className="pl-6">
-                <div className="text-[16px] font-normal leading-[160%] text-[#13132E] opacity-80">
+                <div className="text-[16px] font-normal leading-[160%] text-[#13132E] opacity-80 whitespace-pre-line">
                   {description}
                 </div>
               </div>
@@ -119,7 +120,7 @@ const CurriculumUnit = ({ unit, defaultExpanded = false }: { unit: Unit; default
           <button
             type="button"
             onClick={handleToggle}
-            className="w-full py-[18px] px-3 flex items-center gap-2 hover:bg-gray-50 transition-colors"
+            className="w-full py-[18px] px-3 flex items-center gap-2 hover:bg-gray-50 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#2244BB]"
             aria-expanded={isOpen}
             aria-controls={`curriculum-unit-${unit.id}`}
           >

--- a/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.tsx
@@ -59,8 +59,8 @@ const CourseDetailsSection = () => {
   ];
 
   return (
-    <section className="py-16 bg-[#FAFAF7]">
-      <div className="max-w-max-width mx-auto px-spacing-x flex flex-col items-center gap-16">
+    <section className="w-full bg-[#FAFAF7]">
+      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16">
         {/* Section Title */}
         <H2 className="text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] text-[#13132E] tracking-[-0.01em]">
           AGI Strategy Course Details

--- a/apps/website/src/components/lander/agi-strategy/FAQSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/FAQSection.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Section } from '@bluedot/ui';
 import { FaPlus, FaTimes } from 'react-icons/fa';
 
 const FAQSection = () => {
@@ -31,53 +30,55 @@ const FAQSection = () => {
   };
 
   return (
-    <Section className="bg-white py-16 px-5 md:px-12 lg:px-44">
-      <div className="max-w-[928px] mx-auto flex flex-col gap-16">
-        <h2 className="text-[28px] lg:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center">
-          Frequently Asked Questions
-        </h2>
+    <section className="w-full bg-white">
+      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
+        <div className="max-w-[928px] mx-auto flex flex-col gap-12 md:gap-16">
+          <h2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center">
+            Frequently Asked Questions
+          </h2>
 
-        <div className="flex flex-col gap-6">
-          {faqData.map((item) => {
-            const isOpen = openQuestion === item.id;
+          <div className="flex flex-col gap-6">
+            {faqData.map((item) => {
+              const isOpen = openQuestion === item.id;
 
-            return (
-              <div
-                key={item.id}
-                className="border border-[rgba(19,19,46,0.1)] bg-white rounded-xl overflow-hidden"
-              >
-                <button
-                  type="button"
-                  onClick={() => handleToggle(item.id)}
-                  className={`w-full flex items-center justify-between text-left py-6 px-8 transition-colors ${
-                    !isOpen ? 'hover:bg-gray-50' : ''
-                  }`}
-                  aria-expanded={isOpen}
-                  aria-controls={`faq-answer-${item.id}`}
+              return (
+                <div
+                  key={item.id}
+                  className="border border-[rgba(19,19,46,0.1)] bg-white rounded-xl overflow-hidden"
                 >
-                  <span className="text-[18px] font-semibold leading-[125%] text-[#13132E] pr-4">
-                    {item.question}
-                  </span>
-                  {isOpen ? (
-                    <FaTimes className="size-4 text-[#13132E] flex-shrink-0" />
-                  ) : (
-                    <FaPlus className="size-4 text-[#13132E] flex-shrink-0" />
-                  )}
-                </button>
+                  <button
+                    type="button"
+                    onClick={() => handleToggle(item.id)}
+                    className={`w-full flex items-center justify-between text-left py-6 px-8 transition-colors ${
+                      !isOpen ? 'hover:bg-gray-50' : ''
+                    }`}
+                    aria-expanded={isOpen}
+                    aria-controls={`faq-answer-${item.id}`}
+                  >
+                    <span className="text-[18px] font-semibold leading-[125%] text-[#13132E] pr-4">
+                      {item.question}
+                    </span>
+                    {isOpen ? (
+                      <FaTimes className="size-4 text-[#13132E] flex-shrink-0" />
+                    ) : (
+                      <FaPlus className="size-4 text-[#13132E] flex-shrink-0" />
+                    )}
+                  </button>
 
-                {isOpen && (
-                  <div id={`faq-answer-${item.id}`} className="px-8 pb-6 -mt-2">
-                    <div className="text-[18px] font-normal leading-[160%] text-[#13132E] opacity-80">
-                      {item.answer}
+                  {isOpen && (
+                    <div id={`faq-answer-${item.id}`} className="px-8 pb-6 -mt-2">
+                      <div className="text-[18px] font-normal leading-[160%] text-[#13132E] opacity-80">
+                        {item.answer}
+                      </div>
                     </div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
-    </Section>
+    </section>
   );
 };
 

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.test.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.test.tsx
@@ -10,7 +10,7 @@ describe('WhoIsThisForSection', () => {
 
   it('renders the section title', () => {
     const { getByText } = render(<WhoIsThisForSection />);
-    expect(getByText('Who is this course for?')).toBeDefined();
+    expect(getByText('Who is this course for')).toBeDefined();
   });
 
   it('renders all three target audience cards', () => {

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
@@ -26,7 +26,7 @@ const WhoIsThisForSection = () => {
     <section className="w-full bg-[#FAFAF7]">
       <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
         <H2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]">
-          Who is this course for?
+          Who is this course for
         </H2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
           {targetAudiences.map(({ icon, boldText, normalText }) => (

--- a/apps/website/src/components/lander/agi-strategy/WhyTakeThisCourseSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhyTakeThisCourseSection.tsx
@@ -24,7 +24,7 @@ const valueCards = [
 const WhyTakeThisCourseSection = () => {
   return (
     <section className="w-full bg-white">
-      <div className="max-w-max-width mx-auto px-spacing-x py-16">
+      <div className="max-w-max-width mx-auto px-spacing-x pt-12 pb-16">
         <H2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]">
           How this course will benefit you
         </H2>

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/CourseDetailsSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/CourseDetailsSection.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`CourseDetailsSection > renders correctly 1`] = `
 <section
-  class="py-16 bg-[#FAFAF7]"
+  class="w-full bg-[#FAFAF7]"
 >
   <div
-    class="max-w-max-width mx-auto px-spacing-x flex flex-col items-center gap-16"
+    class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16"
   >
     <h2
       class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] text-center font-semibold leading-[125%] text-[#13132E] tracking-[-0.01em]"

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
     <h2
       class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
     >
-      Who is this course for?
+      Who is this course for
     </h2>
     <div
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhyTakeThisCourseSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhyTakeThisCourseSection.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`WhyTakeThisCourseSection > renders correctly 1`] = `
   class="w-full bg-white"
 >
   <div
-    class="max-w-max-width mx-auto px-spacing-x py-16"
+    class="max-w-max-width mx-auto px-spacing-x pt-12 pb-16"
   >
     <h2
       class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]"

--- a/apps/website/src/globals.css
+++ b/apps/website/src/globals.css
@@ -42,6 +42,31 @@
   font-family: var(--font-inter-display), var(--font-inter), ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
 }
 
+/* Hide default scrollbar while keeping scroll functionality */
+.scrollbar-none {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none; /* Chrome, Safari and Opera */
+}
+
+/* Custom curriculum scrollbar */
+.scrollbar-curriculum::-webkit-scrollbar {
+  width: 4px;
+}
+.scrollbar-curriculum::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 2px;
+}
+.scrollbar-curriculum::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 2px;
+}
+.scrollbar-curriculum::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.4);
+}
+
 /* 
  * Custom font-weight override: Inter font only supports weights up to 600, not 650
  * The UI library uses font-[650] but we need to map this to 600 for Inter

--- a/apps/website/src/globals.css
+++ b/apps/website/src/globals.css
@@ -55,21 +55,21 @@
 .scrollbar-curriculum {
   /* Firefox */
   scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.2);
+  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
 }
 .scrollbar-curriculum::-webkit-scrollbar {
   width: 4px;
 }
 .scrollbar-curriculum::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.2);
-  border-radius: 2px;
+  background: transparent;
 }
 .scrollbar-curriculum::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  min-height: 30px;
 }
 .scrollbar-curriculum::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.2);
 }
 
 /* 

--- a/apps/website/src/globals.css
+++ b/apps/website/src/globals.css
@@ -51,27 +51,6 @@
   display: none; /* Chrome, Safari and Opera */
 }
 
-/* Custom curriculum scrollbar */
-.scrollbar-curriculum {
-  /* Firefox */
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
-}
-.scrollbar-curriculum::-webkit-scrollbar {
-  width: 4px;
-}
-.scrollbar-curriculum::-webkit-scrollbar-track {
-  background: transparent;
-}
-.scrollbar-curriculum::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.2);
-  border-radius: 4px;
-  min-height: 30px;
-}
-.scrollbar-curriculum::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.2);
-}
-
 /* 
  * Custom font-weight override: Inter font only supports weights up to 600, not 650
  * The UI library uses font-[650] but we need to map this to 600 for Inter

--- a/apps/website/src/globals.css
+++ b/apps/website/src/globals.css
@@ -52,6 +52,11 @@
 }
 
 /* Custom curriculum scrollbar */
+.scrollbar-curriculum {
+  /* Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.2);
+}
 .scrollbar-curriculum::-webkit-scrollbar {
   width: 4px;
 }


### PR DESCRIPTION
# Description
Adding new Course Curriculum Section component with expandable/collapsible unit cards displayed in an accordion-style, fetching from Airtable db.  Responsive for desktop and mobile. 

Standardized upper padding pattern across sections for larger screen sizes (course details, faq, graduates section). Reduced upper padding for course benefits section to-spec now that the course curriculum section has been added.

**Out of scope for this PR:**
- Displaying progress-related features (blocked, will create new PR)

**Note:** I still want to test the custom scrollbar in mobile staging.

## Issue
Implements part of #1334 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Desktop
<img width="1512" height="723" alt="course-curriculum" src="https://github.com/user-attachments/assets/f882867b-1733-4b47-8dbf-ac7eb785ee3f" />

![curriculum-overview-desktop](https://github.com/user-attachments/assets/0e47d7be-9d94-4207-b0e4-fab4d2d77d51)

### Mobile
![course-curriculum-mobile](https://github.com/user-attachments/assets/2ea8cf80-4d50-45b8-a7b3-2f3fc7db8ca7)
