### PR TITLE
[Feature] Schema changes for displaying recurring group meeting time, rather than next discussion time

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -327,6 +327,11 @@ export const groupTable = pgAirtable('group', {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldMS1Hxn8OOO5vUb',
     },
+    /** Datetime of first session, can also be used to infer recurring session time */
+    startTimeUtc: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldim9d4xwSmw0QeI',
+    },
   },
 });
 


### PR DESCRIPTION
# Description

Currently in GroupSwitchModal, when "permanent switch" is selected, we display the _next_ discussion time as the indicative time. This isn't ideal as a specific discussion may have moved relative to the usual recurring time. This adds the field that is the source of truth for the recurring time, to be used in a later PR

## Issue

#1210

## Developer checklist

N/A

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
 N/A