### PR TITLE
[feat]: luma event caching

### DIFF
--- a/apps/website/src/server/routers/luma.ts
+++ b/apps/website/src/server/routers/luma.ts
@@ -64,7 +64,7 @@ async function refreshCache(): Promise<Event[]> {
       const apiKey = env.LUMA_API_KEY;
 
       if (!apiKey) {
-        return cachedEvents || [];
+        return [];
       }
 
       const now = new Date().toISOString();


### PR DESCRIPTION
# Description
Add in-memory caching to Luma API endpoint with 1-minute TTL to reduce API calls, improve response time, and handle intermittent API failures gracefully. Implements background refresh, failure tracking with Slack alerts after 3 consecutive failures (rate-limited to 1/min), and concurrent request protection.

## Issue
Closes #1606 

## Developer checklist
N/A

## Screenshot
N/A there are no visual changes.
