### PR TITLE
[Bug] Add tests for SEO related content being populated during SSR

### DIFF
--- a/apps/website/src/__tests__/pages/blog/[slug].test.tsx
+++ b/apps/website/src/__tests__/pages/blog/[slug].test.tsx
@@ -1,0 +1,77 @@
+import {
+  describe, expect, test, beforeEach, vi,
+} from 'vitest';
+import { Blog } from '@bluedot/db';
+import BlogPostPage from '../../../pages/blog/[slug]';
+import { renderWithHead } from '../../testUtils';
+
+// Mock <Head>, which doesn't work in tests. See docstring of
+// `renderWithHead` for more details.
+vi.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => {
+    if (typeof window !== 'undefined' && children) {
+      return (
+        <head-proxy data-testid="head-proxy">
+          {children}
+        </head-proxy>
+      );
+    }
+    return null;
+  },
+}));
+
+const mockBlog: Blog = {
+  id: 'recBlog123',
+  title: 'My Amazing Blog Post',
+  slug: 'my-amazing-blog-post',
+  body: '# Test Blog\n\nThis is test content.',
+  authorName: 'John Doe',
+  authorUrl: 'https://example.com/john',
+  publishedAt: 1609459200,
+  publicationStatus: 'Published',
+  isFeatured: false,
+};
+
+describe('BlogPostPage SSR/SEO', () => {
+  beforeEach(() => {
+    // Required for `renderWithHead`
+    document.head.innerHTML = '';
+  });
+
+  test('renders SEO meta tags during SSR without API calls', () => {
+    renderWithHead(
+      <BlogPostPage
+        slug="my-amazing-blog-post"
+        blog={mockBlog}
+      />,
+    );
+
+    expect(document.title).toBe('My Amazing Blog Post | BlueDot Impact');
+
+    const metaDescription = document.querySelector('meta[name="description"]');
+    expect(metaDescription?.getAttribute('content')).toBe('My Amazing Blog Post - Blog post by John Doe');
+
+    // Check Open Graph tags
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('My Amazing Blog Post');
+
+    const ogType = document.querySelector('meta[property="og:type"]');
+    expect(ogType?.getAttribute('content')).toBe('article');
+
+    const ogUrl = document.querySelector('meta[property="og:url"]');
+    expect(ogUrl?.getAttribute('content')).toBe('https://bluedot.org/blog/my-amazing-blog-post');
+
+    // Check structured data
+    const jsonLdScript = document.querySelector('script[type="application/ld+json"]');
+    expect(jsonLdScript).toBeTruthy();
+
+    if (jsonLdScript?.textContent) {
+      const structuredData = JSON.parse(jsonLdScript.textContent);
+      expect(structuredData['@type']).toBe('BlogPosting');
+      expect(structuredData.headline).toBe('My Amazing Blog Post');
+      expect(structuredData.author.name).toBe('John Doe');
+      expect(structuredData.datePublished).toBe('2021-01-01T00:00:00.000Z');
+    }
+  });
+});

--- a/apps/website/src/__tests__/pages/certification.test.tsx
+++ b/apps/website/src/__tests__/pages/certification.test.tsx
@@ -1,0 +1,53 @@
+import {
+  describe, expect, test, beforeEach, vi,
+} from 'vitest';
+import CertificatePage from '../../pages/certification';
+import { renderWithHead } from '../testUtils';
+import { Certificate } from '../../pages/api/certificates/[certificateId]';
+
+// Mock <Head>, which doesn't work in tests. See docstring of
+// `renderWithHead` for more details.
+vi.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => {
+    if (typeof window !== 'undefined' && children) {
+      return (
+        <head-proxy data-testid="head-proxy">
+          {children}
+        </head-proxy>
+      );
+    }
+    return null;
+  },
+}));
+
+const mockCertificate: Certificate = {
+  certificateId: 'cert123',
+  certificateCreatedAt: 1609459200,
+  recipientName: 'Jane Smith',
+  courseName: 'AI Safety Fundamentals',
+  certificationDescription: 'Has successfully completed the course',
+  certificationBadgeImageSrc: 'https://example.com/badge.svg',
+  courseDetailsUrl: 'https://example.com/course',
+};
+
+describe('CertificatePage SSR/SEO', () => {
+  beforeEach(() => {
+    // Required for `renderWithHead`
+    document.head.innerHTML = '';
+  });
+
+  test('renders SEO meta tags during SSR without API calls', () => {
+    renderWithHead(
+      <CertificatePage
+        certificate={mockCertificate}
+        certificateId="cert123"
+      />,
+    );
+
+    expect(document.title).toBe("Jane Smith's Certificate | BlueDot Impact");
+
+    const metaDescription = document.querySelector('meta[name="description"]');
+    expect(metaDescription?.getAttribute('content')).toBe('Certificate of completion for AI Safety Fundamentals');
+  });
+});

--- a/apps/website/src/__tests__/pages/courses/[courseSlug]/index.test.tsx
+++ b/apps/website/src/__tests__/pages/courses/[courseSlug]/index.test.tsx
@@ -1,0 +1,90 @@
+import {
+  describe, expect, test, beforeEach, vi,
+} from 'vitest';
+import { Course, Unit } from '@bluedot/db';
+import CoursePage from '../../../../pages/courses/[courseSlug]/index';
+import { renderWithHead } from '../../../testUtils';
+
+// Mock <Head>, which doesn't work in tests. See docstring of
+// `renderWithHead` for more details.
+vi.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => {
+    if (typeof window !== 'undefined' && children) {
+      return (
+        <head-proxy data-testid="head-proxy">
+          {children}
+        </head-proxy>
+      );
+    }
+    return null;
+  },
+}));
+
+const mockCourse: Course = {
+  id: 'recCourse123',
+  title: 'AI Safety Fundamentals',
+  slug: 'ai-safety-fundamentals',
+  description: 'Learn about AI safety and alignment',
+  path: '/courses/ai-safety-fundamentals',
+  status: 'published',
+  durationHours: 40,
+  durationDescription: '8 weeks',
+  level: 'Beginner',
+  cadence: 'Weekly',
+  shortDescription: 'Introduction to AI safety',
+  image: '/images/courses/ai-safety.jpg',
+  detailsUrl: 'https://example.com/details',
+  certificationDescription: 'Certificate description',
+  certificationBadgeImage: 'badge.png',
+  displayOnCourseHubIndex: true,
+  averageRating: 4.8,
+  isFeatured: true,
+  isNew: false,
+  publicLastUpdated: null,
+  units: [],
+};
+
+const mockUnits: Unit[] = [
+  {
+    id: 'recUnit1',
+    courseId: 'recCourse123',
+    unitNumber: '1',
+    title: 'Introduction to AI Safety',
+    path: '/courses/ai-safety-fundamentals/1',
+    courseSlug: 'ai-safety-fundamentals',
+    courseTitle: 'AI Safety Fundamentals',
+    coursePath: '/courses/ai-safety-fundamentals',
+    courseUnit: null,
+    content: 'Unit content',
+    description: 'Unit description',
+    learningOutcomes: 'Learning outcomes',
+    duration: 30,
+    chunks: ['recChunk1'],
+    menuText: 'Introduction',
+    unitPodcastUrl: '',
+    unitStatus: 'Active',
+    autoNumberId: 1,
+  },
+];
+
+describe('CoursePage SSR/SEO', () => {
+  beforeEach(() => {
+    // Required for `renderWithHead`
+    document.head.innerHTML = '';
+  });
+
+  test('renders SEO meta tags during SSR without API calls', () => {
+    renderWithHead(
+      <CoursePage
+        courseSlug="ai-safety-fundamentals"
+        courseData={{ course: mockCourse, units: mockUnits }}
+      />,
+    );
+
+    expect(document.title).toBe('AI Safety Fundamentals | BlueDot Impact');
+
+    const metaDescription = document.querySelector('meta[name="description"]');
+    expect(metaDescription?.getAttribute('content')).toBe('Learn about AI safety and alignment');
+  });
+});

--- a/apps/website/src/__tests__/pages/join-us/[slug].test.tsx
+++ b/apps/website/src/__tests__/pages/join-us/[slug].test.tsx
@@ -1,0 +1,64 @@
+import {
+  describe, expect, test, beforeEach, vi,
+} from 'vitest';
+import { JobPosting } from '@bluedot/db';
+import JobPostingPage from '../../../pages/join-us/[slug]';
+import { renderWithHead } from '../../testUtils';
+
+// Mock <Head>, which doesn't work in tests. See docstring of
+// `renderWithHead` for more details.
+vi.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => {
+    if (typeof window !== 'undefined' && children) {
+      return (
+        <head-proxy data-testid="head-proxy">
+          {children}
+        </head-proxy>
+      );
+    }
+    return null;
+  },
+}));
+
+const mockJob: JobPosting = {
+  id: 'recJob123',
+  title: 'AI Safety Researcher',
+  slug: 'ai-safety-researcher',
+  subtitle: 'Join our research team',
+  body: '# About the role\n\nWe are looking for researchers...',
+  applicationUrl: 'https://example.com/apply',
+  publishedAt: 1609459200,
+  publicationStatus: 'Published',
+};
+
+describe('JobPostingPage SSR/SEO', () => {
+  beforeEach(() => {
+    // Required for `renderWithHead`
+    document.head.innerHTML = '';
+  });
+
+  test('renders SEO meta tags during SSR without API calls', () => {
+    renderWithHead(
+      <JobPostingPage
+        slug="ai-safety-researcher"
+        job={mockJob}
+      />,
+    );
+
+    expect(document.title).toBe('AI Safety Researcher | BlueDot Impact');
+
+    const metaDescription = document.querySelector('meta[name="description"]');
+    expect(metaDescription?.getAttribute('content')).toBe('Join our research team');
+
+    const jsonLdScript = document.querySelector('script[type="application/ld+json"]');
+    expect(jsonLdScript).toBeTruthy();
+
+    if (jsonLdScript?.textContent) {
+      const structuredData = JSON.parse(jsonLdScript.textContent);
+      expect(structuredData['@type']).toBe('JobPosting');
+      expect(structuredData.title).toBe('AI Safety Researcher');
+      expect(structuredData.hiringOrganization.name).toBe('BlueDot Impact');
+    }
+  });
+});

--- a/apps/website/src/__tests__/pages/projects/[slug].test.tsx
+++ b/apps/website/src/__tests__/pages/projects/[slug].test.tsx
@@ -1,0 +1,56 @@
+import {
+  describe, expect, test, beforeEach, vi,
+} from 'vitest';
+import { Project } from '@bluedot/db';
+import ProjectPostPage from '../../../pages/projects/[slug]';
+import { renderWithHead } from '../../testUtils';
+
+// Mock <Head>, which doesn't work in tests. See docstring of
+// `renderWithHead` for more details.
+vi.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => {
+    if (typeof window !== 'undefined' && children) {
+      return (
+        <head-proxy data-testid="head-proxy">
+          {children}
+        </head-proxy>
+      );
+    }
+    return null;
+  },
+}));
+
+const mockProject: Project = {
+  id: 'recProject123',
+  title: 'AI Alignment Research Project',
+  slug: 'ai-alignment-research',
+  body: '# Project Overview\n\nThis project explores...',
+  authorName: 'Alex Johnson',
+  authorUrl: 'https://example.com/alex',
+  course: 'AI Safety Fundamentals',
+  tag: ['Research', 'Technical'],
+  publishedAt: 1609459200,
+  publicationStatus: 'Published',
+} as Project;
+
+describe('ProjectPostPage SSR/SEO', () => {
+  beforeEach(() => {
+    // Required for `renderWithHead`
+    document.head.innerHTML = '';
+  });
+
+  test('renders SEO meta tags during SSR without API calls', () => {
+    renderWithHead(
+      <ProjectPostPage
+        slug="ai-alignment-research"
+        project={mockProject}
+      />,
+    );
+
+    expect(document.title).toBe('AI Alignment Research Project | BlueDot Impact');
+
+    const metaDescription = document.querySelector('meta[name="description"]');
+    expect(metaDescription?.getAttribute('content')).toBe('AI Alignment Research Project - Project post by Alex Johnson');
+  });
+});

--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -1,4 +1,45 @@
+import { render, RenderResult } from '@testing-library/react';
 import type { Course } from '@bluedot/db';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface IntrinsicElements {
+      'head-proxy': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}
+
+/**
+ * Mock <Head> for testing. Based on the workaround desribed here:
+ * https://github.com/vercel/next.js/discussions/11060#discussioncomment-33628
+ *
+ * Usage:
+ * ```
+ * vi.mock('next/head', () => ({
+ *   __esModule: true,
+ *   default: ({ children }: { children: React.ReactNode }) => (
+ *     <head-proxy data-testid="head-proxy">{children}</head-proxy>
+ *   ),
+ * }));
+ * ```
+ */
+export const renderWithHead = (ui: React.ReactElement): RenderResult => {
+  const result = render(ui);
+
+  const headProxies = document.querySelectorAll('head-proxy');
+  headProxies.forEach((proxy) => {
+    Array.from(proxy.childNodes).forEach((child) => {
+      if (child.nodeType === Node.ELEMENT_NODE) {
+        const clone = (child as Element).cloneNode(true);
+        document.head.appendChild(clone);
+      }
+    });
+  });
+
+  return result;
+};
 
 export const mockCourse = (overrides: Partial<Course>): Course => ({
   averageRating: 4.5,


### PR DESCRIPTION
# Description
Part of an overarching [ticket](https://github.com/bluedotimpact/bluedot/issues/1365) to render all content that may be needed for SEO or link previews server side. These two previous PRs refactored all pages where this wasn't already the case:
- #1408 
- #1416 

This PR adds tests to assert the SEO relevant content is in the DOM after the first render. The `<Head>` component doesn't work in tests by default, so I've added a `renderWithHead` mocking utility, which was inspired by this github discussion comment: https://github.com/vercel/next.js/discussions/11060#discussioncomment-33628

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1365 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

N/A
