### PR TITLE
AIRTABLE_PERSONAL_ACCESS_TOKEN secret for production build

### DIFF
--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -35,5 +35,9 @@ jobs:
           K8S_KUBECONFIG: ${{ secrets.K8S_KUBECONFIG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set production secrets
+        run: |
+          sed -i 's/^AIRTABLE_PERSONAL_ACCESS_TOKEN=$/AIRTABLE_PERSONAL_ACCESS_TOKEN=${{ secrets.AIRTABLE_PERSONAL_ACCESS_TOKEN }}/' apps/website/.env.local
+
       - name: Deploy production
         run: npm run deploy:multistage:production --workspace apps/website


### PR DESCRIPTION
# Description

Should fix this failing build: https://github.com/bluedotimpact/bluedot/actions/runs/18001215785/job/51211499261.

This change was [added to CI/CD](https://github.com/bluedotimpact/bluedot/pull/1331/commits/a65c822daae5d163b3aae172c122ab5332d23806) workflow as part of https://github.com/bluedotimpact/bluedot/pull/1331 but I didn't update the deployment pipeline.

We could instead append to `.env.production.local` since that takes precedence but I stuck with `sed` for consistency with the ci/cd workflow file.

## Developer checklist

NA

## Screenshot

NA
