### PR TITLE
[Bug] Change undefined to null to fix JSON serialisation error

### DIFF
--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -19,7 +19,7 @@ export const resourcesRouter = router({
         ...resourceCompletion,
         // Trim feedback field (Airtable quirk)
         feedback: resourceCompletion.feedback?.trimEnd(),
-      } : undefined;
+      } : null;
     }),
 
   saveResourceCompletion: protectedProcedure


### PR DESCRIPTION
# Description

We were getting this error on the live site due to `getResourceCompletion` returning undefined, which isn't JSON serialisable
<img width="2246" height="1884" alt="image" src="https://github.com/user-attachments/assets/6f4c3485-43da-4368-a606-6650a41adcb9" />

