### PR TITLE
Explicitly only record course registration when FOAI

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -66,12 +66,11 @@ const CourseUnitChunkPage = ({
     }
   }, [courseSlug, unitNumber]);
 
-  // FoAI course only: If we're logged in, ensures a course registration is recorded
   const { latestUtmParams } = useLatestUtmParams();
   const { mutate: createCourseRegistrationMutation } = trpc.courseRegistrations.ensureExists.useMutation();
 
   useEffect(() => {
-    // If we're logged in, ensures a course registration is recorded for this course
+    // FoAI course only: If we're logged in, ensures a course registration is recorded
     const shouldRecordCourseRegistration = auth && (unit.courseId === FOAI_COURSE_ID);
     if (shouldRecordCourseRegistration) {
       createCourseRegistrationMutation({ courseId: unit.courseId, source: latestUtmParams.utm_source });


### PR DESCRIPTION
# Description

We[ use a mutation that runs every time we have auth && courseId](https://github.com/bluedotimpact/bluedot/blob/96f78aeb2f47b486742d8847f7ddb61832f6bfec/apps/website/src/pages/courses/%5BcourseSlug%5D/%5BunitNumber%5D/%5B%5B...chunkNumber%5D%5D.tsx#L74), but it doesn't do anything [on the server if the course is not FOAI](https://github.com/bluedotimpact/bluedot/blob/96f78aeb2f47b486742d8847f7ddb61832f6bfec/apps/website/src/server/routers/course-registrations.ts#L45). We can just prevent the network call on the client ahead of time, both for efficiency but also to make clear that we should only be doing this for FOAI.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
