### PR TITLE
[Fix] breadcrumb overflow

### DIFF
--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -342,22 +342,22 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
           </div>
 
           {/* Breadcrumbs - left aligned after hide */}
-          <nav className="flex items-center gap-[8px] flex-1 min-h-[18px]">
+          <nav className="flex items-center gap-[8px] flex-1 min-h-[18px] min-w-0">
             <A
               href={ROUTES.courses.url}
-              className="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline inline-flex items-center"
+              className="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline"
             >
               Courses
             </A>
             <FaChevronRight className="size-[14px] text-[#6A6F7A] flex-shrink-0 opacity-50" />
             <A
               href={unit.coursePath}
-              className="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline inline-flex items-center"
+              className="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline truncate"
             >
               {unit.courseTitle}
             </A>
             <FaChevronRight className="size-[14px] text-[#6A6F7A] flex-shrink-0 opacity-50" />
-            <span className="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#13132E] inline-flex items-center">
+            <span className="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#13132E] truncate" title={`${unitNumber}. ${unit.title}`}>
               {unitNumber}. {unit.title}
             </span>
           </nav>

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -463,10 +463,10 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
           />
         </div>
         <nav
-          class="flex items-center gap-[8px] flex-1 min-h-[18px]"
+          class="flex items-center gap-[8px] flex-1 min-h-[18px] min-w-0"
         >
           <a
-            class="bluedot-a not-prose text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline inline-flex items-center"
+            class="bluedot-a not-prose text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline"
             href="/courses"
             tabindex="0"
           >
@@ -487,7 +487,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             />
           </svg>
           <a
-            class="bluedot-a not-prose text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline inline-flex items-center"
+            class="bluedot-a not-prose text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#6A6F7A] hover:text-[#13132E] transition-colors no-underline truncate"
             href="/courses/test-course"
             tabindex="0"
           >
@@ -508,7 +508,8 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
             />
           </svg>
           <span
-            class="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#13132E] inline-flex items-center"
+            class="text-[13px] font-medium leading-[18px] tracking-[-0.005em] text-[#13132E] truncate"
+            title="1. Basic Principles of Fish"
           >
             1
             . 


### PR DESCRIPTION
## Issue

Fixes #1385. Adds truncation to overflowing text. Remove unneeded `inline-flex` and `items-center` classes from anchor elements.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

| 📸 | Before | After |
|---------|---|---|
| | ![before](https://github.com/user-attachments/assets/7420a7e0-b716-454d-bad1-c7379c1f891c) | ![after](https://github.com/user-attachments/assets/fd4f4078-901c-4729-a3db-ff170bdd33d8) |