### PR TITLE
Fix hidden progress dots that vertically expand buttons

### DIFF
--- a/apps/website/src/components/settings/PasswordSection.tsx
+++ b/apps/website/src/components/settings/PasswordSection.tsx
@@ -291,9 +291,9 @@ const ChangePasswordModal = ({
             aria-label="Update password"
           >
             {isLoading ? (
-              <span className="flex items-center [&_.progress-dots]:my-0 [&_.progress-dots_span]:bg-white">
+              <span className="flex items-center gap-2 [&_.progress-dots]:my-0 [&_.progress-dots_span]:bg-white">
                 <ProgressDots />
-                <span className="ml-2">Updating...</span>
+                <span>Updating...</span>
               </span>
             ) : (
               'Update Password'


### PR DESCRIPTION
# Description

We currently render progress dots inside CTA button when changing user password. Two problems:

1. The dots are not visible, since they have the same colour as the button
2. The dots have a vertical margin, which forces the button height to increase on load

This is a quick fix to tidy up these issues. Going forward it would be better to implement a more maintainable solution, or a version of inline progress dots so that we don't have to keep forcefully over-riding styles.

## Issue

NA

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | ![update_pass_old](https://github.com/user-attachments/assets/45d23ea9-efac-4341-973f-7bff3d03c245) | ![update_pass](https://github.com/user-attachments/assets/3c2ac27b-443e-4d9b-906c-79636a77197f) |

