### PR TITLE
Public `certificates.create` does not rely on admin email

### DIFF
--- a/apps/website/src/server/trpc.ts
+++ b/apps/website/src/server/trpc.ts
@@ -101,7 +101,7 @@ const openTelemetryMiddleware = t.middleware(async (opts) => {
   }
 });
 
-export const checkAdminAccess = async (email: string) => {
+const checkAdminAccess = async (email: string) => {
   try {
     const admin = await db.pg.select()
       .from(adminUsersTable)


### PR DESCRIPTION
# Description

This endpoint will be called by an Airtable automation when row conditions are met, not necessarily via a user calling the script (via checking a checkbox). Because of this we cannot guarantee that a user email will be provided. We still rely on the shared secret for authorisation.


## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Part of #1457.

## Developer checklist

NA

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA