### PR TITLE
Use zod `safeParse` rather than inspecting error type

### DIFF
--- a/apps/website/src/components/settings/PasswordSection.tsx
+++ b/apps/website/src/components/settings/PasswordSection.tsx
@@ -6,7 +6,6 @@ import {
 } from '@bluedot/ui';
 import { TRPCClientError } from '@trpc/client';
 import { useEffect, useRef, useState } from 'react';
-import type { ZodError } from 'zod';
 import { changePasswordWithConfirmSchema } from '../../lib/schemas/user/changePassword.schema';
 import { trpc } from '../../utils/trpc';
 import { P } from '../Text';
@@ -99,31 +98,27 @@ const ChangePasswordModal = ({
   const validateForm = (): boolean => {
     const newErrors = { current: '', new: '', confirm: '' };
 
-    try {
-      changePasswordWithConfirmSchema.parse({
-        currentPassword,
-        newPassword,
-        confirmPassword,
+    const result = changePasswordWithConfirmSchema.safeParse({
+      currentPassword,
+      newPassword,
+      confirmPassword,
+    });
+
+    if (!result.success) {
+      result.error.issues.forEach((issue) => {
+        const field = issue.path[0];
+        if (field === 'currentPassword') {
+          newErrors.current = issue.message;
+        } else if (field === 'newPassword') {
+          newErrors.new = issue.message;
+        } else if (field === 'confirmPassword') {
+          newErrors.confirm = issue.message;
+        }
       });
-      setErrors(newErrors);
-      return true;
-    } catch (error) {
-      if (error instanceof Error && 'errors' in error) {
-        const zodError = error as ZodError;
-        zodError.errors.forEach((err) => {
-          const field = err.path[0] as string;
-          if (field === 'currentPassword') {
-            newErrors.current = err.message;
-          } else if (field === 'newPassword') {
-            newErrors.new = err.message;
-          } else if (field === 'confirmPassword') {
-            newErrors.confirm = err.message;
-          }
-        });
-      }
-      setErrors(newErrors);
-      return false;
     }
+
+    setErrors(newErrors);
+    return result.success;
   };
 
   const handleSubmit = async () => {


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Tests are failing on master because we are importing Zod as a type and not using `error.issues`. I'm not sure why latest commits merged after Zod reversion are not failing.

These changes were made as part of upgrade to v4, then reverted. I'm reintroducing them because (1) the fix failing tests and (2) cleaner approach to use `safeParse` and inspect result rather than `try/catch`.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
