### PR TITLE
Fix missing leading underscore for CTA button target

### DIFF
--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -237,7 +237,7 @@ const CourseDetails = ({
                 size="small"
                 url={buttonUrl}
                 disabled={!discussion.zoomLink && isStartingSoon}
-                target="blank"
+                target="_blank"
               >
                 {buttonText}
               </CTALinkOrButton>


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Target should be `_blank`, not `blank`

## Issue

NA

## Developer checklist

NA

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
