### PR TITLE
Refetch exercise response after submitting

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -55,7 +55,7 @@ const Exercise: React.FC<ExerciseProps> = ({
     );
 
     // Refetch the exercise response to update the UI with the newly saved answer
-    await fetchExerciseResponse();
+    await fetchExerciseResponse().catch(() => { /* no op, as we handle errors above */ });
   }, [exerciseId, auth, fetchExerciseResponse]);
 
   if (exerciseLoading) {


### PR DESCRIPTION
# Description

When we submit an MCQ exercise response we don't refetch the answer to update our UI.

This leads to a bug:

1. Have incorrect answer stored
2. Submit correct answer
3. Correct answer shown as incorrect

After submitting the correct answer we need to refetch or optimistically update the UI. Since we are migrating to tRPC and already have https://github.com/bluedotimpact/bluedot/pull/1477/ which invalidates on successful mutation I followed that pattern.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Part of #1598.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x]  Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱 | ![master](https://github.com/user-attachments/assets/6ecc6b7e-3610-439f-b185-4c88668d49d7) | ![updated](https://github.com/user-attachments/assets/b4917fc9-63fd-49d9-b5d2-e7c772c97fe7) |
