### PR TITLE
Add storybook `/public/` to static dirs

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -18,7 +18,7 @@ const config: StorybookConfig = {
     "../../website/src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../../../libraries/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],
-  staticDirs: ["../../website/public"],
+  staticDirs: ["../../website/public", "../public"],
   core: {
     disableTelemetry: true,
     disableWhatsNewNotifications: true,


### PR DESCRIPTION
# Description

In [this comment](https://github.com/bluedotimpact/bluedot/pull/1392#pullrequestreview-3275200237) @marn-in-prod was running into an issue about a missing MSW. I re-cloned the repo, fresh `npm install` and it worked fine. However, while working today I also ran into the same problem. I spent some time switching branches, trying to figure out why this is temperamentally breaking. I don't really have an answer; I've disabled caching, and yet sometimes the MSW can be found, sometimes not.

Explicitly adding the storybook's `/public/` dir to static dirs seems to fix this.

## Developer checklist

NA

## Screenshot

NA
