### PR TITLE
Don't expose sensitive tRPC internal server error or resource not found messages

### DIFF
--- a/apps/website/src/server/trpc.ts
+++ b/apps/website/src/server/trpc.ts
@@ -10,11 +10,8 @@ import { Context } from './context';
 // For instance, the use of a t variable is common in i18n libraries.
 const t = initTRPC.context<Context>().create({
   errorFormatter({ shape, error }) {
-    // Return full error details in development
-    if (process.env.NODE_ENV !== 'production') return shape;
-
     // Hide internal server error details in production
-    if (error.code === 'INTERNAL_SERVER_ERROR') {
+    if (error.code === 'INTERNAL_SERVER_ERROR' && process.env.NODE_ENV === 'production') {
       return {
         ...shape,
         message: 'An internal server error occurred',
@@ -25,8 +22,8 @@ const t = initTRPC.context<Context>().create({
       };
     }
 
-    // Mask not found errors to hide any specific resource information
-    if (error.code === 'NOT_FOUND') {
+    // Mask not found errors to hide any specific resource information in production
+    if (error.code === 'NOT_FOUND' && process.env.NODE_ENV === 'production') {
       return {
         ...shape,
         message: 'Resource not found',


### PR DESCRIPTION
# Description

We shouldn't expose sensitive information when we have internal server errors. To prevent this we replace the error message with a generic 'An internal server error occurred'.

Edit: updating to also exclude 404 errors with a generic 'Resource not found' based on [Martin's feedback.](https://github.com/bluedotimpact/bluedot/pull/1472?notification_referrer_id=NT_kwDOAaN71rQxOTc3NzU2NDAwNzoyNzQ5MTI4Ng#discussion_r2449581252)

## Issue

NA

## Developer checklist

NA
<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
