### PR TITLE
[feat]: less aggressive autosave

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -53,9 +53,7 @@ const Exercise: React.FC<ExerciseProps> = ({
         },
       },
     );
-
-    await fetchExerciseResponse().catch(() => { /* no op, as we handle errors above */ });
-  }, [exerciseId, auth, fetchExerciseResponse]);
+  }, [exerciseId, auth]);
 
   if (exerciseLoading) {
     return <ProgressDots />;

--- a/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
@@ -15,7 +15,7 @@ type SaveStatus = 'idle' | 'typing' | 'saving' | 'saved' | 'error';
 type FreeTextResponseProps = {
   className?: string;
   description: string;
-  onExerciseSubmit: (exerciseResponse: string, complete?: boolean) => void;
+  onExerciseSubmit: (exerciseResponse: string, complete?: boolean) => Promise<void>;
   title: string;
   exerciseResponse?: string;
   isLoggedIn?: boolean;
@@ -150,7 +150,7 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
     return () => clearInterval(intervalId);
   }, [isLoggedIn]);
 
-  // Inactivity auto-save timer (5 seconds)
+  // Inactivity auto-save timer (20 seconds)
   useEffect(() => {
     if (!isEditing || !isLoggedIn) return undefined;
 
@@ -160,7 +160,7 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
     inactivityTimerRef.current = window.setTimeout(() => {
       const currentVal = watch('answer') || '';
       saveValue(currentVal);
-    }, 5000);
+    }, 20000);
 
     return () => {
       if (inactivityTimerRef.current) {

--- a/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
+++ b/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
@@ -55,8 +55,8 @@ export default makeApiRoute({
         type: 'success' as const,
         exerciseResponse: {
           ...exerciseResponse,
-          // For some reason Airtable often adds a newline to the end of the response
-          response: exerciseResponse.response?.trimEnd(),
+          // Preserve trailing whitespace and line feeds as entered by the user
+          response: exerciseResponse.response,
         },
       };
     }


### PR DESCRIPTION
# Description
Increased autosave to 20s. Now preserves whitespaces and line feeds!

## Issue
Closes #1411

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
![saving-whitespaces](https://github.com/user-attachments/assets/b2767bf2-11a6-4779-be73-334013f4ed6b)
