### PR TITLE
`CourseDetails` cleanup

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -1,6 +1,6 @@
 import type { Course } from '@bluedot/db';
 
-export const mockCourse = (overrides?: Partial<Course>): Course => ({
+export const mockCourse = (overrides: Partial<Course> = {}): Course => ({
   averageRating: 4.5,
   cadence: 'Weekly',
   certificationBadgeImage: 'badge.png',

--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -1,6 +1,6 @@
 import type { Course } from '@bluedot/db';
 
-export const mockCourse = (overrides: Partial<Course>): Course => ({
+export const mockCourse = (overrides?: Partial<Course>): Course => ({
   averageRating: 4.5,
   cadence: 'Weekly',
   certificationBadgeImage: 'badge.png',

--- a/apps/website/src/components/settings/CourseDetails.stories.tsx
+++ b/apps/website/src/components/settings/CourseDetails.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { loggedOutStory } from '@bluedot/ui';
 import CourseDetails from './CourseDetails';
+import { mockCourse as createMockCourse } from '../../__tests__/testUtils';
 
 const meta: Meta<typeof CourseDetails> = {
   title: 'Settings/CourseDetails',
@@ -17,29 +18,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Mock course data
-const mockCourse = {
-  id: 'course-1',
-  title: 'Introduction to AI Safety',
-  slug: 'intro-ai-safety',
-  path: '/courses/intro-ai-safety',
-  description: 'Learn the fundamentals of AI safety and alignment',
-  shortDescription: 'AI safety basics',
-  detailsUrl: '/courses/intro-ai-safety',
-  displayOnCourseHubIndex: true,
-  durationDescription: '8 weeks',
-  durationHours: 40,
-  units: ['unit-1', 'unit-2', 'unit-3'],
-  cadence: 'Weekly',
-  level: 'Beginner',
-  status: 'Active',
-  isNew: false,
-  isFeatured: true,
-  image: null,
-  certificationBadgeImage: null,
-  certificationDescription: null,
-  averageRating: null,
-  publicLastUpdated: null,
-};
+const mockCourse = createMockCourse();
 
 // Mock course registration
 const mockCourseRegistration = {
@@ -67,6 +46,7 @@ export const Default: Story = {
     authToken: 'test-token',
     isLast: false,
   },
+              type: 'success',
 };
 
 export const LastItem: Story = {

--- a/apps/website/src/components/settings/CourseDetails.stories.tsx
+++ b/apps/website/src/components/settings/CourseDetails.stories.tsx
@@ -141,7 +141,6 @@ export const Default: Story = {
     course: mockCourse,
     courseRegistration: mockCourseRegistration,
     authToken: 'test-token',
-    isLast: false,
   },
   parameters: {
     msw: {
@@ -168,7 +167,6 @@ export const Facilitator: Story = {
     course: mockCourse,
     courseRegistration: { ...mockCourseRegistration, role: 'Facilitator' },
     authToken: 'test-token',
-    isLast: false,
   },
   parameters: {
     docs: {

--- a/apps/website/src/components/settings/CourseDetails.stories.tsx
+++ b/apps/website/src/components/settings/CourseDetails.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { http, HttpResponse } from 'msw';
 import { loggedOutStory } from '@bluedot/ui';
+import type { MeetPerson } from '@bluedot/db';
 import CourseDetails from './CourseDetails';
 import { mockCourse as createMockCourse } from '../../__tests__/testUtils';
 import { GroupDiscussion } from '../../pages/api/group-discussions/[id]';
@@ -114,7 +115,7 @@ const mockDiscussions: Record<string, GroupDiscussion> = {
   },
 };
 
-const mockMeetPerson = {
+const mockMeetPerson: MeetPerson = {
   id: 'meet-person-1',
   name: 'John Doe',
   applicationsBaseRecordId: null,
@@ -125,7 +126,7 @@ const mockMeetPerson = {
   autoNumberId: 1,
 };
 
-const mockFacilitatorMeetPerson = {
+const mockFacilitatorMeetPerson: MeetPerson = {
   id: 'meet-person-2',
   name: 'Jane Facilitator',
   applicationsBaseRecordId: null,
@@ -136,6 +137,22 @@ const mockFacilitatorMeetPerson = {
   autoNumberId: 2,
 };
 
+const createMswHandlers = (meetPerson: MeetPerson) => [
+  http.get('/api/meet-person', () => {
+    return HttpResponse.json({ type: 'success', meetPerson });
+  }),
+  http.get('/api/group-discussions/:id', ({ params }) => {
+    const { id } = params;
+    const discussion = mockDiscussions[id as string];
+
+    return HttpResponse.json({
+      type: 'success',
+      discussion,
+    });
+  }),
+
+];
+
 export const Default: Story = {
   args: {
     course: mockCourse,
@@ -144,20 +161,7 @@ export const Default: Story = {
   },
   parameters: {
     msw: {
-      handlers: [
-        http.get('/api/meet-person', () => {
-          return HttpResponse.json({ type: 'success', meetPerson: mockMeetPerson });
-        }),
-        http.get('/api/group-discussions/:id', ({ params }) => {
-          const { id } = params;
-          const discussion = mockDiscussions[id as string];
-
-          return HttpResponse.json({
-            type: 'success',
-            discussion,
-          });
-        }),
-      ],
+      handlers: createMswHandlers(mockMeetPerson),
     },
   },
 };
@@ -175,20 +179,7 @@ export const Facilitator: Story = {
       },
     },
     msw: {
-      handlers: [
-        http.get('/api/meet-person', () => {
-          return HttpResponse.json({ type: 'success', meetPerson: mockFacilitatorMeetPerson });
-        }),
-        http.get('/api/group-discussions/:id', ({ params }) => {
-          const { id } = params;
-          const discussion = mockDiscussions[id as string];
-
-          return HttpResponse.json({
-            type: 'success',
-            discussion,
-          });
-        }),
-      ],
+      handlers: createMswHandlers(mockFacilitatorMeetPerson),
     },
   },
 };

--- a/apps/website/src/components/settings/CourseDetails.stories.tsx
+++ b/apps/website/src/components/settings/CourseDetails.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { loggedOutStory } from '@bluedot/ui';
 import CourseDetails from './CourseDetails';
 
 const meta: Meta<typeof CourseDetails> = {
@@ -6,6 +7,9 @@ const meta: Meta<typeof CourseDetails> = {
   component: CourseDetails,
   parameters: {
     layout: 'padded',
+  },
+  args: {
+    ...loggedOutStory,
   },
 };
 
@@ -85,21 +89,6 @@ export const Facilitator: Story = {
     docs: {
       description: {
         story: 'Facilitators do not see the "Switch group" button for discussions.',
-      },
-    },
-  },
-};
-
-export const NoAuthToken: Story = {
-  args: {
-    course: mockCourse,
-    courseRegistration: mockCourseRegistration,
-    isLast: false,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: 'Component can be rendered without an auth token for public viewing.',
       },
     },
   },

--- a/apps/website/src/components/settings/CourseDetails.stories.tsx
+++ b/apps/website/src/components/settings/CourseDetails.stories.tsx
@@ -56,12 +56,6 @@ const mockCourseRegistration = {
   decision: null,
 };
 
-// Mock facilitator registration
-const mockFacilitatorRegistration = {
-  ...mockCourseRegistration,
-  role: 'Facilitator' as const,
-};
-
 export const Default: Story = {
   args: {
     course: mockCourse,
@@ -83,7 +77,7 @@ export const LastItem: Story = {
 export const Facilitator: Story = {
   args: {
     course: mockCourse,
-    courseRegistration: mockFacilitatorRegistration,
+    courseRegistration: { ...mockCourseRegistration, role: 'Facilitator' },
     authToken: 'test-token',
     isLast: false,
   },

--- a/apps/website/src/components/settings/CourseDetails.stories.tsx
+++ b/apps/website/src/components/settings/CourseDetails.stories.tsx
@@ -136,21 +136,6 @@ const mockFacilitatorMeetPerson = {
   autoNumberId: 2,
 };
 
-const handlers = [
-  http.get('/api/meet-person', () => {
-    return HttpResponse.json({ type: 'success', meetPerson: mockMeetPerson });
-  }),
-  http.get('/api/group-discussions/:id', ({ params }) => {
-    const { id } = params;
-    const discussion = mockDiscussions[id as string];
-
-    return HttpResponse.json({
-      type: 'success',
-      discussion,
-    });
-  }),
-];
-
 export const Default: Story = {
   args: {
     course: mockCourse,
@@ -160,21 +145,20 @@ export const Default: Story = {
   },
   parameters: {
     msw: {
-      handlers,
-    },
-  },
-};
+      handlers: [
+        http.get('/api/meet-person', () => {
+          return HttpResponse.json({ type: 'success', meetPerson: mockMeetPerson });
+        }),
+        http.get('/api/group-discussions/:id', ({ params }) => {
+          const { id } = params;
+          const discussion = mockDiscussions[id as string];
 
-export const LastItem: Story = {
-  args: {
-    course: mockCourse,
-    courseRegistration: mockCourseRegistration,
-    authToken: 'test-token',
-    isLast: true,
-  },
-  parameters: {
-    msw: {
-      handlers,
+          return HttpResponse.json({
+            type: 'success',
+            discussion,
+          });
+        }),
+      ],
     },
   },
 };

--- a/apps/website/src/components/settings/CourseDetails.stories.tsx
+++ b/apps/website/src/components/settings/CourseDetails.stories.tsx
@@ -93,35 +93,3 @@ export const Facilitator: Story = {
     },
   },
 };
-
-export const WithDescription: Story = {
-  args: {
-    course: mockCourse,
-    courseRegistration: mockCourseRegistration,
-    authToken: 'test-token',
-    isLast: false,
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: `
-This component displays the expanded details for a course, including:
-- **Upcoming discussions**: Shows all scheduled group discussions
-- **Discussion timing**: Displays time until each discussion starts
-- **Action buttons**: 
-  - "Join Discussion" (when starting within 1 hour)
-  - "Prepare for discussion" (when more than 1 hour away)
-  - "Switch group" (for participants only, not facilitators)
-
-The component fetches discussion data from the \`/api/group-discussions\` endpoint.
-
-Features:
-- Responsive design with different layouts for mobile and desktop
-- Real-time countdown to discussion start times
-- Modal for switching groups
-- Different button states based on timing and user role
-        `,
-      },
-    },
-  },
-};

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -6,6 +6,8 @@ import { GroupDiscussion, GetGroupDiscussionResponse } from '../../pages/api/gro
 import GroupSwitchModal from '../courses/GroupSwitchModal';
 import { formatDateMonthAndDay, formatTime12HourClock } from '../../lib/utils';
 
+const HOUR_IN_SECONDS = 60 * 60; // 1 hour in seconds
+
 type CourseDetailsProps = {
   course: Course;
   courseRegistration: CourseRegistration;
@@ -111,9 +113,9 @@ const CourseDetails = ({
       return 'Discussion has started';
     }
 
-    const days = Math.floor(timeUntilStart / (24 * 60 * 60));
-    const hours = Math.floor((timeUntilStart % (24 * 60 * 60)) / (60 * 60));
-    const minutes = Math.floor((timeUntilStart % (60 * 60)) / 60);
+    const days = Math.floor(timeUntilStart / (24 * HOUR_IN_SECONDS));
+    const hours = Math.floor((timeUntilStart % (24 * HOUR_IN_SECONDS)) / (HOUR_IN_SECONDS));
+    const minutes = Math.floor((timeUntilStart % (HOUR_IN_SECONDS)) / 60);
 
     if (days > 0) {
       if (days === 1) {
@@ -141,9 +143,8 @@ const CourseDetails = ({
 
   const renderDiscussionItem = (discussion: GroupDiscussion, isNext = false, isPast = false) => {
     // Check if discussion starts in less than 1 hour
-    const oneHourInSeconds = 60 * 60;
     const timeUntilStart = discussion.startDateTime - currentTimeSeconds;
-    const isStartingSoon = timeUntilStart < oneHourInSeconds && timeUntilStart > 0;
+    const isStartingSoon = timeUntilStart < HOUR_IN_SECONDS && timeUntilStart > 0;
 
     // Check if user is a facilitator
     const isFacilitator = courseRegistration.role === 'Facilitator';

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -1,13 +1,13 @@
-import { courseTable, courseRegistrationTable, meetPersonTable } from '@bluedot/db';
 import useAxios from 'axios-hooks';
 import { useState, useEffect } from 'react';
+import { Course, CourseRegistration, MeetPerson } from '@bluedot/db';
 import { CTALinkOrButton, ProgressDots } from '@bluedot/ui';
 import { GroupDiscussion, GetGroupDiscussionResponse } from '../../pages/api/group-discussions/[id]';
 import GroupSwitchModal from '../courses/GroupSwitchModal';
 
 type CourseDetailsProps = {
-  course: typeof courseTable.pg.$inferSelect;
-  courseRegistration: typeof courseRegistrationTable.pg.$inferSelect;
+  course: Course;
+  courseRegistration: CourseRegistration;
   authToken?: string;
   isLast?: boolean;
 };
@@ -26,7 +26,7 @@ const CourseDetails = ({
   const [currentTimeSeconds, setCurrentTimeSeconds] = useState(Math.floor(Date.now() / 1000));
 
   // Fetch meetPerson data to get discussion IDs
-  const [{ data: meetPersonData }] = useAxios<{ type: 'success'; meetPerson: typeof meetPersonTable.pg.$inferSelect | null }>({
+  const [{ data: meetPersonData }] = useAxios<{ type: 'success'; meetPerson: MeetPerson | null }>({
     method: 'get',
     url: `/api/meet-person?courseRegistrationId=${courseRegistration.id}`,
     headers: authToken ? {

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -36,6 +36,8 @@ const CourseDetails = ({
     } : undefined,
   });
 
+  const isFacilitator = courseRegistration.role === 'Facilitator';
+
   // Fetch individual discussions when we have the meetPerson data
   useEffect(() => {
     const fetchDiscussions = async () => {
@@ -45,7 +47,6 @@ const CourseDetails = ({
 
       // Fetch all expected discussions (will be filtered later to show only those not ended)
       // Use expectedDiscussionsFacilitator if the user is a facilitator, otherwise use expectedDiscussionsParticipant
-      const isFacilitator = courseRegistration.role === 'Facilitator';
       const expectedDiscussionIds = isFacilitator
         ? (meetPersonData.meetPerson.expectedDiscussionsFacilitator || [])
         : (meetPersonData.meetPerson.expectedDiscussionsParticipant || []);
@@ -145,9 +146,6 @@ const CourseDetails = ({
     // Check if discussion starts in less than 1 hour
     const timeUntilStart = discussion.startDateTime - currentTimeSeconds;
     const isStartingSoon = timeUntilStart < HOUR_IN_SECONDS && timeUntilStart > 0;
-
-    // Check if user is a facilitator
-    const isFacilitator = courseRegistration.role === 'Facilitator';
 
     // Determine button text and URL based on timing
     const buttonText = isStartingSoon ? 'Join Discussion' : 'Prepare for discussion';

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -168,7 +168,7 @@ const CourseDetails = ({
                     size="small"
                     url={buttonUrl}
                     disabled={!discussion.zoomLink && isStartingSoon}
-                    target={isStartingSoon ? '_blank' : undefined}
+                    target="_blank"
                   >
                     {buttonText}
                   </CTALinkOrButton>
@@ -237,7 +237,7 @@ const CourseDetails = ({
                 size="small"
                 url={buttonUrl}
                 disabled={!discussion.zoomLink && isStartingSoon}
-                target={isStartingSoon ? '_blank' : undefined}
+                target="blank"
               >
                 {buttonText}
               </CTALinkOrButton>

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -4,7 +4,7 @@ import { Course, CourseRegistration, MeetPerson } from '@bluedot/db';
 import { CTALinkOrButton, ProgressDots } from '@bluedot/ui';
 import { GroupDiscussion, GetGroupDiscussionResponse } from '../../pages/api/group-discussions/[id]';
 import GroupSwitchModal from '../courses/GroupSwitchModal';
-import { formatDateMonthAndDay, formatTime12HourClock } from '../../lib/utils';
+import { formatDateMonthAndDay, formatDateTimeRelative, formatTime12HourClock } from '../../lib/utils';
 
 const HOUR_IN_SECONDS = 60 * 60; // 1 hour in seconds
 
@@ -105,37 +105,6 @@ const CourseDetails = ({
     return () => clearInterval(interval);
   }, []);
 
-  // Helper function to format time until discussion
-  const formatTimeUntilDiscussion = (startDateTime: number): string => {
-    const timeUntilStart = startDateTime - currentTimeSeconds;
-
-    if (timeUntilStart <= 0) {
-      return 'Discussion has started';
-    }
-
-    const days = Math.floor(timeUntilStart / (24 * HOUR_IN_SECONDS));
-    const hours = Math.floor((timeUntilStart % (24 * HOUR_IN_SECONDS)) / (HOUR_IN_SECONDS));
-    const minutes = Math.floor((timeUntilStart % (HOUR_IN_SECONDS)) / 60);
-
-    if (days > 0) {
-      if (days === 1) {
-        return '1 day';
-      }
-      return `${days} days`;
-    }
-
-    if (hours > 0 && minutes > 0) {
-      return `${hours}hr ${minutes}min`;
-    }
-    if (hours > 0) {
-      return `${hours}hr`;
-    }
-    if (minutes > 0) {
-      return `${minutes}min`;
-    }
-    return 'Less than 1min';
-  };
-
   // Filter expected discussions to only show those where the end datetime hasn't passed yet
   const upcomingDiscussions = expectedDiscussions.filter(
     (discussion) => discussion.endDateTime > currentTimeSeconds,
@@ -180,7 +149,7 @@ const CourseDetails = ({
               </div>
               {!isPast && (
                 <div className={`text-size-xs ${isNext ? 'text-blue-600 font-medium' : 'text-gray-500'}`}>
-                  {`Starts in ${formatTimeUntilDiscussion(discussion.startDateTime)}`}
+                  {`Starts ${formatDateTimeRelative(discussion.startDateTime)}`}
                 </div>
               )}
               {isPast && discussion.groupDetails && (
@@ -249,7 +218,7 @@ const CourseDetails = ({
               </div>
               {!isPast && (
                 <div className={`text-size-xs ${isNext ? 'text-blue-600 font-medium' : 'text-gray-500'}`}>
-                  {`Starts in ${formatTimeUntilDiscussion(discussion.startDateTime)}`}
+                  {`Starts ${formatDateTimeRelative(discussion.startDateTime)}`}
                 </div>
               )}
               {isPast && discussion.groupDetails && (

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -21,13 +21,12 @@ const CourseDetails = ({
   const [activeTab, setActiveTab] = useState<'upcoming' | 'attended'>('upcoming');
   const [expectedDiscussions, setExpectedDiscussions] = useState<GroupDiscussion[]>([]);
   const [attendedDiscussions, setAttendedDiscussions] = useState<GroupDiscussion[]>([]);
-  const [loading, setLoading] = useState(true);
   const [showAllUpcoming, setShowAllUpcoming] = useState(false);
   const [showAllAttended, setShowAllAttended] = useState(false);
   const [currentTimeSeconds, setCurrentTimeSeconds] = useState(Math.floor(Date.now() / 1000));
 
   // Fetch meetPerson data to get discussion IDs
-  const [{ data: meetPersonData }] = useAxios<{ type: 'success'; meetPerson: MeetPerson | null }>({
+  const [{ data: meetPersonData, loading }] = useAxios<{ type: 'success'; meetPerson: MeetPerson | null }>({
     method: 'get',
     url: `/api/meet-person?courseRegistrationId=${courseRegistration.id}`,
     headers: authToken ? {
@@ -39,11 +38,8 @@ const CourseDetails = ({
   useEffect(() => {
     const fetchDiscussions = async () => {
       if (!meetPersonData?.meetPerson) {
-        setLoading(false);
         return;
       }
-
-      setLoading(true);
 
       // Fetch all expected discussions (will be filtered later to show only those not ended)
       // Use expectedDiscussionsFacilitator if the user is a facilitator, otherwise use expectedDiscussionsParticipant
@@ -93,7 +89,6 @@ const CourseDetails = ({
 
       setExpectedDiscussions(validExpected);
       setAttendedDiscussions(validAttended);
-      setLoading(false);
     };
 
     fetchDiscussions();

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -12,11 +12,10 @@ type CourseDetailsProps = {
   course: Course;
   courseRegistration: CourseRegistration;
   authToken?: string;
-  isLast?: boolean;
 };
 
 const CourseDetails = ({
-  course, courseRegistration, authToken, isLast = false,
+  course, courseRegistration, authToken,
 }: CourseDetailsProps) => {
   const [groupSwitchModalOpen, setGroupSwitchModalOpen] = useState(false);
   const [selectedDiscussion, setSelectedDiscussion] = useState<GroupDiscussion | null>(null);
@@ -298,7 +297,7 @@ const CourseDetails = ({
 
   return (
     <>
-      <div className={`bg-white border-x border-b border-gray-200 ${isLast ? 'rounded-b-xl' : ''}`} role="region" aria-label={`Expanded details for ${course.title}`}>
+      <div className="bg-white border-x border-b border-gray-200 last:rounded-b-xl" role="region" aria-label={`Expanded details for ${course.title}`}>
         <div>
           {/* Section header with tabs */}
           <div className="flex border-b border-gray-200">

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -157,7 +157,6 @@ const CourseDetails = ({
     } else if (course.slug && discussion.unitNumber) {
       buttonUrl = `/courses/${course.slug}/${discussion.unitNumber}`;
     }
-    const openInNewTab = isStartingSoon;
 
     return (
       <div key={discussion.id} className="py-4 border-b border-gray-100 last:border-0">
@@ -203,7 +202,7 @@ const CourseDetails = ({
                     size="small"
                     url={buttonUrl}
                     disabled={!discussion.zoomLink && isStartingSoon}
-                    target={openInNewTab ? '_blank' : undefined}
+                    target={isStartingSoon ? '_blank' : undefined}
                   >
                     {buttonText}
                   </CTALinkOrButton>
@@ -272,7 +271,7 @@ const CourseDetails = ({
                 size="small"
                 url={buttonUrl}
                 disabled={!discussion.zoomLink && isStartingSoon}
-                target={openInNewTab ? '_blank' : undefined}
+                target={isStartingSoon ? '_blank' : undefined}
               >
                 {buttonText}
               </CTALinkOrButton>

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -4,6 +4,7 @@ import { Course, CourseRegistration, MeetPerson } from '@bluedot/db';
 import { CTALinkOrButton, ProgressDots } from '@bluedot/ui';
 import { GroupDiscussion, GetGroupDiscussionResponse } from '../../pages/api/group-discussions/[id]';
 import GroupSwitchModal from '../courses/GroupSwitchModal';
+import { formatDateMonthAndDay, formatTime12HourClock } from '../../lib/utils';
 
 type CourseDetailsProps = {
   course: Course;
@@ -143,21 +144,6 @@ const CourseDetails = ({
     (discussion) => discussion.endDateTime > currentTimeSeconds,
   );
 
-  // Format date and time
-  const formatDiscussionDate = (timestamp: number) => {
-    const date = new Date(timestamp * 1000);
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-  };
-
-  const formatDiscussionTime = (timestamp: number) => {
-    const date = new Date(timestamp * 1000);
-    return date.toLocaleTimeString('en-US', {
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
-    });
-  };
-
   const renderDiscussionItem = (discussion: GroupDiscussion, isNext = false, isPast = false) => {
     // Check if discussion starts in less than 1 hour
     const oneHourInSeconds = 60 * 60;
@@ -184,10 +170,10 @@ const CourseDetails = ({
           {/* Date and time column */}
           <div className="flex flex-col items-center justify-start min-w-[50px] pt-1">
             <div className="text-size-sm font-semibold text-gray-900 text-center">
-              {formatDiscussionDate(discussion.startDateTime)}
+              {formatDateMonthAndDay(discussion.startDateTime)}
             </div>
             <div className="text-size-xs text-gray-500 text-center">
-              {formatDiscussionTime(discussion.startDateTime)}
+              {formatTime12HourClock(discussion.startDateTime)}
             </div>
           </div>
 
@@ -255,10 +241,10 @@ const CourseDetails = ({
             {/* Date and time */}
             <div className="flex flex-col items-center justify-center min-w-[60px]">
               <div className="text-size-sm font-semibold text-gray-900 text-center">
-                {formatDiscussionDate(discussion.startDateTime)}
+                {formatDateMonthAndDay(discussion.startDateTime)}
               </div>
               <div className="text-size-xs text-gray-500 text-center">
-                {formatDiscussionTime(discussion.startDateTime)}
+                {formatTime12HourClock(discussion.startDateTime)}
               </div>
             </div>
 

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -94,7 +94,7 @@ const CourseDetails = ({
     };
 
     fetchDiscussions();
-  }, [meetPersonData, courseRegistration.role]);
+  }, [meetPersonData, isFacilitator]);
 
   // Update current time every 30 seconds for real-time countdown
   useEffect(() => {

--- a/apps/website/src/components/settings/CourseListRow.tsx
+++ b/apps/website/src/components/settings/CourseListRow.tsx
@@ -384,7 +384,6 @@ const CourseListRow = ({
           course={course}
           courseRegistration={courseRegistration}
           authToken={authToken}
-          isLast={isLast}
         />
       )}
     </div>


### PR DESCRIPTION
# Description

Was taking a look at the `CourseDetails` component as part of #1405. Made some changes:

1. Re-use existing DB types
2. Prefer axios `loading` instead of dedicated loading state
3. Re-use existing time formatting utils
4. Prefer `last:` tailwind CSS class to prop drilling `isLast`. We can also make this change for parent components, but I didn't want this PR to get too large
5. Mock HTTP requests for stories (so that they actually work, which they didn't before?!)

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories


## Screenshot

As a result of re-using some of the time formatting utils the abbreviations for time units have been expanded:

| Before | After |
|---|---|
| <img width="406" height="214" alt="image" src="https://github.com/user-attachments/assets/645cf592-ab3e-409e-b266-c186daa8c7bc" /> | <img width="387" height="231" alt="image" src="https://github.com/user-attachments/assets/569f4d2c-d9f3-49bd-b7a9-a1b90248959a" /> |

