### PR TITLE
[Bug] Prefer NEXT_PUBLIC_SITE_URL to http://localhost:8000 in axios setup

### DIFF
--- a/apps/website/src/lib/axios.ts
+++ b/apps/website/src/lib/axios.ts
@@ -3,7 +3,7 @@ import { configure } from 'axios-hooks';
 
 // Create axios instance with base URL
 const axiosInstance = axios.create({
-  baseURL: typeof window !== 'undefined' ? window.location.origin : 'http://localhost:8000',
+  baseURL: typeof window !== 'undefined' ? window.location.origin : (process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:8000'),
 });
 
 // Configure axios-hooks to use our configured instance


### PR DESCRIPTION
# Description

We were getting `ECONNREFUSED` errors due to an axios request firing during SSR. The Axios instance was configured to use localhost:8000 which worked on dev, but on prod the internal port used is 8080, causing these errors.

I could only find this happening on one specific page which was https://bluedot.org/courses/technical-ai-safety/3/1 , so I don't think this was a serious issue. Regardless, this PR makes it use the NEXT_PUBLIC_SITE_URL if available, to match what we do for tRPC.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1588 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->
