### PR TITLE
[fix]: login + sign up appear in mobile

### DIFF
--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -63,6 +63,7 @@ export const Nav: React.FC<NavProps> = ({
               expandedSections={expandedSections}
               updateExpandedSections={updateExpandedSections}
               isScrolled={isScrolled}
+              isLoggedIn={isLoggedIn}
             />
 
             {/* Logo */}

--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -41,6 +41,23 @@ export const Nav: React.FC<NavProps> = ({
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  // Handle viewport breakpoint changes to reset dropdown states on mobile/desktop transitions
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 1024px)');
+
+    const handleBreakpointChange = () => {
+      setExpandedSections({
+        about: false,
+        explore: false,
+        mobileNav: false,
+        profile: false,
+      });
+    };
+
+    mediaQuery.addEventListener('change', handleBreakpointChange);
+    return () => mediaQuery.removeEventListener('change', handleBreakpointChange);
+  }, []);
+
   return (
     <nav
       className={clsx(

--- a/apps/website/src/components/Nav/_MobileNavLinks.tsx
+++ b/apps/website/src/components/Nav/_MobileNavLinks.tsx
@@ -1,19 +1,27 @@
 import clsx from 'clsx';
-import { IconButton } from '@bluedot/ui';
+import { IconButton, CTALinkOrButton } from '@bluedot/ui';
 import { HamburgerIcon } from '@bluedot/ui/src/IconButton';
+import { useRouter } from 'next/router';
 
 import { NavLinks } from './_NavLinks';
 import { DRAWER_CLASSES, ExpandedSectionsState } from './utils';
+import { getLoginUrl } from '../../utils/getLoginUrl';
 
 export const MobileNavLinks: React.FC<{
   expandedSections: ExpandedSectionsState;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
   isScrolled: boolean;
+  isLoggedIn: boolean;
 }> = ({
   expandedSections,
   updateExpandedSections,
   isScrolled,
+  isLoggedIn,
 }) => {
+  const router = useRouter();
+  const loginUrl = getLoginUrl(router.asPath);
+  const joinUrl = getLoginUrl(router.asPath, true);
+
   const onToggleMobileNav = () => {
     updateExpandedSections({
       mobileNav: !expandedSections.mobileNav,
@@ -63,6 +71,30 @@ export const MobileNavLinks: React.FC<{
             updateExpandedSections={updateExpandedSections}
             isScrolled={isScrolled}
           />
+
+          {/* CTA Buttons for mobile - prevent duplication with navbar buttons */}
+          {!isLoggedIn && (
+            <div className="mobile-nav-cta flex flex-wrap gap-3 pt-6 mt-6 border-t border-color-divider">
+              {/* Login button: Show when screen < 640px (since navbar login is hidden below 640px) */}
+              <CTALinkOrButton
+                className={`mobile-nav-cta__login max-[639px]:flex hidden ${
+                  isScrolled ? 'border-white text-white hover:bg-white/10' : ''
+                }`}
+                variant="secondary"
+                url={loginUrl}
+              >
+                Login
+              </CTALinkOrButton>
+              {/* Join button: Show when screen < 640px (same as Login for unified breakpoint) */}
+              <CTALinkOrButton
+                className="mobile-nav-cta__join max-[639px]:flex hidden"
+                variant="primary"
+                url={joinUrl}
+              >
+                Join for free
+              </CTALinkOrButton>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/website/src/components/Nav/_MobileNavLinks.tsx
+++ b/apps/website/src/components/Nav/_MobileNavLinks.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import clsx from 'clsx';
 import { IconButton, CTALinkOrButton } from '@bluedot/ui';
 import { HamburgerIcon } from '@bluedot/ui/src/IconButton';
@@ -74,7 +76,7 @@ export const MobileNavLinks: React.FC<{
 
           {/* CTA Buttons for mobile - prevent duplication with navbar buttons */}
           {!isLoggedIn && (
-            <div className="mobile-nav-cta flex flex-wrap gap-3 pt-6 mt-6 border-t border-color-divider">
+            <div className="mobile-nav-cta flex flex-col gap-4 pt-6 mt-6 border-t border-color-divider">
               {/* Login button: Show when screen < 640px (since navbar login is hidden below 640px) */}
               <CTALinkOrButton
                 className={`mobile-nav-cta__login max-[639px]:flex hidden ${

--- a/apps/website/src/components/Nav/_NavCta.tsx
+++ b/apps/website/src/components/Nav/_NavCta.tsx
@@ -51,7 +51,7 @@ export const NavCta: React.FC<{
             Login
           </CTALinkOrButton>
           <CTALinkOrButton
-            className="nav-cta__primary-cta min-[370px]:flex hidden" // Hide on very small screens smaller than 380px
+            className="nav-cta__primary-cta hidden sm:flex" // Hide on small screens (same as Login)
             variant="primary"
             url={joinUrl}
           >

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -200,6 +200,24 @@ exports[`Nav > renders with courses 1`] = `
                   We're hiring!
                 </a>
               </div>
+              <div
+                class="mobile-nav-cta flex flex-wrap gap-3 pt-6 mt-6 border-t border-color-divider"
+              >
+                <a
+                  class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter mobile-nav-cta__login max-[639px]:flex hidden"
+                  href="http://localhost:3000/login?redirect_to=%2Ftest-page"
+                  tabindex="0"
+                >
+                  Login
+                </a>
+                <a
+                  class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark mobile-nav-cta__join max-[639px]:flex hidden"
+                  href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-page"
+                  tabindex="0"
+                >
+                  Join for free
+                </a>
+              </div>
             </div>
           </div>
         </div>
@@ -373,7 +391,7 @@ exports[`Nav > renders with courses 1`] = `
             Login
           </a>
           <a
-            class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav-cta__primary-cta min-[370px]:flex hidden"
+            class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav-cta__primary-cta hidden sm:flex"
             href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-page"
             tabindex="0"
           >

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`Nav > renders with courses 1`] = `
                 </a>
               </div>
               <div
-                class="mobile-nav-cta flex flex-wrap gap-3 pt-6 mt-6 border-t border-color-divider"
+                class="mobile-nav-cta flex flex-col gap-4 pt-6 mt-6 border-t border-color-divider"
               >
                 <a
                   class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter mobile-nav-cta__login max-[639px]:flex hidden"

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -205,14 +205,14 @@ exports[`Nav > renders with courses 1`] = `
               >
                 <a
                   class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter mobile-nav-cta__login max-[639px]:flex hidden"
-                  href="http://localhost:3000/login?redirect_to=%2Ftest-page"
+                  href="/login?redirect_to=%2Ftest-page"
                   tabindex="0"
                 >
                   Login
                 </a>
                 <a
                   class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark mobile-nav-cta__join max-[639px]:flex hidden"
-                  href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-page"
+                  href="/login?register=true&redirect_to=%2Ftest-page"
                   tabindex="0"
                 >
                   Join for free
@@ -385,14 +385,14 @@ exports[`Nav > renders with courses 1`] = `
         >
           <a
             class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter nav-cta__secondary-cta hidden sm:block"
-            href="http://localhost:3000/login?redirect_to=%2Ftest-page"
+            href="/login?redirect_to=%2Ftest-page"
             tabindex="0"
           >
             Login
           </a>
           <a
             class="cta-button items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark nav-cta__primary-cta hidden sm:flex"
-            href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-page"
+            href="/login?register=true&redirect_to=%2Ftest-page"
             tabindex="0"
           >
             Join for free

--- a/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse, delay } from 'msw';
 import type { Course, Unit } from '@bluedot/db';
 import GroupSwitchModal from './GroupSwitchModal';

--- a/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse, delay } from 'msw';
 import type { Course, Unit } from '@bluedot/db';
 import GroupSwitchModal from './GroupSwitchModal';

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
     >
       <a
         class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark !w-auto !whitespace-normal text-center min-w-0"
-        href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-path"
+        href="/login?register=true&redirect_to=%2Ftest-path"
         tabindex="0"
       >
         Create a free account to save your answers

--- a/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/MultipleChoice.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`MultipleChoice > renders default as expected 1`] = `
       </div>
       <a
         class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark !bg-[#2244BB] !whitespace-normal"
-        href="http://localhost:3000/login?register=true&redirect_to=%2Ftest-path"
+        href="/login?register=true&redirect_to=%2Ftest-path"
         tabindex="0"
       >
         Create a free account to check your answer

--- a/apps/website/src/components/settings/__snapshots__/CourseListRow.test.tsx.snap
+++ b/apps/website/src/components/settings/__snapshots__/CourseListRow.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`CourseListRow > renders completed course correctly (snapshot) 1`] = `
           >
             <a
               class="cta-button flex items-center justify-center transition-all duration-200 whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-[13px] px-3 py-2.5 h-9 rounded-md font-semibold cta-button--black bg-bluedot-darker link-on-dark hover:bg-bluedot-darkest w-full"
-              href="http://localhost:3000/certification?id=cert-123"
+              href="/certification?id=cert-123"
               tabindex="0"
             >
               View your certificate
@@ -109,7 +109,7 @@ exports[`CourseListRow > renders completed course correctly (snapshot) 1`] = `
           >
             <a
               class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-[13px] px-3 py-2.5 h-9 rounded-md font-semibold cta-button--black bg-bluedot-darker link-on-dark hover:bg-bluedot-darkest"
-              href="http://localhost:3000/certification?id=cert-123"
+              href="/certification?id=cert-123"
               tabindex="0"
             >
               View your certificate

--- a/libraries/ui/src/utils/addQueryParam.test.ts
+++ b/libraries/ui/src/utils/addQueryParam.test.ts
@@ -23,7 +23,7 @@ describe('addQueryParam', () => {
   test('adds query parameter to relative path URL', () => {
     const url = '/login';
     const result = addQueryParam(url, 'key', 'value');
-    expect(result).toBe('http://localhost:3000/login?key=value');
+    expect(result).toBe('/login?key=value');
   });
 
   test('can set param with empty string key', () => {
@@ -38,7 +38,8 @@ describe('addQueryParam', () => {
     expect(result).toBe('https://example.com/?key=');
   });
 
-  test('throws error when URL is empty', () => {
-    expect(() => addQueryParam('', 'key', 'value')).toThrow('URL is required');
+  test('handles empty URL', () => {
+    const result = addQueryParam('', 'key', 'value');
+    expect(result).toBe('?key=value');
   });
 });

--- a/libraries/ui/src/utils/addQueryParam.ts
+++ b/libraries/ui/src/utils/addQueryParam.ts
@@ -1,14 +1,17 @@
 export const addQueryParam = (url: string, key: string, value: string) => {
-  if (!url) {
-    throw new Error('addQueryParam: URL is required');
+  // Try to parse as absolute URL first
+  try {
+    const urlObj = new URL(url);
+    urlObj.searchParams.set(key, value);
+    return urlObj.toString();
+  } catch {
+    // Handle as relative URL (including empty strings)
+    const [pathAndSearch = '', hash = ''] = url.split('#');
+    const [path = '', existingSearch = ''] = pathAndSearch.split('?');
+
+    const params = new URLSearchParams(existingSearch);
+    params.set(key, value);
+
+    return `${path}?${params.toString()}${hash ? `#${hash}` : ''}`;
   }
-
-  // Handle SSR: use a base URL when window is not available
-  const base = typeof window !== 'undefined'
-    ? window.location.origin
-    : 'https://bluedot.org'; // Default base for SSR
-
-  const urlObj = new URL(url, base);
-  urlObj.searchParams.set(key, value);
-  return urlObj.toString();
 };

--- a/libraries/ui/src/utils/addQueryParam.ts
+++ b/libraries/ui/src/utils/addQueryParam.ts
@@ -2,7 +2,13 @@ export const addQueryParam = (url: string, key: string, value: string) => {
   if (!url) {
     throw new Error('addQueryParam: URL is required');
   }
-  const urlObj = new URL(url, window.location.origin);
+
+  // Handle SSR: use a base URL when window is not available
+  const base = typeof window !== 'undefined'
+    ? window.location.origin
+    : 'https://bluedot.org'; // Default base for SSR
+
+  const urlObj = new URL(url, base);
   urlObj.searchParams.set(key, value);
   return urlObj.toString();
 };


### PR DESCRIPTION
# Description
Fixes critical issue where login/signup buttons were inaccessible on small mobile devices (<370px width), preventing users from creating accounts or logging in and likely causing user drop off. Added login/signup CTA buttons to the mobile navigation drawer for smaller screens, where buttons appear in either the navbar **or** mobile drawer (never both). Chose to stack buttons in mobile to accommodate for more screen sizes.

At the same time, fixed another navbar dropdown alignment bug that occurred when resizing between mobile/desktop viewports!

## Issue
Fixes #1396 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
![button-nav-fix-desktop-mobile](https://github.com/user-attachments/assets/328b26e1-a597-4d06-84ad-4aeacdcf8f8a)
