### PR TITLE
[fix]: carousel infinite scroll breaking when resizing or in split sc…

### DIFF
--- a/apps/website/src/components/homepage/CourseSection.tsx
+++ b/apps/website/src/components/homepage/CourseSection.tsx
@@ -162,24 +162,31 @@ const CourseCarousel = ({
     const container = containerRef.current;
     if (!container) return undefined;
 
-    const containerWidth = container.scrollWidth;
+    const setupAnimation = () => {
+      const containerWidth = container.scrollWidth;
 
-    // Only start animation if we have valid dimensions
-    if (containerWidth === 0) return undefined;
+      if (containerWidth === 0) return;
 
-    const targetX = -(containerWidth / 2);
+      const targetX = -(containerWidth / 2);
 
-    // Start infinite scroll animation with keyframes [from, to]
-    // Using repeatType 'loop' ensures seamless infinite scrolling
-    animationRef.current = animate(x, [0, targetX], {
-      duration: 40,
-      repeat: Infinity,
-      repeatType: 'loop',
-      ease: 'linear',
-    });
+      animationRef.current?.stop();
+      x.set(0);
+
+      animationRef.current = animate(x, [0, targetX], {
+        duration: 40,
+        repeat: Infinity,
+        repeatType: 'loop',
+        ease: 'linear',
+      });
+    };
+
+    setupAnimation();
+
+    window.addEventListener('resize', setupAnimation);
 
     return () => {
       animationRef.current?.stop();
+      window.removeEventListener('resize', setupAnimation);
     };
   }, [x]);
 


### PR DESCRIPTION
…reen

# Description
The animation was initialized only once when the component mounted and wasn't re-run when viewport size changed. Added a re-size event listener that re-calculates and restarts the animation with correct dimensions when the viewport changes.

## Issue
#1590, Related to #1538

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Before
![previous-carousel](https://github.com/user-attachments/assets/c4947eae-eeed-4b52-acfa-1b8a95324b3b)

### After
![carousel-fixed](https://github.com/user-attachments/assets/c6191d8c-56f8-4e0f-a1c8-0b5ebec3d41b)
