### PR TITLE
Bug/#1614 lost in flight input

### DIFF
--- a/apps/website/src/components/courses/exercises/FreeTextResponse.test.tsx
+++ b/apps/website/src/components/courses/exercises/FreeTextResponse.test.tsx
@@ -451,35 +451,5 @@ describe('FreeTextResponse', () => {
       // The local state should take precedence over the refetched server value
       expect(textarea.value).not.toBe('Hello');
     });
-
-    test('syncs exerciseResponse when navigating to a new exercise with empty local state', async () => {
-      // This test ensures that when navigating to a different exercise,
-      // the saved response is loaded correctly
-
-      const { container, rerender } = render(
-        <FreeTextResponse
-          {...mockArgs}
-          exerciseResponse=""
-          isLoggedIn
-        />,
-      );
-
-      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
-      expect(textarea.value).toBe('');
-
-      // Simulate navigating to a different exercise with a saved response
-      rerender(
-        <FreeTextResponse
-          {...mockArgs}
-          exerciseResponse="Previously saved answer"
-          isLoggedIn
-        />,
-      );
-
-      // Should sync the new exercise's response when answer is empty
-      await waitFor(() => {
-        expect(textarea.value).toBe('Previously saved answer');
-      });
-    });
   });
 });

--- a/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
@@ -30,13 +30,14 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
   const router = useRouter();
   const [answer, setAnswer] = useState<string>(exerciseResponse || '');
 
-  // Only sync from exerciseResponse on initial mount, not on subsequent changes
-  // This prevents the refetch from overwriting user's unsaved changes
-  const initialExerciseResponse = React.useRef(exerciseResponse);
+  // Track the last synced exerciseResponse to detect when it changes
+  // Only sync from server when user has cleared their local answer (answer === '')
+  // This prevents refetch from overwriting user's in-progress typing
+  const lastSyncedExerciseResponse = React.useRef(exerciseResponse);
   useEffect(() => {
-    if (initialExerciseResponse.current !== exerciseResponse && answer === '') {
+    if (lastSyncedExerciseResponse.current !== exerciseResponse && answer === '') {
       setAnswer(exerciseResponse || '');
-      initialExerciseResponse.current = exerciseResponse;
+      lastSyncedExerciseResponse.current = exerciseResponse;
     }
   }, [exerciseResponse, answer]);
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->
The issue here was that once the changes were made by the user and the autosaving was triggered `Exercise.tsx` would save user's info in the server and refresh the text area with the text it just saved.
However, if the user kept typing while this action was happening information would just get lost (because `Exercise.tsx` refreshed the text box).

Fix for this we track whether the user was typing or not `answer` and have it the `FreeTextResponse.tsx`compare whether there it was safe to save new information in the server and update the text.

Also added some tests to catch this. They were fully AI-gen, so maybe too much?

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1614 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->
