### PR TITLE
[feat]: agi strategy hero updates

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -18,10 +18,7 @@ import FAQSection from './agi-strategy/FAQSection';
 const AgiStrategyBanner = ({ title, ctaUrl }: { title: string, ctaUrl: string }) => {
   return (
     <div className="relative w-full max-w-[350px] lg:max-w-[1118px] mx-auto overflow-hidden rounded-xl bg-[#13132E] bg-[url('/images/agi-strategy/hero-banner-split.png')] bg-cover bg-center">
-      {/* First noise layer */}
-      <div className="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light" />
-
-      {/* Second noise layer */}
+      {/* Noise layer */}
       <div className="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light" />
 
       <div className="relative flex flex-col items-center justify-center px-14 py-16 gap-8 text-center">

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -16,16 +16,16 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-white"
     >
       <div
-        class="flex flex-col-reverse lg:grid lg:grid-cols-2 lg:h-[600px]"
+        class="flex flex-col sm:pt-8 sm:gap-12 lg:pt-0 lg:gap-0 lg:grid lg:grid-cols-2 lg:h-[600px]"
       >
         <div
-          class="px-5 py-8 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
+          class="px-5 py-8 sm:px-8 sm:py-0 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
         >
           <div
-            class="w-full lg:max-w-[512px] space-y-8"
+            class="w-full lg:max-w-[512px] space-y-8 sm:space-y-8"
           >
             <div
-              class="space-y-5"
+              class="space-y-5 sm:space-y-4"
             >
               <p
                 class="bluedot-p not-prose text-size-md font-semibold tracking-wide text-[#2244BB]"
@@ -33,12 +33,12 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                 AGI STRATEGY
               </p>
               <h1
-                class="bluedot-h1 not-prose text-[32px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
+                class="bluedot-h1 not-prose text-[32px] sm:text-[40px] sm:leading-tight lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
               >
                 Start building the defences that protect humanity
               </h1>
               <p
-                class="bluedot-p not-prose text-size-md lg:text-lg leading-relaxed text-[#13132E] opacity-80"
+                class="bluedot-p not-prose text-size-md sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
               >
                 Envision a good future. Map the threats from AI. Design effective interventions. Get funded to start shipping. All in 30 hours.
               </p>
@@ -64,12 +64,15 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
           </div>
         </div>
         <div
-          class="h-80 lg:h-full relative overflow-hidden"
+          class="h-80 sm:h-[430px] lg:h-full relative overflow-hidden"
         >
           <img
             alt="AGI Strategy visualization"
             class="size-full object-cover"
             src="/images/agi-strategy/hero-banner-split.png"
+          />
+          <div
+            class="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light"
           />
         </div>
       </div>
@@ -1416,9 +1419,6 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
         <div
           class="relative w-full max-w-[350px] lg:max-w-[1118px] mx-auto overflow-hidden rounded-xl bg-[#13132E] bg-[url('/images/agi-strategy/hero-banner-split.png')] bg-cover bg-center"
         >
-          <div
-            class="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light"
-          />
           <div
             class="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light"
           />

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                 Start building the defences that protect humanity
               </h1>
               <p
-                class="bluedot-p not-prose text-size-md sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
+                class="bluedot-p not-prose text-size-sm sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
               >
                 Envision a good future. Map the threats from AI. Design effective interventions. Get funded to start shipping. All in 30 hours.
               </p>

--- a/apps/website/src/components/lander/agi-strategy/HeroSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/HeroSection.tsx
@@ -25,14 +25,14 @@ const HeroSection = ({
 }: HeroSectionProps) => {
   return (
     <section className="w-full bg-white">
-      <div className="flex flex-col-reverse lg:grid lg:grid-cols-2 lg:h-[600px]">
+      <div className="flex flex-col sm:pt-8 sm:gap-12 lg:pt-0 lg:gap-0 lg:grid lg:grid-cols-2 lg:h-[600px]">
 
         {/* Content - Aligned with site sections */}
-        <div className="px-5 py-8 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8">
-          <div className="w-full lg:max-w-[512px] space-y-8">
+        <div className="px-5 py-8 sm:px-8 sm:py-0 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8">
+          <div className="w-full lg:max-w-[512px] space-y-8 sm:space-y-8">
 
             {/* Text Content */}
-            <div className="space-y-5">
+            <div className="space-y-5 sm:space-y-4">
               {/* Course Category */}
               {categoryLabel && (
                 <P className="text-size-md font-semibold tracking-wide text-[#2244BB]">
@@ -41,12 +41,12 @@ const HeroSection = ({
               )}
 
               {/* Title - Cleaner responsive sizing */}
-              <H1 className="text-[32px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]">
+              <H1 className="text-[32px] sm:text-[40px] sm:leading-tight lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]">
                 {title}
               </H1>
 
               {/* Description */}
-              <P className="text-size-md lg:text-lg leading-relaxed text-[#13132E] opacity-80">
+              <P className="text-size-md sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80">
                 {description}
               </P>
             </div>
@@ -74,12 +74,14 @@ const HeroSection = ({
 
         {/* Image - Automatically ordered by flex-col-reverse */}
         {(visualComponent || imageUrl) && (
-          <div className="h-80 lg:h-full relative overflow-hidden">
+          <div className="h-80 sm:h-[430px] lg:h-full relative overflow-hidden">
             {imageUrl ? (
               <img src={imageUrl} alt="" className="size-full object-cover lg:object-left" />
             ) : (
               visualComponent
             )}
+            {/* Noise layer */}
+            <div className="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light" />
           </div>
         )}
 

--- a/apps/website/src/components/lander/agi-strategy/HeroSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/HeroSection.tsx
@@ -46,7 +46,7 @@ const HeroSection = ({
               </H1>
 
               {/* Description */}
-              <P className="text-size-md sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80">
+              <P className="text-size-sm sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80">
                 {description}
               </P>
             </div>

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/HeroSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/HeroSection.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`HeroSection > renders correctly with visual component (snapshot) 1`] = 
               AGI Strategy – Learn how to navigate humanity's most critical decade
             </h1>
             <p
-              class="bluedot-p not-prose text-size-md sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
+              class="bluedot-p not-prose text-size-sm sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
             >
               Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
             </p>
@@ -88,7 +88,7 @@ exports[`HeroSection > renders correctly without visual component (snapshot) 1`]
               AGI Strategy – Learn how to navigate humanity's most critical decade
             </h1>
             <p
-              class="bluedot-p not-prose text-size-md sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
+              class="bluedot-p not-prose text-size-sm sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
             >
               Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
             </p>

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/HeroSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/HeroSection.test.tsx.snap
@@ -6,24 +6,24 @@ exports[`HeroSection > renders correctly with visual component (snapshot) 1`] = 
     class="w-full bg-white"
   >
     <div
-      class="flex flex-col-reverse lg:grid lg:grid-cols-2 lg:h-[600px]"
+      class="flex flex-col sm:pt-8 sm:gap-12 lg:pt-0 lg:gap-0 lg:grid lg:grid-cols-2 lg:h-[600px]"
     >
       <div
-        class="px-5 py-8 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
+        class="px-5 py-8 sm:px-8 sm:py-0 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
       >
         <div
-          class="w-full lg:max-w-[512px] space-y-8"
+          class="w-full lg:max-w-[512px] space-y-8 sm:space-y-8"
         >
           <div
-            class="space-y-5"
+            class="space-y-5 sm:space-y-4"
           >
             <h1
-              class="bluedot-h1 not-prose text-[32px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
+              class="bluedot-h1 not-prose text-[32px] sm:text-[40px] sm:leading-tight lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
             >
               AGI Strategy – Learn how to navigate humanity's most critical decade
             </h1>
             <p
-              class="bluedot-p not-prose text-size-md lg:text-lg leading-relaxed text-[#13132E] opacity-80"
+              class="bluedot-p not-prose text-size-md sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
             >
               Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
             </p>
@@ -49,12 +49,15 @@ exports[`HeroSection > renders correctly with visual component (snapshot) 1`] = 
         </div>
       </div>
       <div
-        class="h-80 lg:h-full relative overflow-hidden"
+        class="h-80 sm:h-[430px] lg:h-full relative overflow-hidden"
       >
         <img
           alt="AGI Strategy visualization"
           class="size-full object-cover"
           src="/images/agi-strategy/hero-banner.png"
+        />
+        <div
+          class="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light"
         />
       </div>
     </div>
@@ -68,24 +71,24 @@ exports[`HeroSection > renders correctly without visual component (snapshot) 1`]
     class="w-full bg-white"
   >
     <div
-      class="flex flex-col-reverse lg:grid lg:grid-cols-2 lg:h-[600px]"
+      class="flex flex-col sm:pt-8 sm:gap-12 lg:pt-0 lg:gap-0 lg:grid lg:grid-cols-2 lg:h-[600px]"
     >
       <div
-        class="px-5 py-8 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
+        class="px-5 py-8 sm:px-8 sm:py-0 lg:flex lg:items-center lg:px-12 xl:pl-[max(48px,calc((100vw-1436px)/2+48px))] xl:pr-8"
       >
         <div
-          class="w-full lg:max-w-[512px] space-y-8"
+          class="w-full lg:max-w-[512px] space-y-8 sm:space-y-8"
         >
           <div
-            class="space-y-5"
+            class="space-y-5 sm:space-y-4"
           >
             <h1
-              class="bluedot-h1 not-prose text-[32px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
+              class="bluedot-h1 not-prose text-[32px] sm:text-[40px] sm:leading-tight lg:text-[40px] xl:text-5xl leading-tight font-semibold text-[#13132E] tracking-[-0.5px]"
             >
               AGI Strategy – Learn how to navigate humanity's most critical decade
             </h1>
             <p
-              class="bluedot-p not-prose text-size-md lg:text-lg leading-relaxed text-[#13132E] opacity-80"
+              class="bluedot-p not-prose text-size-md sm:text-lg sm:leading-[1.6] lg:text-lg leading-relaxed text-[#13132E] opacity-80"
             >
               Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
             </p>


### PR DESCRIPTION
# Description
New requirements were added to the [figma designs](https://www.figma.com/design/62YlFNK7QS6z7SkrPjrwVb/Blue-Dot?node-id=1275-11437&p=f&t=59pOx5HeM7SyG9w2-0) for the AGI Strategy Lander hero section, so this PR implements them! 

**Specifically:**
- Adds a soft-light noise layer on the hero image
- Reverse order of stacked hero image/text on screen sizes <1024px (hero text is displayed on top of the hero image vs the reverse)
- Updated styling at 320px

## Issue
Implements part of #1404

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
| Mobile  | Desktop |
| ------------- | ------------- |
| <img width="320" height="759" alt="mobile" src="https://github.com/user-attachments/assets/9895f13f-3f9f-458a-8691-c79eb2e76e09" /> | <img width="1512" height="760" alt="desktop" src="https://github.com/user-attachments/assets/eaa177a2-6315-4119-aa55-1a8f82794afe" /> | 

| Zooming Out  |
| ------------- | 
| ![zooming-out](https://github.com/user-attachments/assets/c65aa58b-87d6-4bf4-b040-9b7de47bc1b4) |

| Mobile to Scale  |
| ------------- | 
| ![mobile-to-scaleup](https://github.com/user-attachments/assets/048bc8d3-d875-40ba-87b4-079621074821) |
