### PR TITLE
Luma event wrong location and not local time

### DIFF
--- a/apps/website/src/components/homepage/EventsSection.tsx
+++ b/apps/website/src/components/homepage/EventsSection.tsx
@@ -86,9 +86,19 @@ const DateBadge = ({ month, day }: { month: string; day: string }) => {
 };
 
 const EventCard = ({ event }: { event: Event }) => {
-  const date = new Date(event.startAt);
-  const month = date.toLocaleString('en-US', { month: 'short' }).toUpperCase();
-  const day = date.getDate().toString();
+  const startDate = new Date(event.startAt);
+  const endDate = new Date(event.endAt);
+
+  const timeFormat: Intl.DateTimeFormatOptions = {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  };
+
+  const month = startDate.toLocaleString('en-US', { month: 'short' }).toUpperCase();
+  const day = startDate.getDate().toString();
+  // Use `undefined` to respect user's locale for time formatting
+  const timeString = `${startDate.toLocaleTimeString(undefined, timeFormat)} - ${endDate.toLocaleTimeString(undefined, timeFormat)}`;
 
   return (
     <div className="flex flex-col justify-between h-[264px] min-[680px]:min-h-[248px] min-[1024px]:min-h-[280px] min-[1280px]:min-h-[320px] pl-6 border-l border-[rgba(19,19,46,0.15)] w-[232px] min-[680px]:w-auto flex-shrink-0 min-[680px]:flex-shrink min-[680px]:flex-grow min-[680px]:basis-0">
@@ -110,7 +120,7 @@ const EventCard = ({ event }: { event: Event }) => {
           </h3>
         </a>
         <p className="text-[16px] font-normal leading-[1.55] tracking-[-0.032px] text-[#13132e] opacity-70">
-          {event.time}
+          {timeString}
         </p>
       </div>
     </div>

--- a/apps/website/src/server/routers/luma.ts
+++ b/apps/website/src/server/routers/luma.ts
@@ -21,9 +21,9 @@ function transformEvent(api_id: string, event: LumaEvent) {
   return {
     id: api_id,
     startAt: event.start_at,
+    endAt: event.end_at,
     location: event.geo_address_json?.city?.toUpperCase() || 'REMOTE',
     title: event.name,
-    time: formatStartAndEndTime(event.start_at, event.end_at),
     url: event.url,
   };
 }
@@ -148,20 +148,4 @@ async function sendSlackAlertIfNeeded(error: unknown): Promise<void> {
   ]);
 
   lastSlackAlert = now;
-}
-
-function formatStartAndEndTime(startAt: string, endAt: string): string {
-  const start = new Date(startAt);
-  const end = new Date(endAt);
-  const startTime = start.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
-  const endTime = end.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
-  return `${startTime} - ${endTime}`;
 }


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

All luma events show 'REMOTE' because we are using the wrong key for the API response. [It should be](https://docs.luma.com/reference/get_v1-event-get) `geo_address_json` not `geo_address_info`.

Events are also possibly in the wrong timezone because we convert to a date on the server, not the client. Instead of doing this I'm passing the UTC date from the server to the client, then constructing the date on the client (this should correctly show the date with local time information).

I've also extracted and re-used the `Event` type for safer frontend/backend contract.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1630.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---| |
| 🖥️ | <img width="1169" height="361" alt="image" src="https://github.com/user-attachments/assets/81609917-c80a-431d-958c-dcae29ab644d" /> | <img width="2194" height="678" alt="image" src="https://github.com/user-attachments/assets/bb5d4b1f-1ad4-442a-818c-934c19506e0c" /> |
