### PR TITLE
[Bug] Render SEO related content server side: Course content

### DIFF
--- a/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitNumber].test.tsx
+++ b/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitNumber].test.tsx
@@ -4,11 +4,9 @@ import {
 } from 'vitest';
 import { useRouter } from 'next/router';
 import type { NextRouter } from 'next/router';
-import { unitTable, chunkTable, InferSelectModel } from '@bluedot/db';
+import { Unit } from '@bluedot/db';
 import CourseUnitPage from '../../../../../pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]]';
-
-type Unit = InferSelectModel<typeof unitTable.pg>;
-type Chunk = InferSelectModel<typeof chunkTable.pg>;
+import type { ChunkWithContent } from '../../../../../pages/api/courses/[courseSlug]/[unitNumber]/index';
 
 // Mock next/router
 vi.mock('next/router', () => ({
@@ -29,6 +27,7 @@ const createMockUnit = (unitNumber: string, title: string, content: string): Uni
   courseTitle: 'Test Course',
   coursePath: '/courses/test-course',
   courseSlug: 'test-course',
+  courseUnit: null,
   path: `/courses/test-course/${unitNumber}`,
   title,
   content,
@@ -43,7 +42,7 @@ const createMockUnit = (unitNumber: string, title: string, content: string): Uni
   autoNumberId: 1,
 });
 
-const createMockChunk = (unitId: string): Chunk => ({
+const createMockChunk = (unitId: string): ChunkWithContent => ({
   chunkId: 'recuC87TILbjW4eF4',
   unitId,
   chunkTitle: 'Test Chunk',
@@ -56,6 +55,8 @@ const createMockChunk = (unitId: string): Chunk => ({
   chunkResources: [],
   chunkExercises: [],
   status: 'Active',
+  resources: [],
+  exercises: [],
 });
 
 describe('CourseUnitPage', () => {
@@ -73,16 +74,22 @@ describe('CourseUnitPage', () => {
 
     const mockChunks = [createMockChunk(mockUnits[0]!.id)];
 
+    // Mock the course registration API call (manual: true, so won't execute)
+    // Mock the group discussion API call (returns null for no discussion)
     mockUseAxios.mockReturnValue([{
-      data: {
-        units: mockUnits,
-        unit: mockUnits[0]!,
-        chunks: mockChunks,
-      },
+      data: null,
       loading: false,
     }]);
 
-    const { getByRole, getByText } = render(<CourseUnitPage />);
+    const { getByRole, getByText } = render(
+      <CourseUnitPage
+        units={mockUnits}
+        unit={mockUnits[0]!}
+        chunks={mockChunks}
+        courseSlug="test-course"
+        unitNumber="0"
+      />,
+    );
 
     expect(getByRole('heading', { level: 1 }).textContent).toBe('Test Chunk');
     await waitFor(() => expect(getByText('Test chunk content')).toBeTruthy());
@@ -102,16 +109,21 @@ describe('CourseUnitPage', () => {
 
     const mockChunks = [createMockChunk(mockUnits[3]!.id)];
 
+    // Mock the group discussion API call (returns null for no discussion)
     mockUseAxios.mockReturnValue([{
-      data: {
-        units: mockUnits,
-        unit: mockUnits[3]!,
-        chunks: mockChunks,
-      },
+      data: null,
       loading: false,
     }]);
 
-    const { getByRole, getByText } = render(<CourseUnitPage />);
+    const { getByRole, getByText } = render(
+      <CourseUnitPage
+        units={mockUnits}
+        unit={mockUnits[3]!}
+        chunks={mockChunks}
+        courseSlug="test-course"
+        unitNumber="3"
+      />,
+    );
 
     expect(getByRole('heading', { level: 1 }).textContent).toBe('Test Chunk');
     await waitFor(() => expect(getByText('Test chunk content')).toBeTruthy());
@@ -131,16 +143,21 @@ describe('CourseUnitPage', () => {
 
     const mockChunks = [createMockChunk(mockUnits[2]!.id)];
 
+    // Mock the group discussion API call (returns null for no discussion)
     mockUseAxios.mockReturnValue([{
-      data: {
-        units: mockUnits,
-        unit: mockUnits[2]!,
-        chunks: mockChunks,
-      },
+      data: null,
       loading: false,
     }]);
 
-    const { getByRole, getByText } = render(<CourseUnitPage />);
+    const { getByRole, getByText } = render(
+      <CourseUnitPage
+        units={mockUnits}
+        unit={mockUnits[2]!}
+        chunks={mockChunks}
+        courseSlug="test-course"
+        unitNumber="3"
+      />,
+    );
 
     expect(getByRole('heading', { level: 1 }).textContent).toBe('Test Chunk');
     await waitFor(() => expect(getByText('Test chunk content')).toBeTruthy());
@@ -159,16 +176,21 @@ describe('CourseUnitPage', () => {
 
     const mockChunks = [createMockChunk(mockUnits[1]!.id)];
 
+    // Mock the group discussion API call (returns null for no discussion)
     mockUseAxios.mockReturnValue([{
-      data: {
-        units: mockUnits,
-        unit: mockUnits[1]!,
-        chunks: mockChunks,
-      },
+      data: null,
       loading: false,
     }]);
 
-    const { getByRole, getByText } = render(<CourseUnitPage />);
+    const { getByRole, getByText } = render(
+      <CourseUnitPage
+        units={mockUnits}
+        unit={mockUnits[1]!}
+        chunks={mockChunks}
+        courseSlug="test-course"
+        unitNumber="3"
+      />,
+    );
 
     expect(getByRole('heading', { level: 1 }).textContent).toBe('Test Chunk');
     await waitFor(() => expect(getByText('Test chunk content')).toBeTruthy());

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -13,12 +13,10 @@ import {
 } from 'react-icons/fa6';
 
 import {
-  Chunk,
-  UnitResource,
-  Exercise,
   Unit,
 } from '@bluedot/db';
 import type { GetGroupDiscussionResponse } from '../../pages/api/courses/[courseSlug]/[unitNumber]/groupDiscussion';
+import type { ChunkWithContent } from '../../pages/api/courses/[courseSlug]/[unitNumber]/index';
 import CertificateLinkCard from './CertificateLinkCard';
 import Congratulations from './Congratulations';
 import GroupDiscussionBanner from './GroupDiscussionBanner';
@@ -31,11 +29,6 @@ import { ROUTES } from '../../lib/routes';
 import {
   A, H1, P,
 } from '../Text';
-
-type ChunkWithContent = Chunk & {
-  resources?: UnitResource[];
-  exercises?: Exercise[];
-};
 
 const CourseIcon: React.FC = () => (
   <svg width="32" height="32" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import Head from 'next/head';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import useAxios from 'axios-hooks';
@@ -280,16 +279,8 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
     throw new Error('Unit not found');
   }
 
-  const title = `${unit.courseTitle}: Unit ${unitNumber}${chunk?.chunkTitle ? ` | ${chunk.chunkTitle}` : ''}`;
-  const metaDescription = chunk?.metaDescription || unit.title;
-
   return (
     <div>
-      <Head>
-        <title>{title}</title>
-        <meta name="description" content={metaDescription} />
-      </Head>
-
       {/* Aria live region for screen reader announcements */}
       <div
         role="status"

--- a/apps/website/src/pages/_error.tsx
+++ b/apps/website/src/pages/_error.tsx
@@ -1,0 +1,36 @@
+import { NextPageContext } from 'next';
+import Head from 'next/head';
+import { ErrorSection, Section } from '@bluedot/ui';
+
+type ErrorProps = {
+  statusCode: number;
+  message?: string;
+};
+
+const ErrorPage = ({ statusCode, message }: ErrorProps) => {
+  const errorMessage = message || `A ${statusCode} error occurred`;
+
+  return (
+    <>
+      <Head>
+        <title>An Error Occurred | BlueDot Impact</title>
+      </Head>
+      <Section>
+        <ErrorSection error={new Error(errorMessage)} />
+      </Section>
+    </>
+  );
+};
+
+ErrorPage.getInitialProps = ({ res, err }: NextPageContext) => {
+  const statusCode = res?.statusCode || err?.statusCode || 404;
+  const message = err?.message;
+
+  if (res) {
+    res.statusCode = statusCode;
+  }
+
+  return { statusCode, message };
+};
+
+export default ErrorPage;

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/index.ts
@@ -14,7 +14,7 @@ import db from '../../../../../lib/api/db';
 import { makeApiRoute } from '../../../../../lib/api/makeApiRoute';
 import { unitFilterActiveChunks } from '../../../../../lib/api/utils';
 
-type ChunkWithContent = Chunk & {
+export type ChunkWithContent = Chunk & {
   resources: UnitResource[];
   exercises: Exercise[];
 };

--- a/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/index.ts
+++ b/apps/website/src/pages/api/courses/[courseSlug]/[unitNumber]/index.ts
@@ -64,7 +64,7 @@ export async function getUnitWithContent(courseSlug: string, unitNumber: string)
       resources = resolvedResources
         .filter((r): r is UnitResource => r !== null)
         .sort((a, b) => {
-          // Sort by readingORder
+          // Sort by readingOrder
           const orderA = a.readingOrder ? parseInt(a.readingOrder) : Infinity;
           const orderB = b.readingOrder ? parseInt(b.readingOrder) : Infinity;
           return orderA - orderB;

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -84,7 +84,6 @@ const CourseUnitChunkPage = ({
 
   useEffect(() => {
     if (chunks && (chunkIndex < 0 || chunkIndex >= chunks.length)) {
-      if (unit.unitNumber !== unitNumber) return; // Handle case where data hasn't updated yet
       router.replace(`/courses/${courseSlug}/${unitNumber}/1`);
     }
   }, [chunkIndex, courseSlug, unitNumber, router]);

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -3,6 +3,7 @@ import useAxios from 'axios-hooks';
 import { ProgressDots, useAuthStore } from '@bluedot/ui';
 import { useEffect } from 'react';
 import { GetServerSideProps } from 'next';
+import Head from 'next/head';
 import UnitLayout from '../../../../components/courses/UnitLayout';
 import { UnitWithContent, getUnitWithContent } from '../../../api/courses/[courseSlug]/[unitNumber]';
 import { GetCourseRegistrationResponse } from '../../../api/course-registrations/[courseId]';
@@ -96,16 +97,26 @@ const CourseUnitChunkPage = ({
     return <ProgressDots />;
   }
 
+  const chunk = chunks[chunkIndex];
+  const title = `${unit.courseTitle}: Unit ${unitNumber}${chunk?.chunkTitle ? ` | ${chunk.chunkTitle}` : ''}`;
+  const metaDescription = chunk?.metaDescription || unit.title;
+
   return (
-    <UnitLayout
-      chunks={chunks}
-      unit={unit}
-      units={units}
-      unitNumber={unitNumber}
-      chunkIndex={chunkIndex}
-      setChunkIndex={handleSetChunkIndex}
-      courseSlug={courseSlug}
-    />
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={metaDescription} />
+      </Head>
+      <UnitLayout
+        chunks={chunks}
+        unit={unit}
+        units={units}
+        unitNumber={unitNumber}
+        chunkIndex={chunkIndex}
+        setChunkIndex={handleSetChunkIndex}
+        courseSlug={courseSlug}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
# Description

Part of an overarching [ticket](https://github.com/bluedotimpact/bluedot/issues/1365) to render all content that may be needed for SEO or link previews server side. This covers the case of `apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx`, which I split out because it was slightly more complicated than the ones covered in the [previous PR](https://github.com/bluedotimpact/bluedot/pull/1408).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1365

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 |  |
|---------|---|
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
