### PR TITLE
[Bug] Remove tests for Join group button on settings page (button has been removed)

### DIFF
--- a/apps/website/src/components/settings/CourseListRow.test.tsx
+++ b/apps/website/src/components/settings/CourseListRow.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import {
-  act, render, screen, waitFor,
+  act, render, screen,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {


### PR DESCRIPTION
# Description

This is causing CI to fail due to a semantic conflict between  #1615 and #1640. Otherwise the code itself in `CourseListRow` is still correct as far as I can tell.


