### PR TITLE
Update footer references from Open Philanthropy to Coefficient Giving

### DIFF
--- a/apps/website/src/pages/resources.tsx
+++ b/apps/website/src/pages/resources.tsx
@@ -121,10 +121,10 @@ If you're interested in working on technical AI safety, the current AI paradigm 
   - Applying to the EA Funds is an [easy and flexible process](https://forum.effectivealtruism.org/posts/caayRw2pgNLtqt9Pz/ea-funds-is-more-flexible-than-you-might-think), so we recommend you err on the side of applying if you're not sure.
   - They have historically funded: up-skilling in a field to prepare for future work; movement-building programs; scholarships, academic teaching buy-outs, and additional funding for academics to free up their time; funding to make existing researchers more effective; direct work in AI; seed money for new organizations; and more
   - If you're not sure where to apply, we recommend you default to this.
-- [Career development and transition funding](https://www.openphilanthropy.org/career-development-and-transition-funding/) – Open Philanthropy
+- [Career development and transition funding](https://www.coefficientgiving.org/career-development-and-transition-funding/) – Coefficient Giving
   - This program aims to provide support – primarily in the form of funding for graduate study, but also for other types of one-off career capital-building activities – for early-career individuals who want to pursue careers that help improve the long-term future
   - As with the EA Funds, applying is an easy and flexible process.
-- [Open Philanthropy Undergraduate Scholarship](https://www.openphilanthropy.org/undergraduate-scholarship/)
+- [Coefficient Giving Undergraduate Scholarship](https://www.coefficientgiving.org/undergraduate-scholarship/)
   - This program aims to provide support for highly promising and altruistically-minded students who are hoping to start an undergraduate degree at one of the top universities in the USA or UK, and who do not qualify as domestic students at these institutions for the purposes of admission and financial aid.
 - [Future of Life Institute – Grants](https://grants.futureoflife.org/)
   - Many different grant opportunities: project proposals; PhD fellowships; post-doctoral fellowships; and for professors to join their AI Existential Safety community

--- a/libraries/ui/src/Footer.tsx
+++ b/libraries/ui/src/Footer.tsx
@@ -172,7 +172,7 @@ export const Footer: React.FC<FooterProps> = ({
 
             {/* Copyright */}
             <div className="text-size-sm text-[#CCD7FF] leading-[26px] min-[680px]:mt-0 lg:mt-12 2xl:mt-[64px]">
-              <span>&copy; {new Date().getFullYear()}. <A href="https://bluedot.org/" className="text-[#CCD7FF] hover:text-white">BlueDot Impact</A> is primarily funded by <A href="https://www.openphilanthropy.org/" className="text-[#CCD7FF] hover:text-white">Open Philanthropy</A>, and is a non-profit based in the UK (company number <A href="https://find-and-update.company-information.service.gov.uk/company/14964572" className="text-[#CCD7FF] hover:text-white">14964572</A>).</span>
+              <span>&copy; {new Date().getFullYear()}. <A href="https://bluedot.org/" className="text-[#CCD7FF] hover:text-white">BlueDot Impact</A> is funded by <A href="https://www.coefficientgiving.org/" className="text-[#CCD7FF] hover:text-white">Coefficient Giving</A>, and is a non-profit based in the UK (company number <A href="https://find-and-update.company-information.service.gov.uk/company/14964572" className="text-[#CCD7FF] hover:text-white">14964572</A>).</span>
             </div>
           </div>
         </div>

--- a/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
@@ -512,13 +512,13 @@ exports[`Footer > renders default as expected 1`] = `
             >
               BlueDot Impact
             </a>
-             is primarily funded by 
+             is funded by 
             <a
               class="bluedot-a not-prose text-[#CCD7FF] hover:text-white"
-              href="https://www.openphilanthropy.org/"
+              href="https://www.coefficientgiving.org/"
               tabindex="0"
             >
-              Open Philanthropy
+              Coefficient Giving
             </a>
             , and is a non-profit based in the UK (company number 
             <a
@@ -1049,13 +1049,13 @@ exports[`Footer > renders with optional args 1`] = `
             >
               BlueDot Impact
             </a>
-             is primarily funded by 
+             is funded by 
             <a
               class="bluedot-a not-prose text-[#CCD7FF] hover:text-white"
-              href="https://www.openphilanthropy.org/"
+              href="https://www.coefficientgiving.org/"
               tabindex="0"
             >
-              Open Philanthropy
+              Coefficient Giving
             </a>
             , and is a non-profit based in the UK (company number 
             <a


### PR DESCRIPTION
# Description
OpenPhil has rebranded, so I'm updating the website footer and some other references to them in our codebase. 

**Before** and **After**
<img width="3878" height="582" alt="CleanShot 2025-11-18 at 19 42 20@2x" src="https://github.com/user-attachments/assets/eb775b81-63fd-454a-a82b-e6d36f73b0c9" />