### PR TITLE
[feat]: quote module enhancements

### DIFF
--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -643,98 +643,511 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       </div>
     </section>
     <section
-      class="flex flex-col items-center w-full py-6 px-5 lg:p-12"
+      aria-atomic="true"
+      aria-label="Quote carousel"
+      aria-live="polite"
+      class="relative w-full py-6 px-5 sm:py-6 sm:px-5 min-[680px]:py-6 min-[680px]:px-5 lg:p-12 overflow-x-hidden"
       style="background-color: #FAFAF7;"
     >
       <div
-        class="flex flex-col items-center gap-8 w-full max-w-[350px] lg:max-w-[1120px] mx-auto"
+        class="flex flex-col items-center gap-8 w-full max-w-[90vw] min-[680px]:max-w-none min-[680px]:w-[616px] lg:w-auto lg:max-w-none mx-auto overflow-visible"
       >
         <div
-          class="flex flex-col lg:flex-row w-full rounded-xl overflow-hidden h-[409px] lg:h-[385px]"
-          style="background-color: #ECF0FF;"
+          class="relative w-full"
         >
           <div
-            class="flex flex-col items-center lg:items-start p-8 px-6 lg:p-16 gap-12 flex-grow justify-between lg:justify-start"
+            class="lg:hidden relative"
           >
-            <blockquote
-              class="text-[20px] lg:text-[32px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
-              style="color: #13132E;"
-            >
-              "We should not underestimate the real threats coming from AI [while] we have a narrowing window of opportunity to guide this technology responsibly."
-            </blockquote>
             <div
-              class="flex flex-col items-center lg:items-start gap-4 lg:gap-0"
+              class="flex justify-center w-full"
             >
-              <a
-                class="cursor-pointer"
-                href="https://neighbourhood-enlargement.ec.europa.eu/news/2023-state-union-address-president-von-der-leyen-2023-09-13_en"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <img
-                  alt="Ursula von der Leyen"
-                  class="size-16 object-cover rounded-full lg:hidden"
-                  src="/images/agi-strategy/ursula.png"
-                />
-              </a>
               <div
-                class="flex flex-col items-center lg:items-start"
+                class="w-[90vw] min-[680px]:w-[616px] relative z-10"
               >
                 <div
-                  class="text-[18px] leading-tight font-semibold"
-                  style="color: #13132E;"
+                  class="w-full rounded-xl overflow-hidden"
+                  style="background-color: #ECF0FF;"
                 >
-                  Ursula von der Leyen
+                  <div
+                    class="flex flex-col lg:flex-row-reverse w-full h-[465px] min-[680px]:!h-[377px] lg:h-[385px]"
+                  >
+                    <div
+                      class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
+                    >
+                      <blockquote
+                        class="text-[20px] min-[680px]:text-[24px] lg:text-[28px] xl:text-[32px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                        style="color: #13132E;"
+                      >
+                        "We should not underestimate the real threats coming from AI [while] we have a narrowing window of opportunity to guide this technology responsibly."
+                      </blockquote>
+                      <div
+                        class="flex flex-col items-center lg:items-start gap-4 lg:gap-0"
+                      >
+                        <a
+                          class="cursor-pointer"
+                          href="https://neighbourhood-enlargement.ec.europa.eu/news/2023-state-union-address-president-von-der-leyen-2023-09-13_en"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Ursula von der Leyen"
+                            class="size-12 sm:size-16 object-cover rounded-full lg:hidden"
+                            src="/images/agi-strategy/ursula.png"
+                          />
+                        </a>
+                        <div
+                          class="flex flex-col items-center lg:items-start"
+                        >
+                          <div
+                            class="text-[18px] leading-tight font-semibold"
+                            style="color: #13132E;"
+                          >
+                            Ursula von der Leyen
+                          </div>
+                          <div
+                            class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                            style="color: #13132E;"
+                          >
+                            President, European Commission
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="hidden lg:block w-80 h-[385px] flex-shrink-0 overflow-hidden rounded-l-xl"
+                    >
+                      <a
+                        class="block size-full cursor-pointer"
+                        href="https://neighbourhood-enlargement.ec.europa.eu/news/2023-state-union-address-president-von-der-leyen-2023-09-13_en"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <img
+                          alt="Ursula von der Leyen"
+                          class="size-full object-cover rounded-l-xl"
+                          src="/images/agi-strategy/ursula.png"
+                        />
+                      </a>
+                    </div>
+                  </div>
                 </div>
+              </div>
+            </div>
+            <div
+              class="min-[680px]:hidden absolute top-0 left-1/2 pointer-events-none"
+            >
+              <div
+                class="relative pointer-events-auto"
+                style="left: calc(45vw + 10px);"
+              >
                 <div
-                  class="text-[16px] leading-[1.6] opacity-80"
-                  style="color: #13132E;"
+                  class="w-[90vw]"
                 >
-                  President, European Commission
+                  <button
+                    aria-label="Go to next quote"
+                    class="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+                    style="background-color: #ECF0FF;"
+                    type="button"
+                  >
+                    <div
+                      class="flex flex-col lg:flex-row-reverse w-full h-[465px] min-[680px]:!h-[377px] lg:h-[385px]"
+                    >
+                      <div
+                        class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
+                      >
+                        <blockquote
+                          class="text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                          style="color: #13132E;"
+                        >
+                          "I've always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we've done in the past… The downside is, at some point, that humanity loses control of the technology it's developing."
+                        </blockquote>
+                        <div
+                          class="flex flex-col items-center lg:items-start gap-4 lg:gap-0"
+                        >
+                          <img
+                            alt="Sundar Pichai"
+                            class="size-12 sm:size-16 object-cover rounded-full lg:hidden"
+                            src="/images/agi-strategy/sundar.jpg"
+                          />
+                          <div
+                            class="flex flex-col items-center lg:items-start"
+                          >
+                            <div
+                              class="text-[18px] leading-tight font-semibold"
+                              style="color: #13132E;"
+                            >
+                              Sundar Pichai
+                            </div>
+                            <div
+                              class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                              style="color: #13132E;"
+                            >
+                              CEO, Google
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="hidden lg:block w-80 h-[385px] flex-shrink-0 overflow-hidden rounded-l-xl"
+                      >
+                        <img
+                          alt="Sundar Pichai"
+                          class="size-full object-cover rounded-l-xl"
+                          src="/images/agi-strategy/sundar.jpg"
+                        />
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="hidden min-[680px]:block lg:hidden absolute top-0 pointer-events-none"
+              style="left: calc(50% + 318px);"
+            >
+              <div
+                class="w-[616px] pointer-events-auto"
+              >
+                <button
+                  aria-label="Go to next quote"
+                  class="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+                  style="background-color: #ECF0FF;"
+                  type="button"
+                >
+                  <div
+                    class="flex flex-col lg:flex-row-reverse w-full h-[465px] min-[680px]:!h-[377px] lg:h-[385px]"
+                  >
+                    <div
+                      class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
+                    >
+                      <blockquote
+                        class="text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                        style="color: #13132E;"
+                      >
+                        "I've always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we've done in the past… The downside is, at some point, that humanity loses control of the technology it's developing."
+                      </blockquote>
+                      <div
+                        class="flex flex-col items-center lg:items-start gap-4 lg:gap-0"
+                      >
+                        <img
+                          alt="Sundar Pichai"
+                          class="size-12 sm:size-16 object-cover rounded-full lg:hidden"
+                          src="/images/agi-strategy/sundar.jpg"
+                        />
+                        <div
+                          class="flex flex-col items-center lg:items-start"
+                        >
+                          <div
+                            class="text-[18px] leading-tight font-semibold"
+                            style="color: #13132E;"
+                          >
+                            Sundar Pichai
+                          </div>
+                          <div
+                            class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                            style="color: #13132E;"
+                          >
+                            CEO, Google
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="hidden lg:block w-80 h-[385px] flex-shrink-0 overflow-hidden rounded-l-xl"
+                    >
+                      <img
+                        alt="Sundar Pichai"
+                        class="size-full object-cover rounded-l-xl"
+                        src="/images/agi-strategy/sundar.jpg"
+                      />
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="hidden lg:block relative"
+          >
+            <div
+              class="flex justify-center w-full"
+            >
+              <div
+                class="lg:w-[928px] xl:w-[1120px] relative z-10"
+              >
+                <div
+                  class="w-full rounded-xl overflow-hidden"
+                  style="background-color: #ECF0FF;"
+                >
+                  <div
+                    class="flex flex-col lg:flex-row-reverse w-full h-[465px] min-[680px]:!h-[377px] lg:h-[385px]"
+                  >
+                    <div
+                      class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
+                    >
+                      <blockquote
+                        class="text-[20px] min-[680px]:text-[24px] lg:text-[28px] xl:text-[32px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                        style="color: #13132E;"
+                      >
+                        "We should not underestimate the real threats coming from AI [while] we have a narrowing window of opportunity to guide this technology responsibly."
+                      </blockquote>
+                      <div
+                        class="flex flex-col items-center lg:items-start gap-4 lg:gap-0"
+                      >
+                        <a
+                          class="cursor-pointer"
+                          href="https://neighbourhood-enlargement.ec.europa.eu/news/2023-state-union-address-president-von-der-leyen-2023-09-13_en"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Ursula von der Leyen"
+                            class="size-12 sm:size-16 object-cover rounded-full lg:hidden"
+                            src="/images/agi-strategy/ursula.png"
+                          />
+                        </a>
+                        <div
+                          class="flex flex-col items-center lg:items-start"
+                        >
+                          <div
+                            class="text-[18px] leading-tight font-semibold"
+                            style="color: #13132E;"
+                          >
+                            Ursula von der Leyen
+                          </div>
+                          <div
+                            class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                            style="color: #13132E;"
+                          >
+                            President, European Commission
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="hidden lg:block w-80 h-[385px] flex-shrink-0 overflow-hidden rounded-l-xl"
+                    >
+                      <a
+                        class="block size-full cursor-pointer"
+                        href="https://neighbourhood-enlargement.ec.europa.eu/news/2023-state-union-address-president-von-der-leyen-2023-09-13_en"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <img
+                          alt="Ursula von der Leyen"
+                          class="size-full object-cover rounded-l-xl"
+                          src="/images/agi-strategy/ursula.png"
+                        />
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="absolute inset-0 pointer-events-none"
+            >
+              <div
+                class="absolute top-0 pointer-events-auto hidden lg:block xl:hidden"
+                style="left: calc(50% + 496px);"
+              >
+                <div
+                  class="w-[928px]"
+                >
+                  <button
+                    aria-label="Go to next quote"
+                    class="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+                    style="background-color: #ECF0FF;"
+                    type="button"
+                  >
+                    <div
+                      class="flex flex-col lg:flex-row-reverse w-full h-[465px] min-[680px]:!h-[377px] lg:h-[385px]"
+                    >
+                      <div
+                        class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
+                      >
+                        <blockquote
+                          class="text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                          style="color: #13132E;"
+                        >
+                          "I've always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we've done in the past… The downside is, at some point, that humanity loses control of the technology it's developing."
+                        </blockquote>
+                        <div
+                          class="flex flex-col items-center lg:items-start gap-4 lg:gap-0"
+                        >
+                          <img
+                            alt="Sundar Pichai"
+                            class="size-12 sm:size-16 object-cover rounded-full lg:hidden"
+                            src="/images/agi-strategy/sundar.jpg"
+                          />
+                          <div
+                            class="flex flex-col items-center lg:items-start"
+                          >
+                            <div
+                              class="text-[18px] leading-tight font-semibold"
+                              style="color: #13132E;"
+                            >
+                              Sundar Pichai
+                            </div>
+                            <div
+                              class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                              style="color: #13132E;"
+                            >
+                              CEO, Google
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="hidden lg:block w-80 h-[385px] flex-shrink-0 overflow-hidden rounded-l-xl"
+                      >
+                        <img
+                          alt="Sundar Pichai"
+                          class="size-full object-cover rounded-l-xl"
+                          src="/images/agi-strategy/sundar.jpg"
+                        />
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="absolute top-0 pointer-events-auto hidden xl:block"
+                style="left: calc(50% + 592px);"
+              >
+                <div
+                  class="w-[1120px]"
+                >
+                  <button
+                    aria-label="Go to next quote"
+                    class="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+                    style="background-color: #ECF0FF;"
+                    type="button"
+                  >
+                    <div
+                      class="flex flex-col lg:flex-row-reverse w-full h-[465px] min-[680px]:!h-[377px] lg:h-[385px]"
+                    >
+                      <div
+                        class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
+                      >
+                        <blockquote
+                          class="text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                          style="color: #13132E;"
+                        >
+                          "I've always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we've done in the past… The downside is, at some point, that humanity loses control of the technology it's developing."
+                        </blockquote>
+                        <div
+                          class="flex flex-col items-center lg:items-start gap-4 lg:gap-0"
+                        >
+                          <img
+                            alt="Sundar Pichai"
+                            class="size-12 sm:size-16 object-cover rounded-full lg:hidden"
+                            src="/images/agi-strategy/sundar.jpg"
+                          />
+                          <div
+                            class="flex flex-col items-center lg:items-start"
+                          >
+                            <div
+                              class="text-[18px] leading-tight font-semibold"
+                              style="color: #13132E;"
+                            >
+                              Sundar Pichai
+                            </div>
+                            <div
+                              class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                              style="color: #13132E;"
+                            >
+                              CEO, Google
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="hidden lg:block w-80 h-[385px] flex-shrink-0 overflow-hidden rounded-l-xl"
+                      >
+                        <img
+                          alt="Sundar Pichai"
+                          class="size-full object-cover rounded-l-xl"
+                          src="/images/agi-strategy/sundar.jpg"
+                        />
+                      </div>
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>
           </div>
-          <a
-            class="hidden lg:block w-80 h-[385px] flex-shrink-0 cursor-pointer"
-            href="https://neighbourhood-enlargement.ec.europa.eu/news/2023-state-union-address-president-von-der-leyen-2023-09-13_en"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <img
-              alt="Ursula von der Leyen"
-              class="size-full object-cover"
-              src="/images/agi-strategy/ursula.png"
-            />
-          </a>
         </div>
         <div
-          class="flex gap-2"
+          class="flex items-center justify-center min-[680px]:gap-8 min-[680px]:w-[616px] lg:w-[928px] lg:h-[38px] lg:gap-8 relative z-10"
         >
           <button
-            aria-label="Go to quote 1"
-            class="h-1.5 w-12 rounded cursor-pointer transition-all duration-300 opacity-100"
-            style="background-color: #2244BB;"
+            aria-label="Previous quote"
+            class="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus:outline-none"
             type="button"
-          />
+          >
+            <span
+              class="text-[#13132E] text-[22.4px] font-medium select-none"
+              style="transform: scaleX(-1);"
+            >
+              →
+            </span>
+          </button>
+          <div
+            class="flex gap-2 w-[280px] h-[38px] min-[680px]:w-[408px] min-[680px]:h-[38px] lg:w-[408px] lg:h-[38px]"
+          >
+            <button
+              aria-label="Go to quote 1"
+              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+              type="button"
+            >
+              <div
+                class="w-full min-[680px]:w-24 h-1.5 rounded transition-all duration-300"
+                style="background-color: #2244BB; opacity: 1;"
+              />
+            </button>
+            <button
+              aria-label="Go to quote 2"
+              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+              type="button"
+            >
+              <div
+                class="w-full min-[680px]:w-24 h-1.5 rounded transition-all duration-300"
+                style="background-color: #13132E; opacity: 0.15;"
+              />
+            </button>
+            <button
+              aria-label="Go to quote 3"
+              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+              type="button"
+            >
+              <div
+                class="w-full min-[680px]:w-24 h-1.5 rounded transition-all duration-300"
+                style="background-color: #13132E; opacity: 0.15;"
+              />
+            </button>
+            <button
+              aria-label="Go to quote 4"
+              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+              type="button"
+            >
+              <div
+                class="w-full min-[680px]:w-24 h-1.5 rounded transition-all duration-300"
+                style="background-color: #13132E; opacity: 0.15;"
+              />
+            </button>
+          </div>
           <button
-            aria-label="Go to quote 2"
-            class="h-1.5 w-12 rounded cursor-pointer transition-all duration-300 opacity-15"
-            style="background-color: #13132E;"
+            aria-label="Next quote"
+            class="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus:outline-none"
             type="button"
-          />
-          <button
-            aria-label="Go to quote 3"
-            class="h-1.5 w-12 rounded cursor-pointer transition-all duration-300 opacity-15"
-            style="background-color: #13132E;"
-            type="button"
-          />
-          <button
-            aria-label="Go to quote 4"
-            class="h-1.5 w-12 rounded cursor-pointer transition-all duration-300 opacity-15"
-            style="background-color: #13132E;"
-            type="button"
-          />
+          >
+            <span
+              class="text-[#13132E] text-[22.4px] font-medium select-none"
+            >
+              →
+            </span>
+          </button>
         </div>
       </div>
     </section>

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -650,7 +650,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       style="background-color: #FAFAF7;"
     >
       <div
-        class="flex flex-col items-center gap-8 w-full max-w-[90vw] min-[680px]:max-w-none min-[680px]:w-[616px] lg:w-auto lg:max-w-none mx-auto overflow-visible"
+        class="flex flex-col items-center gap-8 w-full max-w-[calc(100vw-40px)] min-[680px]:max-w-none min-[680px]:w-[calc(100vw-64px)] lg:w-auto lg:max-w-none mx-auto overflow-visible"
       >
         <div
           class="relative w-full"
@@ -662,7 +662,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               class="flex justify-center w-full"
             >
               <div
-                class="w-[90vw] min-[680px]:w-[616px] relative z-10"
+                class="w-[calc(100vw-40px)] min-[680px]:w-[calc(100vw-64px)] relative z-10"
               >
                 <div
                   class="w-full rounded-xl overflow-hidden"
@@ -675,7 +675,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                       class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
                     >
                       <blockquote
-                        class="text-[20px] min-[680px]:text-[24px] lg:text-[28px] xl:text-[32px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                        class="text-[20px] min-[680px]:text-[24px] lg:text-[28px] xl:text-[32px] leading-normal lg:leading-tight font-semibold text-center lg:text-left"
                         style="color: #13132E;"
                       >
                         "We should not underestimate the real threats coming from AI [while] we have a narrowing window of opportunity to guide this technology responsibly."
@@ -705,7 +705,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                             Ursula von der Leyen
                           </div>
                           <div
-                            class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                            class="text-[16px] leading-[1.6] opacity-80 text-center lg:text-left lg:px-0"
                             style="color: #13132E;"
                           >
                             President, European Commission
@@ -738,10 +738,9 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             >
               <div
                 class="relative pointer-events-auto"
-                style="left: calc(45vw + 10px);"
               >
                 <div
-                  class="w-[90vw]"
+                  class="w-[calc(100vw-40px)]"
                 >
                   <button
                     aria-label="Go to next quote"
@@ -756,7 +755,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                         class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
                       >
                         <blockquote
-                          class="text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                          class="text-[16px] sm:text-[18px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-normal lg:leading-tight font-semibold text-center lg:text-left"
                           style="color: #13132E;"
                         >
                           "I've always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we've done in the past… The downside is, at some point, that humanity loses control of the technology it's developing."
@@ -779,7 +778,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                               Sundar Pichai
                             </div>
                             <div
-                              class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                              class="text-[16px] leading-[1.6] opacity-80 text-center lg:text-left lg:px-0"
                               style="color: #13132E;"
                             >
                               CEO, Google
@@ -803,10 +802,9 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             </div>
             <div
               class="hidden min-[680px]:block lg:hidden absolute top-0 pointer-events-none"
-              style="left: calc(50% + 318px);"
             >
               <div
-                class="w-[616px] pointer-events-auto"
+                class="w-[calc(100vw-64px)] pointer-events-auto"
               >
                 <button
                   aria-label="Go to next quote"
@@ -821,7 +819,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                       class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
                     >
                       <blockquote
-                        class="text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                        class="text-[16px] sm:text-[18px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-normal lg:leading-tight font-semibold text-center lg:text-left"
                         style="color: #13132E;"
                       >
                         "I've always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we've done in the past… The downside is, at some point, that humanity loses control of the technology it's developing."
@@ -844,7 +842,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                             Sundar Pichai
                           </div>
                           <div
-                            class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                            class="text-[16px] leading-[1.6] opacity-80 text-center lg:text-left lg:px-0"
                             style="color: #13132E;"
                           >
                             CEO, Google
@@ -886,7 +884,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                       class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
                     >
                       <blockquote
-                        class="text-[20px] min-[680px]:text-[24px] lg:text-[28px] xl:text-[32px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                        class="text-[20px] min-[680px]:text-[24px] lg:text-[28px] xl:text-[32px] leading-normal lg:leading-tight font-semibold text-center lg:text-left"
                         style="color: #13132E;"
                       >
                         "We should not underestimate the real threats coming from AI [while] we have a narrowing window of opportunity to guide this technology responsibly."
@@ -916,7 +914,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                             Ursula von der Leyen
                           </div>
                           <div
-                            class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                            class="text-[16px] leading-[1.6] opacity-80 text-center lg:text-left lg:px-0"
                             style="color: #13132E;"
                           >
                             President, European Commission
@@ -967,7 +965,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                         class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
                       >
                         <blockquote
-                          class="text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                          class="text-[16px] sm:text-[18px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-normal lg:leading-tight font-semibold text-center lg:text-left"
                           style="color: #13132E;"
                         >
                           "I've always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we've done in the past… The downside is, at some point, that humanity loses control of the technology it's developing."
@@ -990,7 +988,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                               Sundar Pichai
                             </div>
                             <div
-                              class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                              class="text-[16px] leading-[1.6] opacity-80 text-center lg:text-left lg:px-0"
                               style="color: #13132E;"
                             >
                               CEO, Google
@@ -1031,7 +1029,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                         class="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between"
                       >
                         <blockquote
-                          class="text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left"
+                          class="text-[16px] sm:text-[18px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px] leading-normal lg:leading-tight font-semibold text-center lg:text-left"
                           style="color: #13132E;"
                         >
                           "I've always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we've done in the past… The downside is, at some point, that humanity loses control of the technology it's developing."
@@ -1054,7 +1052,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                               Sundar Pichai
                             </div>
                             <div
-                              class="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0"
+                              class="text-[16px] leading-[1.6] opacity-80 text-center lg:text-left lg:px-0"
                               style="color: #13132E;"
                             >
                               CEO, Google
@@ -1079,7 +1077,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
           </div>
         </div>
         <div
-          class="flex items-center justify-center min-[680px]:gap-8 min-[680px]:w-[616px] lg:w-[928px] lg:h-[38px] lg:gap-8 relative z-10"
+          class="flex items-center justify-center w-[calc(100vw-40px)] min-[680px]:gap-8 min-[680px]:w-[calc(100vw-64px)] lg:w-[928px] lg:h-[38px] lg:gap-8 relative z-10"
         >
           <button
             aria-label="Previous quote"

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -744,7 +744,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                 >
                   <button
                     aria-label="Go to next quote"
-                    class="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+                    class="w-full cursor-pointer rounded-xl overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
                     style="background-color: #ECF0FF;"
                     type="button"
                   >
@@ -808,7 +808,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               >
                 <button
                   aria-label="Go to next quote"
-                  class="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+                  class="w-full cursor-pointer rounded-xl overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
                   style="background-color: #ECF0FF;"
                   type="button"
                 >
@@ -954,7 +954,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                 >
                   <button
                     aria-label="Go to next quote"
-                    class="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+                    class="w-full cursor-pointer rounded-xl overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
                     style="background-color: #ECF0FF;"
                     type="button"
                   >
@@ -1018,7 +1018,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                 >
                   <button
                     aria-label="Go to next quote"
-                    class="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+                    class="w-full cursor-pointer rounded-xl overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
                     style="background-color: #ECF0FF;"
                     type="button"
                   >
@@ -1081,7 +1081,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
         >
           <button
             aria-label="Previous quote"
-            class="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus:outline-none"
+            class="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
             type="button"
           >
             <span
@@ -1096,7 +1096,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
           >
             <button
               aria-label="Go to quote 1"
-              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
               type="button"
             >
               <div
@@ -1106,7 +1106,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             </button>
             <button
               aria-label="Go to quote 2"
-              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
               type="button"
             >
               <div
@@ -1116,7 +1116,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             </button>
             <button
               aria-label="Go to quote 3"
-              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
               type="button"
             >
               <div
@@ -1126,7 +1126,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             </button>
             <button
               aria-label="Go to quote 4"
-              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+              class="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
               type="button"
             >
               <div
@@ -1137,7 +1137,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
           </div>
           <button
             aria-label="Next quote"
-            class="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus:outline-none"
+            class="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
             type="button"
           >
             <span

--- a/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
@@ -149,7 +149,7 @@ const QuoteCard = ({ quote, isActive = true, onClick }: {
       <button
         type="button"
         onClick={onClick}
-        className="w-full cursor-pointer focus:outline-none rounded-xl overflow-hidden"
+        className="w-full cursor-pointer rounded-xl overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
         style={{ backgroundColor: COLORS.cardBg }}
         aria-label="Go to next quote"
       >
@@ -239,21 +239,21 @@ const QuoteSection = () => {
   }, []);
 
   // Touch/swipe handling for mobile
-  const touchStartX = useRef<number>(0);
-  const touchEndX = useRef<number>(0);
+  const touchStartX = useRef<number | null>(null);
+  const touchEndX = useRef<number | null>(null);
   const minSwipeDistance = 50;
 
   const handleTouchStart = (e: React.TouchEvent) => {
-    touchStartX.current = e.targetTouches[0]?.clientX || 0;
+    touchStartX.current = e.targetTouches[0]?.clientX ?? null;
+    touchEndX.current = null;
   };
 
   const handleTouchMove = (e: React.TouchEvent) => {
-    touchEndX.current = e.targetTouches[0]?.clientX || 0;
+    touchEndX.current = e.targetTouches[0]?.clientX ?? null;
   };
 
   const handleTouchEnd = () => {
-    if (!touchStartX.current || !touchEndX.current) return;
-
+    if (touchStartX.current === null || touchEndX.current === null) return;
     const distance = touchStartX.current - touchEndX.current;
     const isLeftSwipe = distance > minSwipeDistance;
     const isRightSwipe = distance < -minSwipeDistance;
@@ -263,6 +263,8 @@ const QuoteSection = () => {
     } else if (isRightSwipe) {
       handlePrevious();
     }
+    touchStartX.current = null;
+    touchEndX.current = null;
   };
 
   const activeQuote = testimonialQuotes[activeIndex];
@@ -367,8 +369,7 @@ const QuoteSection = () => {
             <button
               type="button"
               onClick={handlePrevious}
-              onKeyDown={(e) => e.key === 'Enter' && handlePrevious()}
-              className="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus:outline-none"
+              className="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
               aria-label="Previous quote"
             >
               <span
@@ -389,8 +390,7 @@ const QuoteSection = () => {
                 type="button"
                 key={`indicator-${quote.name}`}
                 onClick={() => handleIndicatorClick(index)}
-                onKeyDown={(e) => e.key === 'Enter' && handleIndicatorClick(index)}
-                className="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus:outline-none"
+                className="flex-1 py-4 h-[38px] min-[680px]:flex-none min-[680px]:w-24 min-[680px]:h-[38px] lg:w-24 lg:h-[38px] cursor-pointer transition-all duration-300 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
                 aria-label={`Go to quote ${index + 1}`}
               >
                 <div
@@ -409,8 +409,7 @@ const QuoteSection = () => {
             <button
               type="button"
               onClick={handleNext}
-              onKeyDown={(e) => e.key === 'Enter' && handleNext()}
-              className="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus:outline-none"
+              className="size-12 rounded-full flex items-center justify-center bg-[rgba(19,19,46,0.08)] transition-all duration-200 opacity-80 hover:opacity-100 hover:bg-[rgba(19,19,46,0.15)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2244BB]"
               aria-label="Next quote"
             >
               <span

--- a/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
@@ -2,6 +2,7 @@ import {
   useState, useEffect, useRef, useCallback,
 } from 'react';
 import { Quote } from '@bluedot/ui';
+import { useAboveBreakpoint } from '@bluedot/ui/src/hooks/useBreakpoint';
 
 type QuoteWithUrl = Quote & {
   url: string;
@@ -168,37 +169,12 @@ const QuoteCard = ({ quote, isActive = true, onClick }: {
   );
 };
 
-// Hook to detect screen size
-const useIsDesktop = () => {
-  const [isDesktop, setIsDesktop] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-
-    const checkScreenSize = () => {
-      setIsDesktop(window.innerWidth >= 680);
-    };
-
-    // Check on mount
-    checkScreenSize();
-
-    // Add event listener
-    window.addEventListener('resize', checkScreenSize);
-
-    // Cleanup
-    return () => window.removeEventListener('resize', checkScreenSize);
-  }, []);
-
-  return isMounted && isDesktop;
-};
-
 const QuoteSection = () => {
   const [activeIndex, setActiveIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const autorotateTiming = 11000;
-  const isDesktop = useIsDesktop();
+  const isDesktop = useAboveBreakpoint(680); // 680px is the design breakpoint specified
 
   // Single effect that handles all timer logic
   useEffect(() => {

--- a/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
@@ -52,8 +52,8 @@ const FONT_SIZE_THRESHOLDS = {
 } as const;
 
 const FONT_SIZE_CLASSES = {
-  EXTRA_LONG: 'text-[14px] sm:text-[16px] min-[680px]:text-[16px] lg:text-[16px] xl:text-[20px]', // For quotes > 400 chars
-  LONG: 'text-[18px] sm:text-[20px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px]', // For quotes 200-400 chars
+  EXTRA_LONG: 'text-[12px] sm:text-[14px] min-[680px]:text-[16px] lg:text-[16px] xl:text-[20px]', // For quotes > 400 chars
+  LONG: 'text-[16px] sm:text-[18px] min-[680px]:text-[20px] lg:text-[20px] xl:text-[24px]', // For quotes 200-400 chars
   DEFAULT: 'text-[20px] min-[680px]:text-[24px] lg:text-[28px] xl:text-[32px]', // For quotes < 200 chars
 } as const;
 
@@ -81,7 +81,7 @@ const QuoteCard = ({ quote, isActive = true, onClick }: {
       <div className="flex flex-col items-center lg:items-start py-8 px-6 min-[680px]:!py-8 min-[680px]:!px-6 lg:!p-16 gap-6 sm:gap-8 min-[680px]:gap-12 flex-grow justify-between">
         {/* Quote text - sizing automatically determined by content length */}
         <blockquote
-          className={`${getFontSizeForQuote(quote.quote)} leading-[1.4] lg:leading-tight font-semibold text-center lg:text-left`}
+          className={`${getFontSizeForQuote(quote.quote)} leading-normal lg:leading-tight font-semibold text-center lg:text-left`}
           style={{ color: COLORS.text }}
         >
           {quote.quote}
@@ -111,7 +111,7 @@ const QuoteCard = ({ quote, isActive = true, onClick }: {
             <div className="text-[18px] leading-tight font-semibold" style={{ color: COLORS.text }}>
               {quote.name}
             </div>
-            <div className="text-[16px] leading-[1.6] opacity-80 whitespace-nowrap px-2 lg:px-0" style={{ color: COLORS.text }}>
+            <div className="text-[16px] leading-[1.6] opacity-80 text-center lg:text-left lg:px-0" style={{ color: COLORS.text }}>
               {quote.role}
             </div>
           </div>
@@ -286,14 +286,14 @@ const QuoteSection = () => {
       aria-atomic="true"
     >
       {/* Main content container */}
-      <div className="flex flex-col items-center gap-8 w-full max-w-[90vw] min-[680px]:max-w-none min-[680px]:w-[616px] lg:w-auto lg:max-w-none mx-auto overflow-visible">
+      <div className="flex flex-col items-center gap-8 w-full max-w-[calc(100vw-40px)] min-[680px]:max-w-none min-[680px]:w-[calc(100vw-64px)] lg:w-auto lg:max-w-none mx-auto overflow-visible">
         {/* Quote cards container */}
         <div className="relative w-full">
           {/* Mobile and Tablet layout with peek effect (below 1024px) */}
           <div className="lg:hidden relative">
             {/* Main quote card - centered */}
             <div className="flex justify-center w-full">
-              <div className="w-[90vw] min-[680px]:w-[616px] relative z-10">
+              <div className="w-[calc(100vw-40px)] min-[680px]:w-[calc(100vw-64px)] relative z-10">
                 <QuoteCard quote={activeQuote} isActive />
               </div>
             </div>
@@ -303,16 +303,16 @@ const QuoteSection = () => {
               <>
                 {/* Mobile peek card (below 680px) */}
                 <div className="min-[680px]:hidden absolute top-0 left-1/2 pointer-events-none">
-                  <div className="relative pointer-events-auto" style={{ left: 'calc(45vw + 10px)' }}>
-                    <div className="w-[90vw]">
+                  <div className="relative pointer-events-auto" style={{ left: 'calc((100vw - 40px) / 2 + 10px)' }}>
+                    <div className="w-[calc(100vw-40px)]">
                       <QuoteCard quote={nextQuote} isActive={false} onClick={handleNext} />
                     </div>
                   </div>
                 </div>
 
                 {/* Tablet peek card (680px-1023px) */}
-                <div className="hidden min-[680px]:block lg:hidden absolute top-0 pointer-events-none" style={{ left: 'calc(50% + 318px)' }}>
-                  <div className="w-[616px] pointer-events-auto">
+                <div className="hidden min-[680px]:block lg:hidden absolute top-0 pointer-events-none" style={{ left: 'calc(50% + (100vw - 64px) / 2 + 10px)' }}>
+                  <div className="w-[calc(100vw-64px)] pointer-events-auto">
                     <QuoteCard quote={nextQuote} isActive={false} onClick={handleNext} />
                   </div>
                 </div>
@@ -361,7 +361,7 @@ const QuoteSection = () => {
         </div>
 
         {/* Navigation controls - Match 680px Figma specs exactly */}
-        <div className="flex items-center justify-center min-[680px]:gap-8 min-[680px]:w-[616px] lg:w-[928px] lg:h-[38px] lg:gap-8 relative z-10">
+        <div className="flex items-center justify-center w-[calc(100vw-40px)] min-[680px]:gap-8 min-[680px]:w-[calc(100vw-64px)] lg:w-[928px] lg:h-[38px] lg:gap-8 relative z-10">
           {/* Left arrow - Shows at 680px+ matching CommunityMembersSubSection */}
           {isDesktop && (
             <button

--- a/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
@@ -206,6 +206,17 @@ const QuoteSection = () => {
     setIsPaused(false);
   };
 
+  const handleFocusCapture = () => {
+    setIsPaused(true);
+  };
+
+  const handleBlurCapture = (e: React.FocusEvent) => {
+    // Only unpause if focus is leaving the entire section
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setIsPaused(false);
+    }
+  };
+
   const handlePrevious = useCallback(() => {
     setActiveIndex((prevIndex) => (prevIndex === 0 ? testimonialQuotes.length - 1 : prevIndex - 1));
   }, []);
@@ -256,6 +267,8 @@ const QuoteSection = () => {
       style={{ backgroundColor: COLORS.background }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      onFocusCapture={handleFocusCapture}
+      onBlurCapture={handleBlurCapture}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}

--- a/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
@@ -70,7 +70,6 @@ const getFontSizeForQuote = (quote: string): string => {
   return FONT_SIZE_CLASSES.DEFAULT;
 };
 
-// QuoteCard Component - Reusable card structure
 const QuoteCard = ({ quote, isActive = true, onClick }: {
   quote: QuoteWithUrl;
   isActive?: boolean;

--- a/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/QuoteSection.tsx
@@ -210,9 +210,11 @@ const QuoteSection = () => {
     setIsPaused(true);
   };
 
-  const handleBlurCapture = (e: React.FocusEvent) => {
+  const handleBlurCapture = (e: React.FocusEvent<HTMLElement>) => {
     // Only unpause if focus is leaving the entire section
-    if (!e.currentTarget.contains(e.relatedTarget)) {
+    const nextFocusedNode = e.relatedTarget instanceof Node ? e.relatedTarget : null;
+
+    if (!nextFocusedNode || !e.currentTarget.contains(nextFocusedNode)) {
       setIsPaused(false);
     }
   };

--- a/libraries/ui/src/hooks/useBreakpoint.ts
+++ b/libraries/ui/src/hooks/useBreakpoint.ts
@@ -19,7 +19,7 @@ export const useAboveBreakpoint = (breakpoint: number) => {
   // Returns false during SSR when window is undefined.
   // This avoids the initial null state that would cause components to flicker on first render.
   const [isAbove, setIsAbove] = useState<boolean>(
-    typeof window !== 'undefined' ? window.innerWidth >= breakpoint : false
+    typeof window !== 'undefined' ? window.innerWidth >= breakpoint : false,
   );
 
   useEffect(() => {

--- a/libraries/ui/src/hooks/useBreakpoint.ts
+++ b/libraries/ui/src/hooks/useBreakpoint.ts
@@ -15,9 +15,6 @@ export const breakpoints = {
 } as const;
 
 export const useAboveBreakpoint = (breakpoint: number) => {
-  // Initialize with actual boolean value based on current window width to prevent layout shifts.
-  // Returns false during SSR when window is undefined.
-  // This avoids the initial null state that would cause components to flicker on first render.
   const [isAbove, setIsAbove] = useState<boolean | null>(null);
 
   useEffect(() => {

--- a/libraries/ui/src/hooks/useBreakpoint.ts
+++ b/libraries/ui/src/hooks/useBreakpoint.ts
@@ -18,9 +18,7 @@ export const useAboveBreakpoint = (breakpoint: number) => {
   // Initialize with actual boolean value based on current window width to prevent layout shifts.
   // Returns false during SSR when window is undefined.
   // This avoids the initial null state that would cause components to flicker on first render.
-  const [isAbove, setIsAbove] = useState<boolean>(
-    typeof window !== 'undefined' ? window.innerWidth >= breakpoint : false,
-  );
+  const [isAbove, setIsAbove] = useState<boolean | null>(null);
 
   useEffect(() => {
     const checkBreakpoint = () => {

--- a/libraries/ui/src/hooks/useBreakpoint.ts
+++ b/libraries/ui/src/hooks/useBreakpoint.ts
@@ -15,7 +15,12 @@ export const breakpoints = {
 } as const;
 
 export const useAboveBreakpoint = (breakpoint: number) => {
-  const [isAbove, setIsAbove] = useState<boolean | null>(null);
+  // Initialize with actual boolean value based on current window width to prevent layout shifts.
+  // Returns false during SSR when window is undefined.
+  // This avoids the initial null state that would cause components to flicker on first render.
+  const [isAbove, setIsAbove] = useState<boolean>(
+    typeof window !== 'undefined' ? window.innerWidth >= breakpoint : false
+  );
 
   useEffect(() => {
     const checkBreakpoint = () => {


### PR DESCRIPTION
# Description
Variety of quote module enhancements:
- Larger hit-boxes, selector lines
- Navigation arrows
- Next-card stacked horizontally "peeks" to the right with full-bleed, clicking advances to next card
- Additional breakpoint support at 320px and 680px
- Updated styling from new requirements (left-aligned image, bottom-aligned names/titles)
- Text-size logic based on length of quotes

**Out of scope (PR getting too long, can be separate issue):**
- Swipe/carousel animations

## Issue
Closes #1344

Also implements parts of:
- #1404 (bottom-alignment of names/titles)
- #1414 (addtl breakpoint support)

**Note:** timer reset and hover pause were already fixed in #1346 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Larger hit-boxes, navigation arrows
![larger-hitbox](https://github.com/user-attachments/assets/1c9f7324-f837-4685-a75b-6c568887ff24)

### Desktop
![quote-module-enhancements-desktop](https://github.com/user-attachments/assets/a47a6987-f68d-4b78-862d-c23fd3746799)

![quote-module-enhancements-zoom-out](https://github.com/user-attachments/assets/f01153bc-d35c-4c8a-9680-8ea77cdf16da)

#### 1024px
<img width="1026" height="708" alt="1024px" src="https://github.com/user-attachments/assets/a47792ea-db28-4394-a45b-b09e3e8ab112" />

#### 680px
<img width="681" height="647" alt="680px" src="https://github.com/user-attachments/assets/89fa64e6-6508-48c8-bbf6-b7cdd1b97ca0" />

### Mobile (320px)
![quote-module-enhancements-mobile](https://github.com/user-attachments/assets/3091a3db-c41b-4b1d-adf4-e0c14b6bcb60)
