### PR TITLE
[Bug] noindex certificates and remove them from the sitemap

### DIFF
--- a/apps/website/scripts/sitemap-generator.ts
+++ b/apps/website/scripts/sitemap-generator.ts
@@ -9,7 +9,6 @@ const INCLUDED_ROUTES = [
   ROUTES.home,
   ROUTES.about,
   ROUTES.blog,
-  ROUTES.certification,
   ROUTES.contact,
   ROUTES.courses,
   ROUTES.joinUs,

--- a/apps/website/src/pages/certification.tsx
+++ b/apps/website/src/pages/certification.tsx
@@ -87,6 +87,7 @@ const CertificatePage = ({ certificate, certificateId }: CertificatePageProps) =
       <Head>
         <title>{`${certificate.recipientName}'s Certificate | BlueDot Impact`}</title>
         <meta name="description" content={`Certificate of completion for ${certificate.courseName}`} />
+        <meta name="robots" content="noindex" />
       </Head>
 
       <Section className="flex-1 pt-12">


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->
- Removing from the sitemap means that google generally won't find these links unless they are shared online
- `noindex` ensures the links won't be indexed
