### PR TITLE
Fix `CertificateLinkCard` test TS errors

### DIFF
--- a/apps/website/src/components/courses/CertificateLinkCard.test.tsx
+++ b/apps/website/src/components/courses/CertificateLinkCard.test.tsx
@@ -70,7 +70,8 @@ describe('CertificateLinkCard', () => {
 
     test('renders loading state', () => {
       vi.mocked(useAxios).mockReturnValue([
-        { data: undefined, loading: true, error: undefined },
+        { data: undefined, loading: true, error: null },
+        vi.fn(),
         vi.fn(),
       ] as UseAxiosReturnType);
 
@@ -96,8 +97,9 @@ describe('CertificateLinkCard', () => {
             },
           },
           loading: false,
-          error: undefined,
+          error: null,
         },
+        vi.fn(),
         vi.fn(),
       ] as UseAxiosReturnType);
 
@@ -124,16 +126,18 @@ describe('CertificateLinkCard', () => {
               },
             },
             loading: false,
-            error: undefined,
+            error: null,
           },
+          vi.fn(),
           vi.fn(),
         ] as UseAxiosReturnType)
         .mockReturnValueOnce([
           {
             data: undefined,
             loading: false,
-            error: undefined,
+            error: null,
           },
+          vi.fn(),
           vi.fn(),
         ] as UseAxiosReturnType);
 
@@ -166,8 +170,9 @@ describe('CertificateLinkCard', () => {
             },
           },
           loading: false,
-          error: undefined,
+          error: null,
         },
+        vi.fn(),
         vi.fn(),
       ] as UseAxiosReturnType);
 


### PR DESCRIPTION
# Description

1. `type UseAxiosReturnType = [ResponseValues<unknown, unknown, unknown>, RefetchFunction<unknown, unknown>, () => void]`
2. `The types of 'error' are incompatible between these types. Type 'undefined' is not comparable to type 'AxiosError<unknown, unknown> | null'.ts(2352)`

To fix:

1. Add a third (empty) function to the mock
2. Make `error` null, not undefined. 

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
 
<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA