### PR TITLE
[Bug] Render SEO related content server side: course lander, blog posts, job openings, projects, certificates

### DIFF
--- a/apps/website/src/components/lander/FutureOfAiLander.tsx
+++ b/apps/website/src/components/lander/FutureOfAiLander.tsx
@@ -20,7 +20,7 @@ import {
 } from 'react-icons/fa6';
 import { useEffect } from 'react';
 
-import { GetCourseResponse } from '../../pages/api/courses/[courseSlug]';
+import { CourseAndUnits } from '../../pages/api/courses/[courseSlug]';
 import { H1, H2, H3 } from '../Text';
 import TestimonialSubSection, { Testimonial } from '../homepage/CommunitySection/TestimonialSubSection';
 import GraduateSection from '../homepage/GraduateSection';
@@ -115,7 +115,7 @@ const features = [
 
 const FutureOfAiLander = ({
   courseData,
-}: { courseData: GetCourseResponse }) => {
+}: { courseData: CourseAndUnits }) => {
   // Track landing page views
   useEffect(() => {
     if (typeof window !== 'undefined' && window.dataLayer) {

--- a/apps/website/src/pages/api/certificates/[certificateId].ts
+++ b/apps/website/src/pages/api/certificates/[certificateId].ts
@@ -19,6 +19,23 @@ export type GetCertificateResponse = {
   certificate: Certificate;
 };
 
+export async function getCertificateData(certificateId: string): Promise<Certificate> {
+  const courseRegistration = await db.get(courseRegistrationTable, { certificateId });
+  const course = await db.get(courseTable, { id: courseRegistration.courseId });
+
+  const certificate: Certificate = {
+    certificateId,
+    certificateCreatedAt: courseRegistration.certificateCreatedAt ?? Date.now() / 1000,
+    recipientName: courseRegistration.fullName,
+    courseName: course.title,
+    courseDetailsUrl: course.detailsUrl,
+    certificationDescription: course.certificationDescription || '',
+    certificationBadgeImageSrc: course.certificationBadgeImage || '',
+  };
+
+  return certificate;
+}
+
 export default makeApiRoute({
   requireAuth: false,
   responseBody: z.object({
@@ -31,19 +48,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Missing certificateId');
   }
 
-  const courseRegistration = await db.get(courseRegistrationTable, { certificateId });
-
-  const course = await db.get(courseTable, { id: courseRegistration.courseId });
-
-  const certificate: Certificate = {
-    certificateId,
-    certificateCreatedAt: courseRegistration.certificateCreatedAt ?? Date.now() / 1000,
-    recipientName: courseRegistration.fullName,
-    courseName: course.title,
-    courseDetailsUrl: course.detailsUrl,
-    certificationDescription: course.certificationDescription || '',
-    certificationBadgeImageSrc: course.certificationBadgeImage || '',
-  };
+  const certificate = await getCertificateData(certificateId);
 
   return {
     type: 'success' as const,

--- a/apps/website/src/pages/api/cms/blogs/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/blogs/[slug]/index.ts
@@ -36,6 +36,8 @@ export default makeApiRoute({
       blog,
     };
   } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching blog post:', slug, error);
     throw new createHttpError.NotFound('Blog post not found');
   }
 });

--- a/apps/website/src/pages/api/cms/blogs/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/blogs/[slug]/index.ts
@@ -28,10 +28,14 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const blog = await getBlogIfPublished(slug);
+  try {
+    const blog = await getBlogIfPublished(slug);
 
-  return {
-    type: 'success' as const,
-    blog,
-  };
+    return {
+      type: 'success' as const,
+      blog,
+    };
+  } catch (error) {
+    throw new createHttpError.NotFound('Blog post not found');
+  }
 });

--- a/apps/website/src/pages/api/cms/blogs/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/blogs/[slug]/index.ts
@@ -12,13 +12,7 @@ export type GetBlogResponse = {
 };
 
 export async function getBlogIfPublished(slug: string): Promise<Blog> {
-  // Get blog by slug and filter out unpublished ones
   const blog = await db.get(blogTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
-
-  if (!blog) {
-    throw new createHttpError.NotFound(`Blog not found: ${slug}`);
-  }
-
   return blog;
 }
 

--- a/apps/website/src/pages/api/cms/jobs/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/jobs/[slug]/index.ts
@@ -36,6 +36,8 @@ export default makeApiRoute({
       job,
     };
   } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching job listing:', slug, error);
     throw new createHttpError.NotFound('Job listing not found');
   }
 });

--- a/apps/website/src/pages/api/cms/jobs/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/jobs/[slug]/index.ts
@@ -28,10 +28,14 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const job = await getJobIfPublished(slug);
+  try {
+    const job = await getJobIfPublished(slug);
 
-  return {
-    type: 'success' as const,
-    job,
-  };
+    return {
+      type: 'success' as const,
+      job,
+    };
+  } catch (error) {
+    throw new createHttpError.NotFound('Job listing not found');
+  }
 });

--- a/apps/website/src/pages/api/cms/jobs/index.ts
+++ b/apps/website/src/pages/api/cms/jobs/index.ts
@@ -10,13 +10,7 @@ export type GetJobsResponse = {
   jobs: Omit<CmsJobPosting, 'body'>[],
 };
 
-export default makeApiRoute({
-  requireAuth: false,
-  responseBody: z.object({
-    type: z.literal('success'),
-    jobs: z.array(z.any()),
-  }),
-}, async () => {
+export const getAllPublishedJobs = async () => {
   const allJobs = await db.scan(jobPostingTable, { publicationStatus: 'Published' });
 
   // Sort jobs alphabetically by title and remove the body field from each job to make the response lighter
@@ -24,8 +18,20 @@ export default makeApiRoute({
     .sort((a, b) => (a.title).localeCompare(b.title))
     .map(({ body, ...rest }) => rest);
 
+  return jobSummaries;
+};
+
+export default makeApiRoute({
+  requireAuth: false,
+  responseBody: z.object({
+    type: z.literal('success'),
+    jobs: z.array(z.any()),
+  }),
+}, async () => {
+  const jobs = await getAllPublishedJobs();
+
   return {
     type: 'success' as const,
-    jobs: jobSummaries,
+    jobs,
   };
 });

--- a/apps/website/src/pages/api/cms/jobs/index.ts
+++ b/apps/website/src/pages/api/cms/jobs/index.ts
@@ -10,17 +10,6 @@ export type GetJobsResponse = {
   jobs: Omit<CmsJobPosting, 'body'>[],
 };
 
-export const getAllPublishedJobs = async () => {
-  const allJobs = await db.scan(jobPostingTable, { publicationStatus: 'Published' });
-
-  // Sort jobs alphabetically by title and remove the body field from each job to make the response lighter
-  const jobSummaries = allJobs
-    .sort((a, b) => (a.title).localeCompare(b.title))
-    .map(({ body, ...rest }) => rest);
-
-  return jobSummaries;
-};
-
 export default makeApiRoute({
   requireAuth: false,
   responseBody: z.object({
@@ -28,10 +17,15 @@ export default makeApiRoute({
     jobs: z.array(z.any()),
   }),
 }, async () => {
-  const jobs = await getAllPublishedJobs();
+  const allJobs = await db.scan(jobPostingTable, { publicationStatus: 'Published' });
+
+  // Sort jobs alphabetically by title and remove the body field from each job to make the response lighter
+  const jobSummaries = allJobs
+    .sort((a, b) => (a.title).localeCompare(b.title))
+    .map(({ body, ...rest }) => rest);
 
   return {
     type: 'success' as const,
-    jobs,
+    jobs: jobSummaries,
   };
 });

--- a/apps/website/src/pages/api/cms/projects/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/projects/[slug]/index.ts
@@ -28,10 +28,14 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  const project = await getProjectIfPublished(slug);
+  try {
+    const project = await getProjectIfPublished(slug);
 
-  return {
-    type: 'success' as const,
-    project,
-  };
+    return {
+      type: 'success' as const,
+      project,
+    };
+  } catch (error) {
+    throw new createHttpError.NotFound('Project not found');
+  }
 });

--- a/apps/website/src/pages/api/cms/projects/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/projects/[slug]/index.ts
@@ -1,17 +1,20 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
-  projectTable, InferSelectModel,
+  projectTable, Project,
 } from '@bluedot/db';
 import db from '../../../../../lib/api/db';
 import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
 
-type CmsProject = InferSelectModel<typeof projectTable.pg>;
-
 export type GetProjectResponse = {
   type: 'success',
-  project: CmsProject,
+  project: Project,
 };
+
+export async function getProjectIfPublished(slug: string): Promise<Project> {
+  const project = await db.get(projectTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
+  return project;
+}
 
 export default makeApiRoute({
   requireAuth: false,
@@ -25,8 +28,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid slug');
   }
 
-  // Get project by slug and filter out unpublished ones
-  const project = await db.get(projectTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
+  const project = await getProjectIfPublished(slug);
 
   return {
     type: 'success' as const,

--- a/apps/website/src/pages/api/cms/projects/[slug]/index.ts
+++ b/apps/website/src/pages/api/cms/projects/[slug]/index.ts
@@ -36,6 +36,8 @@ export default makeApiRoute({
       project,
     };
   } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching project:', slug, error);
     throw new createHttpError.NotFound('Project not found');
   }
 });

--- a/apps/website/src/pages/api/courses/[courseSlug]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/index.ts
@@ -1,20 +1,45 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
-  courseTable, unitTable, InferSelectModel,
+  courseTable,
+  unitTable,
+  Course,
+  Unit,
 } from '@bluedot/db';
 import db from '../../../../lib/api/db';
 import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
 import { unitFilterActiveChunks } from '../../../../lib/api/utils';
 
-type Course = InferSelectModel<typeof courseTable.pg>;
-type Unit = InferSelectModel<typeof unitTable.pg>;
-
-export type GetCourseResponse = {
-  type: 'success',
+export type CourseAndUnits = {
   course: Course,
   units: Unit[],
 };
+
+export type GetCourseResponse = {
+  type: 'success',
+} & CourseAndUnits;
+
+/**
+ * Fetches course data and its associated units by course slug.
+ * This function is shared between the API route below and getStaticProps/getServerSideProps when needed.
+ */
+export async function getCourseData(courseSlug: string): Promise<CourseAndUnits> {
+  const course = await db.get(courseTable, { slug: courseSlug });
+
+  if (!course) {
+    throw new createHttpError.NotFound(`Course not found: ${courseSlug}`);
+  }
+
+  // Get units for this course with active status, then sort by unit number
+  const allUnitsWithAllChunks = await db.scan(unitTable, { courseSlug, unitStatus: 'Active' });
+  const allUnits = await unitFilterActiveChunks({ units: allUnitsWithAllChunks, db });
+  const units = allUnits.sort((a, b) => (a.unitNumber || '').localeCompare(b.unitNumber || ''));
+
+  return {
+    course,
+    units,
+  };
+}
 
 export default makeApiRoute({
   requireAuth: false,
@@ -29,12 +54,7 @@ export default makeApiRoute({
     throw new createHttpError.BadRequest('Invalid course slug');
   }
 
-  const course = await db.get(courseTable, { slug: courseSlug });
-
-  // Get units for this course with active status, then sort by unit number
-  const allUnitsWithAllChunks = await db.scan(unitTable, { courseSlug, unitStatus: 'Active' });
-  const allUnits = await unitFilterActiveChunks({ units: allUnitsWithAllChunks, db });
-  const units = allUnits.sort((a, b) => (a.unitNumber || '').localeCompare(b.unitNumber || ''));
+  const { course, units } = await getCourseData(courseSlug);
 
   return {
     type: 'success' as const,

--- a/apps/website/src/pages/api/courses/[courseSlug]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/index.ts
@@ -26,10 +26,6 @@ export type GetCourseResponse = {
 export async function getCourseData(courseSlug: string): Promise<CourseAndUnits> {
   const course = await db.get(courseTable, { slug: courseSlug });
 
-  if (!course) {
-    throw new createHttpError.NotFound(`Course not found: ${courseSlug}`);
-  }
-
   // Get units for this course with active status, then sort by unit number
   const allUnitsWithAllChunks = await db.scan(unitTable, { courseSlug, unitStatus: 'Active' });
   const allUnits = await unitFilterActiveChunks({ units: allUnitsWithAllChunks, db });

--- a/apps/website/src/pages/blog/[slug].tsx
+++ b/apps/website/src/pages/blog/[slug].tsx
@@ -8,12 +8,11 @@ import {
   BluedotRoute,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { GetStaticProps, GetStaticPaths } from 'next';
+import { GetServerSideProps } from 'next';
 import { Blog } from '@bluedot/db';
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import { ROUTES } from '../../lib/routes';
 import { getBlogIfPublished } from '../api/cms/blogs/[slug]';
-import { getAllPublishedBlogs } from '../api/cms/blogs';
 import MarkdownExtendedRenderer from '../../components/courses/MarkdownExtendedRenderer';
 import { A } from '../../components/Text';
 
@@ -102,19 +101,7 @@ const BlogPostPage = ({ slug, blog }: BlogPostPageProps) => {
   );
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  const blogs = await getAllPublishedBlogs();
-  const paths = blogs.map((blog) => ({
-    params: { slug: blog.slug },
-  }));
-
-  return {
-    paths,
-    fallback: 'blocking',
-  };
-};
-
-export const getStaticProps: GetStaticProps<BlogPostPageProps> = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async ({ params }) => {
   const slug = params?.slug as string;
 
   if (!slug) {
@@ -131,7 +118,6 @@ export const getStaticProps: GetStaticProps<BlogPostPageProps> = async ({ params
         slug,
         blog,
       },
-      revalidate: 60,
     };
   } catch (error) {
     // Error fetching blog data (likely not found)

--- a/apps/website/src/pages/blog/[slug].tsx
+++ b/apps/website/src/pages/blog/[slug].tsx
@@ -38,65 +38,61 @@ const BlogPostPage = ({ slug, blog }: BlogPostPageProps) => {
 
   return (
     <div>
-      {blog && (
-        <>
-          <Head>
-            <title>{`${blog.title} | BlueDot Impact`}</title>
-            <meta name="description" content={`${blog.title} - Blog post by ${blog.authorName}`} />
-            <meta key="og:title" property="og:title" content={blog.title} />
-            <meta key="og:site_name" property="og:site_name" content="BlueDot Impact" />
-            <meta key="og:description" property="og:description" content={blog.title} />
-            <meta key="og:type" property="og:type" content="article" />
-            <meta key="og:url" property="og:url" content={`https://bluedot.org/blog/${encodeURIComponent(slug)}`} />
-            <script
-              type="application/ld+json"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{
-                __html: JSON.stringify({
-                  '@context': 'https://schema.org',
-                  '@type': 'BlogPosting',
-                  headline: blog.title,
-                  author: {
-                    '@type': 'Person',
-                    name: blog.authorName,
-                    url: blog.authorUrl,
-                  },
-                  ...(blog.publishedAt ? {
-                    datePublished: new Date(blog.publishedAt * 1000).toISOString(),
-                    dateModified: new Date(blog.publishedAt * 1000).toISOString(),
-                  } : {}),
-                  mainEntityOfPage: {
-                    '@type': 'WebPage',
-                    '@id': `${ROUTES.blog.url}/${slug}`,
-                  },
-                  description: blog.title,
-                  publisher: {
-                    '@type': 'Organization',
-                    name: 'BlueDot Impact',
-                    url: 'https://bluedot.org',
-                  },
-                }),
-              }}
-            />
-          </Head>
-          <HeroSection>
-            <HeroMiniTitle>Blog</HeroMiniTitle>
-            <HeroH1>{blog.title}</HeroH1>
-            <HeroH2><A href={blog.authorUrl || '#'} className="text-white">{blog.authorName || 'Unknown Author'}</A> • {formattedDate}</HeroH2>
-          </HeroSection>
-          <Breadcrumbs route={currentRoute} />
-          <Section className="max-w-3xl">
-            <MarkdownExtendedRenderer>
-              {blog.body ?? ''}
-            </MarkdownExtendedRenderer>
-            <div className="my-8 border-t border-color-divider pt-8">
-              <CTALinkOrButton url={ROUTES.blog.url} variant="secondary" withBackChevron>
-                See our other articles
-              </CTALinkOrButton>
-            </div>
-          </Section>
-        </>
-      )}
+      <Head>
+        <title>{`${blog.title} | BlueDot Impact`}</title>
+        <meta name="description" content={`${blog.title} - Blog post by ${blog.authorName}`} />
+        <meta key="og:title" property="og:title" content={blog.title} />
+        <meta key="og:site_name" property="og:site_name" content="BlueDot Impact" />
+        <meta key="og:description" property="og:description" content={blog.title} />
+        <meta key="og:type" property="og:type" content="article" />
+        <meta key="og:url" property="og:url" content={`https://bluedot.org/blog/${encodeURIComponent(slug)}`} />
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'BlogPosting',
+              headline: blog.title,
+              author: {
+                '@type': 'Person',
+                name: blog.authorName,
+                url: blog.authorUrl,
+              },
+              ...(blog.publishedAt ? {
+                datePublished: new Date(blog.publishedAt * 1000).toISOString(),
+                dateModified: new Date(blog.publishedAt * 1000).toISOString(),
+              } : {}),
+              mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': `${ROUTES.blog.url}/${slug}`,
+              },
+              description: blog.title,
+              publisher: {
+                '@type': 'Organization',
+                name: 'BlueDot Impact',
+                url: 'https://bluedot.org',
+              },
+            }),
+          }}
+        />
+      </Head>
+      <HeroSection>
+        <HeroMiniTitle>Blog</HeroMiniTitle>
+        <HeroH1>{blog.title}</HeroH1>
+        <HeroH2><A href={blog.authorUrl || '#'} className="text-white">{blog.authorName || 'Unknown Author'}</A> • {formattedDate}</HeroH2>
+      </HeroSection>
+      <Breadcrumbs route={currentRoute} />
+      <Section className="max-w-3xl">
+        <MarkdownExtendedRenderer>
+          {blog.body ?? ''}
+        </MarkdownExtendedRenderer>
+        <div className="my-8 border-t border-color-divider pt-8">
+          <CTALinkOrButton url={ROUTES.blog.url} variant="secondary" withBackChevron>
+            See our other articles
+          </CTALinkOrButton>
+        </div>
+      </Section>
     </div>
   );
 };

--- a/apps/website/src/pages/blog/[slug].tsx
+++ b/apps/website/src/pages/blog/[slug].tsx
@@ -8,7 +8,7 @@ import {
   BluedotRoute,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps, GetStaticPaths } from 'next';
 import { Blog } from '@bluedot/db';
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import { ROUTES } from '../../lib/routes';
@@ -97,7 +97,16 @@ const BlogPostPage = ({ slug, blog }: BlogPostPageProps) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async ({ params }) => {
+export const getStaticPaths: GetStaticPaths = async () => {
+  // CI is not currently set up to support connecting to the database at build
+  // time, so return no paths, and rely on `fallback: 'blocking'` to render the pages on demand.
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
+
+export const getStaticProps: GetStaticProps<BlogPostPageProps> = async ({ params }) => {
   const slug = params?.slug as string;
 
   if (!slug) {
@@ -114,6 +123,7 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
         slug,
         blog,
       },
+      revalidate: 300,
     };
   } catch (error) {
     // Error fetching blog data (likely not found)

--- a/apps/website/src/pages/certification.tsx
+++ b/apps/website/src/pages/certification.tsx
@@ -99,7 +99,7 @@ const CertificatePage = ({ certificate, certificateId }: CertificatePageProps) =
   );
 };
 
-export const getServerSideProps: GetServerSideProps<CertificatePageProps> = async ({ query }) => {
+export const getServerSideProps: GetServerSideProps<CertificatePageProps> = async ({ query, res }) => {
   const certificateId = (query.id || query.r) as string | undefined;
 
   if (!certificateId) {
@@ -113,6 +113,13 @@ export const getServerSideProps: GetServerSideProps<CertificatePageProps> = asyn
 
   try {
     const certificate = await getCertificateData(certificateId);
+
+    // Equivalent to `revalidate: 300` in getStaticProps. That can't be used here because we are
+    // using query params rather than path params.
+    res.setHeader(
+      'Cache-Control',
+      'public, max-age=300, stale-while-revalidate=86400',
+    );
 
     return {
       props: {

--- a/apps/website/src/pages/certification.tsx
+++ b/apps/website/src/pages/certification.tsx
@@ -122,6 +122,8 @@ export const getServerSideProps: GetServerSideProps<CertificatePageProps> = asyn
     };
   } catch (error) {
     // Certificate not found or error fetching
+    // eslint-disable-next-line no-console
+    console.error('Error fetching certificate:', certificateId, error);
     return {
       props: {
         certificate: null,

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -25,7 +25,7 @@ type CoursePageProps = {
 const CoursePage = ({ courseSlug, courseData }: CoursePageProps) => {
   return (
     <div>
-      {courseData?.course && renderCoursePage({ slug: courseSlug, courseData })}
+      {renderCoursePage({ slug: courseSlug, courseData })}
     </div>
   );
 };

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -6,7 +6,7 @@ import {
   HeroSection,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps, GetStaticPaths } from 'next';
 import { CourseAndUnits, getCourseData } from '../../api/courses/[courseSlug]';
 
 import { ROUTES } from '../../../lib/routes';
@@ -88,7 +88,16 @@ const StandardCoursePage = ({ courseData }: { courseData: CourseAndUnits }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps<CoursePageProps> = async ({ params }) => {
+export const getStaticPaths: GetStaticPaths = async () => {
+  // CI is not currently set up to support connecting to the database at build
+  // time, so return no paths, and rely on `fallback: 'blocking'` to render the pages on demand.
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
+
+export const getStaticProps: GetStaticProps<CoursePageProps> = async ({ params }) => {
   const courseSlug = params?.courseSlug as string;
 
   if (!courseSlug) {
@@ -105,6 +114,7 @@ export const getServerSideProps: GetServerSideProps<CoursePageProps> = async ({ 
         courseSlug,
         courseData,
       },
+      revalidate: 300,
     };
   } catch (error) {
     // Error fetching course data (likely not found)

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -6,8 +6,7 @@ import {
   HeroSection,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { GetStaticProps, GetStaticPaths } from 'next';
-import { getAllActiveCourses } from '../../api/courses';
+import { GetServerSideProps } from 'next';
 import { CourseAndUnits, getCourseData } from '../../api/courses/[courseSlug]';
 
 import { ROUTES } from '../../../lib/routes';
@@ -89,19 +88,7 @@ const StandardCoursePage = ({ courseData }: { courseData: CourseAndUnits }) => {
   );
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  const courses = await getAllActiveCourses();
-  const paths = courses.map((course) => ({
-    params: { courseSlug: course.slug },
-  }));
-
-  return {
-    paths,
-    fallback: 'blocking',
-  };
-};
-
-export const getStaticProps: GetStaticProps<CoursePageProps> = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps<CoursePageProps> = async ({ params }) => {
   const courseSlug = params?.courseSlug as string;
 
   if (!courseSlug) {
@@ -118,7 +105,6 @@ export const getStaticProps: GetStaticProps<CoursePageProps> = async ({ params }
         courseSlug,
         courseData,
       },
-      revalidate: 60,
     };
   } catch (error) {
     // Error fetching course data (likely not found)

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -1,18 +1,16 @@
 import {
   Breadcrumbs,
   CTALinkOrButton,
-  ErrorSection,
   HeroCTAContainer,
   HeroH1,
   HeroSection,
-  ProgressDots,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import useAxios from 'axios-hooks';
-import { useRouter } from 'next/router';
+import { GetStaticProps, GetStaticPaths } from 'next';
+import { getAllActiveCourses } from '../../api/courses';
+import { CourseAndUnits, getCourseData } from '../../api/courses/[courseSlug]';
 
 import { ROUTES } from '../../../lib/routes';
-import { GetCourseResponse } from '../../api/courses/[courseSlug]';
 import MarkdownExtendedRenderer from '../../../components/courses/MarkdownExtendedRenderer';
 import FutureOfAiLander from '../../../components/lander/FutureOfAiLander';
 import AiSafetyOpsLander from '../../../components/lander/AiSafetyOpsLander';
@@ -20,32 +18,24 @@ import AgiStrategyLander from '../../../components/lander/AgiStrategyLander';
 import GraduateSection from '../../../components/homepage/GraduateSection';
 import { CourseUnitsSection } from '../../../components/courses/CourseUnitsSection';
 
-const CoursePage = () => {
-  const { query: { courseSlug } } = useRouter();
+type CoursePageProps = {
+  courseSlug: string;
+  courseData: CourseAndUnits;
+};
 
-  if (typeof courseSlug !== 'string') {
-    return <ProgressDots />;
-  }
-
-  const [{ data, loading, error }] = useAxios<GetCourseResponse>({
-    method: 'get',
-    url: `/api/courses/${courseSlug}`,
-  });
-
+const CoursePage = ({ courseSlug, courseData }: CoursePageProps) => {
   return (
     <div>
-      {loading && <ProgressDots />}
-      {error && <ErrorSection error={error} />}
-      {data?.course && renderCoursePage(courseSlug, data)}
+      {courseData?.course && renderCoursePage({ slug: courseSlug, courseData })}
     </div>
   );
 };
 
 // Helper function to render the appropriate course page based on slug
-const renderCoursePage = (slug: string, data: GetCourseResponse) => {
+const renderCoursePage = ({ slug, courseData }: { slug: string; courseData: CourseAndUnits; }) => {
   // Custom lander cases
   if (slug === 'future-of-ai') {
-    return <FutureOfAiLander courseData={data} />;
+    return <FutureOfAiLander courseData={courseData} />;
   }
 
   if (slug === 'ops') {
@@ -57,10 +47,10 @@ const renderCoursePage = (slug: string, data: GetCourseResponse) => {
   }
 
   // Default case
-  return <StandardCoursePage courseData={data} />;
+  return <StandardCoursePage courseData={courseData} />;
 };
 
-const StandardCoursePage = ({ courseData }: { courseData: GetCourseResponse }) => {
+const StandardCoursePage = ({ courseData }: { courseData: CourseAndUnits }) => {
   return (
     <div>
       {courseData.course && (
@@ -97,6 +87,45 @@ const StandardCoursePage = ({ courseData }: { courseData: GetCourseResponse }) =
       )}
     </div>
   );
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const courses = await getAllActiveCourses();
+  const paths = courses.map((course) => ({
+    params: { courseSlug: course.slug },
+  }));
+
+  return {
+    paths,
+    fallback: 'blocking',
+  };
+};
+
+export const getStaticProps: GetStaticProps<CoursePageProps> = async ({ params }) => {
+  const courseSlug = params?.courseSlug as string;
+
+  if (!courseSlug) {
+    return {
+      notFound: true,
+    };
+  }
+
+  try {
+    const courseData = await getCourseData(courseSlug);
+
+    return {
+      props: {
+        courseSlug,
+        courseData,
+      },
+      revalidate: 60,
+    };
+  } catch (error) {
+    // Error fetching course data (likely not found)
+    return {
+      notFound: true,
+    };
+  }
 };
 
 export default CoursePage;

--- a/apps/website/src/pages/join-us/[slug].tsx
+++ b/apps/website/src/pages/join-us/[slug].tsx
@@ -29,66 +29,62 @@ const JobPostingPage = ({ slug, job }: JobPostingPageProps) => {
 
   return (
     <div>
-      {job && (
-        <>
-          <Head>
-            <title>{`${job.title} | BlueDot Impact`}</title>
-            <meta name="description" content={job.subtitle} />
-            <script
-              type="application/ld+json"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{
-                __html: JSON.stringify({
-                  '@context': 'https://schema.org',
-                  '@type': 'JobPosting',
-                  title: job.title,
-                  description: job.body,
-                  datePosted: job.publishedAt ? new Date(job.publishedAt * 1000).toISOString() : undefined,
-                  hiringOrganization: {
-                    '@type': 'Organization',
-                    name: 'BlueDot Impact',
-                    sameAs: 'https://bluedot.org',
-                    logo: 'https://bluedot.org/images/logo/icon-on-blue.svg',
-                  },
-                  jobLocation: {
-                    '@type': 'Place',
-                    address: {
-                      '@type': 'PostalAddress',
-                      addressLocality: 'London',
-                      addressCountry: 'United Kingdom',
-                    },
-                  },
-                  identifier: job.id,
-                  mainEntityOfPage: {
-                    '@type': 'WebPage',
-                    '@id': `${ROUTES.joinUs.url}/${slug}`,
-                  },
-                }),
-              }}
-            />
-          </Head>
-          <HeroSection>
-            <HeroH1>{job.title}</HeroH1>
-            {job.subtitle && <HeroH2>{job.subtitle}</HeroH2>}
-            {job.applicationUrl && (
-              <HeroCTAContainer>
-                <CTALinkOrButton url={job.applicationUrl}>Apply Now</CTALinkOrButton>
-              </HeroCTAContainer>
-            )}
-          </HeroSection>
-          <Breadcrumbs route={currentRoute} />
-          <Section className="max-w-3xl">
-            <MarkdownExtendedRenderer>
-              {job.body}
-            </MarkdownExtendedRenderer>
-            {job.applicationUrl && (
-              <div className="my-8">
-                <CTALinkOrButton url={job.applicationUrl}>Apply Now</CTALinkOrButton>
-              </div>
-            )}
-          </Section>
-        </>
-      )}
+      <Head>
+        <title>{`${job.title} | BlueDot Impact`}</title>
+        <meta name="description" content={job.subtitle} />
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'JobPosting',
+              title: job.title,
+              description: job.body,
+              datePosted: job.publishedAt ? new Date(job.publishedAt * 1000).toISOString() : undefined,
+              hiringOrganization: {
+                '@type': 'Organization',
+                name: 'BlueDot Impact',
+                sameAs: 'https://bluedot.org',
+                logo: 'https://bluedot.org/images/logo/icon-on-blue.svg',
+              },
+              jobLocation: {
+                '@type': 'Place',
+                address: {
+                  '@type': 'PostalAddress',
+                  addressLocality: 'London',
+                  addressCountry: 'United Kingdom',
+                },
+              },
+              identifier: job.id,
+              mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': `${ROUTES.joinUs.url}/${slug}`,
+              },
+            }),
+          }}
+        />
+      </Head>
+      <HeroSection>
+        <HeroH1>{job.title}</HeroH1>
+        {job.subtitle && <HeroH2>{job.subtitle}</HeroH2>}
+        {job.applicationUrl && (
+          <HeroCTAContainer>
+            <CTALinkOrButton url={job.applicationUrl}>Apply Now</CTALinkOrButton>
+          </HeroCTAContainer>
+        )}
+      </HeroSection>
+      <Breadcrumbs route={currentRoute} />
+      <Section className="max-w-3xl">
+        <MarkdownExtendedRenderer>
+          {job.body}
+        </MarkdownExtendedRenderer>
+        {job.applicationUrl && (
+          <div className="my-8">
+            <CTALinkOrButton url={job.applicationUrl}>Apply Now</CTALinkOrButton>
+          </div>
+        )}
+      </Section>
     </div>
   );
 };

--- a/apps/website/src/pages/join-us/[slug].tsx
+++ b/apps/website/src/pages/join-us/[slug].tsx
@@ -9,11 +9,10 @@ import {
   CTALinkOrButton,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { GetStaticProps, GetStaticPaths } from 'next';
+import { GetServerSideProps } from 'next';
 import { JobPosting } from '@bluedot/db';
 import { ROUTES } from '../../lib/routes';
 import { getJobIfPublished } from '../api/cms/jobs/[slug]';
-import { getAllPublishedJobs } from '../api/cms/jobs';
 import MarkdownExtendedRenderer from '../../components/courses/MarkdownExtendedRenderer';
 
 type JobPostingPageProps = {
@@ -94,19 +93,7 @@ const JobPostingPage = ({ slug, job }: JobPostingPageProps) => {
   );
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  const jobs = await getAllPublishedJobs();
-  const paths = jobs.map((job) => ({
-    params: { slug: job.slug },
-  }));
-
-  return {
-    paths,
-    fallback: 'blocking',
-  };
-};
-
-export const getStaticProps: GetStaticProps<JobPostingPageProps> = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps<JobPostingPageProps> = async ({ params }) => {
   const slug = params?.slug as string;
 
   if (!slug) {
@@ -123,7 +110,6 @@ export const getStaticProps: GetStaticProps<JobPostingPageProps> = async ({ para
         slug,
         job,
       },
-      revalidate: 60,
     };
   } catch (error) {
     // Error fetching job data (likely not found)

--- a/apps/website/src/pages/join-us/[slug].tsx
+++ b/apps/website/src/pages/join-us/[slug].tsx
@@ -9,7 +9,7 @@ import {
   CTALinkOrButton,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps, GetStaticPaths } from 'next';
 import { JobPosting } from '@bluedot/db';
 import { ROUTES } from '../../lib/routes';
 import { getJobIfPublished } from '../api/cms/jobs/[slug]';
@@ -89,7 +89,16 @@ const JobPostingPage = ({ slug, job }: JobPostingPageProps) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps<JobPostingPageProps> = async ({ params }) => {
+export const getStaticPaths: GetStaticPaths = async () => {
+  // CI is not currently set up to support connecting to the database at build
+  // time, so return no paths, and rely on `fallback: 'blocking'` to render the pages on demand.
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
+
+export const getStaticProps: GetStaticProps<JobPostingPageProps> = async ({ params }) => {
   const slug = params?.slug as string;
 
   if (!slug) {
@@ -106,6 +115,7 @@ export const getServerSideProps: GetServerSideProps<JobPostingPageProps> = async
         slug,
         job,
       },
+      revalidate: 300,
     };
   } catch (error) {
     // Error fetching job data (likely not found)

--- a/apps/website/src/pages/projects/[slug].tsx
+++ b/apps/website/src/pages/projects/[slug].tsx
@@ -6,37 +6,30 @@ import {
   Section,
   Breadcrumbs,
   BluedotRoute,
-  ErrorSection,
-  ProgressDots,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import useAxios from 'axios-hooks';
-import { useRouter } from 'next/router';
+import { GetServerSideProps } from 'next';
+import { Project } from '@bluedot/db';
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import { ROUTES } from '../../lib/routes';
-import { GetProjectResponse } from '../api/cms/projects/[slug]';
+import { getProjectIfPublished } from '../api/cms/projects/[slug]';
 import MarkdownExtendedRenderer from '../../components/courses/MarkdownExtendedRenderer';
 import { A } from '../../components/Text';
 
-const ProjectPostPage = () => {
-  const { query: { slug } } = useRouter();
-  if (typeof slug !== 'string') {
-    return <ProgressDots />;
-  }
+type ProjectPostPageProps = {
+  slug: string;
+  project: Project;
+};
 
-  const [{ data, loading, error }] = useAxios<GetProjectResponse>({
-    method: 'get',
-    url: `/api/cms/projects/${slug}`,
-  });
-
+const ProjectPostPage = ({ slug, project }: ProjectPostPageProps) => {
   const currentRoute: BluedotRoute = {
-    title: data?.project?.title || 'Project',
+    title: project.title || 'Project',
     url: `${ROUTES.projects.url}/${slug}`,
     parentPages: [...(ROUTES.projects.parentPages ?? []), ROUTES.projects],
   };
 
-  const formattedDate = data?.project?.publishedAt
-    ? new Date(data.project.publishedAt * 1000).toLocaleDateString('en-US', {
+  const formattedDate = project.publishedAt
+    ? new Date(project.publishedAt * 1000).toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
     })
@@ -44,23 +37,21 @@ const ProjectPostPage = () => {
 
   return (
     <div>
-      {loading && <ProgressDots />}
-      {error && <ErrorSection error={error} />}
-      {data?.project && (
+      {project && (
         <>
           <Head>
-            <title>{`${data.project.title} | BlueDot Impact`}</title>
-            <meta name="description" content={`${data.project.title} - Project post by ${data.project.authorName}`} />
+            <title>{`${project.title} | BlueDot Impact`}</title>
+            <meta name="description" content={`${project.title} - Project post by ${project.authorName}`} />
           </Head>
           <HeroSection>
-            <HeroMiniTitle>{data.project.course} Project</HeroMiniTitle>
-            <HeroH1>{data.project.title}</HeroH1>
-            <HeroH2><A href={data.project.authorUrl || '#'} className="text-white">{data.project.authorName}</A>{data.project.tag?.length ? ` • ${data.project.tag.join(' • ')}` : ''} • {formattedDate}</HeroH2>
+            <HeroMiniTitle>{project.course} Project</HeroMiniTitle>
+            <HeroH1>{project.title}</HeroH1>
+            <HeroH2><A href={project.authorUrl || '#'} className="text-white">{project.authorName}</A>{project.tag?.length ? ` • ${project.tag.join(' • ')}` : ''} • {formattedDate}</HeroH2>
           </HeroSection>
           <Breadcrumbs route={currentRoute} />
           <Section className="max-w-3xl">
             <MarkdownExtendedRenderer>
-              {data.project.body}
+              {project.body}
             </MarkdownExtendedRenderer>
             <div className="my-8 border-t border-color-divider pt-8">
               <CTALinkOrButton url={ROUTES.projects.url} variant="secondary" withBackChevron>
@@ -72,6 +63,32 @@ const ProjectPostPage = () => {
       )}
     </div>
   );
+};
+
+export const getServerSideProps: GetServerSideProps<ProjectPostPageProps> = async ({ params }) => {
+  const slug = params?.slug as string;
+
+  if (!slug) {
+    return {
+      notFound: true,
+    };
+  }
+
+  try {
+    const project = await getProjectIfPublished(slug);
+
+    return {
+      props: {
+        slug,
+        project,
+      },
+    };
+  } catch (error) {
+    // Error fetching project data (likely not found)
+    return {
+      notFound: true,
+    };
+  }
 };
 
 export default ProjectPostPage;

--- a/apps/website/src/pages/projects/[slug].tsx
+++ b/apps/website/src/pages/projects/[slug].tsx
@@ -37,30 +37,26 @@ const ProjectPostPage = ({ slug, project }: ProjectPostPageProps) => {
 
   return (
     <div>
-      {project && (
-        <>
-          <Head>
-            <title>{`${project.title} | BlueDot Impact`}</title>
-            <meta name="description" content={`${project.title} - Project post by ${project.authorName}`} />
-          </Head>
-          <HeroSection>
-            <HeroMiniTitle>{project.course} Project</HeroMiniTitle>
-            <HeroH1>{project.title}</HeroH1>
-            <HeroH2><A href={project.authorUrl || '#'} className="text-white">{project.authorName}</A>{project.tag?.length ? ` • ${project.tag.join(' • ')}` : ''} • {formattedDate}</HeroH2>
-          </HeroSection>
-          <Breadcrumbs route={currentRoute} />
-          <Section className="max-w-3xl">
-            <MarkdownExtendedRenderer>
-              {project.body}
-            </MarkdownExtendedRenderer>
-            <div className="my-8 border-t border-color-divider pt-8">
-              <CTALinkOrButton url={ROUTES.projects.url} variant="secondary" withBackChevron>
-                See other student projects
-              </CTALinkOrButton>
-            </div>
-          </Section>
-        </>
-      )}
+      <Head>
+        <title>{`${project.title} | BlueDot Impact`}</title>
+        <meta name="description" content={`${project.title} - Project post by ${project.authorName}`} />
+      </Head>
+      <HeroSection>
+        <HeroMiniTitle>{project.course} Project</HeroMiniTitle>
+        <HeroH1>{project.title}</HeroH1>
+        <HeroH2><A href={project.authorUrl || '#'} className="text-white">{project.authorName}</A>{project.tag?.length ? ` • ${project.tag.join(' • ')}` : ''} • {formattedDate}</HeroH2>
+      </HeroSection>
+      <Breadcrumbs route={currentRoute} />
+      <Section className="max-w-3xl">
+        <MarkdownExtendedRenderer>
+          {project.body}
+        </MarkdownExtendedRenderer>
+        <div className="my-8 border-t border-color-divider pt-8">
+          <CTALinkOrButton url={ROUTES.projects.url} variant="secondary" withBackChevron>
+            See other student projects
+          </CTALinkOrButton>
+        </div>
+      </Section>
     </div>
   );
 };

--- a/apps/website/src/pages/projects/[slug].tsx
+++ b/apps/website/src/pages/projects/[slug].tsx
@@ -8,7 +8,7 @@ import {
   BluedotRoute,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps, GetStaticPaths } from 'next';
 import { Project } from '@bluedot/db';
 import { HeroMiniTitle } from '@bluedot/ui/src/HeroSection';
 import { ROUTES } from '../../lib/routes';
@@ -61,7 +61,16 @@ const ProjectPostPage = ({ slug, project }: ProjectPostPageProps) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps<ProjectPostPageProps> = async ({ params }) => {
+export const getStaticPaths: GetStaticPaths = async () => {
+  // CI is not currently set up to support connecting to the database at build
+  // time, so return no paths, and rely on `fallback: 'blocking'` to render the pages on demand.
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+};
+
+export const getStaticProps: GetStaticProps<ProjectPostPageProps> = async ({ params }) => {
   const slug = params?.slug as string;
 
   if (!slug) {
@@ -78,6 +87,7 @@ export const getServerSideProps: GetServerSideProps<ProjectPostPageProps> = asyn
         slug,
         project,
       },
+      revalidate: 300,
     };
   } catch (error) {
     // Error fetching project data (likely not found)


### PR DESCRIPTION
# Description

Part of an overarching [ticket](https://github.com/bluedotimpact/bluedot/issues/1365) to render all content that may be needed for SEO or link previews server side. This covers all the straightforward cases.

Remaining things to do after this PR:
- There is one remaining case, `apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx`, which is a bit more complicated because `<Head>` is buried inside `<UnitLayout>`.
- I want to add tests that the head tags are set correctly. `next/head` doesn't work out of the box in tests, so I will need to use something like [this workaround](https://github.com/vercel/next.js/discussions/11060#discussioncomment-33628) I found in a discussion thread. This could be fiddly to set up so I'd like to have it reviewed separately.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1365

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

N/A
