### PR TITLE
[feat]: justify-between spacing for 1200px+ on who this course is for section

### DIFF
--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -100,10 +100,10 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
           class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"
         >
           <div
-            class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+            class="flex flex-col items-start gap-6 min-[1200px]:gap-0 min-[1200px]:justify-between bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none min-[1200px]:h-[264px]"
           >
             <div
-              class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+              class="size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
             >
               <svg
                 class="text-white"
@@ -121,7 +121,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               </svg>
             </div>
             <p
-              class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+              class="bluedot-p not-prose text-[18px] leading-[1.6] text-[#13132E]"
             >
               <span
                 class="font-semibold"
@@ -134,10 +134,10 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             </p>
           </div>
           <div
-            class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+            class="flex flex-col items-start gap-6 min-[1200px]:gap-0 min-[1200px]:justify-between bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none min-[1200px]:h-[264px]"
           >
             <div
-              class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+              class="size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
             >
               <svg
                 class="text-white"
@@ -155,7 +155,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               </svg>
             </div>
             <p
-              class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+              class="bluedot-p not-prose text-[18px] leading-[1.6] text-[#13132E]"
             >
               <span
                 class="font-semibold"
@@ -168,10 +168,10 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             </p>
           </div>
           <div
-            class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+            class="flex flex-col items-start gap-6 min-[1200px]:gap-0 min-[1200px]:justify-between bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none min-[1200px]:h-[264px]"
           >
             <div
-              class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+              class="size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
             >
               <svg
                 class="text-white"
@@ -189,7 +189,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               </svg>
             </div>
             <p
-              class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+              class="bluedot-p not-prose text-[18px] leading-[1.6] text-[#13132E]"
             >
               <span
                 class="font-semibold"

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
@@ -30,11 +30,14 @@ const WhoIsThisForSection = () => {
         </H2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
           {targetAudiences.map(({ icon, boldText, normalText }) => (
-            <div key={boldText} className="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none">
-              <div className="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0">
+            <div
+              key={boldText}
+              className="flex flex-col items-start gap-6 min-[1200px]:gap-0 min-[1200px]:justify-between bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none min-[1200px]:h-[264px]"
+            >
+              <div className="size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0">
                 {icon}
               </div>
-              <P className="text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left">
+              <P className="text-[18px] leading-[1.6] text-[#13132E]">
                 <span className="font-semibold">{boldText}</span>
                 <span>{normalText}</span>
               </P>

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
@@ -16,10 +16,10 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"
     >
       <div
-        class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+        class="flex flex-col items-start gap-6 min-[1200px]:gap-0 min-[1200px]:justify-between bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none min-[1200px]:h-[264px]"
       >
         <div
-          class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+          class="size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
         >
           <svg
             class="text-white"
@@ -37,7 +37,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
           </svg>
         </div>
         <p
-          class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+          class="bluedot-p not-prose text-[18px] leading-[1.6] text-[#13132E]"
         >
           <span
             class="font-semibold"
@@ -50,10 +50,10 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
         </p>
       </div>
       <div
-        class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+        class="flex flex-col items-start gap-6 min-[1200px]:gap-0 min-[1200px]:justify-between bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none min-[1200px]:h-[264px]"
       >
         <div
-          class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+          class="size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
         >
           <svg
             class="text-white"
@@ -71,7 +71,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
           </svg>
         </div>
         <p
-          class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+          class="bluedot-p not-prose text-[18px] leading-[1.6] text-[#13132E]"
         >
           <span
             class="font-semibold"
@@ -84,10 +84,10 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
         </p>
       </div>
       <div
-        class="flex flex-col items-center md:items-start gap-6 bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-6 md:p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none"
+        class="flex flex-col items-start gap-6 min-[1200px]:gap-0 min-[1200px]:justify-between bg-white border border-[rgba(19,19,46,0.1)] rounded-xl p-8 mx-auto md:mx-0 max-w-[350px] md:max-w-none min-[1200px]:h-[264px]"
       >
         <div
-          class="size-12 md:size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
+          class="size-14 bg-[#2244BB] rounded-lg flex items-center justify-center flex-shrink-0"
         >
           <svg
             class="text-white"
@@ -105,7 +105,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
           </svg>
         </div>
         <p
-          class="bluedot-p not-prose text-[16px] md:text-[18px] leading-[1.6] text-[#13132E] text-center md:text-left"
+          class="bluedot-p not-prose text-[18px] leading-[1.6] text-[#13132E]"
         >
           <span
             class="font-semibold"


### PR DESCRIPTION
# Description
Adding justify-between spacing for 1200px+ on the Who this course is for section on the AGI strategy lander

## Issue
Related to #1334 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
![updated-who-is-course-for-spacing](https://github.com/user-attachments/assets/1d812cd4-e9e4-480e-afd5-afdf898711b5)

