### PR TITLE
[Fix] Animate CSS max-h for mobile dropdown content

### DIFF
--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -135,7 +135,13 @@ const NavDropdown: React.FC<{
       // Desktop dropdowns: dark when scrolled on non-homepage pages
       return DRAWER_CLASSES(!isHomepage && isScrolled, isExpanded);
     }
-    return isExpanded ? 'pt-4' : '';
+    // Mobile dropdowns: apply collapse/expand classes
+    return clsx(
+      'transition-all duration-300 ease-in-out',
+      isExpanded
+        ? 'max-h-[500px] opacity-100 pt-4'
+        : 'max-h-0 opacity-0 pt-0',
+    );
   };
 
   return (


### PR DESCRIPTION
# Description

On mobile the available courses are not being shown/hidden correctly when you expand/de-expand the section because we are not adding the appropriate CSS classes to expand/de-expand (we need to explicitly set height to 0.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1542 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | ![no_expand](https://github.com/user-attachments/assets/81a8a288-af3d-4cc5-9273-3e9093f31238) | ![expand](https://github.com/user-attachments/assets/2a87d73e-bc77-4c32-b2f9-4d07796fc19d) |
