### PR TITLE
[fix prod] Expanding log storage volume

### DIFF
--- a/apps/infra/src/k8s/pvc.ts
+++ b/apps/infra/src/k8s/pvc.ts
@@ -5,6 +5,6 @@ export const minioPvc = new k8s.core.v1.PersistentVolumeClaim('minio-pvc', {
   metadata: { name: 'minio-pvc' },
   spec: {
     accessModes: ['ReadWriteOnce'],
-    resources: { requests: { storage: '10Gi' } },
+    resources: { requests: { storage: '50Gi' } },
   },
 }, { provider });


### PR DESCRIPTION
# Description
Loki Log storage is down because MinIO has had it's storage completely full. Instead automatically deleting logs, we decided keeping everything for now is worth the marginal cost increase. 

Increased storage size form 10 -> 50Gi


## Issue
Currently [Grafana and logs viewing is down](https://grafana.k8s.bluedot.org/a/grafana-lokiexplore-app/explore/service/bluedot-pg-sync-service/logs?patterns=%5B%5D&from=now-15m&to=now&var-lineFormat=&var-ds=fekp33muo5pfka&var-filters=service_name%7C%3D%7Cbluedot-pg-sync-service&var-fields=&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&displayedFields=%5B%5D&urlColumns=%5B%22timestamp%22,%22Time%22,%22Line%22%5D&visualizationType=%22logs%22&var-fieldBy=$__all&timezone=browser&var-all-fields=&prettifyLogMessage=false&sortOrder=%22Descending%22&wrapLogMessage=false) from what I suspect is because there isn't enough space left for Loki to operate. 