### PR TITLE
[feat]: simplify homepage story section

### DIFF
--- a/apps/website/src/components/homepage/StorySection.tsx
+++ b/apps/website/src/components/homepage/StorySection.tsx
@@ -4,75 +4,37 @@ import { ROUTES } from '../../lib/routes';
 
 const StorySection = () => {
   return (
-    <section className="bg-white border-b border-[rgba(19,19,46,0.1)] overflow-hidden">
-      <style>{`
-        :root { --s: 1; }
-        @media (min-width: 680px) { :root { --s: 1.41; } }
-        @media (min-width: 1280px) { :root { --s: 1.73; } }
-        @media (min-width: 1440px) { :root { --s: 1.96; } }
-        @media (min-width: 1536px) { :root { --s: 2.0; } }
+    <section className="bg-white border-b border-[rgba(19,19,46,0.1)] py-[48px] px-5 min-[680px]:py-[64px] min-[680px]:px-8 min-[1024px]:py-[80px] lg:px-12 min-[1280px]:py-[96px] xl:px-16 2xl:px-20">
+      <div className="flex flex-col min-[1024px]:flex-row items-center justify-center gap-[64px] min-[1024px]:gap-[80px] min-[1280px]:gap-[96px] min-[1440px]:gap-[120px] max-w-screen-xl mx-auto">
 
-        .story-decorative {
-          left: calc(-79px * var(--s));
-          top: calc(-122px * var(--s));
-          width: calc(314px * var(--s));
-          height: calc(314px * var(--s));
-        }
-
-        .story-large {
-          left: calc(43px * var(--s));
-          top: calc(25px * var(--s));
-          width: calc(236px * var(--s));
-          height: calc(229px * var(--s));
-        }
-
-        .story-small {
-          left: 0;
-          top: 0;
-          width: calc(106px * var(--s));
-          height: calc(125px * var(--s));
-        }
-      `}
-      </style>
-
-      <div className="flex flex-col min-[1024px]:flex-row items-center justify-center gap-16 min-[1024px]:gap-20 min-[1280px]:gap-[94px] min-[1440px]:gap-[120px] py-12 px-5 min-[680px]:py-16 min-[680px]:px-8 min-[1024px]:py-20 min-[1024px]:px-12 min-[1280px]:py-24 min-[1280px]:px-16 min-[1440px]:px-20 max-w-[1360px] mx-auto">
-        <div className="relative shrink-0 w-[278px] aspect-[278/254] min-[680px]:w-[394px] min-[1280px]:w-[482px] min-[1440px]:w-[547px] 2xl:w-[556px]">
-          <img
-            src="/images/homepage/decorative-vector.svg"
-            alt=""
-            aria-hidden="true"
-            className="absolute story-decorative"
-          />
+        <div className="shrink-0 w-[234px] aspect-[234/229] min-[680px]:w-[334px] min-[680px]:aspect-square min-[1280px]:w-[400px] min-[1440px]:w-[450px]">
           <img
             src="/images/homepage/large-photo.png"
             alt="BlueDot team members at an event"
-            className="absolute story-large rounded-xl border border-[rgba(19,19,46,0.1)] object-cover object-center"
-          />
-          <img
-            src="/images/logo/BlueDot_Impact_Icon.svg"
-            alt="BlueDot Impact"
-            className="absolute story-small rounded-xl border border-[rgba(19,19,46,0.1)] object-contain object-center bg-white p-10"
+            className="size-full rounded-[12px] border border-[rgba(19,19,46,0.1)] object-cover object-center"
           />
         </div>
 
-        <div className="flex flex-col items-start gap-12 min-[680px]:gap-8 min-[1024px]:flex-1">
-          <H2 className="text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-center min-[680px]:text-left w-full">
+        <div className="flex flex-col items-start min-[1024px]:flex-1 w-full min-[680px]:w-auto">
+          <H2 className="text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-center min-[680px]:text-left w-full min-[680px]:w-auto mb-[48px] min-[680px]:mb-[32px]">
             Who is BlueDot?
           </H2>
 
-          <div className="flex flex-col items-center min-[680px]:items-start gap-8 w-full">
-            <P className="text-[16px] min-[680px]:text-[18px] leading-[1.6] opacity-80">
-              BlueDot Impact is a non-profit based out of London. We train and accelerate talented people into opportunities that positively impact the trajectory of AI.
-            </P>
+          <div className="flex flex-col gap-[32px] items-center min-[680px]:items-start w-full">
+            <div className="flex flex-col w-full">
+              <P className="text-[16px] min-[680px]:text-[18px] leading-[1.6] opacity-80 mb-[1em]">
+                BlueDot Impact is a non-profit based out of London. We train and accelerate talented people into opportunities that positively impact the trajectory of AI.
+              </P>
 
-            <P className="text-[16px] min-[680px]:text-[18px] leading-[1.6] opacity-80">
-              Since 2022, we've trained over 5,000 professionals worldwide – from technical staff at frontier AI companies to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M.
-            </P>
+              <P className="text-[16px] min-[680px]:text-[18px] leading-[1.6] opacity-80 mb-0">
+                Since 2022, we've trained over 5,000 professionals worldwide – from technical staff at frontier AI companies to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M.
+              </P>
+            </div>
 
             <CTALinkOrButton
               size="small"
               url={ROUTES.joinUs.url}
-              className="h-11 px-3 py-2.5 text-[14px] font-normal tracking-[0.42px] text-white bg-[#0033CC] rounded-md hover:bg-[#0029A3] transition-all duration-200"
+              className="h-[44px] px-[17px] py-[16px] text-[14px] font-normal leading-[18.2px] tracking-[0.42px] text-white bg-[#0033CC] rounded-[6px] hover:bg-[#0029A3] transition-all duration-200"
             >
               We're hiring
             </CTALinkOrButton>

--- a/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -3,84 +3,47 @@
 exports[`StorySection > renders default as expected 1`] = `
 <div>
   <section
-    class="bg-white border-b border-[rgba(19,19,46,0.1)] overflow-hidden"
+    class="bg-white border-b border-[rgba(19,19,46,0.1)] py-[48px] px-5 min-[680px]:py-[64px] min-[680px]:px-8 min-[1024px]:py-[80px] lg:px-12 min-[1280px]:py-[96px] xl:px-16 2xl:px-20"
   >
-    <style>
-      
-        :root { --s: 1; }
-        @media (min-width: 680px) { :root { --s: 1.41; } }
-        @media (min-width: 1280px) { :root { --s: 1.73; } }
-        @media (min-width: 1440px) { :root { --s: 1.96; } }
-        @media (min-width: 1536px) { :root { --s: 2.0; } }
-
-        .story-decorative {
-          left: calc(-79px * var(--s));
-          top: calc(-122px * var(--s));
-          width: calc(314px * var(--s));
-          height: calc(314px * var(--s));
-        }
-
-        .story-large {
-          left: calc(43px * var(--s));
-          top: calc(25px * var(--s));
-          width: calc(236px * var(--s));
-          height: calc(229px * var(--s));
-        }
-
-        .story-small {
-          left: 0;
-          top: 0;
-          width: calc(106px * var(--s));
-          height: calc(125px * var(--s));
-        }
-      
-    </style>
     <div
-      class="flex flex-col min-[1024px]:flex-row items-center justify-center gap-16 min-[1024px]:gap-20 min-[1280px]:gap-[94px] min-[1440px]:gap-[120px] py-12 px-5 min-[680px]:py-16 min-[680px]:px-8 min-[1024px]:py-20 min-[1024px]:px-12 min-[1280px]:py-24 min-[1280px]:px-16 min-[1440px]:px-20 max-w-[1360px] mx-auto"
+      class="flex flex-col min-[1024px]:flex-row items-center justify-center gap-[64px] min-[1024px]:gap-[80px] min-[1280px]:gap-[96px] min-[1440px]:gap-[120px] max-w-screen-xl mx-auto"
     >
       <div
-        class="relative shrink-0 w-[278px] aspect-[278/254] min-[680px]:w-[394px] min-[1280px]:w-[482px] min-[1440px]:w-[547px] 2xl:w-[556px]"
+        class="shrink-0 w-[234px] aspect-[234/229] min-[680px]:w-[334px] min-[680px]:aspect-square min-[1280px]:w-[400px] min-[1440px]:w-[450px]"
       >
         <img
-          alt=""
-          aria-hidden="true"
-          class="absolute story-decorative"
-          src="/images/homepage/decorative-vector.svg"
-        />
-        <img
           alt="BlueDot team members at an event"
-          class="absolute story-large rounded-xl border border-[rgba(19,19,46,0.1)] object-cover object-center"
+          class="size-full rounded-[12px] border border-[rgba(19,19,46,0.1)] object-cover object-center"
           src="/images/homepage/large-photo.png"
-        />
-        <img
-          alt="BlueDot Impact"
-          class="absolute story-small rounded-xl border border-[rgba(19,19,46,0.1)] object-contain object-center bg-white p-10"
-          src="/images/logo/BlueDot_Impact_Icon.svg"
         />
       </div>
       <div
-        class="flex flex-col items-start gap-12 min-[680px]:gap-8 min-[1024px]:flex-1"
+        class="flex flex-col items-start min-[1024px]:flex-1 w-full min-[680px]:w-auto"
       >
         <h2
-          class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-center min-[680px]:text-left w-full"
+          class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-center min-[680px]:text-left w-full min-[680px]:w-auto mb-[48px] min-[680px]:mb-[32px]"
         >
           Who is BlueDot?
         </h2>
         <div
-          class="flex flex-col items-center min-[680px]:items-start gap-8 w-full"
+          class="flex flex-col gap-[32px] items-center min-[680px]:items-start w-full"
         >
-          <p
-            class="bluedot-p not-prose text-[16px] min-[680px]:text-[18px] leading-[1.6] opacity-80"
+          <div
+            class="flex flex-col w-full"
           >
-            BlueDot Impact is a non-profit based out of London. We train and accelerate talented people into opportunities that positively impact the trajectory of AI.
-          </p>
-          <p
-            class="bluedot-p not-prose text-[16px] min-[680px]:text-[18px] leading-[1.6] opacity-80"
-          >
-            Since 2022, we've trained over 5,000 professionals worldwide – from technical staff at frontier AI companies to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M.
-          </p>
+            <p
+              class="bluedot-p not-prose text-[16px] min-[680px]:text-[18px] leading-[1.6] opacity-80 mb-[1em]"
+            >
+              BlueDot Impact is a non-profit based out of London. We train and accelerate talented people into opportunities that positively impact the trajectory of AI.
+            </p>
+            <p
+              class="bluedot-p not-prose text-[16px] min-[680px]:text-[18px] leading-[1.6] opacity-80 mb-0"
+            >
+              Since 2022, we've trained over 5,000 professionals worldwide – from technical staff at frontier AI companies to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M.
+            </p>
+          </div>
           <a
-            class="cta-button flex items-center justify-center w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark h-11 px-3 py-2.5 text-[14px] font-normal tracking-[0.42px] text-white bg-[#0033CC] rounded-md hover:bg-[#0029A3] transition-all duration-200"
+            class="cta-button flex items-center justify-center w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none cta-button--primary link-on-dark h-[44px] px-[17px] py-[16px] text-[14px] font-normal leading-[18.2px] tracking-[0.42px] text-white bg-[#0033CC] rounded-[6px] hover:bg-[#0029A3] transition-all duration-200"
             href="/join-us"
             tabindex="0"
           >


### PR DESCRIPTION
# Description
Simplifying story section on homepage - removing second small image and background Bluedot logo.

## Issue
#1590, Related to #1552

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Desktop/Tablet

### 1920
<img width="960" height="321" alt="1920" src="https://github.com/user-attachments/assets/c8013080-1bbe-453b-9dd4-dc5a09da155e" />

### 1440
<img width="1077" height="484" alt="1440" src="https://github.com/user-attachments/assets/1999c9c4-c960-428c-a6a9-b502f18a648a" />

### 1280
<img width="961" height="446" alt="1280" src="https://github.com/user-attachments/assets/068cce02-c129-4bbe-ae02-ca3406a8ec14" />

### 1024
<img width="768" height="450" alt="1024" src="https://github.com/user-attachments/assets/d40c0025-2e10-4de3-ac95-761533e983b9" />

### 680
<img width="511" height="703" alt="680" src="https://github.com/user-attachments/assets/30d8874e-0395-431e-9a31-2fc02b0f881f" />

### Mobile (320)
<img width="239" height="720" alt="320" src="https://github.com/user-attachments/assets/f69b00c8-5593-49c2-be2d-53f9ef493b2c" />
