### PR TITLE
[fix]: prevent course carousel reset post-hover

### DIFF
--- a/apps/website/src/components/homepage/CourseSection.tsx
+++ b/apps/website/src/components/homepage/CourseSection.tsx
@@ -5,7 +5,9 @@ import {
   H1, H3, H4, P,
 } from '@bluedot/ui/src/Text';
 import clsx from 'clsx';
-import { motion, useMotionValue, animate, AnimationPlaybackControls } from 'framer-motion';
+import {
+  motion, useMotionValue, animate, AnimationPlaybackControls,
+} from 'framer-motion';
 import { useEffect, useRef } from 'react';
 import { PiShieldStarLight, PiShootingStarLight, PiUsersThreeLight } from 'react-icons/pi';
 import { withClickTracking } from '../../lib/withClickTracking';
@@ -158,12 +160,12 @@ const CourseCarousel = ({
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container) return;
+    if (!container) return undefined;
 
     const containerWidth = container.scrollWidth;
 
     // Only start animation if we have valid dimensions
-    if (containerWidth === 0) return;
+    if (containerWidth === 0) return undefined;
 
     const targetX = -(containerWidth / 2);
 


### PR DESCRIPTION
# Description
Found a bug from switching to Framer Motion where the course carousel resets after pause-on-hover. This PR fixes that.

### Before:
![bug-carousel-reset](https://github.com/user-attachments/assets/abbcdc04-671a-4cc4-9e57-946222cf3884)

### After:
![carousel-bug-fixed](https://github.com/user-attachments/assets/fe9f53c9-35a3-4504-8cfd-06347a040a93)

## Issue
#1590, Related to #1538 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories
