### PR TITLE
[Bug] Group switching: Add slack warning for misconfigured buckets

### DIFF
--- a/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/group-switching/available.ts
@@ -229,7 +229,7 @@ export default makeApiRoute({
 
   if (allowedGroups.length === 0) {
     await slackAlert(env, [
-      `[Group switching] Warning for course registration ${participant.id}: No groups allowed to switch into. This is likely due to "Who can switch into this group" field on the user's group not being set correctly.`,
+      `[Group switching] Warning for course registration ${participant.id} (Course runner base id): No groups allowed to switch into. This is likely due to "Who can switch into this group" field on the user's group not being set correctly.`,
     ]);
   }
 


### PR DESCRIPTION
# Description

We have seen a couple of issues with group switching due to the "Who can switch into this group" field not being set on the group. See [previous (closed) issue](https://github.com/bluedotimpact/bluedot/issues/1352) about this for more info, this has happened again since that issue was closed.

Since this is a recurring problem I'm adding a slack alert for specifically this case, to hopefully save time investigating it in future.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1352

## Developer checklist

N/A

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

N/A
