### PR TITLE
[fix]: Update 404 caching to 1 minute for blog, courses, job postings…

### DIFF
--- a/apps/website/src/pages/blog/[slug].tsx
+++ b/apps/website/src/pages/blog/[slug].tsx
@@ -129,6 +129,7 @@ export const getStaticProps: GetStaticProps<BlogPostPageProps> = async ({ params
     // Error fetching blog data (likely not found)
     return {
       notFound: true,
+      revalidate: 60, // Cache 404s for only 1 minute instead of 1 year
     };
   }
 };

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -110,6 +110,7 @@ export const getStaticProps: GetStaticProps<CoursePageProps> = async ({ params }
   if (!courseSlug) {
     return {
       notFound: true,
+      revalidate: 60, // Cache 404s for only 1 minute instead of 1 year
     };
   }
 
@@ -127,6 +128,7 @@ export const getStaticProps: GetStaticProps<CoursePageProps> = async ({ params }
     // Error fetching course data (likely not found)
     return {
       notFound: true,
+      revalidate: 60, // Cache 404s for only 1 minute instead of 1 year
     };
   }
 };

--- a/apps/website/src/pages/join-us/[slug].tsx
+++ b/apps/website/src/pages/join-us/[slug].tsx
@@ -122,6 +122,7 @@ export const getStaticProps: GetStaticProps<JobPostingPageProps> = async ({ para
     // Error fetching job data (likely not found)
     return {
       notFound: true,
+      revalidate: 60, // Cache 404s for only 1 minute instead of 1 year
     };
   }
 };

--- a/apps/website/src/pages/projects/[slug].tsx
+++ b/apps/website/src/pages/projects/[slug].tsx
@@ -76,6 +76,7 @@ export const getStaticProps: GetStaticProps<ProjectPostPageProps> = async ({ par
   if (!slug) {
     return {
       notFound: true,
+      revalidate: 60, // Cache 404s for only 1 minute instead of 1 year
     };
   }
 
@@ -93,6 +94,7 @@ export const getStaticProps: GetStaticProps<ProjectPostPageProps> = async ({ par
     // Error fetching project data (likely not found)
     return {
       notFound: true,
+      revalidate: 60, // Cache 404s for only 1 minute instead of 1 year
     };
   }
 };


### PR DESCRIPTION
Currently we're caching 404 pages for up to a year (Next.js default). This is causing blog posts, jobs, courses, etc. to show up as 404 until we do a new release. I've set it to a minute for now which means that there would be roughly a 70 second delay between a new job being created and it showing up.

I can't test this locally, but I don't think there's any risk to pushing this and seeing if it fixes the issue.

## Issue
Fixes https://github.com/bluedotimpact/bluedot/issues/1489

Fixes #

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
No UX changes.
