### PR TITLE
[fix]: aspect ratios stay same while scaling down on careers page

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -173,32 +173,32 @@ exports[`JoinUsPage > should render correctly 1`] = `
           >
             <img
               alt="BlueDot Impact team"
-              class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+              class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
               src="/images/culture/culture_dewi_v1.jpeg"
             />
             <img
               alt="BlueDot Impact team"
-              class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+              class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
               src="/images/culture/culture_talking_v2.jpeg"
             />
             <img
               alt="BlueDot Impact team"
-              class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+              class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
               src="/images/culture/culture_cap_v1.jpeg"
             />
             <img
               alt="BlueDot Impact team"
-              class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+              class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
               src="/images/culture/culture_will_v1.jpeg"
             />
             <img
               alt="BlueDot Impact team"
-              class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+              class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
               src="/images/culture/culture_josh_v1.jpg"
             />
             <img
               alt="BlueDot Impact team"
-              class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+              class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
               src="/images/culture/culture_keyboard_v1.jpeg"
             />
           </div>

--- a/apps/website/src/components/join-us/CultureSection.tsx
+++ b/apps/website/src/components/join-us/CultureSection.tsx
@@ -12,12 +12,12 @@ const CultureSection = () => {
           <P>We seek exceptional people who combine a sense of urgency with the empathy to help others thrive, whether that's fellow team members or the thousands of professionals in our global community.</P>
         </div>
         <div className="culture-section__image-grid grid mt-6 grid-cols-2 gap-x-2 gap-y-4 sm:mt-0 sm:grid-cols-3 sm:gap-4">
-          <img className="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm" src="/images/culture/culture_dewi_v1.jpeg" alt="BlueDot Impact team" />
-          <img className="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm" src="/images/culture/culture_talking_v2.jpeg" alt="BlueDot Impact team" />
-          <img className="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm" src="/images/culture/culture_cap_v1.jpeg" alt="BlueDot Impact team" />
-          <img className="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm" src="/images/culture/culture_will_v1.jpeg" alt="BlueDot Impact team" />
-          <img className="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm" src="/images/culture/culture_josh_v1.jpg" alt="BlueDot Impact team" />
-          <img className="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm" src="/images/culture/culture_keyboard_v1.jpeg" alt="BlueDot Impact team" />
+          <img className="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm" src="/images/culture/culture_dewi_v1.jpeg" alt="BlueDot Impact team" />
+          <img className="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm" src="/images/culture/culture_talking_v2.jpeg" alt="BlueDot Impact team" />
+          <img className="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm" src="/images/culture/culture_cap_v1.jpeg" alt="BlueDot Impact team" />
+          <img className="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm" src="/images/culture/culture_will_v1.jpeg" alt="BlueDot Impact team" />
+          <img className="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm" src="/images/culture/culture_josh_v1.jpg" alt="BlueDot Impact team" />
+          <img className="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm" src="/images/culture/culture_keyboard_v1.jpeg" alt="BlueDot Impact team" />
         </div>
       </div>
     </Section>

--- a/apps/website/src/components/join-us/__snapshots__/CultureSection.test.tsx.snap
+++ b/apps/website/src/components/join-us/__snapshots__/CultureSection.test.tsx.snap
@@ -48,32 +48,32 @@ exports[`CultureSection > renders default as expected 1`] = `
         >
           <img
             alt="BlueDot Impact team"
-            class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+            class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
             src="/images/culture/culture_dewi_v1.jpeg"
           />
           <img
             alt="BlueDot Impact team"
-            class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+            class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
             src="/images/culture/culture_talking_v2.jpeg"
           />
           <img
             alt="BlueDot Impact team"
-            class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+            class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
             src="/images/culture/culture_cap_v1.jpeg"
           />
           <img
             alt="BlueDot Impact team"
-            class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+            class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
             src="/images/culture/culture_will_v1.jpeg"
           />
           <img
             alt="BlueDot Impact team"
-            class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+            class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
             src="/images/culture/culture_josh_v1.jpg"
           />
           <img
             alt="BlueDot Impact team"
-            class="culture-section__image max-h-[100px] sm:max-h-[178px] w-full object-cover rounded-sm"
+            class="culture-section__image w-full h-[clamp(100px,_13.5vw,_178px)] object-cover rounded-sm"
             src="/images/culture/culture_keyboard_v1.jpeg"
           />
         </div>


### PR DESCRIPTION
# Description
Aspect ratios on career page images were inconsistent on smaller screen sizes + while scaling down. This fix maintains the ratio of the images to be the same at different screen sizes.

## Issue
Fixes #1361 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Before
![grid-before](https://github.com/user-attachments/assets/e70f15bc-1cab-486d-a1de-0bfeec5c3109)

### After
![grid-after](https://github.com/user-attachments/assets/f66f2d20-bf02-44dd-a1b2-b54dda918323)

