### PR TITLE
[feat + fix]: full bleed on hero image, update non-dev-friendly snapshots, …

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -98,6 +98,7 @@ const AgiStrategyLander = () => {
       </Head>
 
       <HeroSection
+        categoryLabel="AGI STRATEGY"
         title="Start building the defences that protect humanity"
         description="Envision a good future. Map the threats from AI. Design effective interventions. Get funded to start shipping. All in 30 hours."
         primaryCta={{

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -16,46 +16,55 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-white"
     >
       <div
-        class="w-full grid grid-cols-1 lg:h-[600px] lg:grid-cols-2 lg:max-w-[1440px] lg:mx-auto"
+        class="flex flex-col-reverse lg:grid lg:grid-cols-2 lg:h-[600px]"
       >
         <div
-          class="w-full px-5 py-8 pb-12 space-y-8 order-2 lg:order-1 lg:pl-12 lg:pr-8 lg:py-12 lg:flex lg:flex-col lg:justify-center xl:pr-16 xl:pl-12"
+          class="px-5 py-8 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
         >
           <div
-            class="space-y-4 text-left"
+            class="w-full lg:max-w-[512px] space-y-8"
           >
-            <h1
-              class="bluedot-h1 not-prose text-[32px] leading-tight font-semibold text-[#13132E] lg:text-5xl lg:leading-[3.75rem] lg:tracking-[-0.5px]"
+            <div
+              class="space-y-5"
             >
-              Start building the defences that protect humanity
-            </h1>
-            <p
-              class="bluedot-p not-prose text-[18px] leading-relaxed text-[#13132E] opacity-80 lg:text-lg lg:leading-[1.6] lg:max-w-lg"
+              <p
+                class="bluedot-p not-prose text-size-md font-semibold tracking-wide text-[#2244BB]"
+              >
+                AGI STRATEGY
+              </p>
+              <h1
+                class="bluedot-h1 not-prose text-[32px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
+              >
+                Start building the defences that protect humanity
+              </h1>
+              <p
+                class="bluedot-p not-prose text-size-md lg:text-lg leading-relaxed text-[#13132E] opacity-80"
+              >
+                Envision a good future. Map the threats from AI. Design effective interventions. Get funded to start shipping. All in 30 hours.
+              </p>
+            </div>
+            <div
+              class="flex gap-3"
             >
-              Envision a good future. Map the threats from AI. Design effective interventions. Get funded to start shipping. All in 30 hours.
-            </p>
-          </div>
-          <div
-            class="flex flex-row gap-3"
-          >
-            <a
-              class="cta-button flex items-center justify-center whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark w-auto h-11 px-5 py-3 text-[14px] font-medium rounded-md bg-[#2244BB] text-white hover:bg-[#1a3399] focus:bg-[#1a3399] transition-colors duration-200 lg:h-[3.125rem] lg:text-[16px]"
-              href="https://web.miniextensions.com/9Kuya4AzFGWgayC3gQaX?utm_source=website_lander"
-              tabindex="0"
-            >
-              Apply now
-            </a>
-            <a
-              class="cta-button flex items-center justify-center whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark w-auto h-11 px-5 py-3.5 text-[14px] font-medium rounded-md border border-[rgba(19,19,46,0.3)] text-[#13132E] bg-transparent hover:border-[rgba(19,19,46,0.5)] hover:bg-[rgba(19,19,46,0.05)] hover:text-[#13132E] transition-colors duration-200 lg:h-[3.125rem] lg:text-[16px]"
-              href="/courses/agi-strategy/1"
-              tabindex="0"
-            >
-              Browse curriculum
-            </a>
+              <a
+                class="cta-button flex items-center justify-center duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark h-10 lg:h-[50px] px-5 py-2.5 text-[14px] lg:text-[16px] font-medium rounded-md bg-[#2244BB] text-white hover:bg-[#1a3399] focus:bg-[#1a3399] transition-colors"
+                href="https://web.miniextensions.com/9Kuya4AzFGWgayC3gQaX?utm_source=website_lander"
+                tabindex="0"
+              >
+                Apply now
+              </a>
+              <a
+                class="cta-button flex items-center justify-center duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark h-10 lg:h-[50px] px-5 py-2.5 text-[14px] lg:text-[16px] font-medium rounded-md border border-[rgba(19,19,46,0.3)] text-[#13132E] bg-transparent hover:border-[rgba(19,19,46,0.5)] hover:bg-[rgba(19,19,46,0.05)] hover:text-[#13132E] transition-colors"
+                href="/courses/agi-strategy/1"
+                tabindex="0"
+              >
+                Browse curriculum
+              </a>
+            </div>
           </div>
         </div>
         <div
-          class="w-full h-60 order-1 lg:order-2 lg:h-[600px] relative overflow-hidden"
+          class="h-80 lg:h-full relative overflow-hidden"
         >
           <img
             alt="AGI Strategy visualization"

--- a/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.test.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.test.tsx
@@ -38,7 +38,5 @@ describe('CourseDetailsSection', () => {
     expect(getByText('join ~8 peers in a 2-hour Zoom meeting')).toBeDefined();
     expect(getByText(/facilitated by an AI safety expert/)).toBeDefined();
     expect(getByText(/pay-what-you-want/)).toBeDefined();
-    expect(getByText('29th Sep')).toBeDefined();
-    expect(getByText('21st Sep')).toBeDefined();
   });
 });

--- a/apps/website/src/components/lander/agi-strategy/HeroSection.stories.tsx
+++ b/apps/website/src/components/lander/agi-strategy/HeroSection.stories.tsx
@@ -14,9 +14,9 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {
-    metadata: {
-      description: 'Course metadata displayed as badges',
-      control: 'object',
+    categoryLabel: {
+      description: 'Optional category label displayed above the title',
+      control: 'text',
     },
     title: {
       description: 'Main heading text',
@@ -47,11 +47,7 @@ type Story = StoryObj<typeof meta>;
 // Default story with all props including image
 export const Default: Story = {
   args: {
-    metadata: {
-      duration: '30 hours',
-      certification: 'Verified certificate',
-      level: 'Beginner-friendly',
-    },
+    categoryLabel: 'AGI STRATEGY',
     title: "AGI Strategy – Learn how to navigate humanity's most critical decade",
     description: 'Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.',
     primaryCta: {

--- a/apps/website/src/components/lander/agi-strategy/HeroSection.test.tsx
+++ b/apps/website/src/components/lander/agi-strategy/HeroSection.test.tsx
@@ -5,11 +5,6 @@ import HeroSection from './HeroSection';
 
 describe('HeroSection', () => {
   const defaultProps = {
-    metadata: {
-      duration: '30 hours',
-      certification: 'Verified certificate',
-      level: 'Beginner-friendly',
-    },
     title: "AGI Strategy – Learn how to navigate humanity's most critical decade",
     description: 'Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.',
     primaryCta: {
@@ -40,14 +35,6 @@ describe('HeroSection', () => {
       <HeroSection {...defaultProps} visualComponent={visualComponent} />,
     );
     expect(container).toMatchSnapshot();
-  });
-
-  it('renders metadata badges correctly', () => {
-    render(<HeroSection {...defaultProps} />);
-
-    expect(screen.getByText('30 hours')).toBeInTheDocument();
-    expect(screen.getByText('Verified certificate')).toBeInTheDocument();
-    expect(screen.getByText('Beginner-friendly')).toBeInTheDocument();
   });
 
   it('renders title and description correctly', () => {

--- a/apps/website/src/components/lander/agi-strategy/HeroSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/HeroSection.tsx
@@ -1,17 +1,10 @@
 import React from 'react';
 import { CTALinkOrButton, NewText } from '@bluedot/ui';
-import { PiLightbulb, PiCertificate, PiClockBold } from 'react-icons/pi';
 
 const { H1, P } = NewText;
 
-type CourseMetaData = {
-  duration: string;
-  certification: string;
-  level: string;
-};
-
 type HeroSectionProps = {
-  metadata?: CourseMetaData;
+  categoryLabel?: string; // Optional course category label
   title: string;
   description: string;
   primaryCta: { text: string; url: string };
@@ -22,7 +15,7 @@ type HeroSectionProps = {
 
 // Main exported component
 const HeroSection = ({
-  metadata,
+  categoryLabel,
   title,
   description,
   primaryCta,
@@ -32,80 +25,67 @@ const HeroSection = ({
 }: HeroSectionProps) => {
   return (
     <section className="w-full bg-white">
-      <div className="w-full grid grid-cols-1 lg:h-[600px] lg:grid-cols-2 lg:max-w-[1440px] lg:mx-auto">
+      <div className="flex flex-col-reverse lg:grid lg:grid-cols-2 lg:h-[600px]">
 
-        {/* Content Area */}
-        <div className="w-full px-5 py-8 pb-12 space-y-8 order-2 lg:order-1 lg:pl-12 lg:pr-8 lg:py-12 lg:flex lg:flex-col lg:justify-center xl:pr-16 xl:pl-12">
+        {/* Content - Aligned with site sections */}
+        <div className="px-5 py-8 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8">
+          <div className="w-full lg:max-w-[512px] space-y-8">
 
-          {/* Metadata Badges */}
-          {metadata && (
-            <div className="flex flex-wrap gap-3 justify-start">
-              <MetaBadge icon={PiClockBold} text={metadata.duration} />
-              <MetaBadge icon={PiCertificate} text={metadata.certification} />
-              <MetaBadge icon={PiLightbulb} text={metadata.level} />
+            {/* Text Content */}
+            <div className="space-y-5">
+              {/* Course Category */}
+              {categoryLabel && (
+                <P className="text-size-md font-semibold tracking-wide text-[#2244BB]">
+                  {categoryLabel}
+                </P>
+              )}
+
+              {/* Title - Cleaner responsive sizing */}
+              <H1 className="text-[32px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]">
+                {title}
+              </H1>
+
+              {/* Description */}
+              <P className="text-size-md lg:text-lg leading-relaxed text-[#13132E] opacity-80">
+                {description}
+              </P>
             </div>
-          )}
 
-          {/* Text Content */}
-          <div className="space-y-4 text-left">
-            <H1 className="text-[32px] leading-tight font-semibold text-[#13132E] lg:text-5xl lg:leading-[3.75rem] lg:tracking-[-0.5px]">
-              {title}
-            </H1>
+            {/* CTA Buttons */}
+            <div className="flex gap-3">
+              <CTALinkOrButton
+                url={primaryCta.url}
+                size="small"
+                className="h-10 lg:h-[50px] px-5 py-2.5 text-[14px] lg:text-[16px] font-medium rounded-md bg-[#2244BB] text-white hover:bg-[#1a3399] focus:bg-[#1a3399] transition-colors"
+              >
+                {primaryCta.text}
+              </CTALinkOrButton>
 
-            <P className="text-[18px] leading-relaxed text-[#13132E] opacity-80 lg:text-lg lg:leading-[1.6] lg:max-w-lg">
-              {description}
-            </P>
-          </div>
-
-          {/* CTA Buttons */}
-          <div className="flex flex-row gap-3">
-            <CTALinkOrButton
-              url={primaryCta.url}
-              size="small"
-              className="w-auto h-11 px-5 py-3 text-[14px] font-medium rounded-md bg-[#2244BB] text-white hover:bg-[#1a3399] focus:bg-[#1a3399] transition-colors duration-200 lg:h-[3.125rem] lg:text-[16px]"
-            >
-              {primaryCta.text}
-            </CTALinkOrButton>
-
-            <CTALinkOrButton
-              url={secondaryCta.url}
-              size="small"
-              className="w-auto h-11 px-5 py-3.5 text-[14px] font-medium rounded-md border border-[rgba(19,19,46,0.3)] text-[#13132E] bg-transparent hover:border-[rgba(19,19,46,0.5)] hover:bg-[rgba(19,19,46,0.05)] hover:text-[#13132E] transition-colors duration-200 lg:h-[3.125rem] lg:text-[16px]"
-            >
-              {secondaryCta.text}
-            </CTALinkOrButton>
+              <CTALinkOrButton
+                url={secondaryCta.url}
+                size="small"
+                className="h-10 lg:h-[50px] px-5 py-2.5 text-[14px] lg:text-[16px] font-medium rounded-md border border-[rgba(19,19,46,0.3)] text-[#13132E] bg-transparent hover:border-[rgba(19,19,46,0.5)] hover:bg-[rgba(19,19,46,0.05)] hover:text-[#13132E] transition-colors"
+              >
+                {secondaryCta.text}
+              </CTALinkOrButton>
+            </div>
           </div>
         </div>
 
-        {/* Visual Component / Image Container */}
+        {/* Image - Automatically ordered by flex-col-reverse */}
         {(visualComponent || imageUrl) && (
-          <div className="w-full h-60 order-1 lg:order-2 lg:h-[600px] relative overflow-hidden">
+          <div className="h-80 lg:h-full relative overflow-hidden">
             {imageUrl ? (
-              <img src={imageUrl} alt="" className="size-full object-cover" />
+              <img src={imageUrl} alt="" className="size-full object-cover lg:object-left" />
             ) : (
               visualComponent
             )}
           </div>
         )}
-      </div>
 
+      </div>
     </section>
   );
 };
-
-// Badge Component - inline sub-component
-type MetaBadgeProps = {
-  icon: React.ComponentType<{ className?: string }>;
-  text: string;
-};
-
-const MetaBadge: React.FC<MetaBadgeProps> = ({ icon: Icon, text }) => (
-  <div className="flex items-center gap-1.5 px-2.5 py-1.5 h-[2.125rem] border border-gray-200 rounded">
-    <Icon className="size-[18px] text-[#13132E] opacity-80" />
-    <P className="text-size-xs font-normal text-[#13132E] opacity-80">
-      {text}
-    </P>
-  </div>
-);
 
 export default HeroSection;

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/HeroSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/HeroSection.test.tsx.snap
@@ -6,119 +6,50 @@ exports[`HeroSection > renders correctly with visual component (snapshot) 1`] = 
     class="w-full bg-white"
   >
     <div
-      class="w-full grid grid-cols-1 lg:h-[600px] lg:grid-cols-2 lg:max-w-[1440px] lg:mx-auto"
+      class="flex flex-col-reverse lg:grid lg:grid-cols-2 lg:h-[600px]"
     >
       <div
-        class="w-full px-5 py-8 pb-12 space-y-8 order-2 lg:order-1 lg:pl-12 lg:pr-8 lg:py-12 lg:flex lg:flex-col lg:justify-center xl:pr-16 xl:pl-12"
+        class="px-5 py-8 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
       >
         <div
-          class="flex flex-wrap gap-3 justify-start"
+          class="w-full lg:max-w-[512px] space-y-8"
         >
           <div
-            class="flex items-center gap-1.5 px-2.5 py-1.5 h-[2.125rem] border border-gray-200 rounded"
+            class="space-y-5"
           >
-            <svg
-              class="size-[18px] text-[#13132E] opacity-80"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 256 256"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <h1
+              class="bluedot-h1 not-prose text-[32px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
             >
-              <path
-                d="M128,20A108,108,0,1,0,236,128,108.12,108.12,0,0,0,128,20Zm0,192a84,84,0,1,1,84-84A84.09,84.09,0,0,1,128,212Zm68-84a12,12,0,0,1-12,12H128a12,12,0,0,1-12-12V72a12,12,0,0,1,24,0v44h44A12,12,0,0,1,196,128Z"
-              />
-            </svg>
+              AGI Strategy – Learn how to navigate humanity's most critical decade
+            </h1>
             <p
-              class="bluedot-p not-prose text-size-xs font-normal text-[#13132E] opacity-80"
+              class="bluedot-p not-prose text-size-md lg:text-lg leading-relaxed text-[#13132E] opacity-80"
             >
-              30 hours
+              Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
             </p>
           </div>
           <div
-            class="flex items-center gap-1.5 px-2.5 py-1.5 h-[2.125rem] border border-gray-200 rounded"
+            class="flex gap-3"
           >
-            <svg
-              class="size-[18px] text-[#13132E] opacity-80"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 256 256"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              class="cta-button flex items-center justify-center duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark h-10 lg:h-[50px] px-5 py-2.5 text-[14px] lg:text-[16px] font-medium rounded-md bg-[#2244BB] text-white hover:bg-[#1a3399] focus:bg-[#1a3399] transition-colors"
+              href="https://example.com/apply"
+              tabindex="0"
             >
-              <path
-                d="M128,136a8,8,0,0,1-8,8H72a8,8,0,0,1,0-16h48A8,8,0,0,1,128,136Zm-8-40H72a8,8,0,0,0,0,16h48a8,8,0,0,0,0-16Zm112,65.47V224A8,8,0,0,1,220,231l-24-13.74L172,231A8,8,0,0,1,160,224V200H40a16,16,0,0,1-16-16V56A16,16,0,0,1,40,40H216a16,16,0,0,1,16,16V86.53a51.88,51.88,0,0,1,0,74.94ZM160,184V161.47A52,52,0,0,1,216,76V56H40V184Zm56-12a51.88,51.88,0,0,1-40,0v38.22l16-9.16a8,8,0,0,1,7.94,0l16,9.16Zm16-48a36,36,0,1,0-36,36A36,36,0,0,0,232,124Z"
-              />
-            </svg>
-            <p
-              class="bluedot-p not-prose text-size-xs font-normal text-[#13132E] opacity-80"
+              Apply now
+            </a>
+            <a
+              class="cta-button flex items-center justify-center duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark h-10 lg:h-[50px] px-5 py-2.5 text-[14px] lg:text-[16px] font-medium rounded-md border border-[rgba(19,19,46,0.3)] text-[#13132E] bg-transparent hover:border-[rgba(19,19,46,0.5)] hover:bg-[rgba(19,19,46,0.05)] hover:text-[#13132E] transition-colors"
+              href="/courses/agi-strategy/1"
+              tabindex="0"
             >
-              Verified certificate
-            </p>
+              Browse curriculum
+            </a>
           </div>
-          <div
-            class="flex items-center gap-1.5 px-2.5 py-1.5 h-[2.125rem] border border-gray-200 rounded"
-          >
-            <svg
-              class="size-[18px] text-[#13132E] opacity-80"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 256 256"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M176,232a8,8,0,0,1-8,8H88a8,8,0,0,1,0-16h80A8,8,0,0,1,176,232Zm40-128a87.55,87.55,0,0,1-33.64,69.21A16.24,16.24,0,0,0,176,186v6a16,16,0,0,1-16,16H96a16,16,0,0,1-16-16v-6a16,16,0,0,0-6.23-12.66A87.59,87.59,0,0,1,40,104.49C39.74,56.83,78.26,17.14,125.88,16A88,88,0,0,1,216,104Zm-16,0a72,72,0,0,0-73.74-72c-39,.92-70.47,33.39-70.26,72.39a71.65,71.65,0,0,0,27.64,56.3A32,32,0,0,1,96,186v6h64v-6a32.15,32.15,0,0,1,12.47-25.35A71.65,71.65,0,0,0,200,104Zm-16.11-9.34a57.6,57.6,0,0,0-46.56-46.55,8,8,0,0,0-2.66,15.78c16.57,2.79,30.63,16.85,33.44,33.45A8,8,0,0,0,176,104a9,9,0,0,0,1.35-.11A8,8,0,0,0,183.89,94.66Z"
-              />
-            </svg>
-            <p
-              class="bluedot-p not-prose text-size-xs font-normal text-[#13132E] opacity-80"
-            >
-              Beginner-friendly
-            </p>
-          </div>
-        </div>
-        <div
-          class="space-y-4 text-left"
-        >
-          <h1
-            class="bluedot-h1 not-prose text-[32px] leading-tight font-semibold text-[#13132E] lg:text-5xl lg:leading-[3.75rem] lg:tracking-[-0.5px]"
-          >
-            AGI Strategy – Learn how to navigate humanity's most critical decade
-          </h1>
-          <p
-            class="bluedot-p not-prose text-[18px] leading-relaxed text-[#13132E] opacity-80 lg:text-lg lg:leading-[1.6] lg:max-w-lg"
-          >
-            Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
-          </p>
-        </div>
-        <div
-          class="flex flex-row gap-3"
-        >
-          <a
-            class="cta-button flex items-center justify-center whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark w-auto h-11 px-5 py-3 text-[14px] font-medium rounded-md bg-[#2244BB] text-white hover:bg-[#1a3399] focus:bg-[#1a3399] transition-colors duration-200 lg:h-[3.125rem] lg:text-[16px]"
-            href="https://example.com/apply"
-            tabindex="0"
-          >
-            Apply now
-          </a>
-          <a
-            class="cta-button flex items-center justify-center whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark w-auto h-11 px-5 py-3.5 text-[14px] font-medium rounded-md border border-[rgba(19,19,46,0.3)] text-[#13132E] bg-transparent hover:border-[rgba(19,19,46,0.5)] hover:bg-[rgba(19,19,46,0.05)] hover:text-[#13132E] transition-colors duration-200 lg:h-[3.125rem] lg:text-[16px]"
-            href="/courses/agi-strategy/1"
-            tabindex="0"
-          >
-            Browse curriculum
-          </a>
         </div>
       </div>
       <div
-        class="w-full h-60 order-1 lg:order-2 lg:h-[600px] relative overflow-hidden"
+        class="h-80 lg:h-full relative overflow-hidden"
       >
         <img
           alt="AGI Strategy visualization"
@@ -137,115 +68,46 @@ exports[`HeroSection > renders correctly without visual component (snapshot) 1`]
     class="w-full bg-white"
   >
     <div
-      class="w-full grid grid-cols-1 lg:h-[600px] lg:grid-cols-2 lg:max-w-[1440px] lg:mx-auto"
+      class="flex flex-col-reverse lg:grid lg:grid-cols-2 lg:h-[600px]"
     >
       <div
-        class="w-full px-5 py-8 pb-12 space-y-8 order-2 lg:order-1 lg:pl-12 lg:pr-8 lg:py-12 lg:flex lg:flex-col lg:justify-center xl:pr-16 xl:pl-12"
+        class="px-5 py-8 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
       >
         <div
-          class="flex flex-wrap gap-3 justify-start"
+          class="w-full lg:max-w-[512px] space-y-8"
         >
           <div
-            class="flex items-center gap-1.5 px-2.5 py-1.5 h-[2.125rem] border border-gray-200 rounded"
+            class="space-y-5"
           >
-            <svg
-              class="size-[18px] text-[#13132E] opacity-80"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 256 256"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <h1
+              class="bluedot-h1 not-prose text-[32px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
             >
-              <path
-                d="M128,20A108,108,0,1,0,236,128,108.12,108.12,0,0,0,128,20Zm0,192a84,84,0,1,1,84-84A84.09,84.09,0,0,1,128,212Zm68-84a12,12,0,0,1-12,12H128a12,12,0,0,1-12-12V72a12,12,0,0,1,24,0v44h44A12,12,0,0,1,196,128Z"
-              />
-            </svg>
+              AGI Strategy – Learn how to navigate humanity's most critical decade
+            </h1>
             <p
-              class="bluedot-p not-prose text-size-xs font-normal text-[#13132E] opacity-80"
+              class="bluedot-p not-prose text-size-md lg:text-lg leading-relaxed text-[#13132E] opacity-80"
             >
-              30 hours
+              Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
             </p>
           </div>
           <div
-            class="flex items-center gap-1.5 px-2.5 py-1.5 h-[2.125rem] border border-gray-200 rounded"
+            class="flex gap-3"
           >
-            <svg
-              class="size-[18px] text-[#13132E] opacity-80"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 256 256"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              class="cta-button flex items-center justify-center duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark h-10 lg:h-[50px] px-5 py-2.5 text-[14px] lg:text-[16px] font-medium rounded-md bg-[#2244BB] text-white hover:bg-[#1a3399] focus:bg-[#1a3399] transition-colors"
+              href="https://example.com/apply"
+              tabindex="0"
             >
-              <path
-                d="M128,136a8,8,0,0,1-8,8H72a8,8,0,0,1,0-16h48A8,8,0,0,1,128,136Zm-8-40H72a8,8,0,0,0,0,16h48a8,8,0,0,0,0-16Zm112,65.47V224A8,8,0,0,1,220,231l-24-13.74L172,231A8,8,0,0,1,160,224V200H40a16,16,0,0,1-16-16V56A16,16,0,0,1,40,40H216a16,16,0,0,1,16,16V86.53a51.88,51.88,0,0,1,0,74.94ZM160,184V161.47A52,52,0,0,1,216,76V56H40V184Zm56-12a51.88,51.88,0,0,1-40,0v38.22l16-9.16a8,8,0,0,1,7.94,0l16,9.16Zm16-48a36,36,0,1,0-36,36A36,36,0,0,0,232,124Z"
-              />
-            </svg>
-            <p
-              class="bluedot-p not-prose text-size-xs font-normal text-[#13132E] opacity-80"
+              Apply now
+            </a>
+            <a
+              class="cta-button flex items-center justify-center duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark h-10 lg:h-[50px] px-5 py-2.5 text-[14px] lg:text-[16px] font-medium rounded-md border border-[rgba(19,19,46,0.3)] text-[#13132E] bg-transparent hover:border-[rgba(19,19,46,0.5)] hover:bg-[rgba(19,19,46,0.05)] hover:text-[#13132E] transition-colors"
+              href="/courses/agi-strategy/1"
+              tabindex="0"
             >
-              Verified certificate
-            </p>
+              Browse curriculum
+            </a>
           </div>
-          <div
-            class="flex items-center gap-1.5 px-2.5 py-1.5 h-[2.125rem] border border-gray-200 rounded"
-          >
-            <svg
-              class="size-[18px] text-[#13132E] opacity-80"
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 256 256"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M176,232a8,8,0,0,1-8,8H88a8,8,0,0,1,0-16h80A8,8,0,0,1,176,232Zm40-128a87.55,87.55,0,0,1-33.64,69.21A16.24,16.24,0,0,0,176,186v6a16,16,0,0,1-16,16H96a16,16,0,0,1-16-16v-6a16,16,0,0,0-6.23-12.66A87.59,87.59,0,0,1,40,104.49C39.74,56.83,78.26,17.14,125.88,16A88,88,0,0,1,216,104Zm-16,0a72,72,0,0,0-73.74-72c-39,.92-70.47,33.39-70.26,72.39a71.65,71.65,0,0,0,27.64,56.3A32,32,0,0,1,96,186v6h64v-6a32.15,32.15,0,0,1,12.47-25.35A71.65,71.65,0,0,0,200,104Zm-16.11-9.34a57.6,57.6,0,0,0-46.56-46.55,8,8,0,0,0-2.66,15.78c16.57,2.79,30.63,16.85,33.44,33.45A8,8,0,0,0,176,104a9,9,0,0,0,1.35-.11A8,8,0,0,0,183.89,94.66Z"
-              />
-            </svg>
-            <p
-              class="bluedot-p not-prose text-size-xs font-normal text-[#13132E] opacity-80"
-            >
-              Beginner-friendly
-            </p>
-          </div>
-        </div>
-        <div
-          class="space-y-4 text-left"
-        >
-          <h1
-            class="bluedot-h1 not-prose text-[32px] leading-tight font-semibold text-[#13132E] lg:text-5xl lg:leading-[3.75rem] lg:tracking-[-0.5px]"
-          >
-            AGI Strategy – Learn how to navigate humanity's most critical decade
-          </h1>
-          <p
-            class="bluedot-p not-prose text-[18px] leading-relaxed text-[#13132E] opacity-80 lg:text-lg lg:leading-[1.6] lg:max-w-lg"
-          >
-            Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
-          </p>
-        </div>
-        <div
-          class="flex flex-row gap-3"
-        >
-          <a
-            class="cta-button flex items-center justify-center whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark w-auto h-11 px-5 py-3 text-[14px] font-medium rounded-md bg-[#2244BB] text-white hover:bg-[#1a3399] focus:bg-[#1a3399] transition-colors duration-200 lg:h-[3.125rem] lg:text-[16px]"
-            href="https://example.com/apply"
-            tabindex="0"
-          >
-            Apply now
-          </a>
-          <a
-            class="cta-button flex items-center justify-center whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark w-auto h-11 px-5 py-3.5 text-[14px] font-medium rounded-md border border-[rgba(19,19,46,0.3)] text-[#13132E] bg-transparent hover:border-[rgba(19,19,46,0.5)] hover:bg-[rgba(19,19,46,0.05)] hover:text-[#13132E] transition-colors duration-200 lg:h-[3.125rem] lg:text-[16px]"
-            href="/courses/agi-strategy/1"
-            tabindex="0"
-          >
-            Browse curriculum
-          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
…remove some deprecated code

# Description
  **1. Hero Section Layout Improvements**
  - Completed the full-bleed image implementation that was temporarily constrained in the [previous hero section PR](https://github.com/bluedotimpact/bluedot/pull/1298) under "Note" to fix distortions quickly. This PR implements the fully-intended hero image full-bleed on larger screens, allowing the image to extend to the viewport edge and removes the maxwidth constraint that previously ended at the edge of the container
  - Improved responsive padding and added dynamic padding calculations to properly align content while letting the
  image extend to screen edge
  - Simplified component structure, e.g removing unused metadata badges (duration, certification, level) from previous designs
    - Added back category AGI STRATEGY label and marked optional for flexibility
  
  **2. Test Improvements**
  - Deprecating date assertions from CourseDetailsSection.test.tsx ("29th Sep" and "21st Sep") so that non-technical team members can update course dates without CI/CD failures (a likely common change going forward)
    - In future [I want to investigate other areas in the codebase where we can improve on brittle tests like this
](https://github.com/bluedotimpact/bluedot/pull/1373#issuecomment-3319504166)
## Issue
Implements part of #1334, unblocks #1373 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshots
### Desktop
<img width="1512" height="763" alt="new-hero-desktop" src="https://github.com/user-attachments/assets/976a0082-71db-4ff6-b1c1-d4669cc5f523" />

![new-hero-desktop](https://github.com/user-attachments/assets/b2a5a706-a4a0-444b-ab65-f7d04e5b7394)

### Zooming out
![new-hero-desktop-zoom-out](https://github.com/user-attachments/assets/6fbed10f-4fb8-498a-97e4-3618da86afb9)

### Mobile
<img width="391" height="833" alt="new-hero-mobile" src="https://github.com/user-attachments/assets/38924b63-8496-4b7f-ba19-525f68b66586" />

![new-hero-mobile](https://github.com/user-attachments/assets/f59af719-c1d4-4029-a467-4fd8f56ac057)
