### PR TITLE
[feat]: removing scroll-triggered dark mode on nav

### DIFF
--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -13,11 +13,7 @@ import { ExpandedSectionsState } from './utils';
 export const Nav: React.FC = () => {
   const router = useRouter();
   const isLoggedIn = !!useAuthStore((s) => s.auth);
-  const [isScrolled, setIsScrolled] = useState(false);
   const isHomepage = router.pathname === '/';
-  const logo = isHomepage
-    ? '/images/logo/BlueDot_Impact_Logo_White.svg'
-    : '/images/logo/BlueDot_Impact_Logo.svg';
 
   const [expandedSections, setExpandedSections] = useState<ExpandedSectionsState>({
     about: false,
@@ -29,15 +25,6 @@ export const Nav: React.FC = () => {
   const updateExpandedSections = (updates: Partial<ExpandedSectionsState>) => {
     setExpandedSections((prev: ExpandedSectionsState) => ({ ...prev, ...updates }));
   };
-
-  useEffect(() => {
-    const handleScroll = () => {
-      setIsScrolled(window.scrollY > 0);
-    };
-
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   // Handle viewport breakpoint changes to reset dropdown states on mobile/desktop transitions
   useEffect(() => {
@@ -66,13 +53,8 @@ export const Nav: React.FC = () => {
     }
     return clsx(
       'nav sticky top-0 z-50 w-full transition-all duration-300',
-      !isScrolled && [
-        'bg-white',
-        'border-b border-color-divider',
-      ],
-      isScrolled && [
-        'bg-color-canvas-dark',
-      ],
+      'bg-white',
+      'border-b border-color-divider',
     );
   };
 
@@ -93,13 +75,12 @@ export const Nav: React.FC = () => {
               <MobileNavLinks
                 expandedSections={expandedSections}
                 updateExpandedSections={updateExpandedSections}
-                isScrolled={isScrolled}
                 isLoggedIn={isLoggedIn}
                 isHomepage={isHomepage}
               />
 
               {/* Logo */}
-              <NavLogo logo={logo} isScrolled={isScrolled} isHomepage={isHomepage} />
+              <NavLogo isHomepage={isHomepage} />
             </div>
 
             {/* Center/Right side: Nav Links and CTA */}
@@ -108,14 +89,12 @@ export const Nav: React.FC = () => {
               <DesktopNavLinks
                 expandedSections={expandedSections}
                 updateExpandedSections={updateExpandedSections}
-                isScrolled={isScrolled}
                 isHomepage={isHomepage}
               />
 
               {/* CTA Buttons */}
               <NavCta
                 isLoggedIn={isLoggedIn}
-                isScrolled={isScrolled}
                 isHomepage={isHomepage}
                 expandedSections={expandedSections}
                 updateExpandedSections={updateExpandedSections}

--- a/apps/website/src/components/Nav/_DesktopNavLinks.tsx
+++ b/apps/website/src/components/Nav/_DesktopNavLinks.tsx
@@ -4,19 +4,16 @@ import { ExpandedSectionsState } from './utils';
 export const DesktopNavLinks: React.FC<{
   expandedSections: ExpandedSectionsState;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
-  isScrolled: boolean;
   isHomepage?: boolean;
 }> = ({
   expandedSections,
   updateExpandedSections,
-  isScrolled,
   isHomepage = false,
 }) => {
   return (
     <NavLinks
       expandedSections={expandedSections}
       updateExpandedSections={updateExpandedSections}
-      isScrolled={isScrolled}
       isHomepage={isHomepage}
       className="hidden lg:flex"
     />

--- a/apps/website/src/components/Nav/_MobileNavLinks.tsx
+++ b/apps/website/src/components/Nav/_MobileNavLinks.tsx
@@ -15,13 +15,11 @@ import { getLoginUrl } from '../../utils/getLoginUrl';
 export const MobileNavLinks: React.FC<{
   expandedSections: ExpandedSectionsState;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
-  isScrolled: boolean;
   isLoggedIn: boolean;
   isHomepage?: boolean;
 }> = ({
   expandedSections,
   updateExpandedSections,
-  isScrolled,
   isLoggedIn,
   isHomepage = false,
 }) => {
@@ -52,10 +50,10 @@ export const MobileNavLinks: React.FC<{
         setOpen={onToggleMobileNav}
         className={clsx(
           'mobile-nav-links__btn',
-          (isHomepage || isScrolled) && 'text-white [&_svg]:text-white',
+          isHomepage && 'text-white [&_svg]:text-white',
         )}
       />
-      <div className={clsx('mobile-nav-links__drawer', DRAWER_CLASSES(!isHomepage && isScrolled, expandedSections.mobileNav))}>
+      <div className={clsx('mobile-nav-links__drawer', DRAWER_CLASSES(expandedSections.mobileNav))}>
         <div
           className="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
           onClick={(e) => {
@@ -86,7 +84,6 @@ export const MobileNavLinks: React.FC<{
             className="mobile-nav-links__nav-links flex-col"
             expandedSections={expandedSections}
             updateExpandedSections={updateExpandedSections}
-            isScrolled={isScrolled}
             isHomepage={isHomepage}
           />
 

--- a/apps/website/src/components/Nav/_NavCta.tsx
+++ b/apps/website/src/components/Nav/_NavCta.tsx
@@ -11,14 +11,12 @@ import { ExpandedSectionsState } from './utils';
 export const NavCta: React.FC<{
   // Required
   expandedSections: ExpandedSectionsState;
-  isScrolled: boolean;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
   // Optional
   isLoggedIn?: boolean;
   isHomepage?: boolean;
 }> = ({
   isLoggedIn,
-  isScrolled,
   expandedSections,
   updateExpandedSections,
   isHomepage = false,
@@ -34,13 +32,12 @@ export const NavCta: React.FC<{
     }
   }, [router.asPath]);
   const getButtonClasses = (type: 'primary' | 'secondary') => {
-    const isDark = isHomepage || isScrolled;
     const baseClasses = 'px-3 py-[5px] rounded-[5px] text-size-sm font-[450] leading-[160%] items-center justify-center';
 
     if (type === 'primary') {
       return clsx(
         baseClasses,
-        isDark
+        isHomepage
           ? 'bg-white hover:bg-white/90 text-[#02034B] hover:text-[#02034B]'
           : 'bg-[#2244BB] hover:bg-[#1a3599] text-white hover:text-white',
       );
@@ -48,7 +45,7 @@ export const NavCta: React.FC<{
 
     return clsx(
       baseClasses,
-      isDark
+      isHomepage
         ? 'bg-white/15 border border-white/20 text-white hover:text-white hover:bg-white/20 backdrop-blur-sm'
         : 'border border-color-divider text-color-text hover:text-color-text hover:bg-gray-50',
     );
@@ -58,7 +55,6 @@ export const NavCta: React.FC<{
     <div className="nav-cta flex flex-row items-center gap-4">
       {isLoggedIn ? (
         <ProfileLinks
-          isScrolled={isScrolled}
           expandedSections={expandedSections}
           updateExpandedSections={updateExpandedSections}
           isHomepage={isHomepage}

--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -20,13 +20,11 @@ export const NavLinks: React.FC<{
   expandedSections: ExpandedSectionsState;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
   className?: string;
-  isScrolled: boolean;
   isHomepage?: boolean;
 }> = ({
   expandedSections,
   updateExpandedSections,
   className,
-  isScrolled,
   isHomepage = false,
 }) => {
   const { courses, loading } = useCourses();
@@ -40,18 +38,16 @@ export const NavLinks: React.FC<{
     { title: 'Browse all', url: ROUTES.courses.url },
   ];
   const getLinkClasses = (isCurrentPathValue?: boolean) => {
-    if (expandedSections.mobileNav) {
-      // Mobile drawer: On homepage always white bg, on other pages dark bg when scrolled
-      const isDarkDrawer = !isHomepage && isScrolled;
-      return clsx(
-        'nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle',
-        isDarkDrawer ? 'text-white hover:text-white nav-link-animation-dark' : 'text-[#02034B] hover:text-[#02034B]',
-        isCurrentPathValue && 'font-bold',
-      );
+    // Mobile drawer always has white background, so always use dark text
+    // Desktop navbar uses white text on homepage, dark text elsewhere
+    let textColor = 'text-color-text hover:text-color-text';
+    if (!expandedSections.mobileNav && isHomepage) {
+      textColor = 'text-white hover:text-white nav-link-animation-dark';
     }
+
     return clsx(
       'nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle',
-      (isHomepage || isScrolled) ? 'text-white hover:text-white nav-link-animation-dark' : 'text-color-text hover:text-color-text',
+      textColor,
       isCurrentPathValue && 'font-bold',
     );
   };
@@ -61,7 +57,6 @@ export const NavLinks: React.FC<{
       <NavDropdown
         expandedSections={expandedSections}
         isExpanded={expandedSections.explore}
-        isScrolled={isScrolled}
         isHomepage={isHomepage}
         links={navCourses}
         onToggle={() => updateExpandedSections({
@@ -99,7 +94,6 @@ const NavDropdown: React.FC<{
   // Required
   expandedSections: ExpandedSectionsState;
   isExpanded: boolean;
-  isScrolled: boolean;
   isHomepage: boolean;
   links: { title: string; url: string; isNew?: boolean | null }[];
   onToggle: () => void;
@@ -110,7 +104,6 @@ const NavDropdown: React.FC<{
 }> = ({
   expandedSections,
   isExpanded,
-  isScrolled,
   isHomepage,
   links,
   onToggle,
@@ -119,12 +112,12 @@ const NavDropdown: React.FC<{
   loading,
 }) => {
   const getDropdownButtonClasses = () => {
+    // Mobile drawer always has white background, so always use dark text
+    // Desktop navbar uses white text on homepage, dark text elsewhere
     if (expandedSections.mobileNav) {
-      // Mobile drawer: On homepage always white bg, on other pages dark bg when scrolled
-      const isDarkDrawer = !isHomepage && isScrolled;
-      return isDarkDrawer ? 'text-white hover:text-white nav-link-animation-dark' : 'text-[#02034B] hover:text-[#02034B]';
+      return 'text-color-text hover:text-color-text';
     }
-    if (isHomepage || isScrolled) {
+    if (isHomepage) {
       return 'text-white hover:text-white nav-link-animation-dark';
     }
     return 'text-color-text hover:text-color-text';
@@ -132,8 +125,8 @@ const NavDropdown: React.FC<{
 
   const getDropdownContentClasses = () => {
     if (!expandedSections.mobileNav) {
-      // Desktop dropdowns: dark when scrolled on non-homepage pages
-      return DRAWER_CLASSES(!isHomepage && isScrolled, isExpanded);
+      // Desktop dropdowns: always white background
+      return DRAWER_CLASSES(isExpanded);
     }
     // Mobile dropdowns: apply collapse/expand classes
     return clsx(
@@ -178,13 +171,8 @@ const NavDropdown: React.FC<{
             </div>
           ) : (
             links?.map((link) => {
-              // Dropdown links: white text when dropdown has dark bg, dark text otherwise
-              let linkTextColor = 'text-[#02034B]';
-              const isDarkDrawer = !isHomepage && isScrolled;
-              // Both mobile and desktop dropdowns can be dark when scrolled on non-homepage
-              if (isDarkDrawer) {
-                linkTextColor = 'text-white hover:text-white';
-              }
+              // Dropdown links: always dark text on white background
+              const linkTextColor = 'text-[#02034B] hover:text-[#02034B]';
 
               return (
                 <A

--- a/apps/website/src/components/Nav/_NavLogo.tsx
+++ b/apps/website/src/components/Nav/_NavLogo.tsx
@@ -1,22 +1,18 @@
-import clsx from 'clsx';
-
-import { A, H3 } from '../Text';
+import { A } from '../Text';
 import { TRANSITION_DURATION_CLASS } from './utils';
 
-export const NavLogo: React.FC<{ logo?: string; isScrolled: boolean; isHomepage?: boolean }> = ({ logo, isScrolled, isHomepage = false }) => (
-  <A href="/" className="logo shrink-0 w-[151px] min-[681px]:w-[200px] no-underline">
-    {logo ? (
+export const NavLogo: React.FC<{ isHomepage: boolean }> = ({ isHomepage }) => {
+  const logo = isHomepage
+    ? '/images/logo/BlueDot_Impact_Logo_White.svg'
+    : '/images/logo/BlueDot_Impact_Logo.svg';
+
+  return (
+    <A href="/" className="logo shrink-0 w-[151px] min-[681px]:w-[200px] no-underline">
       <img
-        className={clsx(
-          `logo__img h-5 min-[681px]:h-6 mr-auto transition-all ${TRANSITION_DURATION_CLASS}`,
-          // Don't invert on homepage (already white), only invert on other pages when scrolled
-          !isHomepage && isScrolled && 'brightness-0 invert',
-        )}
+        className={`logo__img h-5 min-[681px]:h-6 mr-auto transition-all ${TRANSITION_DURATION_CLASS}`}
         src={logo}
         alt="BlueDot Impact Logo"
       />
-    ) : (
-      <H3 className="logo__placeholder h-8 mr-auto">BlueDot Impact</H3>
-    )}
-  </A>
-);
+    </A>
+  );
+};

--- a/apps/website/src/components/Nav/_ProfileLinks.tsx
+++ b/apps/website/src/components/Nav/_ProfileLinks.tsx
@@ -8,12 +8,10 @@ import { ROUTES } from '../../lib/routes';
 import { A } from '../Text';
 
 export const ProfileLinks: React.FC<{
-  isScrolled: boolean;
   expandedSections: ExpandedSectionsState;
   updateExpandedSections: (updates: Partial<ExpandedSectionsState>) => void;
   isHomepage?: boolean;
 }> = ({
-  isScrolled,
   expandedSections,
   updateExpandedSections,
   isHomepage = false,
@@ -28,13 +26,10 @@ export const ProfileLinks: React.FC<{
   });
 
   const getNavLinkClasses = () => {
-    // Profile dropdown links: white text when dropdown has dark bg, dark text otherwise
-    const isDarkDrawer = !isHomepage && isScrolled;
-    const textColor = isDarkDrawer ? 'text-white hover:text-white' : 'text-[#02034B] hover:text-[#02034B]';
-
+    // Profile dropdown links: always dark text on white background
     return clsx(
       'nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle',
-      textColor,
+      'text-[#02034B] hover:text-[#02034B]',
     );
   };
 
@@ -43,7 +38,7 @@ export const ProfileLinks: React.FC<{
       <IconButton
         className={clsx(
           'profile-links__btn',
-          (isHomepage || isScrolled) && 'text-white [&_svg]:text-white',
+          isHomepage && 'text-white [&_svg]:text-white',
         )}
         open={expandedSections.profile}
         Icon={<FaCircleUser className="size-6 opacity-75" />}
@@ -52,7 +47,7 @@ export const ProfileLinks: React.FC<{
       <div
         className={clsx(
           'profile-links__drawer',
-          DRAWER_CLASSES(!isHomepage && isScrolled, expandedSections.profile, DRAWER_Z_PROFILE),
+          DRAWER_CLASSES(expandedSections.profile, DRAWER_Z_PROFILE),
         )}
       >
         <div className="profile-links__links flex flex-col gap-4 items-end section-base">

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -89,14 +89,14 @@ exports[`Nav > renders with courses 1`] = `
                         class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty"
                       >
                         <a
-                          class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B]"
+                          class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                           href="/courses/future-of-ai"
                           tabindex="0"
                         >
                           Featured Course
                         </a>
                         <a
-                          class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B]"
+                          class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                           href="/courses/ops"
                           tabindex="0"
                         >
@@ -109,7 +109,7 @@ exports[`Nav > renders with courses 1`] = `
                           </span>
                         </a>
                         <a
-                          class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B]"
+                          class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                           href="/courses"
                           tabindex="0"
                         >
@@ -213,14 +213,14 @@ exports[`Nav > renders with courses 1`] = `
                   class="nav-dropdown__dropdown-content flex flex-col gap-3 w-fit overflow-hidden mx-auto text-pretty"
                 >
                   <a
-                    class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B]"
+                    class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                     href="/courses/future-of-ai"
                     tabindex="0"
                   >
                     Featured Course
                   </a>
                   <a
-                    class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B]"
+                    class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                     href="/courses/ops"
                     tabindex="0"
                   >
@@ -233,7 +233,7 @@ exports[`Nav > renders with courses 1`] = `
                     </span>
                   </a>
                   <a
-                    class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B]"
+                    class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                     href="/courses"
                     tabindex="0"
                   >

--- a/apps/website/src/components/Nav/utils.ts
+++ b/apps/website/src/components/Nav/utils.ts
@@ -5,11 +5,11 @@ export const TRANSITION_DURATION_CLASS = 'duration-300';
 export const DRAWER_Z_DEFAULT = 'z-40' as const;
 export const DRAWER_Z_PROFILE = 'z-50' as const;
 
-export const DRAWER_CLASSES = (isDark: boolean, isOpen: boolean, zIndex: typeof DRAWER_Z_DEFAULT | typeof DRAWER_Z_PROFILE = DRAWER_Z_DEFAULT) => clsx(
+export const DRAWER_CLASSES = (isOpen: boolean, zIndex: typeof DRAWER_Z_DEFAULT | typeof DRAWER_Z_PROFILE = DRAWER_Z_DEFAULT) => clsx(
   'absolute top-[60px] min-[1024px]:top-[76px] left-0 w-full',
   'lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))]',
   'px-spacing-x transition-all duration-300 ease-in-out',
-  isDark ? 'bg-color-canvas-dark' : 'bg-white',
+  'bg-white',
   isOpen
     ? `max-h-[700px] opacity-100 pt-4 pb-10 border-b border-color-border ${zIndex}`
     : 'max-h-0 opacity-0 pb-0 pointer-events-none',


### PR DESCRIPTION
# Description
Removes scroll-triggered dark mode from navbar across the site. Preserving homepage dark style routing for when the new navbar's design is finalized (currently blocked on dropdown design).

## Issue
#1590

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
### Before
![before-dark-nav](https://github.com/user-attachments/assets/335f8893-fc55-4130-8ae8-140de49635f6)

### After
![after-no-dark-nav](https://github.com/user-attachments/assets/bed4628d-f045-4e44-8376-f703ccceaba9)