### PR TITLE
[Bug] Gracefully handle some missing courseBuilderUnitRecordIds in getByDiscussionIds

### DIFF
--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -41,6 +41,9 @@ export const groupDiscussionsRouter = router({
         });
       }
 
+      // There are cases where `courseBuilderUnitRecordId` is missing for unknown reasons,
+      // filter these out so we can proceed with as many valid discussions as we can.
+      // See https://github.com/bluedotimpact/bluedot/issues/1557 for discussion of the underlying issue.
       const validDiscussions = rawDiscussions.filter((d) => !!d.courseBuilderUnitRecordId);
 
       if (validDiscussions.length < rawDiscussions.length) {


### PR DESCRIPTION
# Description

We are seeing errors due to group discussions missing `courseBuilderUnitRecordId`. This occurs on the https://bluedot.org/settings/courses page, and the current behaviour for users is that the list of upcoming and attended discussions doesn't appear at all if any of the discussions have this issue. This PR makes it so that the specific erroring discussions are filtered out, but the section otherwise loads as normal.

There are a large number of discussions that have this issue, and I haven't been able to work out a general cause. The one that is triggering errors currently is the 6th discussion in the now 5 part AGI Strategy course, which possibly explains that case. But there are past examples that look different, e.g. sessions that were actually attended.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1557

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
  - Decided against it for this straightforward change
- [x] N/A Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
N/A