### PR TITLE
[feat]: 320px support

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.tsx
@@ -9,7 +9,7 @@ import { H3 } from '../Text';
 import CommunityMembersSubSection, { CommunityMember } from './agi-strategy/CommunityMembersSubSection';
 import GraduateSection from './agi-strategy/GraduateSection';
 import PartnerSection from './agi-strategy/PartnerSection';
-import WhyTakeThisCourseSection from './agi-strategy/WhyTakeThisCourseSection';
+import CourseBenefitsSection from './agi-strategy/CourseBenefitsSection';
 import WhoIsThisForSection from './agi-strategy/WhoIsThisForSection';
 import HeroSection from './agi-strategy/HeroSection';
 import QuoteSection from './agi-strategy/QuoteSection';
@@ -19,14 +19,14 @@ import FAQSection from './agi-strategy/FAQSection';
 
 const AgiStrategyBanner = ({ title, ctaUrl }: { title: string, ctaUrl: string }) => {
   return (
-    <div className="relative w-full mx-auto overflow-hidden rounded-xl bg-[#13132E] bg-[url('/images/agi-strategy/hero-banner-split.png')] bg-cover bg-center xl:max-w-[1118px]">
+    <div className="relative w-full h-[382px] min-[680px]:h-[360px] mx-auto overflow-hidden rounded-xl bg-[#13132E] bg-[url('/images/agi-strategy/hero-banner-split.png')] bg-cover bg-center xl:max-w-[1118px]">
       {/* Noise layer */}
       <div className="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light" />
 
-      <div className="relative flex flex-col items-center justify-center px-14 py-16 gap-8 text-center">
+      <div className="relative flex flex-col items-center justify-center h-full px-14 py-16 gap-8 text-center">
         <img src="/images/agi-strategy/bluedot-icon.svg" alt="BlueDot" className="w-8 h-[30px]" />
 
-        <H3 className="max-w-[238px] min-[680px]:max-w-[496px] text-[20px] min-[680px]:text-[36px] font-semibold text-white">
+        <H3 className="max-w-[238px] min-[680px]:max-w-[496px] text-[20px] min-[680px]:text-[36px] font-[600] text-white leading-[140%] min-[680px]:leading-[125%]">
           {title}
         </H3>
 
@@ -133,8 +133,8 @@ const AgiStrategyLander = () => {
       {/* Course Curriculum Section */}
       <CourseCurriculumSection />
 
-      {/* Why take this course section */}
-      <WhyTakeThisCourseSection />
+      {/* Course Benefits Section */}
+      <CourseBenefitsSection />
 
       {/* Course Details Section */}
       <CourseDetailsSection />
@@ -153,7 +153,7 @@ const AgiStrategyLander = () => {
 
       {/* Banner */}
       <section className="w-full bg-white pt-0 pb-12 md:pb-16 lg:pb-20">
-        <div className="max-w-max-width mx-auto px-4 min-[680px]:px-8 lg:px-spacing-x">
+        <div className="max-w-max-width mx-auto px-5 min-[680px]:px-8 lg:px-spacing-x">
           <AgiStrategyBanner
             title="Start building towards a good future today"
             ctaUrl={applicationUrlWithUtm}

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-[#FAFAF7]"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
+        class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
       >
         <h2
           class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
@@ -208,7 +208,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-white"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
+        class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
       >
         <h2
           class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
@@ -241,7 +241,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-white"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x pt-12 pb-16"
+        class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12"
       >
         <h2
           class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]"
@@ -366,7 +366,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-[#FAFAF7]"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16"
+        class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16"
       >
         <h2
           class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] text-center font-semibold leading-[125%] text-[#13132E] tracking-[-0.01em]"
@@ -1161,7 +1161,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-[#FAFAF7]"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x py-12 md:py-20 lg:py-24"
+        class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:py-20 lg:py-24"
       >
         <h2
           class="text-[28px] min-[680px]:text-[32px] min-[1280px]:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center mb-12 md:mb-16 max-w-[734px] mx-auto"
@@ -1169,7 +1169,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
           Co-created with our network of leading AI industry partners
         </h2>
         <div
-          class="max-lg:block hidden -mx-spacing-x"
+          class="max-lg:block hidden -mx-5 min-[680px]:-mx-spacing-x"
         >
           <div
             class="w-full inline-flex flex-nowrap overflow-hidden group"
@@ -1702,7 +1702,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-white"
     >
       <div
-        class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
+        class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
       >
         <div
           class="max-w-[928px] mx-auto flex flex-col gap-12 md:gap-16"
@@ -1825,16 +1825,16 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
       class="w-full bg-white pt-0 pb-12 md:pb-16 lg:pb-20"
     >
       <div
-        class="max-w-max-width mx-auto px-4 min-[680px]:px-8 lg:px-spacing-x"
+        class="max-w-max-width mx-auto px-5 min-[680px]:px-8 lg:px-spacing-x"
       >
         <div
-          class="relative w-full mx-auto overflow-hidden rounded-xl bg-[#13132E] bg-[url('/images/agi-strategy/hero-banner-split.png')] bg-cover bg-center xl:max-w-[1118px]"
+          class="relative w-full h-[382px] min-[680px]:h-[360px] mx-auto overflow-hidden rounded-xl bg-[#13132E] bg-[url('/images/agi-strategy/hero-banner-split.png')] bg-cover bg-center xl:max-w-[1118px]"
         >
           <div
             class="absolute inset-0 pointer-events-none bg-[url('/images/agi-strategy/noise.png')] bg-contain bg-repeat mix-blend-soft-light"
           />
           <div
-            class="relative flex flex-col items-center justify-center px-14 py-16 gap-8 text-center"
+            class="relative flex flex-col items-center justify-center h-full px-14 py-16 gap-8 text-center"
           >
             <img
               alt="BlueDot"
@@ -1842,7 +1842,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               src="/images/agi-strategy/bluedot-icon.svg"
             />
             <h3
-              class="bluedot-h3 not-prose max-w-[238px] min-[680px]:max-w-[496px] text-[20px] min-[680px]:text-[36px] font-semibold text-white"
+              class="bluedot-h3 not-prose max-w-[238px] min-[680px]:max-w-[496px] text-[20px] min-[680px]:text-[36px] font-[600] text-white leading-[140%] min-[680px]:leading-[125%]"
             >
               Start building towards a good future today
             </h3>

--- a/apps/website/src/components/lander/agi-strategy/CourseBenefitsSection.test.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseBenefitsSection.test.tsx
@@ -1,15 +1,15 @@
 import { render } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import WhyTakeThisCourseSection from './WhyTakeThisCourseSection';
+import CourseBenefitsSection from './CourseBenefitsSection';
 
-describe('WhyTakeThisCourseSection', () => {
+describe('CourseBenefitsSection', () => {
   it('renders correctly', () => {
-    const { container } = render(<WhyTakeThisCourseSection />);
+    const { container } = render(<CourseBenefitsSection />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders all three value cards', () => {
-    const { getByText } = render(<WhyTakeThisCourseSection />);
+    const { getByText } = render(<CourseBenefitsSection />);
 
     // Check all card titles are rendered
     expect(getByText('Join a network of builders')).toBeDefined();
@@ -18,7 +18,7 @@ describe('WhyTakeThisCourseSection', () => {
   });
 
   it('renders value card descriptions', () => {
-    const { getByText } = render(<WhyTakeThisCourseSection />);
+    const { getByText } = render(<CourseBenefitsSection />);
 
     // Check first card description
     expect(getByText(/This course isn.t for everyone/)).toBeDefined();

--- a/apps/website/src/components/lander/agi-strategy/CourseBenefitsSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseBenefitsSection.tsx
@@ -21,10 +21,10 @@ const valueCards = [
   },
 ];
 
-const WhyTakeThisCourseSection = () => {
+const CourseBenefitsSection = () => {
   return (
     <section className="w-full bg-white">
-      <div className="max-w-max-width mx-auto px-spacing-x pt-12 pb-16">
+      <div className="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12">
         <H2 className="text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]">
           How this course will benefit you
         </H2>
@@ -50,4 +50,4 @@ const WhyTakeThisCourseSection = () => {
   );
 };
 
-export default WhyTakeThisCourseSection;
+export default CourseBenefitsSection;

--- a/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseCurriculumSection.tsx
@@ -12,7 +12,7 @@ import type { GetCourseResponse } from '../../../pages/api/courses/[courseSlug]'
 /* Common Section Wrapper */
 const SectionWrapper = ({ children }: { children: React.ReactNode }) => (
   <section className="w-full bg-white">
-    <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
+    <div className="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
       <H2 className="text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]">
         Curriculum Overview
       </H2>

--- a/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/CourseDetailsSection.tsx
@@ -62,7 +62,7 @@ const CourseDetailsSection = () => {
 
   return (
     <section className="w-full bg-[#FAFAF7]">
-      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16">
+      <div className="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16">
         {/* Section Title */}
         <H2 className="text-[28px] min-[680px]:text-[32px] xl:text-[36px] text-center font-semibold leading-[125%] text-[#13132E] tracking-[-0.01em]">
           Course information

--- a/apps/website/src/components/lander/agi-strategy/FAQSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/FAQSection.tsx
@@ -34,7 +34,7 @@ const FAQSection = () => {
 
   return (
     <section className="w-full bg-white">
-      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
+      <div className="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
         <div className="max-w-[928px] mx-auto flex flex-col gap-12 md:gap-16">
           <h2 className="text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center">
             Frequently Asked Questions

--- a/apps/website/src/components/lander/agi-strategy/GraduateSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/GraduateSection.tsx
@@ -25,7 +25,7 @@ const logos = [
 
 const GraduateSection = () => {
   return (
-    <section className="graduate-section w-full max-w-max-width mx-auto px-spacing-x py-8 overflow-hidden flex flex-col">
+    <section className="graduate-section w-full max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-8 overflow-hidden flex flex-col">
       <div className="flex flex-col lg:flex-row gap-6 items-center">
         <div className="flex flex-col lg:flex-row lg:items-center gap-4 lg:gap-2 shrink-0 items-center">
           <FaceTiles faces={faces} />

--- a/apps/website/src/components/lander/agi-strategy/PartnerSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/PartnerSection.tsx
@@ -135,7 +135,7 @@ const PartnerCard = ({
 const PartnerSection = () => {
   return (
     <section className="w-full bg-[#FAFAF7]">
-      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:py-20 lg:py-24">
+      <div className="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:py-20 lg:py-24">
 
         {/* Section Header */}
         <h2 className="text-[28px] min-[680px]:text-[32px] min-[1280px]:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-[#13132E] text-center mb-12 md:mb-16 max-w-[734px] mx-auto">
@@ -143,7 +143,7 @@ const PartnerSection = () => {
         </h2>
 
         {/* Mobile Infinite Scroll Carousel (1024px and below) */}
-        <div className="max-lg:block hidden -mx-spacing-x">
+        <div className="max-lg:block hidden -mx-5 min-[680px]:-mx-spacing-x">
           <div className="w-full inline-flex flex-nowrap overflow-hidden group">
             {/* Duplicate the partners array for infinite scroll */}
             {[1, 2].map((setIndex) => (

--- a/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
+++ b/apps/website/src/components/lander/agi-strategy/WhoIsThisForSection.tsx
@@ -24,7 +24,7 @@ const targetAudiences = [
 const WhoIsThisForSection = () => {
   return (
     <section className="w-full bg-[#FAFAF7]">
-      <div className="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
+      <div className="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20">
         <H2 className="text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]">
           Who this course is for
         </H2>

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/CourseBenefitsSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/CourseBenefitsSection.test.tsx.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`WhyTakeThisCourseSection > renders correctly 1`] = `
+exports[`CourseBenefitsSection > renders correctly 1`] = `
 <section
   class="w-full bg-white"
 >
   <div
-    class="max-w-max-width mx-auto px-spacing-x pt-12 pb-16"
+    class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12"
   >
     <h2
       class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]"

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/CourseDetailsSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/CourseDetailsSection.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`CourseDetailsSection > renders correctly 1`] = `
   class="w-full bg-[#FAFAF7]"
 >
   <div
-    class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16"
+    class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20 flex flex-col items-center gap-12 md:gap-16"
   >
     <h2
       class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] text-center font-semibold leading-[125%] text-[#13132E] tracking-[-0.01em]"

--- a/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
+++ b/apps/website/src/components/lander/agi-strategy/__snapshots__/WhoIsThisForSection.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
   class="w-full bg-[#FAFAF7]"
 >
   <div
-    class="max-w-max-width mx-auto px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
+    class="max-w-max-width mx-auto px-5 min-[680px]:px-spacing-x py-12 md:pt-20 md:pb-16 lg:pt-24 lg:pb-20"
   >
     <h2
       class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"


### PR DESCRIPTION
# Description
Implementing support for the new 320px breakpoint that was added to the [design](https://www.figma.com/design/62YlFNK7QS6z7SkrPjrwVb/Blue-Dot?node-id=1740-1919&t=9Nu5OQ5WazNgyiC8-0) (updated styling, padding for each section). Also re-named `WhyTakeThisCourseSection.tsx` to `CourseBenefitsSection.tsx` for clarity. Support for the newly added 680px breakpoint will be implemented in a second PR.

## Issue
PR 1/2 for #1414 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Video Screenshot (320px)
![320px-support](https://github.com/user-attachments/assets/b9a3a98b-70d0-4c0a-a1e7-d233828b0c00)

