### PR TITLE
[Feature] Show GroupDiscussionBanner for facilitators

### DIFF
--- a/apps/website/src/components/courses/GroupDiscussionBanner.tsx
+++ b/apps/website/src/components/courses/GroupDiscussionBanner.tsx
@@ -23,7 +23,7 @@ type GroupDiscussionBannerProps = {
   unit: Unit;
   groupDiscussion: GroupDiscussion;
   userRole?: 'participant' | 'facilitator';
-  hostKey?: string;
+  hostKeyForFacilitators?: string;
   onClickPrepare: () => void;
 };
 
@@ -31,7 +31,7 @@ const GroupDiscussionBanner: React.FC<GroupDiscussionBannerProps> = ({
   unit,
   groupDiscussion,
   userRole,
-  hostKey,
+  hostKeyForFacilitators,
   onClickPrepare,
 }) => {
   const [groupSwitchModalOpen, setGroupSwitchModalOpen] = useState(false);
@@ -89,9 +89,9 @@ const GroupDiscussionBanner: React.FC<GroupDiscussionBannerProps> = ({
     : '';
 
   const copyHostKeyIfFacilitator = async () => {
-    if (userRole === 'facilitator' && hostKey) {
+    if (userRole === 'facilitator' && hostKeyForFacilitators) {
       try {
-        await navigator.clipboard.writeText(hostKey);
+        await navigator.clipboard.writeText(hostKeyForFacilitators);
       } catch (error) {
         // eslint-disable-next-line no-console
         console.warn('Failed to copy host key to clipboard:', error);
@@ -99,7 +99,7 @@ const GroupDiscussionBanner: React.FC<GroupDiscussionBannerProps> = ({
     }
   };
 
-  const joinButtonText = userRole === 'facilitator' && hostKey ? `Join discussion (Host key: ${hostKey})` : 'Join discussion';
+  const joinButtonText = userRole === 'facilitator' && hostKeyForFacilitators ? `Join discussion (Host key: ${hostKeyForFacilitators})` : 'Join discussion';
 
   return (
     <div className="flex flex-col p-2 border-1 border-charcoal-light gap-2">

--- a/apps/website/src/components/courses/GroupDiscussionBanner.tsx
+++ b/apps/website/src/components/courses/GroupDiscussionBanner.tsx
@@ -22,12 +22,16 @@ const ONE_HOUR_MS = 3600_000; // 1 hour in milliseconds
 type GroupDiscussionBannerProps = {
   unit: Unit;
   groupDiscussion: GroupDiscussion;
+  userRole?: 'participant' | 'facilitator';
+  hostKey?: string;
   onClickPrepare: () => void;
 };
 
 const GroupDiscussionBanner: React.FC<GroupDiscussionBannerProps> = ({
   unit,
   groupDiscussion,
+  userRole,
+  hostKey,
   onClickPrepare,
 }) => {
   const [groupSwitchModalOpen, setGroupSwitchModalOpen] = useState(false);
@@ -84,6 +88,19 @@ const GroupDiscussionBanner: React.FC<GroupDiscussionBannerProps> = ({
     ? `https://app.slack.com/client/T01K0M15NEQ/${groupDiscussion.slackChannelId}`
     : '';
 
+  const copyHostKeyIfFacilitator = async () => {
+    if (userRole === 'facilitator' && hostKey) {
+      try {
+        await navigator.clipboard.writeText(hostKey);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to copy host key to clipboard:', error);
+      }
+    }
+  };
+
+  const joinButtonText = userRole === 'facilitator' && hostKey ? `Join discussion (Host key: ${hostKey})` : 'Join discussion';
+
   return (
     <div className="flex flex-col p-2 border-1 border-charcoal-light gap-2">
       <div className="flex justify-between items-center px-4 my-1 gap-4">
@@ -100,9 +117,10 @@ const GroupDiscussionBanner: React.FC<GroupDiscussionBannerProps> = ({
           <CTALinkOrButton
             target="_blank"
             url={discussionMeetLink}
+            onClick={copyHostKeyIfFacilitator}
             className="w-full"
           >
-            Join discussion
+            {joinButtonText}
           </CTALinkOrButton>
         ) : (
           <CTALinkOrButton onClick={onClickPrepare} className="w-full">
@@ -128,13 +146,15 @@ const GroupDiscussionBanner: React.FC<GroupDiscussionBannerProps> = ({
           >
             Message your group
           </CTALinkOrButton>
-          <CTALinkOrButton
-            variant="secondary"
-            className="w-full"
-            onClick={() => setGroupSwitchModalOpen(true)}
-          >
-            Can't make it?
-          </CTALinkOrButton>
+          {userRole !== 'facilitator' && (
+            <CTALinkOrButton
+              variant="secondary"
+              className="w-full"
+              onClick={() => setGroupSwitchModalOpen(true)}
+            >
+              Can't make it?
+            </CTALinkOrButton>
+          )}
         </div>
       </div>
       {groupSwitchModalOpen && (

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -14,7 +14,7 @@ import {
 import {
   unitTable, chunkTable, unitResourceTable, exerciseTable, InferSelectModel,
 } from '@bluedot/db';
-import { GroupDiscussionWithZoomInfo } from '../../pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion';
+import type { GroupDiscussionWithZoomInfo } from '../../pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion';
 import CertificateLinkCard from './CertificateLinkCard';
 import Congratulations from './Congratulations';
 import GroupDiscussionBanner from './GroupDiscussionBanner';

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -14,6 +14,7 @@ import {
 import {
   unitTable, chunkTable, unitResourceTable, exerciseTable, InferSelectModel, groupDiscussionTable,
 } from '@bluedot/db';
+import { GroupDiscussionWithZoomInfo } from '../../pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion';
 import CertificateLinkCard from './CertificateLinkCard';
 import Congratulations from './Congratulations';
 import GroupDiscussionBanner from './GroupDiscussionBanner';
@@ -54,7 +55,7 @@ type UnitLayoutProps = {
   chunkIndex: number;
   setChunkIndex: (index: number) => void;
   // Optional
-  groupDiscussion?: GroupDiscussion;
+  groupDiscussionWithZoomInfo?: GroupDiscussionWithZoomInfo;
   groupDiscussionError?: Error | null;
 };
 
@@ -144,7 +145,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
   units,
   chunkIndex,
   setChunkIndex,
-  groupDiscussion,
+  groupDiscussionWithZoomInfo,
   groupDiscussionError,
 }) => {
   const router = useRouter();
@@ -398,18 +399,22 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
           {groupDiscussionError && (
             <ErrorSection error={groupDiscussionError} />
           )}
-          {groupDiscussion && (
+          {groupDiscussionWithZoomInfo?.groupDiscussion && (
             <div className="mb-8 md:mb-6">
               <GroupDiscussionBanner
                 unit={unit}
-                groupDiscussion={groupDiscussion}
+                groupDiscussion={groupDiscussionWithZoomInfo.groupDiscussion}
+                userRole={groupDiscussionWithZoomInfo.userRole}
+                hostKey={groupDiscussionWithZoomInfo.hostKey}
                 // If the discussion has a courseBuilderUnitRecordId that matches current unit, stay here
                 onClickPrepare={() => {
-                  if (groupDiscussion.courseBuilderUnitRecordId === unit.id) {
+                  const { groupDiscussion } = groupDiscussionWithZoomInfo;
+
+                  if (groupDiscussion?.courseBuilderUnitRecordId === unit.id) {
                     handleChunkSelect(0);
-                  } else if (groupDiscussion.unitNumber) {
+                  } else if (groupDiscussion?.unitNumber) {
                     // Otherwise, try to navigate to the discussion's unit number
-                    const discussionUnit = units.find((u) => u.unitNumber === groupDiscussion.unitNumber?.toString());
+                    const discussionUnit = units.find((u) => u.unitNumber === groupDiscussion?.unitNumber?.toString());
                     if (discussionUnit) {
                       router.push(discussionUnit.path);
                     } else {

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -407,13 +407,11 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
                 hostKey={groupDiscussionWithZoomInfo.hostKey}
                 // If the discussion has a courseBuilderUnitRecordId that matches current unit, stay here
                 onClickPrepare={() => {
-                  const { groupDiscussion } = groupDiscussionWithZoomInfo;
-
-                  if (groupDiscussion?.courseBuilderUnitRecordId === unit.id) {
+                  if (groupDiscussionWithZoomInfo.groupDiscussion!.courseBuilderUnitRecordId === unit.id) {
                     handleChunkSelect(0);
-                  } else if (groupDiscussion?.unitNumber) {
+                  } else if (groupDiscussionWithZoomInfo.groupDiscussion!.unitNumber) {
                     // Otherwise, try to navigate to the discussion's unit number
-                    const discussionUnit = units.find((u) => u.unitNumber === groupDiscussion?.unitNumber?.toString());
+                    const discussionUnit = units.find((u) => u.unitNumber === groupDiscussionWithZoomInfo.groupDiscussion!.unitNumber?.toString());
                     if (discussionUnit) {
                       router.push(discussionUnit.path);
                     } else {

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -12,7 +12,10 @@ import {
 } from 'react-icons/fa6';
 
 import {
-  unitTable, chunkTable, unitResourceTable, exerciseTable, InferSelectModel,
+  Chunk,
+  UnitResource,
+  Exercise,
+  Unit,
 } from '@bluedot/db';
 import type { GroupDiscussionWithZoomInfo } from '../../pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion';
 import CertificateLinkCard from './CertificateLinkCard';
@@ -28,14 +31,9 @@ import {
   A, H1, P,
 } from '../Text';
 
-type Unit = InferSelectModel<typeof unitTable.pg>;
-type Chunk = InferSelectModel<typeof chunkTable.pg>;
-type UnitResource = InferSelectModel<typeof unitResourceTable.pg>;
-type ExerciseType = InferSelectModel<typeof exerciseTable.pg>;
-
 type ChunkWithContent = Chunk & {
   resources?: UnitResource[];
-  exercises?: ExerciseType[];
+  exercises?: Exercise[];
 };
 
 const CourseIcon: React.FC = () => (
@@ -404,7 +402,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
                 unit={unit}
                 groupDiscussion={groupDiscussionWithZoomInfo.groupDiscussion}
                 userRole={groupDiscussionWithZoomInfo.userRole}
-                hostKey={groupDiscussionWithZoomInfo.hostKey}
+                hostKeyForFacilitators={groupDiscussionWithZoomInfo.hostKeyForFacilitators}
                 // If the discussion has a courseBuilderUnitRecordId that matches current unit, stay here
                 onClickPrepare={() => {
                   if (groupDiscussionWithZoomInfo.groupDiscussion!.courseBuilderUnitRecordId === unit.id) {

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-icons/fa6';
 
 import {
-  unitTable, chunkTable, unitResourceTable, exerciseTable, InferSelectModel, groupDiscussionTable,
+  unitTable, chunkTable, unitResourceTable, exerciseTable, InferSelectModel,
 } from '@bluedot/db';
 import { GroupDiscussionWithZoomInfo } from '../../pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion';
 import CertificateLinkCard from './CertificateLinkCard';

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -32,7 +32,6 @@ type Unit = InferSelectModel<typeof unitTable.pg>;
 type Chunk = InferSelectModel<typeof chunkTable.pg>;
 type UnitResource = InferSelectModel<typeof unitResourceTable.pg>;
 type ExerciseType = InferSelectModel<typeof exerciseTable.pg>;
-type GroupDiscussion = InferSelectModel<typeof groupDiscussionTable.pg>;
 
 type ChunkWithContent = Chunk & {
   resources?: UnitResource[];

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion.ts
@@ -19,7 +19,7 @@ import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
 export type GroupDiscussionWithZoomInfo = {
   groupDiscussion?: GroupDiscussion,
   userRole?: 'participant' | 'facilitator',
-  hostKey?: string,
+  hostKeyForFacilitators?: string,
 };
 
 export type GetGroupDiscussionResponse = {
@@ -32,7 +32,7 @@ export default makeApiRoute({
     type: z.literal('success'),
     groupDiscussion: z.any().nullable(),
     userRole: z.enum(['participant', 'facilitator']).optional(),
-    hostKey: z.string().optional(),
+    hostKeyForFacilitators: z.string().optional(),
   }),
 }, async (body, { auth, raw }) => {
   const { courseSlug, unitNumber } = raw.req.query;
@@ -124,7 +124,7 @@ export default makeApiRoute({
 
   // Determine user role and get host key if facilitator
   let userRole: 'participant' | 'facilitator' | undefined;
-  let hostKey: string | undefined;
+  let hostKeyForFacilitators: string | undefined;
 
   if (groupDiscussion) {
     if (groupDiscussion.facilitators.includes(participant.id)) {
@@ -133,9 +133,9 @@ export default makeApiRoute({
       if (groupDiscussion.zoomAccount) {
         try {
           const zoomAccount: ZoomAccount = await db.get(zoomAccountTable, { id: groupDiscussion.zoomAccount });
-          hostKey = zoomAccount.hostKey || undefined;
+          hostKeyForFacilitators = zoomAccount.hostKey || undefined;
         } catch (error) {
-          hostKey = undefined;
+          hostKeyForFacilitators = undefined;
         }
       }
     } else if (groupDiscussion.participantsExpected.includes(participant.id)) {
@@ -147,6 +147,6 @@ export default makeApiRoute({
     type: 'success' as const,
     groupDiscussion,
     userRole,
-    hostKey,
+    hostKeyForFacilitators,
   };
 });

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -123,7 +123,7 @@ const CourseUnitChunkPage = () => {
       unitNumber={parseInt(unitNumber)}
       chunkIndex={chunkIndex}
       setChunkIndex={handleSetChunkIndex}
-      groupDiscussion={groupDiscussionData?.groupDiscussion}
+      groupDiscussionWithZoomInfo={groupDiscussionData}
       groupDiscussionError={groupDiscussionError}
     />
   );


### PR DESCRIPTION
# Description
- Make GroupDiscussionBanner display for facilitators
- Show the host key in the button for facilitators, copy it to the clipboard on click

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

No issue, requested by @anglilian in Slack

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests (will add tests for this component overall in #1389 )
- [X] Considered adding Storybook stories (also covered in #1389 )

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 |  |
|---------|---|
| 📱  | <img width="660" height="1466" alt="Screenshot 2025-09-25 at 11 42 50" src="https://github.com/user-attachments/assets/59c55b4c-7983-48e1-b8d5-baf31ffa8f59" /> |
| 🖥️ | <img width="1674" height="452" alt="Screenshot 2025-09-25 at 11 42 44" src="https://github.com/user-attachments/assets/f2bb1260-53e3-4e73-89c6-fa63bae6c0c7" /> |
