### PR TITLE
[Bug] Use 'warn-and-retry' option in airtable-ts to gracefully handle errors due to edits to Airtable bases

### DIFF
--- a/apps/website/src/lib/api/db/index.ts
+++ b/apps/website/src/lib/api/db/index.ts
@@ -1,7 +1,12 @@
 import { PgAirtableDb } from '@bluedot/db';
+import { slackAlert } from '@bluedot/utils';
 import env from '../env';
 
 export default new PgAirtableDb({
   pgConnString: env.PG_URL,
   airtableApiKey: env.AIRTABLE_PERSONAL_ACCESS_TOKEN,
+  airtableTsOptions: {
+    validationMode: 'warn-and-retry',
+    onWarning: (warning: string) => slackAlert(env, [warning]),
+  },
 });

--- a/libraries/db/package.json
+++ b/libraries/db/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@bluedot/utils": "*",
-        "airtable-ts": "^1.5.0",
+        "airtable-ts": "^1.7.0",
         "drizzle-orm": "^0.43.1",
         "happy-dom": "18.0.1",
         "pg": "^8.15.6"

--- a/libraries/db/src/lib/client.ts
+++ b/libraries/db/src/lib/client.ts
@@ -3,8 +3,9 @@ import {
 } from 'drizzle-orm';
 import { PgInsertValue, PgUpdateSetSource, PgColumn } from 'drizzle-orm/pg-core';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { AirtableTs, AirtableTsError } from 'airtable-ts';
-import { ErrorType } from 'airtable-ts/dist/AirtableTsError';
+import {
+  AirtableTs, AirtableTsError, AirtableTsOptions, ErrorType,
+} from 'airtable-ts';
 import { PgAirtableTable } from './db-core';
 import { AirtableItemFromColumnsMap, BasePgTableType, PgAirtableColumnInput } from './typeUtils';
 
@@ -112,9 +113,18 @@ export class PgAirtableDb {
   /** @deprecated Old name. Use .remove() instead */
   public airtableDelete = this.remove.bind(this);
 
-  constructor({ pgConnString, airtableApiKey }: { pgConnString: string; airtableApiKey: string }) {
+  constructor({
+    pgConnString,
+    airtableApiKey,
+    airtableTsOptions,
+  }: {
+    pgConnString: string;
+    airtableApiKey: string;
+    airtableTsOptions: AirtableTsOptions;
+  }) {
     this.airtableClient = new AirtableTs({
       apiKey: airtableApiKey,
+      ...airtableTsOptions,
     });
     this.pgUnrestricted = drizzle(pgConnString);
     this.pg = this.pgUnrestricted as RestrictedPgDatabase;

--- a/libraries/ui/src/utils/makeMakeApiRoute.ts
+++ b/libraries/ui/src/utils/makeMakeApiRoute.ts
@@ -5,7 +5,7 @@ import {
   trace, metrics,
   SpanStatusCode,
 } from '@opentelemetry/api';
-import { slackAlert } from '@bluedot/utils/src/slackNotifications';
+import { slackAlert } from '@bluedot/utils';
 import { logger } from './logger';
 
 export type RouteOptions<ReqZT extends ZodType, ResZT extends ZodType, RequiresAuth extends boolean> = {

--- a/libraries/utils/src/index.ts
+++ b/libraries/utils/src/index.ts
@@ -1,1 +1,2 @@
 export { validateEnv } from './validateEnv';
+export { slackAlert } from './slackNotifications';

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,23 @@
         "node": "^22"
       }
     },
+    "../airtable-ts": {
+      "version": "1.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "airtable": "^0.12.2"
+      },
+      "devDependencies": {
+        "@tsconfig/node-lts": "^22.0.1",
+        "@tsconfig/strictest": "^2.0.2",
+        "@types/node": "^22.15.3",
+        "eslint": "^9.25.1",
+        "eslint-config-domdomegg": "^2.0.8",
+        "tsconfig-domdomegg": "^1.0.0",
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.2"
+      }
+    },
     "apps/app-template": {
       "name": "@bluedot/app-template",
       "version": "1.0.0",
@@ -556,7 +573,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@bluedot/utils": "*",
-        "airtable-ts": "^1.5.0",
+        "airtable-ts": "file:../../../airtable-ts",
         "drizzle-orm": "^0.43.1",
         "happy-dom": "18.0.1",
         "pg": "^8.15.6"
@@ -16388,6 +16405,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -16395,12 +16413,6 @@
       "engines": {
         "node": ">=6.5"
       }
-    },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
-      "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
-      "license": "MIT"
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -16552,37 +16564,9 @@
         }
       }
     },
-    "node_modules/airtable": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.12.2.tgz",
-      "integrity": "sha512-HS3VytUBTKj8A0vPl7DDr5p/w3IOGv6RXL0fv7eczOWAtj9Xe8ri4TAiZRXoOyo+Z/COADCj+oARFenbxhmkIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": ">=8.0.0 <15",
-        "abort-controller": "^3.0.0",
-        "abortcontroller-polyfill": "^1.4.0",
-        "lodash": "^4.17.21",
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/airtable-ts": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/airtable-ts/-/airtable-ts-1.6.0.tgz",
-      "integrity": "sha512-l7ineeeSrJ2AfuRXwbJZi/29eRNHfso3l7gF/8ewQzn4mC+jM5Pyj8V4jb+vGVdxxiq9KnqVXAwRIu+sRD3g1w==",
-      "license": "MIT",
-      "dependencies": {
-        "airtable": "^0.12.2",
-        "axios": "^1.6.8"
-      }
-    },
-    "node_modules/airtable/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
+      "resolved": "../airtable-ts",
+      "link": true
     },
     "node_modules/ajv": {
       "version": "8.17.1",
@@ -21370,6 +21354,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

_Pending merging a PR against the airtable-ts repo, I'm putting this up first so I can explain how we plan to use this_

We have seen errors in production due to:
- Unused fields being deleted from Airtable
- The types of fields being edited in Airtable

This PR adopts a change to [airtable-ts](https://github.com/domdomegg/airtable-ts), to support 'warn-and-retry' for these specific errors during queries (but not during write operations).

When one of these errors occurs, an `onWarning` callback will be called to send a slack alert with the content of the error. The query will then be retried, attempting to bypass the above validation steps. If this succeeds it will return the object with the affected fields set to null/undefined, if it fails it will throw another error which will also appear in slack.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1190

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 |  |
|---------|---|
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
