### PR TITLE
Fix Dockerfile key/value warnings

### DIFF
--- a/apps/app-template/Dockerfile
+++ b/apps/app-template/Dockerfile
@@ -28,6 +28,5 @@ USER node
 
 EXPOSE 8080
 
-ENV HOSTNAME=0.0.0.0
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node ./apps/${APP_NAME}/server.js"]
+CMD HOSTNAME="0.0.0.0" PORT="8080" dumb-init node ./apps/${APP_NAME}/server.js
+

--- a/apps/availability/Dockerfile
+++ b/apps/availability/Dockerfile
@@ -22,6 +22,4 @@ USER node
 
 EXPOSE 8080
 
-ENV HOSTNAME=0.0.0.0
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node ./apps/${APP_NAME}/server.js"]
+CMD HOSTNAME="0.0.0.0" PORT="8080" dumb-init node ./apps/${APP_NAME}/server.js

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -22,5 +22,4 @@ COPY --chown=node:node ./dist/ .
 
 EXPOSE 8080
 
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node index.js"]
+CMD PORT="8080" dumb-init node index.js

--- a/apps/course-demos/Dockerfile
+++ b/apps/course-demos/Dockerfile
@@ -28,6 +28,4 @@ USER node
 
 EXPOSE 8080
 
-ENV HOSTNAME=0.0.0.0
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node ./apps/${APP_NAME}/server.js"]
+CMD HOSTNAME="0.0.0.0" PORT="8080" dumb-init node ./apps/${APP_NAME}/server.js

--- a/apps/editor/Dockerfile
+++ b/apps/editor/Dockerfile
@@ -28,6 +28,4 @@ USER node
 
 EXPOSE 8080
 
-ENV HOSTNAME=0.0.0.0
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node ./apps/${APP_NAME}/server.js"]
+CMD HOSTNAME="0.0.0.0" PORT="8080" dumb-init node ./apps/${APP_NAME}/server.js

--- a/apps/frontend-example/Dockerfile
+++ b/apps/frontend-example/Dockerfile
@@ -22,6 +22,4 @@ USER node
 
 EXPOSE 8080
 
-ENV HOSTNAME=0.0.0.0
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node ./apps/${APP_NAME}/server.js"]
+CMD HOSTNAME="0.0.0.0" PORT="8080" dumb-init node ./apps/${APP_NAME}/server.js

--- a/apps/meet/Dockerfile
+++ b/apps/meet/Dockerfile
@@ -22,6 +22,4 @@ USER node
 
 EXPOSE 8080
 
-ENV HOSTNAME=0.0.0.0
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node ./apps/${APP_NAME}/server.js"]
+CMD HOSTNAME="0.0.0.0" PORT="8080" dumb-init node ./apps/${APP_NAME}/server.js

--- a/apps/pg-sync-service/Dockerfile
+++ b/apps/pg-sync-service/Dockerfile
@@ -22,5 +22,4 @@ COPY --chown=node:node ./dist/ .
 
 EXPOSE 8080
 
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node index.js"]
+CMD PORT="8080" dumb-init node index.js

--- a/apps/room/Dockerfile
+++ b/apps/room/Dockerfile
@@ -28,6 +28,4 @@ USER node
 
 EXPOSE 8080
 
-ENV HOSTNAME=0.0.0.0
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node ./apps/${APP_NAME}/server.js"]
+CMD HOSTNAME="0.0.0.0" PORT="8080" dumb-init node ./apps/${APP_NAME}/server.js

--- a/apps/website/Dockerfile
+++ b/apps/website/Dockerfile
@@ -22,6 +22,4 @@ USER node
 
 EXPOSE 8080
 
-ENV HOSTNAME=0.0.0.0
-ENV PORT=8080
-CMD ["sh", "-c", "dumb-init node ./apps/${APP_NAME}/server.js"]
+CMD HOSTNAME="0.0.0.0" PORT="8080" dumb-init node ./apps/${APP_NAME}/server.js


### PR DESCRIPTION
# Description

Fix  `Legacy key/value format with whitespace separator should not be used ("ENV key=value" should be used instead of legacy "ENV key value" format) - https://docs.docker.com/reference/build-checks/legacy-key-value-format/` warning

## Issue

NA

## Developer checklist

NA

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
