### PR TITLE
[feat + fix]: logged-in-state support for navigation bar

### DIFF
--- a/apps/website/src/components/Nav/_ProfileLinks.tsx
+++ b/apps/website/src/components/Nav/_ProfileLinks.tsx
@@ -50,48 +50,41 @@ export const ProfileLinks: React.FC<{
         setOpen={onToggleProfile}
       />
       <div className={clsx('profile-links__drawer', DRAWER_CLASSES(!isHomepage && isScrolled, expandedSections.profile))}>
-        <div
-          className={clsx(
-            'profile-links__content-wrapper overflow-hidden transition-all duration-300 ease-in-out',
-            expandedSections.profile ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0',
-          )}
-        >
-          <div className="profile-links__links flex flex-col gap-4 items-end section-base">
-            <A
-              href={ROUTES.settingsAccount.url}
-              className={getNavLinkClasses()}
-              onClick={onToggleProfile}
-            >Account
-            </A>
-            <A
-              href={ROUTES.settingsCourses.url}
-              className={getNavLinkClasses()}
-              onClick={onToggleProfile}
-            >Courses
-            </A>
-            <A
-              href={ROUTES.contact.url}
-              className={getNavLinkClasses()}
-              onClick={onToggleProfile}
-            >Help
-            </A>
-            <button
-              type="button"
-              onClick={() => {
-                setIsModalOpen(true);
-                updateExpandedSections({ profile: false });
-              }}
-              className={clsx('bluedot-a', getNavLinkClasses())}
-            >
-              Submit Feedback
-            </button>
-            <A
-              href={ROUTES.logout.url}
-              className={getNavLinkClasses()}
-              onClick={onToggleProfile}
-            >Log out
-            </A>
-          </div>
+        <div className="profile-links__links flex flex-col gap-4 items-end section-base">
+          <A
+            href={ROUTES.settingsAccount.url}
+            className={getNavLinkClasses()}
+            onClick={onToggleProfile}
+          >Account
+          </A>
+          <A
+            href={ROUTES.settingsCourses.url}
+            className={getNavLinkClasses()}
+            onClick={onToggleProfile}
+          >Courses
+          </A>
+          <A
+            href={ROUTES.contact.url}
+            className={getNavLinkClasses()}
+            onClick={onToggleProfile}
+          >Help
+          </A>
+          <button
+            type="button"
+            onClick={() => {
+              setIsModalOpen(true);
+              updateExpandedSections({ profile: false });
+            }}
+            className={clsx('bluedot-a', getNavLinkClasses())}
+          >
+            Submit Feedback
+          </button>
+          <A
+            href={ROUTES.logout.url}
+            className={getNavLinkClasses()}
+            onClick={onToggleProfile}
+          >Log out
+          </A>
         </div>
       </div>
       <BugReportModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />


### PR DESCRIPTION
# Description
Adding styling in the navigation bar to support when the user is logged-in (profile icon, dropdown, homepage/scrolled states). Also fixed profile dropdown links appearing white instead of dark text. These styling decisions aren't explicitly in the [design](https://www.figma.com/design/EkPoEvKmaqkd4iVDV5qwWS/1.4----Homepage--Oct-2025-?node-id=0-1&p=f&t=nqTYHWhhNzwZenWH-0), but I'm implementing a best guess based on previous patterns so that it looks better than the current default.

## Issue
#1590, Related to #1525 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Desktop
![logged-in-support-homepage](https://github.com/user-attachments/assets/6f30fe25-d02b-4dfe-baa8-056fec28b593)

### Mobile
![logged-in-mobile](https://github.com/user-attachments/assets/70650436-c7ee-49aa-af4a-6c898acabdef)

### On-Scroll (Non-Homepage)
![light-transitioning-dark-on-scroll](https://github.com/user-attachments/assets/3997c8a1-4ae4-4ad7-838a-e6b619093924)

![dark-non-homepage](https://github.com/user-attachments/assets/c1ebdbd4-5f6b-4251-90f0-60d994f331e2)
