### PR TITLE
Prevent log spam: Return 200 and undefined for missing resource completion or exercise response, rather than 404

### DIFF
--- a/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
+++ b/apps/website/src/pages/api/courses/exercises/[exerciseId]/response.ts
@@ -51,17 +51,13 @@ export default makeApiRoute({
   switch (raw.req.method) {
     // Get exercise response
     case 'GET': {
-      if (!exerciseResponse) {
-        throw new createHttpError.NotFound('Exercise response not found');
-      }
-
       return {
         type: 'success' as const,
-        exerciseResponse: {
+        exerciseResponse: exerciseResponse ? {
           ...exerciseResponse,
           // Preserve trailing whitespace and line feeds as entered by the user
           response: exerciseResponse.response,
-        },
+        } : undefined,
       };
     }
 

--- a/apps/website/src/pages/api/courses/resource-completion/[unitResourceId]/index.ts
+++ b/apps/website/src/pages/api/courses/resource-completion/[unitResourceId]/index.ts
@@ -60,17 +60,13 @@ export default makeApiRoute({
   switch (raw.req.method) {
     // Get resource completion
     case 'GET': {
-      if (!resourceCompletion) {
-        throw new createHttpError.NotFound('Resource completion not found');
-      }
-
       return {
         type: 'success' as const,
-        resourceCompletion: {
+        resourceCompletion: resourceCompletion ? {
           ...resourceCompletion,
           // For some reason Airtable often adds a newline to the end of the feedback
           feedback: resourceCompletion.feedback?.trimEnd(),
-        },
+        } : undefined,
       };
     }
 


### PR DESCRIPTION
# Description
As noted in #1462, it is expected that resource completions don't exist if the user hasn't visited the page before so return undefined rather than returning a 404 (which was handled already, but spammed the logs with "Resource completion not found").

There was an almost identical case with exercise responses (they don't exist if the user hasn't visited the page, and trigger a 404), so I fixed that in this PR too. The change is simple enough that I don't think it's worth adding tests.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1462

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

N/A