### PR TITLE
Revert rename `exerciseNumber` -> `exerciseOrder`

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -186,12 +186,12 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
       const exercisePromises = chunk.chunkExercises.map((exerciseId) => db.get(exerciseTable, { id: exerciseId }).catch(() => null));
       const resolvedExercises = await Promise.all(exercisePromises);
 
-      // Filter for exercises that exist and are active, sort by exerciseOrder
+      // Filter for exercises that exist and are active, sort by exerciseNumber
       exercises = resolvedExercises
         .filter((e): e is Exercise => e !== null && e.status === 'Active')
         .sort((a, b) => {
-          const numA = Number(a.exerciseOrder) || Infinity;
-          const numB = Number(b.exerciseOrder) || Infinity;
+          const numA = Number(a.exerciseNumber) || Infinity;
+          const numB = Number(b.exerciseNumber) || Infinity;
           return numA - numB;
         });
     }

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -890,7 +890,7 @@ export const exerciseTable = pgAirtable('exercise', {
       pgColumn: text().notNull(),
       airtableId: 'fldc9oyPwJSkeMiAW',
     },
-    exerciseOrder: {
+    exerciseNumber: {
       pgColumn: text(),
       airtableId: 'fldOoKVFSrToAicfT',
     },


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

In https://github.com/bluedotimpact/bluedot/pull/1539 I renamed `exerciseNumber` -> `exerciseOrder` since (1) the Airtable column is named order and (2) it is the order we sort by

This might be responsible for breaking some exercise things so reverting. Not exactly sure how it's possible for it to break things since it hasn't yet been deployed, and schema syncing hasn't run 🤔 

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

NA
<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
