### PR TITLE
Prefer pointer events to separate mouse and touch events

### DIFF
--- a/apps/availability/src/components/TimeAvailabilityInput.tsx
+++ b/apps/availability/src/components/TimeAvailabilityInput.tsx
@@ -168,7 +168,7 @@ const TimeAvailabilityGrid: React.FC<{ show24: boolean, value: TimeAvailabilityM
                 );
 
               return (
-                // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+
                 <div
                   // eslint-disable-next-line react/no-array-index-key
                   key={i}

--- a/apps/availability/src/components/TimeAvailabilityInput.tsx
+++ b/apps/availability/src/components/TimeAvailabilityInput.tsx
@@ -80,7 +80,7 @@ const TimeAvailabilityGrid: React.FC<{ show24: boolean, value: TimeAvailabilityM
   const mainGrid = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const mouseMoveListener = (e: MouseEvent) => {
+    const movePointerListener = (e: PointerEvent) => {
       if (!dragState.dragging || !mainGrid.current) return;
 
       const mousepos = { x: e.clientX, y: e.clientY };
@@ -99,9 +99,9 @@ const TimeAvailabilityGrid: React.FC<{ show24: boolean, value: TimeAvailabilityM
         setDragState((prev) => ({ ...prev, cursor: cell.coord }));
       }
     };
-    document.addEventListener('mousemove', mouseMoveListener);
+    document.addEventListener('pointermove', movePointerListener);
 
-    const mouseUpListener = () => {
+    const pointerUpListener = () => {
       if (!dragState.dragging || !dragState.anchor || !dragState.cursor) return;
       const { min, max } = normalizeBlock({
         anchor: dragState.anchor,
@@ -119,11 +119,11 @@ const TimeAvailabilityGrid: React.FC<{ show24: boolean, value: TimeAvailabilityM
       onChange(valueCopy);
       setDragState({ dragging: false });
     };
-    document.addEventListener('mouseup', mouseUpListener);
+    document.addEventListener('pointerup', pointerUpListener);
 
     return () => {
-      document.removeEventListener('mousemove', mouseMoveListener);
-      document.removeEventListener('mouseup', mouseUpListener);
+      document.removeEventListener('pointermove', movePointerListener);
+      document.removeEventListener('pointerup', pointerUpListener);
     };
   }, [value, cellRefs, dragState, mainGrid]);
 
@@ -174,11 +174,7 @@ const TimeAvailabilityGrid: React.FC<{ show24: boolean, value: TimeAvailabilityM
                   key={i}
                   ref={(ref) => { cellRefs[i] = { ref, coord }; }}
                   className={clsx(`relative h-4 border-gray-800 border-r border-b ${borderStyle}`, isBlocked && 'bg-green-400')}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    dragStart(coord);
-                  }}
-                  onTouchStart={(e) => {
+                  onPointerDown={(e) => {
                     e.preventDefault();
                     dragStart(coord);
                   }}


### PR DESCRIPTION
# Description

Explicit handling of [touch events](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events) is only needed when you need to handle complex multi-touch interactions. Since we don't do this, I simplified our event handling by relying on more modern [pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) instead of separate mouse and touch events. This makes the availability form respond to touch drags correctly.

Tested on desktop and mobile variants.

## Issue

Fixes #1351.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

| 📸 | Before | After |
|---------|---|---|
|  | ![before](https://github.com/user-attachments/assets/817adac1-8d34-43ea-866b-98b82b7894b8) | ![after](https://github.com/user-attachments/assets/bb0ea914-0e71-4c8a-b6cd-2880d669945a) |

