### PR TITLE
[feat]: updated carousel arrow styling

### DIFF
--- a/apps/website/src/components/lander/agi-strategy/CommunityMembersSubSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CommunityMembersSubSection.tsx
@@ -89,23 +89,19 @@ const HeaderNavigationButton = ({
     onClick={onClick}
     disabled={disabled}
     className={clsx(
-      'cursor-pointer',
-      'size-12 rounded-full flex items-center justify-center transition-all duration-200',
-      'hover:opacity-100 disabled:cursor-not-allowed',
-      disabled ? 'opacity-30' : 'opacity-30 hover:opacity-60',
+      'size-12 rounded-full flex items-center justify-center',
+      'bg-[rgba(19,19,46,0.08)]',
+      'transition-all duration-200',
+      disabled
+        ? 'opacity-50 cursor-not-allowed'
+        : 'opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer',
     )}
-    style={{
-      background: 'rgba(19, 19, 46, 0.1)',
-    }}
     aria-label={`Scroll ${direction}`}
   >
     <span
-      className="text-[22.4px] font-medium text-[#13132E] inline-flex items-center justify-center"
+      className="text-[#13132E] text-[22.4px] font-medium select-none"
       style={{
         transform: direction === 'left' ? 'scaleX(-1)' : 'none',
-        lineHeight: 1,
-        width: '24px',
-        height: '24px',
       }}
     >
       →


### PR DESCRIPTION
# Description
Since the AGI strategy lander community subsection carousel no longer has a definitive beginning/end, the active-state and hover-state styling was updated for its arrows to reflect that. Also added cursor pointers for the clickable elements.

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
![updated-buttons](https://github.com/user-attachments/assets/9151a786-8e7c-4205-b9f5-34311e6c4645)

