### PR TITLE
[Bug] Use 'prefill_Source=x' rather than 'utm_source=x' in miniextensions application forms

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import {
+  addQueryParam,
   CTALinkOrButton,
   useLatestUtmParams,
 } from '@bluedot/ui';
@@ -89,8 +90,8 @@ const communityMembers: CommunityMember[] = [
 ];
 
 const AgiStrategyLander = () => {
-  const { appendLatestUtmParamsToUrl } = useLatestUtmParams();
-  const applicationUrlWithUtm = appendLatestUtmParamsToUrl(applicationUrl);
+  const { latestUtmParams } = useLatestUtmParams();
+  const applicationUrlWithUtm = latestUtmParams.utm_source ? addQueryParam(applicationUrl, 'prefill_Source', latestUtmParams.utm_source) : applicationUrl;
 
   return (
     <div className="bg-white">

--- a/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.tsx
@@ -1,4 +1,9 @@
-import { NewText, CTALinkOrButton, useLatestUtmParams } from '@bluedot/ui';
+import {
+  NewText,
+  CTALinkOrButton,
+  useLatestUtmParams,
+  addQueryParam,
+} from '@bluedot/ui';
 import {
   PiGraduationCap,
   PiClockClockwise,
@@ -12,8 +17,8 @@ const { H2, P } = NewText;
 const applicationUrl = 'https://web.miniextensions.com/9Kuya4AzFGWgayC3gQaX';
 
 const CourseDetailsSection = () => {
-  const { appendLatestUtmParamsToUrl } = useLatestUtmParams();
-  const applicationUrlWithUtm = appendLatestUtmParamsToUrl(applicationUrl);
+  const { latestUtmParams } = useLatestUtmParams();
+  const applicationUrlWithUtm = latestUtmParams.utm_source ? addQueryParam(applicationUrl, 'prefill_Source', latestUtmParams.utm_source) : applicationUrl;
 
   const courseDetails = [
     {

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -1,4 +1,5 @@
 import {
+  addQueryParam,
   Breadcrumbs,
   CTALinkOrButton,
   HeroCTAContainer,
@@ -50,9 +51,11 @@ const renderCoursePage = ({ slug, courseData }: { slug: string; courseData: Cour
   return <StandardCoursePage courseData={courseData} />;
 };
 
+const registerInterestUrl = 'https://web.miniextensions.com/aGd0mXnpcN1gfqlnYNZc';
+
 const StandardCoursePage = ({ courseData }: { courseData: CourseAndUnits }) => {
-  const { appendLatestUtmParamsToUrl } = useLatestUtmParams();
-  const registerInterestUrl = appendLatestUtmParamsToUrl('https://web.miniextensions.com/aGd0mXnpcN1gfqlnYNZc');
+  const { latestUtmParams } = useLatestUtmParams();
+  const registerInterestUrlWithUtm = latestUtmParams.utm_source ? addQueryParam(registerInterestUrl, 'prefill_Source', latestUtmParams.utm_source) : registerInterestUrl;
 
   return (
     <div>
@@ -72,7 +75,7 @@ const StandardCoursePage = ({ courseData }: { courseData: CourseAndUnits }) => {
                 </HeroCTAContainer>
               )}
               <HeroCTAContainer>
-                <CTALinkOrButton url={registerInterestUrl}>Register interest</CTALinkOrButton>
+                <CTALinkOrButton url={registerInterestUrlWithUtm}>Register interest</CTALinkOrButton>
               </HeroCTAContainer>
             </div>
           </HeroSection>


### PR DESCRIPTION
# Description

I [previously](https://github.com/bluedotimpact/bluedot/pull/1420) set things up to pass forward utm parameters to miniextensions form links, with the goal of populating the [Source](https://airtable.com/appnJbsG1eWbAdEvf/tblXKnWoXK3R63F6D/viwLQvVM8i8Q261Qb/fldQ9PM3ejhilPFc6) field in the Course registrations table when the user submits the application.

I didn't realise that the format needs to be `?prefill_Source=xyz` rather than `?utm_source=xyz`. I've now tested this end to end and confirmed that the source comes through to the airtable record.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1354

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

N/A