### PR TITLE
fix: improve grammar in course section heading

### DIFF
--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
         <h2
           class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
         >
-          Who is this course for
+          Who this course is for
         </h2>
         <div
           class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.test.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.test.tsx
@@ -10,7 +10,7 @@ describe('WhoIsThisForSection', () => {
 
   it('renders the section title', () => {
     const { getByText } = render(<WhoIsThisForSection />);
-    expect(getByText('Who is this course for')).toBeDefined();
+    expect(getByText('Who this course is for')).toBeDefined();
   });
 
   it('renders all three target audience cards', () => {

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
@@ -26,7 +26,7 @@ const WhoIsThisForSection = () => {
     <section className="w-full bg-[#FAFAF7]">
       <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
         <H2 className="text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]">
-          Who is this course for
+          Who this course is for
         </H2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
           {targetAudiences.map(({ icon, boldText, normalText }) => (

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
     <h2
       class="bluedot-h2 not-prose text-[28px] md:text-[32px] lg:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
     >
-      Who is this course for
+      Who this course is for
     </h2>
     <div
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"


### PR DESCRIPTION
Change "Who is this course for" to "Who this course is for" to improve readability and natural language flow in the WhoIsThisForSection component and update corresponding tests and snapshots.