### PR TITLE
[Bug] Track `utm_source` of current session when creating course registration from the website

### DIFF
--- a/apps/website/src/pages/api/course-registrations/[courseId]/index.tsx
+++ b/apps/website/src/pages/api/course-registrations/[courseId]/index.tsx
@@ -14,7 +14,7 @@ export type GetCourseRegistrationResponse = {
 export default makeApiRoute({
   requireAuth: true,
   requestBody: z.object({
-    source: z.string().nullish(),
+    source: z.string().trim().max(255).nullish(),
   }).optional(),
   responseBody: z.object({
     type: z.literal('success'),

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -74,15 +74,14 @@ const CourseUnitChunkPage = ({
     headers: {
       Authorization: `Bearer ${auth?.token}`,
     },
-    data: { source: latestUtmParams.utm_source ?? null },
   }, { manual: true });
 
   useEffect(() => {
     const shouldRecordCourseRegistration = !!(auth && unit.courseId);
     if (shouldRecordCourseRegistration) {
-      fetchCourseRegistration().catch(() => { /* no op, as we ignore errors */ });
+      fetchCourseRegistration({ data: { source: latestUtmParams.utm_source ?? null } }).catch(() => { /* no op, as we ignore errors */ });
     }
-  }, [auth, unit.courseId, fetchCourseRegistration]);
+  }, [auth, unit.courseId, fetchCourseRegistration, latestUtmParams.utm_source]);
 
   useEffect(() => {
     if (chunks && (chunkIndex < 0 || chunkIndex >= chunks.length)) {


### PR DESCRIPTION
# Description

Course registrations can be created in two ways:
1. When a logged in user visits the course content (e.g. https://bluedot.org/courses/future-of-ai/1/1) page for the first time
2. When a user submits the miniextensions application form

We want to track the `utm_source` the user arrives with in both cases. This PR covers the first case, making it so that the latest `utm_source` seen in the current session (since the last refresh) is tracked in the [source](https://airtable.com/appnJbsG1eWbAdEvf/tblXKnWoXK3R63F6D/viwLQvVM8i8Q261Qb/fldQ9PM3ejhilPFc6) column when a course registration is created.

This will still work if the user lands logged out, as a result of [this change](https://github.com/bluedotimpact/bluedot/pull/1442) to patch the UTM params back onto the url the user is redirected to after login. It won't work however if they do a hard refresh or open an internal link in a new tab, if the UTM params are no longer in the URL.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1354 (specifically see https://github.com/bluedotimpact/bluedot/issues/1354#issuecomment-3416547482)

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
  - Decided against because it's a trivial usage of `useLatestUtmParams` which already has tests
- [x] Considered adding Storybook stories

## Screenshot
N/A