### PR TITLE
[fix]: update from rounded dropdown icons

### DIFF
--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -764,26 +764,26 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               <button
                 aria-controls="faq-answer-funding"
                 aria-expanded="false"
-                class="w-full flex items-center justify-between text-left py-6 px-8 transition-colors hover:bg-gray-50"
+                class="w-full flex items-center gap-8 text-left px-8 py-6 transition-colors hover:bg-gray-50"
                 type="button"
               >
                 <span
-                  class="text-[18px] font-semibold leading-[125%] text-[#13132E] pr-4"
+                  class="text-[18px] font-semibold leading-[125%] text-[#13132E] flex-grow"
                 >
                   Can I just apply for funding?
                 </span>
                 <svg
-                  class="size-4 text-[#13132E] flex-shrink-0"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 448 512"
-                  width="1em"
+                  class="flex-shrink-0 transition-transform "
+                  fill="none"
+                  height="17"
+                  viewBox="0 0 16 17"
+                  width="16"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                    d="M0 8.5H16M8 0.5L8 16.5"
+                    stroke="#001133"
+                    stroke-width="2"
                   />
                 </svg>
               </button>
@@ -794,26 +794,26 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               <button
                 aria-controls="faq-answer-bluedot"
                 aria-expanded="false"
-                class="w-full flex items-center justify-between text-left py-6 px-8 transition-colors hover:bg-gray-50"
+                class="w-full flex items-center gap-8 text-left px-8 py-6 transition-colors hover:bg-gray-50"
                 type="button"
               >
                 <span
-                  class="text-[18px] font-semibold leading-[125%] text-[#13132E] pr-4"
+                  class="text-[18px] font-semibold leading-[125%] text-[#13132E] flex-grow"
                 >
                   Who is BlueDot Impact?
                 </span>
                 <svg
-                  class="size-4 text-[#13132E] flex-shrink-0"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 448 512"
-                  width="1em"
+                  class="flex-shrink-0 transition-transform "
+                  fill="none"
+                  height="17"
+                  viewBox="0 0 16 17"
+                  width="16"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                    d="M0 8.5H16M8 0.5L8 16.5"
+                    stroke="#001133"
+                    stroke-width="2"
                   />
                 </svg>
               </button>

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -4,7 +4,7 @@ import {
   ProgressDots,
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
-import { FaChevronDown } from 'react-icons/fa';
+import { CgChevronDown } from 'react-icons/cg';
 import type { Unit } from '@bluedot/db';
 import { H2, P } from '../../Text';
 import type { GetCourseResponse } from '../../../pages/api/courses/[courseSlug]';
@@ -127,7 +127,7 @@ const CurriculumUnit = ({ unit, defaultExpanded = false }: { unit: Unit; default
                 aria-expanded={isOpen}
                 aria-controls={`curriculum-unit-${unit.id}`}
               >
-                <FaChevronDown className="size-3 text-[#13132E] transition-transform duration-200" />
+                <CgChevronDown className="size-4 md:size-5 text-[#13132E] transition-transform duration-200" />
               </button>
             </div>
             {description && (
@@ -153,7 +153,7 @@ const CurriculumUnit = ({ unit, defaultExpanded = false }: { unit: Unit; default
               {unitTitle}
             </h3>
             <div className="size-5 flex items-center justify-center">
-              <FaChevronDown className="size-3 text-[#13132E] -rotate-90 transition-transform duration-200" />
+              <CgChevronDown className="size-4 md:size-5 text-[#13132E] -rotate-90 transition-transform duration-200" />
             </div>
           </button>
         </div>

--- a/apps/website/src/components/lander/agi-strategy/FAQSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/FAQSection.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { FaPlus, FaTimes } from 'react-icons/fa';
 
 const FAQSection = () => {
   const [openQuestion, setOpenQuestion] = useState<string | null>(null);
@@ -49,20 +48,27 @@ const FAQSection = () => {
                   <button
                     type="button"
                     onClick={() => handleToggle(item.id)}
-                    className={`w-full flex items-center justify-between text-left py-6 px-8 transition-colors ${
+                    className={`w-full flex items-center gap-8 text-left px-8 py-6 transition-colors ${
                       !isOpen ? 'hover:bg-gray-50' : ''
                     }`}
                     aria-expanded={isOpen}
                     aria-controls={`faq-answer-${item.id}`}
                   >
-                    <span className="text-[18px] font-semibold leading-[125%] text-[#13132E] pr-4">
+                    <span className="text-[18px] font-semibold leading-[125%] text-[#13132E] flex-grow">
                       {item.question}
                     </span>
-                    {isOpen ? (
-                      <FaTimes className="size-4 text-[#13132E] flex-shrink-0" />
-                    ) : (
-                      <FaPlus className="size-4 text-[#13132E] flex-shrink-0" />
-                    )}
+                    <svg
+                      width="16"
+                      height="17"
+                      viewBox="0 0 16 17"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className={`flex-shrink-0 transition-transform ${
+                        isOpen ? 'rotate-45' : ''
+                      }`}
+                    >
+                      <path d="M0 8.5H16M8 0.5L8 16.5" stroke="#001133" strokeWidth="2" />
+                    </svg>
                   </button>
 
                   {isOpen && (


### PR DESCRIPTION
# Description
Updating from rounded chevron, open and close icons

## Issue
Related to #1334, #1364, #1355 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots

![icon-update](https://github.com/user-attachments/assets/12b38637-4734-46ed-a21c-b3d00ebb3f25)

<img width="1010" height="551" alt="Screenshot 2025-09-19 at 6 27 43 PM" src="https://github.com/user-attachments/assets/d375442b-75d6-4533-ab68-b5fc839e4d26" />

<img width="381" height="550" alt="Screenshot 2025-09-19 at 6 30 58 PM" src="https://github.com/user-attachments/assets/af0e5089-34fb-418c-8e1b-74664b8224cc" />

