### PR TITLE
Make community link exclusive to Future of AI course

### DIFF
--- a/apps/website/src/components/courses/CertificateLinkCard.test.tsx
+++ b/apps/website/src/components/courses/CertificateLinkCard.test.tsx
@@ -136,7 +136,8 @@ describe('CertificateLinkCard', () => {
       // Verify not eligible message
       expect(screen.getByText('Your Certificate')).toBeTruthy();
       expect(screen.getByText("This course doesn't currently issue certificates to independent learners. Join a facilitated version to get a certificate.")).toBeTruthy();
-      expect(screen.getByText('Join the Community')).toBeTruthy();
+      // Community section should NOT appear for non-FoAI courses
+      expect(screen.queryByText('Join the Community')).toBeNull();
     });
 
     test('renders course without certificate - FoAI shows request button', () => {
@@ -164,9 +165,12 @@ describe('CertificateLinkCard', () => {
       // Verify FoAI-specific content is shown
       expect(screen.getByText("Download your certificate, show you're taking AI seriously")).toBeTruthy();
       expect(screen.getByText('Complete all answers to unlock your certificate, then share your accomplishment on social media.')).toBeTruthy();
+
+      // Verify community section DOES appear for FoAI course
+      expect(screen.getByText('Join the Community')).toBeTruthy();
     });
 
-    test('renders course with certificate (works for both regular and FoAI)', () => {
+    test('renders regular course with certificate - no community section', () => {
       mockUseQuery.mockReturnValue({
         data: createMockCourseRegistration({
           courseId: 'rec123456789',
@@ -189,6 +193,31 @@ describe('CertificateLinkCard', () => {
       // Verify the certificate link opens in a new tab
       const viewCertificateLink = screen.getByRole('link', { name: 'View Certificate' });
       expect(viewCertificateLink.getAttribute('target')).toBe('_blank');
+
+      // Community section should NOT appear for regular courses
+      expect(screen.queryByText('Join the Community')).toBeNull();
+    });
+
+    test('renders FoAI course with certificate - includes community section', () => {
+      mockUseQuery.mockReturnValue({
+        data: createMockCourseRegistration({
+          courseId: FOAI_COURSE_ID,
+          certificateId: 'cert123',
+          certificateCreatedAt: 1704067200, // 2024-01-01 in Unix timestamp
+        }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+
+      render(<CertificateLinkCard courseId={FOAI_COURSE_ID} />);
+
+      // Verify certificate content
+      expect(screen.getByText('Earned by Test User')).toBeTruthy();
+      expect(screen.getByText('View Certificate')).toBeTruthy();
+
+      // Community section SHOULD appear for FoAI course
+      expect(screen.getByText('Join the Community')).toBeTruthy();
     });
   });
 });

--- a/apps/website/src/components/courses/CertificateLinkCard.tsx
+++ b/apps/website/src/components/courses/CertificateLinkCard.tsx
@@ -49,7 +49,7 @@ type CertificateConfig = {
 
 const regularCourseConfig: CertificateConfig = {
   useCard: true,
-  showCommunity: true,
+  showCommunity: false,
   texts: {
     notLoggedIn: {
       title: 'Your Certificate',
@@ -81,7 +81,7 @@ const regularCourseConfig: CertificateConfig = {
 
 const foaiCourseConfig: CertificateConfig = {
   useCard: false,
-  showCommunity: false,
+  showCommunity: true,
   texts: {
     notLoggedIn: {
       header: "Download your certificate, show you're taking AI seriously",


### PR DESCRIPTION
- Set showCommunity to false for regular courses
- Set showCommunity to true for FoAI course config
- Update tests to verify community section only appears on FoAI
- Add separate test cases for FoAI vs regular course behavior

This ensures the FoAI graduate community link (community.bluedot.org) only appears on the Future of AI course completion pages, not on other course pages.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 |  |
|---------|---|
| 📱  | <!-- Include a **Mobile** screenshot or screen recording demonstrating your change--> |
| 🖥️ | <!-- Include a **Desktop** screenshot or screen recording demonstrating your change--> |
