### PR TITLE
[Feature] GroupSwitchModal miscellaneous cleanup

### DIFF
--- a/apps/website/src/components/courses/GroupDiscussionBanner.tsx
+++ b/apps/website/src/components/courses/GroupDiscussionBanner.tsx
@@ -11,7 +11,7 @@ import {
 } from '@bluedot/ui';
 import useAxios from 'axios-hooks';
 import GroupSwitchModal from './GroupSwitchModal';
-import { getDiscussionTimeDisplayStrings } from '../../lib/utils';
+import { formatDateTimeRelative, formatDateMonthAndDay, formatTime12HourClock } from '../../lib/utils';
 
 type GroupDiscussion = InferSelectModel<typeof groupDiscussionTable.pg>;
 type Unit = InferSelectModel<typeof unitTable.pg>;
@@ -68,7 +68,9 @@ const GroupDiscussionBanner: React.FC<GroupDiscussionBannerProps> = ({
     : `Unit ${groupDiscussion.unitNumber || ''}`; // Fallback to unitNumber if unit not found
 
   // Recalculate time strings when currentTime changes
-  const { startTimeDisplayRelative, startTimeDisplayDate, startTimeDisplayTime } = useMemo(() => getDiscussionTimeDisplayStrings(groupDiscussion.startDateTime), [groupDiscussion.startDateTime, currentTime]);
+  const startTimeDisplayRelative = useMemo(() => formatDateTimeRelative(groupDiscussion.startDateTime), [groupDiscussion.startDateTime, currentTime]);
+  const startTimeDisplayDate = useMemo(() => formatDateMonthAndDay(groupDiscussion.startDateTime), [groupDiscussion.startDateTime]);
+  const startTimeDisplayTime = useMemo(() => formatTime12HourClock(groupDiscussion.startDateTime), [groupDiscussion.startDateTime]);
 
   // Dynamic discussion starts soon check
   const discussionStartsSoon = useMemo(

--- a/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
@@ -109,12 +109,12 @@ const mockSwitchingData: GetGroupSwitchingAvailableResponse = {
         groupDiscussions: [],
         round: '',
         participants: [],
-        startTimeUtc: null,
+        startTimeUtc: Math.floor(new Date('2024-01-01T09:00:00Z').getTime() / 1000), // 9:00 AM UTC
         whoCanSwitchIntoThisGroup: [],
       },
       userIsParticipant: true,
-      spotsLeft: 0,
-      nextDiscussionStartDateTime: Math.floor((Date.now() + 2 * 60 * 60 * 1000) / 1000), // 2 hours from now
+      spotsLeftIfKnown: 0,
+      allDiscussionsHaveStarted: false,
     },
     {
       group: {
@@ -124,12 +124,12 @@ const mockSwitchingData: GetGroupSwitchingAvailableResponse = {
         groupDiscussions: [],
         round: '',
         participants: [],
-        startTimeUtc: null,
+        startTimeUtc: Math.floor(new Date('2024-01-01T19:00:00Z').getTime() / 1000), // 7:00 PM UTC
         whoCanSwitchIntoThisGroup: [],
       },
       userIsParticipant: false,
-      spotsLeft: 3,
-      nextDiscussionStartDateTime: Math.floor((Date.now() + 24 * 60 * 60 * 1000) / 1000), // 24 hours from now
+      spotsLeftIfKnown: 3,
+      allDiscussionsHaveStarted: false,
     },
     {
       group: {
@@ -139,12 +139,12 @@ const mockSwitchingData: GetGroupSwitchingAvailableResponse = {
         groupDiscussions: [],
         round: '',
         participants: [],
-        startTimeUtc: null,
+        startTimeUtc: Math.floor(new Date('2024-01-06T14:00:00Z').getTime() / 1000), // Saturday 2:00 PM UTC
         whoCanSwitchIntoThisGroup: [],
       },
       userIsParticipant: false,
-      spotsLeft: 0,
-      nextDiscussionStartDateTime: Math.floor((Date.now() + 48 * 60 * 60 * 1000) / 1000), // 48 hours from now
+      spotsLeftIfKnown: 0,
+      allDiscussionsHaveStarted: false,
     },
   ],
   discussionsAvailable: {
@@ -171,7 +171,8 @@ const mockSwitchingData: GetGroupSwitchingAvailableResponse = {
         },
         groupName: 'Morning Group A',
         userIsParticipant: true,
-        spotsLeft: 0,
+        spotsLeftIfKnown: 0,
+        hasStarted: false,
       },
       {
         discussion: {
@@ -195,7 +196,8 @@ const mockSwitchingData: GetGroupSwitchingAvailableResponse = {
         },
         groupName: 'Evening Group B',
         userIsParticipant: false,
-        spotsLeft: 2,
+        spotsLeftIfKnown: 2,
+        hasStarted: false,
       },
     ],
     2: [
@@ -221,7 +223,8 @@ const mockSwitchingData: GetGroupSwitchingAvailableResponse = {
         },
         groupName: 'Weekend Group C',
         userIsParticipant: false,
-        spotsLeft: 1,
+        spotsLeftIfKnown: 1,
+        hasStarted: false,
       },
     ],
   },

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -136,7 +136,9 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
     : [];
 
   const unitOptions = useMemo(() => {
-    return courseUnits.map((u) => {
+    if (!courseData?.units) return [];
+
+    return courseData.units.map((u) => {
       const unitDiscussions = switchingData?.discussionsAvailable?.[u.unitNumber];
       const hasAvailableDiscussions = unitDiscussions?.some((d) => !d.hasStarted);
 
@@ -146,7 +148,7 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
         disabled: !isManualRequest && !hasAvailableDiscussions,
       };
     });
-  }, [courseUnits, switchingData?.discussionsAvailable, isManualRequest]);
+  }, [courseData?.units, switchingData?.discussionsAvailable, isManualRequest]);
 
   // Note: There are cases of people being in multiple discussions per unit, and there may be
   // people in multiple groups too. We're not explicitly supporting that case at the moment, but

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -50,13 +50,13 @@ const getGroupSwitchDescription = ({
   isSelected,
   isTemporarySwitch,
   selectedUnitNumber,
-  spotsLeft,
+  spotsLeftIfKnown,
 }: {
   userIsParticipant?: boolean;
   isSelected: boolean;
   isTemporarySwitch: boolean;
   selectedUnitNumber?: string;
-  spotsLeft: number | null;
+  spotsLeftIfKnown: number | null;
 }): React.ReactNode => {
   if (isTemporarySwitch) {
     if (userIsParticipant) {
@@ -81,14 +81,14 @@ const getGroupSwitchDescription = ({
   }
 
   // Default: N spots left
-  const hasAnySpotsLeft = spotsLeft !== 0;
+  const hasAnySpotsLeft = spotsLeftIfKnown !== 0;
   if (!hasAnySpotsLeft) {
     return <><UserIcon className="-translate-y-px" /><span>No spots left</span></>;
   }
-  if (spotsLeft === null) {
+  if (spotsLeftIfKnown === null) {
     return <><UserIcon className="-translate-y-px" /><span>Spots available</span></>;
   }
-  return <><UserIcon className="-translate-y-px" /><span>{spotsLeft} spot{spotsLeft === 1 ? '' : 's'} left</span></>;
+  return <><UserIcon className="-translate-y-px" /><span>{spotsLeftIfKnown} spot{spotsLeftIfKnown === 1 ? '' : 's'} left</span></>;
 };
 
 const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
@@ -172,7 +172,7 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
           isSelected: !selectedDiscussionId,
           isTemporarySwitch,
           selectedUnitNumber,
-          spotsLeft: null,
+          spotsLeftIfKnown: null,
         }),
         userIsParticipant: true,
       };
@@ -188,7 +188,7 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
           isSelected: !selectedGroupId,
           isTemporarySwitch,
           selectedUnitNumber,
-          spotsLeft: null,
+          spotsLeftIfKnown: null,
         }),
         userIsParticipant: true,
         isRecurringTime: true,
@@ -288,14 +288,14 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
         id: g.group.id,
         groupName: g.group.groupName ?? 'Group [Unknown]',
         dateTime: g.group.startTimeUtc,
-        isDisabled: g.spotsLeft === 0 || g.allDiscussionsHaveStarted,
+        isDisabled: g.spotsLeftIfKnown === 0 || g.allDiscussionsHaveStarted,
         isSelected,
         isRecurringTime: true,
         description: getGroupSwitchDescription({
           isSelected,
           isTemporarySwitch: false,
           selectedUnitNumber,
-          spotsLeft: g.spotsLeft,
+          spotsLeftIfKnown: g.spotsLeftIfKnown,
         }),
         onSelect: () => setSelectedGroupId(g.group.id),
         onConfirm: handleSubmit,
@@ -312,13 +312,13 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
         id: d.discussion.id,
         groupName: d.groupName,
         dateTime: d.discussion.startDateTime,
-        isDisabled: d.spotsLeft === 0 || d.hasStarted,
+        isDisabled: d.spotsLeftIfKnown === 0 || d.hasStarted,
         isSelected,
         description: getGroupSwitchDescription({
           isSelected,
           isTemporarySwitch: true,
           selectedUnitNumber,
-          spotsLeft: d.spotsLeft,
+          spotsLeftIfKnown: d.spotsLeftIfKnown,
         }),
         onSelect: () => setSelectedDiscussionId(d.discussion.id),
         onConfirm: handleSubmit,

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -426,22 +426,36 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
           )}
 
           {isManualRequest && (
-            <div className="flex gap-2 justify-end">
-              <CTALinkOrButton
-                variant="secondary"
-                onClick={handleClose}
-                aria-label="Cancel group switching"
-              >
-                Cancel
-              </CTALinkOrButton>
-              <CTALinkOrButton
-                onClick={handleSubmit}
-                disabled={isSubmitDisabled}
-                aria-label={isSubmitting ? 'Submitting group switch request' : 'Submit group switch request'}
-              >
-                {isSubmitting ? 'Submitting...' : 'Confirm'}
-              </CTALinkOrButton>
-            </div>
+            <>
+              {auth?.email && (
+                <div className="flex flex-col gap-2">
+                  <h3 className="text-size-sm font-medium text-[#00114D]">Update your availability</h3>
+                  <p className="text-size-xs text-[#666C80]">
+                    This helps us assign you to a group which best suits you. Then, return here to click "Submit".
+                  </p>
+                  <CTALinkOrButton
+                    variant="secondary"
+                    className="mx-auto"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    url={`https://availability.bluedot.org/form/bluedot-course?email=${encodeURIComponent(auth.email)}&utm_source=bluedot-group-switch-modal`}
+                    aria-label="Request manual group switch"
+                  >
+                    Update availability
+                  </CTALinkOrButton>
+                </div>
+              )}
+              <div className="flex gap-2 justify-end">
+                <CTALinkOrButton
+                  className="mx-auto"
+                  onClick={handleSubmit}
+                  disabled={isSubmitDisabled}
+                  aria-label={isSubmitting ? 'Submitting group switch request' : 'Submit group switch request'}
+                >
+                  {isSubmitting ? 'Submitting...' : 'Submit'}
+                </CTALinkOrButton>
+              </div>
+            </>
           )}
         </form>
         )}

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -390,7 +390,7 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
             <>
               <div className="h-px bg-color-divider" />
               <div className="flex flex-col gap-2">
-                <div className="block text-size-sm font-medium">
+                <div className="block text-size-sm font-medium text-[#00114D]">
                   Select a group
                 </div>
                 {currentInfo && (

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -64,7 +64,7 @@ const getGroupSwitchDescription = ({
     }
 
     if (isSelected && selectedUnitNumber !== undefined) {
-      return <span className="text-[#0037FF]">You are joining this group for <strong>Unit {selectedUnitNumber}</strong> <FaCheck className="size-3 -translate-y-px inline-block ml-[2px]" aria-hidden="true" /></span>;
+      return <span className="text-[#0037FF]">You are joining this group for <strong>Unit {selectedUnitNumber}</strong></span>;
     }
 
     return undefined;
@@ -78,7 +78,7 @@ const getGroupSwitchDescription = ({
   }
 
   if (isSelected) {
-    return <span className="text-[#0037FF] flex gap-2 items-center">You are switching into this group for all upcoming units <FaCheck className="size-3 -translate-y-px inline-block ml-[2px]" aria-hidden="true" /></span>;
+    return <span className="text-[#0037FF]">You are switching into this group for all upcoming units</span>;
   }
 
   return undefined;
@@ -629,7 +629,7 @@ const GroupSwitchOption: React.FC<GroupSwitchOptionProps> = ({
     // Later classes have higher priority
     classNames.push('rounded-lg p-3 transition-all cursor-pointer border bg-white hover:bg-blue-50 border-gray-200 hover:border-gray-300');
     if (isSelected) classNames.push('border-[#0037FF] hover:border-[#0037FF] bg-blue-50');
-    if (!hasAnySpotsLeft || hasStarted) classNames.push('opacity-50 cursor-not-allowed hover:bg-white');
+    if (isDisabled && !userIsParticipant) classNames.push('opacity-50 cursor-not-allowed hover:bg-white');
     if (userIsParticipant) classNames.push('border-none bg-transparent hover:bg-transparent cursor-auto');
 
     return cn(...classNames);

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -245,10 +245,20 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
 
   const getModalTitle = () => {
     if (isManualRequest) {
-      return !showSuccess ? 'Request manual switch' : 'We are working on your request';
+      return !showSuccess ? 'Request manual switch' : (
+        <div className="flex items-center gap-3">
+          <SendIcon />
+          <span>We are working on your request</span>
+        </div>
+      );
     }
     if (showSuccess) {
-      return 'Success!';
+      return (
+        <div className="flex items-center gap-3">
+          <SuccessIcon />
+          <span>Success!</span>
+        </div>
+      );
     }
     return 'Group switching';
   };
@@ -545,6 +555,20 @@ const Select: React.FC<SelectProps> = ({
 const UserIcon = ({ className }: { className?: string }) => (
   <svg className={className} width="1em" height="1em" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M10 10.5V9.5C10 8.96957 9.78929 8.46086 9.41421 8.08579C9.03914 7.71071 8.53043 7.5 8 7.5H4C3.46957 7.5 2.96086 7.71071 2.58579 8.08579C2.21071 8.46086 2 8.96957 2 9.5V10.5M8 3.5C8 4.60457 7.10457 5.5 6 5.5C4.89543 5.5 4 4.60457 4 3.5C4 2.39543 4.89543 1.5 6 1.5C7.10457 1.5 8 2.39543 8 3.5Z" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const SuccessIcon = () => (
+  <svg width="30" height="30" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" rx="12" fill="#0037FF" />
+    <path d="M16 9L10.6496 14.3504C10.567 14.433 10.433 14.433 10.3504 14.3504L8 12" stroke="white" strokeWidth="1.75" strokeLinecap="round" />
+  </svg>
+);
+
+const SendIcon = () => (
+  <svg width="30" height="30" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" rx="12" fill="#0037FF" />
+    <path d="M17 7L11.5 12.5M17 7L13.5 17L11.5 12.5M17 7L7 10.5L11.5 12.5" stroke="white" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );
 

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -561,7 +561,7 @@ const GroupSwitchOption: React.FC<GroupSwitchOptionProps> = ({
   canSubmit,
 }) => {
   const hasAnySpotsLeft = spotsLeft !== 0;
-  const isDisabled = userIsParticipant || !hasAnySpotsLeft;
+  const isDisabled = userIsParticipant || !hasAnySpotsLeft || hasStarted;
 
   const displayDateTimeStrings = useMemo(() => {
     if (!dateTime) return null;
@@ -582,7 +582,7 @@ const GroupSwitchOption: React.FC<GroupSwitchOptionProps> = ({
     // Later classes have higher priority
     classNames.push('rounded-lg p-3 transition-all cursor-pointer border bg-white hover:bg-blue-50 border-gray-200 hover:border-gray-300');
     if (isSelected) classNames.push('border-[#0037FF] hover:border-[#0037FF] bg-blue-50');
-    if (!hasAnySpotsLeft) classNames.push('opacity-50 cursor-not-allowed hover:bg-white');
+    if (!hasAnySpotsLeft || hasStarted) classNames.push('opacity-50 cursor-not-allowed hover:bg-white');
     if (userIsParticipant) classNames.push('border-none bg-transparent hover:bg-transparent cursor-auto');
 
     return cn(...classNames);

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -14,7 +14,6 @@ import {
   Select as AriaSelect,
 } from 'react-aria-components';
 import useAxios from 'axios-hooks';
-import { twMerge } from 'tailwind-merge';
 import { FaChevronDown, FaCheck } from 'react-icons/fa6';
 import clsx from 'clsx';
 import { Course, Unit } from '@bluedot/db';
@@ -633,7 +632,7 @@ const GroupSwitchOption: React.FC<GroupSwitchOptionProps> = ({
               ) : description}
             </div>
           </div>
-          {isSelected && !isCurrentGroup && (
+          {isSelected && !userIsParticipant && (
             <CTALinkOrButton
               onClick={(e) => {
                 e.stopPropagation(); // Avoid triggering parent onClick

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -14,6 +14,7 @@ import {
   Select as AriaSelect,
 } from 'react-aria-components';
 import useAxios from 'axios-hooks';
+import { twMerge } from 'tailwind-merge';
 import { FaChevronDown, FaCheck } from 'react-icons/fa6';
 import clsx from 'clsx';
 import { Course, Unit } from '@bluedot/db';
@@ -64,7 +65,7 @@ const getGroupSwitchDescription = ({
     }
 
     if (isSelected && selectedUnitNumber !== undefined) {
-      return <span className="text-[#0037FF]">You are joining this group for Unit {selectedUnitNumber}</span>;
+      return <span className="text-[#0037FF]">You are joining this group for <strong>Unit {selectedUnitNumber}</strong> <FaCheck className="size-3 -translate-y-px inline-block ml-[2px]" aria-hidden="true" /></span>;
     }
 
     return undefined;
@@ -78,7 +79,7 @@ const getGroupSwitchDescription = ({
   }
 
   if (isSelected) {
-    return <span className="text-[#0037FF]">You are switching into this group for all upcoming units</span>;
+    return <span className="text-[#0037FF] flex gap-2 items-center">You are switching into this group for all upcoming units <FaCheck className="size-3 -translate-y-px inline-block ml-[2px]" aria-hidden="true" /></span>;
   }
 
   return undefined;
@@ -312,6 +313,8 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
 
   const groupSwitchOptions = isTemporarySwitch ? discussionOptions : groupOptions;
 
+  const selectedOption = groupSwitchOptions.filter((op) => op.isSelected)?.[0];
+
   const alternativeCount = groupSwitchOptions.filter((op) => op.spotsLeft !== 0 && !op.hasStarted).length;
   const alternativeCountMessage = isTemporarySwitch
     ? `There ${alternativeCount === 1 ? 'is' : 'are'} ${alternativeCount} alternative time slot${alternativeCount === 1 ? '' : 's'} available for this discussion`
@@ -326,6 +329,9 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
         {!!error && <ErrorSection error={error} />}
         {showSuccess && (
           <div className="flex flex-col gap-4">
+            {!isManualRequest && selectedOption && (
+              <GroupSwitchOption {...selectedOption} userIsParticipant />
+            )}
             {successMessages.map((message) => (
               <p key={message} className="text-size-sm text-[#666C80]">
                 {message}
@@ -625,7 +631,7 @@ const GroupSwitchOption: React.FC<GroupSwitchOptionProps> = ({
               ) : description}
             </div>
           </div>
-          {isSelected && (
+          {isSelected && !isCurrentGroup && (
             <CTALinkOrButton
               onClick={(e) => {
                 e.stopPropagation(); // Avoid triggering parent onClick

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -136,10 +136,8 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
     method: 'post',
   }, { manual: true });
 
-  const groups = switchingData?.groupsAvailable ? switchingData.groupsAvailable : [];
-  const discussions = switchingData?.discussionsAvailable && selectedUnitNumber
-    ? switchingData.discussionsAvailable[selectedUnitNumber] || []
-    : [];
+  const groups = switchingData?.groupsAvailable ?? [];
+  const discussions = switchingData?.discussionsAvailable?.[selectedUnitNumber] ?? [];
 
   const unitOptions = useMemo(() => {
     if (!courseData?.units) return [];
@@ -330,10 +328,9 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
     });
 
   const groupSwitchOptions = isTemporarySwitch ? discussionOptions : groupOptions;
+  const selectedOption = groupSwitchOptions.find((op) => op.isSelected);
 
-  const selectedOption = groupSwitchOptions.filter((op) => op.isSelected)?.[0];
-
-  const alternativeCount = groupSwitchOptions.filter((op) => op.spotsLeft !== 0 && !op.hasStarted).length;
+  const alternativeCount = groupSwitchOptions.filter((op) => !op.isDisabled).length;
   const alternativeCountMessage = isTemporarySwitch
     ? `There ${alternativeCount === 1 ? 'is' : 'are'} ${alternativeCount} alternative time slot${alternativeCount === 1 ? '' : 's'} available for this discussion`
     : `There ${alternativeCount === 1 ? 'is' : 'are'} ${alternativeCount} alternative group${alternativeCount === 1 ? '' : 's'} available`;
@@ -456,7 +453,7 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
                     target="_blank"
                     rel="noopener noreferrer"
                     url={`https://availability.bluedot.org/form/bluedot-course?email=${encodeURIComponent(auth.email)}&utm_source=bluedot-group-switch-modal`}
-                    aria-label="Request manual group switch"
+                    aria-label="Update availability (open in new tab)"
                   >
                     Update availability
                   </CTALinkOrButton>

--- a/apps/website/src/lib/utils.test.ts
+++ b/apps/website/src/lib/utils.test.ts
@@ -170,6 +170,15 @@ describe('formatDateTimeRelative', () => {
 });
 
 describe('formatDateMonthAndDay', () => {
+  beforeEach(() => {
+    // Set timezone to UTC for consistent test results
+    vi.stubEnv('TZ', 'UTC');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('should format date correctly', () => {
     const testDate = new Date('2024-06-20T15:00:00.000Z');
     const timestamp = Math.floor(testDate.getTime() / 1000);
@@ -180,21 +189,50 @@ describe('formatDateMonthAndDay', () => {
 });
 
 describe('formatTime12HourClock', () => {
-  it('should format time correctly accounting for timezone', () => {
+  beforeEach(() => {
+    // Set timezone to UTC for consistent test results
+    vi.stubEnv('TZ', 'UTC');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should format time correctly with hardcoded expected value', () => {
+    // 3:30 PM UTC
     const testDate = new Date('2024-06-15T15:30:00.000Z');
     const timestamp = Math.floor(testDate.getTime() / 1000);
     const result = formatTime12HourClock(timestamp);
-    const expectedTime = testDate.toLocaleTimeString('en-US', {
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
-    });
 
-    expect(result).toBe(expectedTime);
+    // Hardcoded expected value instead of testing implementation against itself
+    expect(result).toBe('3:30 PM');
+  });
+
+  it('should format different times correctly', () => {
+    // Morning time: 9:00 AM UTC
+    const morningDate = new Date('2024-06-15T09:00:00.000Z');
+    const morningTimestamp = Math.floor(morningDate.getTime() / 1000);
+    const morningResult = formatTime12HourClock(morningTimestamp);
+    expect(morningResult).toBe('9:00 AM');
+
+    // Evening time: 8:45 PM UTC
+    const eveningDate = new Date('2024-06-15T20:45:00.000Z');
+    const eveningTimestamp = Math.floor(eveningDate.getTime() / 1000);
+    const eveningResult = formatTime12HourClock(eveningTimestamp);
+    expect(eveningResult).toBe('8:45 PM');
   });
 });
 
 describe('formatDateDayOfWeek', () => {
+  beforeEach(() => {
+    // Set timezone to UTC for consistent test results
+    vi.stubEnv('TZ', 'UTC');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('should display day of week correctly', () => {
     // Tuesday, June 18, 2024, 3:30 PM UTC
     const testDate = new Date('2024-06-18T15:30:00.000Z');

--- a/apps/website/src/lib/utils.test.ts
+++ b/apps/website/src/lib/utils.test.ts
@@ -7,7 +7,13 @@ import {
   afterEach,
 } from 'vitest';
 import { AxiosError, AxiosResponse } from 'axios';
-import { parseZodValidationError, getDiscussionTimeDisplayStrings } from './utils';
+import {
+  parseZodValidationError,
+  formatTime12HourClock,
+  formatDateMonthAndDay,
+  formatDateDayOfWeek,
+  formatDateTimeRelative,
+} from './utils';
 
 // Test constants
 const DEFAULT_ERROR = 'An error occurred';
@@ -77,7 +83,7 @@ describe('parseZodValidationError', () => {
   });
 });
 
-describe('getDiscussionTimeDisplayStrings', () => {
+describe('formatDateTimeRelative', () => {
   let mockNow: Date;
 
   beforeEach(() => {
@@ -92,94 +98,144 @@ describe('getDiscussionTimeDisplayStrings', () => {
 
   it('should display "starting now" for times within 60 seconds', () => {
     const timestamp = Math.floor(mockNow.getTime() / 1000) + 30;
-    const result = getDiscussionTimeDisplayStrings(timestamp);
+    const result = formatDateTimeRelative(timestamp);
 
-    expect(result.startTimeDisplayRelative).toBe('starting now');
+    expect(result).toBe('starting now');
   });
 
   it('should display singular vs plural minutes', () => {
     // 1 minute
     const timestamp1 = Math.floor(mockNow.getTime() / 1000) + 60;
-    const result1 = getDiscussionTimeDisplayStrings(timestamp1);
-    expect(result1.startTimeDisplayRelative).toBe('in 1 minute');
+    const result1 = formatDateTimeRelative(timestamp1);
+    expect(result1).toBe('in 1 minute');
 
     // 5 minutes
     const timestamp5 = Math.floor(mockNow.getTime() / 1000) + 300;
-    const result5 = getDiscussionTimeDisplayStrings(timestamp5);
-    expect(result5.startTimeDisplayRelative).toBe('in 5 minutes');
+    const result5 = formatDateTimeRelative(timestamp5);
+    expect(result5).toBe('in 5 minutes');
   });
 
   it('should display singular vs plural hours', () => {
     // 1 hour
     const timestamp1 = Math.floor(mockNow.getTime() / 1000) + 3600;
-    const result1 = getDiscussionTimeDisplayStrings(timestamp1);
-    expect(result1.startTimeDisplayRelative).toBe('in 1 hour');
+    const result1 = formatDateTimeRelative(timestamp1);
+    expect(result1).toBe('in 1 hour');
 
     // 2 hours
     const timestamp2 = Math.floor(mockNow.getTime() / 1000) + 7200;
-    const result2 = getDiscussionTimeDisplayStrings(timestamp2);
-    expect(result2.startTimeDisplayRelative).toBe('in 2 hours');
+    const result2 = formatDateTimeRelative(timestamp2);
+    expect(result2).toBe('in 2 hours');
   });
 
   it('should display mixed hours and minutes correctly', () => {
     // 1 hour 1 minute
     const timestamp1 = Math.floor(mockNow.getTime() / 1000) + 3660;
-    const result1 = getDiscussionTimeDisplayStrings(timestamp1);
-    expect(result1.startTimeDisplayRelative).toBe('in 1 hour 1 minute');
+    const result1 = formatDateTimeRelative(timestamp1);
+    expect(result1).toBe('in 1 hour 1 minute');
 
     // 1 hour 30 minutes
     const timestamp30 = Math.floor(mockNow.getTime() / 1000) + 5400;
-    const result30 = getDiscussionTimeDisplayStrings(timestamp30);
-    expect(result30.startTimeDisplayRelative).toBe('in 1 hour 30 minutes');
+    const result30 = formatDateTimeRelative(timestamp30);
+    expect(result30).toBe('in 1 hour 30 minutes');
   });
 
   it('should display days correctly', () => {
     // 1 day
     const timestamp1 = Math.floor(mockNow.getTime() / 1000) + 86400;
-    const result1 = getDiscussionTimeDisplayStrings(timestamp1);
-    expect(result1.startTimeDisplayRelative).toBe('in 1 day');
+    const result1 = formatDateTimeRelative(timestamp1);
+    expect(result1).toBe('in 1 day');
 
     // 2 days
     const timestamp2 = Math.floor(mockNow.getTime() / 1000) + 172800;
-    const result2 = getDiscussionTimeDisplayStrings(timestamp2);
-    expect(result2.startTimeDisplayRelative).toBe('in 2 days');
+    const result2 = formatDateTimeRelative(timestamp2);
+    expect(result2).toBe('in 2 days');
   });
 
   it('should display past times with "ago" suffix', () => {
     // 5 minutes ago
     const timestamp5 = Math.floor(mockNow.getTime() / 1000) - 300;
-    const result5 = getDiscussionTimeDisplayStrings(timestamp5);
-    expect(result5.startTimeDisplayRelative).toBe('5 minutes ago');
+    const result5 = formatDateTimeRelative(timestamp5);
+    expect(result5).toBe('5 minutes ago');
 
     // 2 hours ago
     const timestamp2h = Math.floor(mockNow.getTime() / 1000) - 7200;
-    const result2h = getDiscussionTimeDisplayStrings(timestamp2h);
-    expect(result2h.startTimeDisplayRelative).toBe('2 hours ago');
+    const result2h = formatDateTimeRelative(timestamp2h);
+    expect(result2h).toBe('2 hours ago');
 
     // 1 day ago
     const timestamp1d = Math.floor(mockNow.getTime() / 1000) - 86400;
-    const result1d = getDiscussionTimeDisplayStrings(timestamp1d);
-    expect(result1d.startTimeDisplayRelative).toBe('1 day ago');
+    const result1d = formatDateTimeRelative(timestamp1d);
+    expect(result1d).toBe('1 day ago');
   });
+});
 
+describe('formatDateMonthAndDay', () => {
   it('should format date correctly', () => {
     const testDate = new Date('2024-06-20T15:00:00.000Z');
     const timestamp = Math.floor(testDate.getTime() / 1000);
-    const result = getDiscussionTimeDisplayStrings(timestamp);
+    const result = formatDateMonthAndDay(timestamp);
 
-    expect(result.startTimeDisplayDate).toBe('Jun 20');
+    expect(result).toBe('Jun 20');
   });
+});
 
+describe('formatTime12HourClock', () => {
   it('should format time correctly accounting for timezone', () => {
     const testDate = new Date('2024-06-15T15:30:00.000Z');
     const timestamp = Math.floor(testDate.getTime() / 1000);
-    const result = getDiscussionTimeDisplayStrings(timestamp);
+    const result = formatTime12HourClock(timestamp);
     const expectedTime = testDate.toLocaleTimeString('en-US', {
       hour: 'numeric',
       minute: '2-digit',
       hour12: true,
     });
 
-    expect(result.startTimeDisplayTime).toBe(expectedTime);
+    expect(result).toBe(expectedTime);
+  });
+});
+
+describe('formatDateDayOfWeek', () => {
+  it('should display day of week correctly', () => {
+    // Tuesday, June 18, 2024, 3:30 PM UTC
+    const testDate = new Date('2024-06-18T15:30:00.000Z');
+    const timestamp = Math.floor(testDate.getTime() / 1000);
+    const result = formatDateDayOfWeek(timestamp);
+
+    expect(result).toBe('Tue');
+  });
+
+  it('should display different days of week correctly', () => {
+    const testCases = [
+      { date: '2024-06-16T15:30:00.000Z', expected: 'Sun' }, // Sunday
+      { date: '2024-06-17T15:30:00.000Z', expected: 'Mon' }, // Monday
+      { date: '2024-06-18T15:30:00.000Z', expected: 'Tue' }, // Tuesday
+      { date: '2024-06-19T15:30:00.000Z', expected: 'Wed' }, // Wednesday
+      { date: '2024-06-20T15:30:00.000Z', expected: 'Thu' }, // Thursday
+      { date: '2024-06-21T15:30:00.000Z', expected: 'Fri' }, // Friday
+      { date: '2024-06-22T15:30:00.000Z', expected: 'Sat' }, // Saturday
+    ];
+
+    testCases.forEach(({ date, expected }) => {
+      const testDate = new Date(date);
+      const timestamp = Math.floor(testDate.getTime() / 1000);
+      const result = formatDateDayOfWeek(timestamp);
+      expect(result).toBe(expected);
+    });
+  });
+
+  it('should handle different times correctly', () => {
+    // Test morning time
+    const morningDate = new Date('2024-06-18T09:00:00.000Z');
+    const morningTimestamp = Math.floor(morningDate.getTime() / 1000);
+    const morningResult = formatDateDayOfWeek(morningTimestamp);
+
+    expect(morningResult).toBe('Tue');
+
+    // Test evening time
+    const eveningDate = new Date('2024-06-18T20:45:00.000Z');
+    const eveningTimestamp = Math.floor(eveningDate.getTime() / 1000);
+    const eveningResult = formatDateDayOfWeek(eveningTimestamp);
+
+    expect(eveningResult).toBe('Tue');
   });
 });

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -31,14 +31,36 @@ export const parseZodValidationError = (err: AxiosError<{ error?: string }>, def
   return defaultErrorMessage;
 };
 
-/**
- * Takes a timestamp (in Airtable format, seconds) and returns display strings:
- * - startTimeDisplayRelative: 'starting now'/'in 5 minutes'/'5 minutes ago'
- * - startTimeDisplayDate: 'Jun 8'
- * - startTimeDisplayTime: '3:00 PM'
- */
-export const getDiscussionTimeDisplayStrings = (startDateTime: number) => {
-  const startDate = new Date(startDateTime * 1000);
+/** Example: '3:00 PM' */
+export const formatTime12HourClock = (dateTime: number): string => {
+  const date = new Date(dateTime * 1000);
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+};
+
+/** Example: 'Jun 19' */
+export const formatDateMonthAndDay = (dateTime: number): string => {
+  const date = new Date(dateTime * 1000);
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+/** Example: 'Tue' */
+export const formatDateDayOfWeek = (dateTime: number): string => {
+  const date = new Date(dateTime * 1000);
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+  });
+};
+
+/** Examples: 'starting now', 'in 5 minutes', 'in 1 hour 30 minutes', '5 minutes ago' */
+export const formatDateTimeRelative = (dateTime: number): string => {
+  const startDate = new Date(dateTime * 1000);
   const now = new Date();
   const timeDiffMs = startDate.getTime() - now.getTime();
 
@@ -66,25 +88,11 @@ export const getDiscussionTimeDisplayStrings = (startDateTime: number) => {
   const absDays = Math.floor(absHours / 24);
 
   // Determine relative time string
-  let startTimeDisplayRelative: string;
   if (timeDiffMs >= 0 && timeDiffMs < 60000) {
-    startTimeDisplayRelative = 'starting now';
-  } else if (timeDiffMs > 0) {
-    startTimeDisplayRelative = `in ${buildRelativeTimeString(absMinutes, absHours, absDays, '')}`;
-  } else {
-    startTimeDisplayRelative = buildRelativeTimeString(absMinutes, absHours, absDays, ' ago');
+    return 'starting now';
   }
-
-  // Format date and time
-  const startTimeDisplayDate = startDate.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-  });
-  const startTimeDisplayTime = startDate.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
-
-  return { startTimeDisplayRelative, startTimeDisplayDate, startTimeDisplayTime };
+  if (timeDiffMs > 0) {
+    return `in ${buildRelativeTimeString(absMinutes, absHours, absDays, '')}`;
+  }
+  return buildRelativeTimeString(absMinutes, absHours, absDays, ' ago');
 };

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -32,8 +32,8 @@ export const parseZodValidationError = (err: AxiosError<{ error?: string }>, def
 };
 
 /** Example: '3:00 PM' */
-export const formatTime12HourClock = (dateTime: number): string => {
-  const date = new Date(dateTime * 1000);
+export const formatTime12HourClock = (dateTimeSeconds: number): string => {
+  const date = new Date(dateTimeSeconds * 1000);
   return date.toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
@@ -42,8 +42,8 @@ export const formatTime12HourClock = (dateTime: number): string => {
 };
 
 /** Example: 'Jun 19' */
-export const formatDateMonthAndDay = (dateTime: number): string => {
-  const date = new Date(dateTime * 1000);
+export const formatDateMonthAndDay = (dateTimeSeconds: number): string => {
+  const date = new Date(dateTimeSeconds * 1000);
   return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
@@ -51,16 +51,16 @@ export const formatDateMonthAndDay = (dateTime: number): string => {
 };
 
 /** Example: 'Tue' */
-export const formatDateDayOfWeek = (dateTime: number): string => {
-  const date = new Date(dateTime * 1000);
+export const formatDateDayOfWeek = (dateTimeSeconds: number): string => {
+  const date = new Date(dateTimeSeconds * 1000);
   return date.toLocaleDateString('en-US', {
     weekday: 'short',
   });
 };
 
 /** Examples: 'starting now', 'in 5 minutes', 'in 1 hour 30 minutes', '5 minutes ago' */
-export const formatDateTimeRelative = (dateTime: number): string => {
-  const startDate = new Date(dateTime * 1000);
+export const formatDateTimeRelative = (dateTimeSeconds: number): string => {
+  const startDate = new Date(dateTimeSeconds * 1000);
   const now = new Date();
   const timeDiffMs = startDate.getTime() - now.getTime();
 

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.test.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.test.ts
@@ -56,9 +56,9 @@ describe('calculateGroupAvailability', () => {
     });
 
     expect(result.groupsAvailable).toHaveLength(1);
-    expect(result.groupsAvailable[0]?.spotsLeft).toBe(4); // 5 max - 1 existing participant
+    expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBe(4); // 5 max - 1 existing participant
     expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]).toHaveLength(1);
-    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeft).toBe(4);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeftIfKnown).toBe(4);
   });
 
   it('should handle null maxParticipants', () => {
@@ -72,8 +72,8 @@ describe('calculateGroupAvailability', () => {
       participantId: mockParticipantId,
     });
 
-    expect(result.groupsAvailable[0]?.spotsLeft).toBeNull();
-    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeft).toBeNull();
+    expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBeNull();
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeftIfKnown).toBeNull();
   });
 
   it('should identify when user is a participant', () => {
@@ -160,8 +160,8 @@ describe('calculateGroupAvailability', () => {
 
     // Group should show allDiscussionsHaveStarted as false (mixed)
     expect(result.groupsAvailable[0]?.allDiscussionsHaveStarted).toBe(false);
-    // Group spotsLeft should be the minimum of available spots from non-started discussions
-    expect(result.groupsAvailable[0]?.spotsLeft).toBe(3); // 5 max - 2 participants from future discussion
+    // Group spotsLeftIfKnown should be the minimum of available spots from non-started discussions
+    expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBe(3); // 5 max - 2 participants from future discussion
   });
 
   it('should handle groups with all discussions started', () => {
@@ -185,7 +185,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     expect(result.groupsAvailable[0]?.allDiscussionsHaveStarted).toBe(true);
-    expect(result.groupsAvailable[0]?.spotsLeft).toBeNull(); // No spots available when all started
+    expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBeNull(); // No spots available when all started
   });
 
   it('should skip discussions without unit numbers', () => {
@@ -292,7 +292,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     // Should take minimum: min(5-2, 5-3) = min(3, 2) = 2
-    expect(result.groupsAvailable[0]?.spotsLeft).toBe(2);
+    expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBe(2);
   });
 
   it('should enforce minimum spots left of 0', () => {
@@ -308,8 +308,8 @@ describe('calculateGroupAvailability', () => {
       participantId: mockParticipantId,
     });
 
-    expect(result.groupsAvailable[0]?.spotsLeft).toBe(0);
-    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeft).toBe(0);
+    expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBe(0);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeftIfKnown).toBe(0);
   });
 
   it('should exclude participant from count when calculating spots', () => {
@@ -326,7 +326,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     // Should calculate based on 2 other participants: 5 - 2 = 3
-    expect(result.groupsAvailable[0]?.spotsLeft).toBe(3);
-    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeft).toBe(3);
+    expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBe(3);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeftIfKnown).toBe(3);
   });
 });

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.test.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.test.ts
@@ -6,9 +6,9 @@ type GroupDiscussion = InferSelectModel<typeof groupDiscussionTable.pg>;
 type Group = InferSelectModel<typeof groupTable.pg>;
 
 describe('calculateGroupAvailability', () => {
-  const now = Date.now();
-  const futureTime = now + 24 * 60 * 60 * 1000; // 24 hours from now
-  const pastTime = now - 24 * 60 * 60 * 1000; // 24 hours ago
+  const now = Math.floor(Date.now() / 1000);
+  const futureTimeSeconds = now + 24 * 60 * 60; // 24 hours from now, in seconds
+  const pastTimeSeconds = now - 24 * 60 * 60; // 24 hours ago, in seconds
 
   const mockParticipantId = 'participant-123';
 
@@ -20,7 +20,7 @@ describe('calculateGroupAvailability', () => {
     participants: ['other-participant'],
     whoCanSwitchIntoThisGroup: [],
     autoNumberId: 1,
-    startTimeUtc: futureTime / 1000,
+    startTimeUtc: futureTimeSeconds,
     ...overrides,
   } as Group);
 
@@ -29,8 +29,8 @@ describe('calculateGroupAvailability', () => {
     facilitators: ['facilitator-1'],
     participantsExpected: ['other-participant'],
     attendees: [],
-    startDateTime: futureTime / 1000,
-    endDateTime: (futureTime + 2 * 60 * 60 * 1000) / 1000,
+    startDateTime: futureTimeSeconds,
+    endDateTime: futureTimeSeconds + 2 * 60 * 60,
     group: 'group-1',
     zoomAccount: null,
     courseSite: null,
@@ -47,12 +47,11 @@ describe('calculateGroupAvailability', () => {
   it('should calculate spots left correctly with maxParticipants', () => {
     const groups = [createMockGroup()];
     const discussions = [createMockDiscussion()];
-    const maxParticipants = 5;
 
     const result = calculateGroupAvailability({
       groupDiscussions: discussions,
       groups,
-      maxParticipants,
+      maxParticipants: 5,
       participantId: mockParticipantId,
     });
 
@@ -109,7 +108,7 @@ describe('calculateGroupAvailability', () => {
 
   it('should detect when discussions have started', () => {
     const groups = [createMockGroup()];
-    const discussions = [createMockDiscussion({ startDateTime: pastTime / 1000 })];
+    const discussions = [createMockDiscussion({ startDateTime: pastTimeSeconds })];
 
     const result = calculateGroupAvailability({
       groupDiscussions: discussions,
@@ -124,7 +123,7 @@ describe('calculateGroupAvailability', () => {
 
   it('should detect when discussions have not started', () => {
     const groups = [createMockGroup()];
-    const discussions = [createMockDiscussion({ startDateTime: futureTime / 1000 })];
+    const discussions = [createMockDiscussion({ startDateTime: futureTimeSeconds })];
 
     const result = calculateGroupAvailability({
       groupDiscussions: discussions,
@@ -142,12 +141,12 @@ describe('calculateGroupAvailability', () => {
     const discussions = [
       createMockDiscussion({
         id: 'discussion-1',
-        startDateTime: futureTime / 1000,
+        startDateTime: futureTimeSeconds,
         participantsExpected: ['participant-1', 'participant-2'],
       }),
       createMockDiscussion({
         id: 'discussion-2',
-        startDateTime: pastTime / 1000,
+        startDateTime: pastTimeSeconds,
         participantsExpected: ['participant-3'],
       }),
     ];
@@ -170,11 +169,11 @@ describe('calculateGroupAvailability', () => {
     const discussions = [
       createMockDiscussion({
         id: 'discussion-1',
-        startDateTime: pastTime / 1000,
+        startDateTime: pastTimeSeconds,
       }),
       createMockDiscussion({
         id: 'discussion-2',
-        startDateTime: pastTime / 1000 - 1000,
+        startDateTime: pastTimeSeconds - 1000,
       }),
     ];
 
@@ -275,13 +274,13 @@ describe('calculateGroupAvailability', () => {
         id: 'discussion-1',
         unitNumber: 1,
         participantsExpected: ['p1', 'p2'], // 2 participants
-        startDateTime: futureTime / 1000,
+        startDateTime: futureTimeSeconds,
       }),
       createMockDiscussion({
         id: 'discussion-2',
         unitNumber: 2,
         participantsExpected: ['p1', 'p2', 'p3'], // 3 participants
-        startDateTime: futureTime / 1000,
+        startDateTime: futureTimeSeconds,
       }),
     ];
 

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.test.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.test.ts
@@ -58,8 +58,8 @@ describe('calculateGroupAvailability', () => {
 
     expect(result.groupsAvailable).toHaveLength(1);
     expect(result.groupsAvailable[0]?.spotsLeft).toBe(4); // 5 max - 1 existing participant
-    expect(result.discussionsAvailable['1']).toHaveLength(1);
-    expect(result.discussionsAvailable['1']?.[0]?.spotsLeft).toBe(4);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]).toHaveLength(1);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeft).toBe(4);
   });
 
   it('should handle null maxParticipants', () => {
@@ -74,7 +74,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     expect(result.groupsAvailable[0]?.spotsLeft).toBeNull();
-    expect(result.discussionsAvailable['1']?.[0]?.spotsLeft).toBeNull();
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeft).toBeNull();
   });
 
   it('should identify when user is a participant', () => {
@@ -89,7 +89,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     expect(result.groupsAvailable[0]?.userIsParticipant).toBe(true);
-    expect(result.discussionsAvailable['1']?.[0]?.userIsParticipant).toBe(true);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.userIsParticipant).toBe(true);
   });
 
   it('should identify when user is not a participant', () => {
@@ -104,7 +104,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     expect(result.groupsAvailable[0]?.userIsParticipant).toBe(false);
-    expect(result.discussionsAvailable['1']?.[0]?.userIsParticipant).toBe(false);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.userIsParticipant).toBe(false);
   });
 
   it('should detect when discussions have started', () => {
@@ -119,7 +119,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     expect(result.groupsAvailable[0]?.allDiscussionsHaveStarted).toBe(true);
-    expect(result.discussionsAvailable['1']?.[0]?.hasStarted).toBe(true);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.hasStarted).toBe(true);
   });
 
   it('should detect when discussions have not started', () => {
@@ -134,7 +134,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     expect(result.groupsAvailable[0]?.allDiscussionsHaveStarted).toBe(false);
-    expect(result.discussionsAvailable['1']?.[0]?.hasStarted).toBe(false);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.hasStarted).toBe(false);
   });
 
   it('should handle multiple discussions per group correctly', () => {
@@ -249,8 +249,8 @@ describe('calculateGroupAvailability', () => {
       participantId: mockParticipantId,
     });
 
-    expect(result.discussionsAvailable['1']).toHaveLength(2);
-    expect(result.discussionsAvailable['2']).toHaveLength(1);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]).toHaveLength(2);
+    expect(result.discussionsAvailable[String(discussions[2]!.unitNumber)]).toHaveLength(1);
     expect(result.groupsAvailable).toHaveLength(2);
   });
 
@@ -265,7 +265,7 @@ describe('calculateGroupAvailability', () => {
       participantId: mockParticipantId,
     });
 
-    expect(result.discussionsAvailable['1']?.[0]?.groupName).toBe('Group [Unknown]');
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.groupName).toBe('Group [Unknown]');
   });
 
   it('should calculate minimum spots left across multiple discussions for a group', () => {
@@ -310,7 +310,7 @@ describe('calculateGroupAvailability', () => {
     });
 
     expect(result.groupsAvailable[0]?.spotsLeft).toBe(0);
-    expect(result.discussionsAvailable['1']?.[0]?.spotsLeft).toBe(0);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeft).toBe(0);
   });
 
   it('should exclude participant from count when calculating spots', () => {
@@ -328,6 +328,6 @@ describe('calculateGroupAvailability', () => {
 
     // Should calculate based on 2 other participants: 5 - 2 = 3
     expect(result.groupsAvailable[0]?.spotsLeft).toBe(3);
-    expect(result.discussionsAvailable['1']?.[0]?.spotsLeft).toBe(3);
+    expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeft).toBe(3);
   });
 });

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.test.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.test.ts
@@ -1,0 +1,333 @@
+import { groupDiscussionTable, groupTable, InferSelectModel } from '@bluedot/db';
+import { describe, expect, it } from 'vitest';
+import { calculateGroupAvailability } from './available';
+
+type GroupDiscussion = InferSelectModel<typeof groupDiscussionTable.pg>;
+type Group = InferSelectModel<typeof groupTable.pg>;
+
+describe('calculateGroupAvailability', () => {
+  const now = Date.now();
+  const futureTime = now + 24 * 60 * 60 * 1000; // 24 hours from now
+  const pastTime = now - 24 * 60 * 60 * 1000; // 24 hours ago
+
+  const mockParticipantId = 'participant-123';
+
+  const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
+    id: 'group-1',
+    groupName: 'Test Group',
+    groupDiscussions: ['discussion-1'],
+    round: 'round-1',
+    participants: ['other-participant'],
+    whoCanSwitchIntoThisGroup: [],
+    autoNumberId: 1,
+    startTimeUtc: futureTime / 1000,
+    ...overrides,
+  } as Group);
+
+  const createMockDiscussion = (overrides: Partial<GroupDiscussion> = {}): GroupDiscussion => ({
+    id: 'discussion-1',
+    facilitators: ['facilitator-1'],
+    participantsExpected: ['other-participant'],
+    attendees: [],
+    startDateTime: futureTime / 1000,
+    endDateTime: (futureTime + 2 * 60 * 60 * 1000) / 1000,
+    group: 'group-1',
+    zoomAccount: null,
+    courseSite: null,
+    unitNumber: 1,
+    unit: 'unit-1',
+    round: null,
+    autoNumberId: null,
+    zoomLink: null,
+    activityDoc: null,
+    courseBuilderUnitRecordId: null,
+    ...overrides,
+  } as GroupDiscussion);
+
+  it('should calculate spots left correctly with maxParticipants', () => {
+    const groups = [createMockGroup()];
+    const discussions = [createMockDiscussion()];
+    const maxParticipants = 5;
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable).toHaveLength(1);
+    expect(result.groupsAvailable[0]?.spotsLeft).toBe(4); // 5 max - 1 existing participant
+    expect(result.discussionsAvailable['1']).toHaveLength(1);
+    expect(result.discussionsAvailable['1']?.[0]?.spotsLeft).toBe(4);
+  });
+
+  it('should handle null maxParticipants', () => {
+    const groups = [createMockGroup()];
+    const discussions = [createMockDiscussion()];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: null,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable[0]?.spotsLeft).toBeNull();
+    expect(result.discussionsAvailable['1']?.[0]?.spotsLeft).toBeNull();
+  });
+
+  it('should identify when user is a participant', () => {
+    const groups = [createMockGroup({ participants: [mockParticipantId, 'other-participant'] })];
+    const discussions = [createMockDiscussion({ participantsExpected: [mockParticipantId, 'other-participant'] })];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable[0]?.userIsParticipant).toBe(true);
+    expect(result.discussionsAvailable['1']?.[0]?.userIsParticipant).toBe(true);
+  });
+
+  it('should identify when user is not a participant', () => {
+    const groups = [createMockGroup()];
+    const discussions = [createMockDiscussion()];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable[0]?.userIsParticipant).toBe(false);
+    expect(result.discussionsAvailable['1']?.[0]?.userIsParticipant).toBe(false);
+  });
+
+  it('should detect when discussions have started', () => {
+    const groups = [createMockGroup()];
+    const discussions = [createMockDiscussion({ startDateTime: pastTime / 1000 })];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable[0]?.allDiscussionsHaveStarted).toBe(true);
+    expect(result.discussionsAvailable['1']?.[0]?.hasStarted).toBe(true);
+  });
+
+  it('should detect when discussions have not started', () => {
+    const groups = [createMockGroup()];
+    const discussions = [createMockDiscussion({ startDateTime: futureTime / 1000 })];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable[0]?.allDiscussionsHaveStarted).toBe(false);
+    expect(result.discussionsAvailable['1']?.[0]?.hasStarted).toBe(false);
+  });
+
+  it('should handle multiple discussions per group correctly', () => {
+    const groups = [createMockGroup()];
+    const discussions = [
+      createMockDiscussion({
+        id: 'discussion-1',
+        startDateTime: futureTime / 1000,
+        participantsExpected: ['participant-1', 'participant-2'],
+      }),
+      createMockDiscussion({
+        id: 'discussion-2',
+        startDateTime: pastTime / 1000,
+        participantsExpected: ['participant-3'],
+      }),
+    ];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    // Group should show allDiscussionsHaveStarted as false (mixed)
+    expect(result.groupsAvailable[0]?.allDiscussionsHaveStarted).toBe(false);
+    // Group spotsLeft should be the minimum of available spots from non-started discussions
+    expect(result.groupsAvailable[0]?.spotsLeft).toBe(3); // 5 max - 2 participants from future discussion
+  });
+
+  it('should handle groups with all discussions started', () => {
+    const groups = [createMockGroup()];
+    const discussions = [
+      createMockDiscussion({
+        id: 'discussion-1',
+        startDateTime: pastTime / 1000,
+      }),
+      createMockDiscussion({
+        id: 'discussion-2',
+        startDateTime: pastTime / 1000 - 1000,
+      }),
+    ];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable[0]?.allDiscussionsHaveStarted).toBe(true);
+    expect(result.groupsAvailable[0]?.spotsLeft).toBeNull(); // No spots available when all started
+  });
+
+  it('should skip discussions without unit numbers', () => {
+    const groups = [createMockGroup()];
+    const discussions = [createMockDiscussion({ unitNumber: null })];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable).toHaveLength(0);
+    expect(Object.keys(result.discussionsAvailable)).toHaveLength(0);
+  });
+
+  it('should skip discussions without corresponding groups', () => {
+    const groups: Group[] = [];
+    const discussions = [createMockDiscussion()];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable).toHaveLength(0);
+    expect(Object.keys(result.discussionsAvailable)).toHaveLength(0);
+  });
+
+  it('should group discussions by unit number', () => {
+    const groups = [
+      createMockGroup({ id: 'group-1' }),
+      createMockGroup({ id: 'group-2' }),
+    ];
+    const discussions = [
+      createMockDiscussion({
+        id: 'discussion-1',
+        group: 'group-1',
+        unitNumber: 1,
+      }),
+      createMockDiscussion({
+        id: 'discussion-2',
+        group: 'group-2',
+        unitNumber: 1,
+      }),
+      createMockDiscussion({
+        id: 'discussion-3',
+        group: 'group-1',
+        unitNumber: 2,
+      }),
+    ];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.discussionsAvailable['1']).toHaveLength(2);
+    expect(result.discussionsAvailable['2']).toHaveLength(1);
+    expect(result.groupsAvailable).toHaveLength(2);
+  });
+
+  it('should handle groups with no name gracefully', () => {
+    const groups = [createMockGroup({ groupName: null })];
+    const discussions = [createMockDiscussion()];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.discussionsAvailable['1']?.[0]?.groupName).toBe('Group [Unknown]');
+  });
+
+  it('should calculate minimum spots left across multiple discussions for a group', () => {
+    const groups = [createMockGroup()];
+    const discussions = [
+      createMockDiscussion({
+        id: 'discussion-1',
+        unitNumber: 1,
+        participantsExpected: ['p1', 'p2'], // 2 participants
+        startDateTime: futureTime / 1000,
+      }),
+      createMockDiscussion({
+        id: 'discussion-2',
+        unitNumber: 2,
+        participantsExpected: ['p1', 'p2', 'p3'], // 3 participants
+        startDateTime: futureTime / 1000,
+      }),
+    ];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    // Should take minimum: min(5-2, 5-3) = min(3, 2) = 2
+    expect(result.groupsAvailable[0]?.spotsLeft).toBe(2);
+  });
+
+  it('should enforce minimum spots left of 0', () => {
+    const groups = [createMockGroup()];
+    const discussions = [createMockDiscussion({
+      participantsExpected: ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'], // 6 participants, exceeds max
+    })];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    expect(result.groupsAvailable[0]?.spotsLeft).toBe(0);
+    expect(result.discussionsAvailable['1']?.[0]?.spotsLeft).toBe(0);
+  });
+
+  it('should exclude participant from count when calculating spots', () => {
+    const groups = [createMockGroup()];
+    const discussions = [createMockDiscussion({
+      participantsExpected: [mockParticipantId, 'p1', 'p2'], // 3 total, but participant should be excluded
+    })];
+
+    const result = calculateGroupAvailability({
+      groupDiscussions: discussions,
+      groups,
+      maxParticipants: 5,
+      participantId: mockParticipantId,
+    });
+
+    // Should calculate based on 2 other participants: 5 - 2 = 3
+    expect(result.groupsAvailable[0]?.spotsLeft).toBe(3);
+    expect(result.discussionsAvailable['1']?.[0]?.spotsLeft).toBe(3);
+  });
+});

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
@@ -22,7 +22,6 @@ export type GetGroupSwitchingAvailableResponse = {
   groupsAvailable: {
     group: Group;
     spotsLeft: number | null;
-    nextDiscussionStartDateTime: number | null;
     userIsParticipant: boolean;
     allDiscussionsHaveStarted: boolean;
   }[],
@@ -56,7 +55,6 @@ function calculateGroupAvailability({
   const groupData: Record<string, {
     group: Group;
     spotsLeft: number | null;
-    nextDiscussionStartDateTime: number | null;
     userIsParticipant: boolean;
     allDiscussionsHaveStarted: boolean;
   }> = {};
@@ -105,7 +103,6 @@ function calculateGroupAvailability({
       groupData[groupId] = {
         group,
         spotsLeft: !hasStarted ? spotsLeft : null,
-        nextDiscussionStartDateTime: !hasStarted ? discussion.startDateTime : null,
         userIsParticipant: group.participants.includes(participantId),
         allDiscussionsHaveStarted: hasStarted,
       };
@@ -122,16 +119,6 @@ function calculateGroupAvailability({
           existing.spotsLeft = Math.max(Math.min(existing.spotsLeft, spotsLeft), 0);
         } else if (spotsLeft !== null) {
           existing.spotsLeft = spotsLeft;
-        }
-
-        // Update next discussion start time (earliest upcoming)
-        if (existing.nextDiscussionStartDateTime === null) {
-          existing.nextDiscussionStartDateTime = discussion.startDateTime;
-        } else {
-          existing.nextDiscussionStartDateTime = Math.min(
-            existing.nextDiscussionStartDateTime,
-            discussion.startDateTime,
-          );
         }
       }
     }
@@ -150,7 +137,6 @@ export default makeApiRoute({
     groupsAvailable: z.array(z.object({
       group: z.any(),
       spotsLeft: z.number().nullable(),
-      nextDiscussionStartDateTime: z.number().nullable(),
       userIsParticipant: z.boolean(),
       allDiscussionsHaveStarted: z.boolean(),
     })),

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
@@ -34,7 +34,7 @@ export type GetGroupSwitchingAvailableResponse = {
   }[]>
 };
 
-function calculateGroupAvailability({
+export function calculateGroupAvailability({
   groupDiscussions,
   groups,
   maxParticipants,

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
@@ -21,13 +21,13 @@ export type GetGroupSwitchingAvailableResponse = {
   type: 'success',
   groupsAvailable: {
     group: Group;
-    spotsLeft: number | null;
+    spotsLeftIfKnown: number | null;
     userIsParticipant: boolean;
     allDiscussionsHaveStarted: boolean;
   }[],
   discussionsAvailable: Record<string, {
     discussion: GroupDiscussion
-    spotsLeft: number | null;
+    spotsLeftIfKnown: number | null;
     userIsParticipant: boolean;
     groupName: string;
     hasStarted: boolean;
@@ -54,7 +54,7 @@ export function calculateGroupAvailability({
 
   const groupData: Record<string, {
     group: Group;
-    spotsLeft: number | null;
+    spotsLeftIfKnown: number | null;
     userIsParticipant: boolean;
     allDiscussionsHaveStarted: boolean;
   }> = {};
@@ -72,7 +72,7 @@ export function calculateGroupAvailability({
 
     // Calculate spots left for this discussion
     const otherParticipants = discussion.participantsExpected.filter((id) => id !== participantId);
-    const spotsLeft = typeof maxParticipants === 'number'
+    const spotsLeftIfKnown = typeof maxParticipants === 'number'
       ? Math.max(0, maxParticipants - otherParticipants.length)
       : null;
 
@@ -89,7 +89,7 @@ export function calculateGroupAvailability({
 
     discussionsByUnit[unitKey].push({
       discussion,
-      spotsLeft,
+      spotsLeftIfKnown,
       userIsParticipant,
       groupName,
       hasStarted,
@@ -102,7 +102,7 @@ export function calculateGroupAvailability({
       // First time seeing this group
       groupData[groupId] = {
         group,
-        spotsLeft: !hasStarted ? spotsLeft : null,
+        spotsLeftIfKnown: !hasStarted ? spotsLeftIfKnown : null,
         userIsParticipant: group.participants.includes(participantId),
         allDiscussionsHaveStarted: hasStarted,
       };
@@ -113,11 +113,11 @@ export function calculateGroupAvailability({
       existing.allDiscussionsHaveStarted = existing.allDiscussionsHaveStarted && hasStarted;
 
       if (!hasStarted) {
-        // Update spotsLeft
-        if (existing.spotsLeft !== null && spotsLeft !== null) {
-          existing.spotsLeft = Math.min(existing.spotsLeft, spotsLeft);
-        } else if (spotsLeft !== null) {
-          existing.spotsLeft = spotsLeft;
+        // Update spotsLeftIfKnown
+        if (existing.spotsLeftIfKnown !== null && spotsLeftIfKnown !== null) {
+          existing.spotsLeftIfKnown = Math.min(existing.spotsLeftIfKnown, spotsLeftIfKnown);
+        } else if (spotsLeftIfKnown !== null) {
+          existing.spotsLeftIfKnown = spotsLeftIfKnown;
         }
       }
     }
@@ -135,13 +135,13 @@ export default makeApiRoute({
     type: z.literal('success'),
     groupsAvailable: z.array(z.object({
       group: z.any(),
-      spotsLeft: z.number().nullable(),
+      spotsLeftIfKnown: z.number().nullable(),
       userIsParticipant: z.boolean(),
       allDiscussionsHaveStarted: z.boolean(),
     })),
     discussionsAvailable: z.record(z.array(z.object({
       discussion: z.any(),
-      spotsLeft: z.number().nullable(),
+      spotsLeftIfKnown: z.number().nullable(),
       userIsParticipant: z.boolean(),
       groupName: z.string(),
       hasStarted: z.boolean(),

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
@@ -115,8 +115,7 @@ export function calculateGroupAvailability({
       if (!hasStarted) {
         // Update spotsLeft
         if (existing.spotsLeft !== null && spotsLeft !== null) {
-          // Clamp spotsLeft to be >= 0
-          existing.spotsLeft = Math.max(Math.min(existing.spotsLeft, spotsLeft), 0);
+          existing.spotsLeft = Math.min(existing.spotsLeft, spotsLeft);
         } else if (spotsLeft !== null) {
           existing.spotsLeft = spotsLeft;
         }

--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/index.ts
@@ -124,8 +124,8 @@ export default makeApiRoute({
     }
 
     if (newDiscussion && !isManualRequest && typeof maxParticipants === 'number') {
-      const spotsLeft = Math.max(0, maxParticipants - newDiscussion.participantsExpected.length);
-      if (spotsLeft === 0) {
+      const spotsLeftIfKnown = Math.max(0, maxParticipants - newDiscussion.participantsExpected.length);
+      if (spotsLeftIfKnown === 0) {
         throw new createHttpError.BadRequest('Selected discussion has no spots remaining');
       }
     }
@@ -174,12 +174,12 @@ export default makeApiRoute({
       // Calculate spots left based on the minimum spots across all discussions in the group
       // This matches the logic in available.ts
       const groupDiscussions = await db.scan(groupDiscussionTable, { group: newGroup.id });
-      const spotsLeftValues = groupDiscussions
+      const spotsLeftIfKnownValues = groupDiscussions
         .map((d) => Math.max(0, maxParticipants - d.participantsExpected.filter((pId) => pId !== participantId).length))
         .filter((v) => typeof v === 'number');
 
-      const spotsLeft = spotsLeftValues.length ? Math.min(...spotsLeftValues) : null;
-      if (spotsLeft === 0) {
+      const spotsLeftIfKnown = spotsLeftIfKnownValues.length ? Math.min(...spotsLeftIfKnownValues) : null;
+      if (spotsLeftIfKnown === 0) {
         throw new createHttpError.BadRequest('Selected group has no spots remaining');
       }
     }


### PR DESCRIPTION
# Description

The last few bits of cleanup to match the designs in the original group switching issue (#1210):
- Add info about the group being switched into to the "Success!" screen
- Add "Update availability" to the manual switching screen
- When switching permanently, use the recurring time on the group rather than the time of the next discussion. Also display this as e.g. "Wed 11:00 AM", rather than "Nov 13 11:00 AM"
- Add icons to the title of "Success!" and "We are working on your request" screens
- Don't allow switching into discussions that have already passed
- I also added some tests for the calculateGroupAvailability function used on the backend

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1210

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] [Lacking, see #1372] Considered having snapshot tests and/or happy path functional tests#13
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 |  |
|---------|---|
| 📱  | <img width="417" height="924" alt="Screenshot 2025-09-23 at 09 03 36" src="https://github.com/user-attachments/assets/f080718e-9b2c-4e41-8a80-f40a6c4415d8" /> |
| | <img width="417" height="924" alt="Screenshot 2025-09-23 at 09 03 05" src="https://github.com/user-attachments/assets/08309ccb-666c-4788-bcd4-e1f08dda3731" /> |
| | <img width="417" height="924" alt="Screenshot 2025-09-23 at 09 03 19" src="https://github.com/user-attachments/assets/596b069d-ebb2-4c5e-b883-5ba13e6805cf" /> |
| | <img width="417" height="924" alt="Screenshot 2025-09-23 at 09 04 36" src="https://github.com/user-attachments/assets/0840aaec-7d78-4178-b973-3e6536b6c450" /> |
| 🖥️ | <img width="635" height="338" alt="Screenshot 2025-09-23 at 08 58 36" src="https://github.com/user-attachments/assets/50378ebe-01ae-448f-ba85-f169b5305c2c" /> |
| | <img width="740" height="322" alt="Screenshot 2025-09-23 at 08 59 01" src="https://github.com/user-attachments/assets/e69f7989-292a-4d92-9e8e-70e0cc5e8dce" /> |
| | <img width="719" height="249" alt="Screenshot 2025-09-23 at 09 01 13" src="https://github.com/user-attachments/assets/f913d93f-fb39-4e93-9bd3-f50f674b46de" /> |
| | <img width="732" height="769" alt="Screenshot 2025-09-23 at 09 00 58" src="https://github.com/user-attachments/assets/ebc7dad4-ae7f-4b70-b91c-219aab59fef7" /> |
