### PR TITLE
[feat]: bottomCTA in WhoIsThisCourseFor

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.test.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.test.tsx
@@ -78,10 +78,10 @@ describe('AgiStrategyLander', () => {
     // Check description
     expect(screen.getByText(/Envision a good future. Map the threats from AI. Design effective interventions. Get funded to start shipping. All in 30 hours./)).toBeInTheDocument();
 
-    // Check CTAs - "Apply now" appears in HeroSection and banner (2 times total)
+    // Check CTAs - "Apply now" appears in HeroSection, WhoIsThisForSection bottomCta, and banner (3 times total)
     // CourseInformationSection shows loading state since it's fetching schedule data
     const applyButtons = screen.getAllByRole('link', { name: /Apply now/i });
-    expect(applyButtons).toHaveLength(2);
+    expect(applyButtons).toHaveLength(3);
   });
 
   it('renders Graduate section', () => {

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -257,6 +257,30 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             </p>
           </div>
         </div>
+        <div
+          class="w-full max-w-[924px] mx-auto flex flex-col items-center gap-6 mt-12 md:mt-16"
+        >
+          <p
+            class="bluedot-p not-prose text-size-sm text-[#13132E]/80 text-center"
+          >
+            <span
+              class="font-semibold"
+            >
+              Don't fit these perfectly? Apply anyway.
+            </span>
+            <span>
+               
+              Some of our most impactful participants have included teachers, policymakers, engineers, and community leaders. We bet on drive and ambition, not CVs.
+            </span>
+          </p>
+          <a
+            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm rounded-sm font-[650] cta-button--outline-black bg-transparent border border-black hover:bg-gray-50 !font-medium text-size-sm px-5 py-2.5 !rounded-md !border-[rgba(19,19,46,0.3)] !text-[#13132e]"
+            href="https://web.miniextensions.com/9Kuya4AzFGWgayC3gQaX"
+            tabindex="0"
+          >
+            Apply now
+          </a>
+        </div>
       </div>
     </section>
     <div

--- a/apps/website/src/components/lander/components/WhoIsThisForSection.test.tsx
+++ b/apps/website/src/components/lander/components/WhoIsThisForSection.test.tsx
@@ -21,6 +21,13 @@ const mockTargetAudiences = [
   },
 ];
 
+const mockBottomCta = {
+  boldText: "Don't fit these perfectly? Apply anyway.",
+  text: 'Some of our most impactful participants have included teachers, policymakers, engineers, and community leaders. We bet on drive and ambition, not CVs.',
+  buttonText: 'Apply now',
+  buttonUrl: 'https://example.com/apply',
+};
+
 describe('WhoIsThisForSection', () => {
   it('renders correctly', () => {
     const { container } = render(<WhoIsThisForSection targetAudiences={mockTargetAudiences} />);
@@ -48,5 +55,24 @@ describe('WhoIsThisForSection', () => {
     expect(getByText('who want to build solutions that protect humanity.')).toBeDefined();
     expect(getByText('who want to steer AI\'s trajectory towards beneficial outcomes for humanity.')).toBeDefined();
     expect(getByText('who want to take big bets on the most impactful research ideas.')).toBeDefined();
+  });
+
+  it('renders bottom CTA section when provided', () => {
+    const { getByText, getByRole } = render(
+      <WhoIsThisForSection targetAudiences={mockTargetAudiences} bottomCta={mockBottomCta} />,
+    );
+
+    expect(getByText("Don't fit these perfectly? Apply anyway.")).toBeDefined();
+    expect(getByText(/We bet on drive and ambition, not CVs./)).toBeDefined();
+
+    const applyButton = getByRole('link', { name: 'Apply now' });
+    expect(applyButton).toBeDefined();
+    expect(applyButton.getAttribute('href')).toBe('https://example.com/apply');
+  });
+
+  it('does not render bottom CTA section when not provided', () => {
+    const { queryByText } = render(<WhoIsThisForSection targetAudiences={mockTargetAudiences} />);
+
+    expect(queryByText("Don't fit these perfectly? Apply anyway.")).toBeNull();
   });
 });

--- a/apps/website/src/components/lander/components/WhoIsThisForSection.tsx
+++ b/apps/website/src/components/lander/components/WhoIsThisForSection.tsx
@@ -1,4 +1,4 @@
-import { NewText } from '@bluedot/ui';
+import { CTALinkOrButton, NewText } from '@bluedot/ui';
 import { IconType } from 'react-icons';
 
 const { H2, P } = NewText;
@@ -9,14 +9,23 @@ export type TargetAudience = {
   description: string;
 };
 
+export type BottomCta = {
+  boldText: string;
+  text: string;
+  buttonText: string;
+  buttonUrl: string;
+};
+
 export type WhoIsThisForSectionProps = {
   title?: string;
   targetAudiences: TargetAudience[];
+  bottomCta?: BottomCta;
 };
 
 const WhoIsThisForSection = ({
   title = 'Who this course is for',
   targetAudiences,
+  bottomCta,
 }: WhoIsThisForSectionProps) => {
   return (
     <section className="w-full bg-white">
@@ -40,6 +49,23 @@ const WhoIsThisForSection = ({
             </div>
           ))}
         </div>
+
+        {/* Bottom CTA Section */}
+        {bottomCta && (
+          <div className="w-full max-w-[924px] mx-auto flex flex-col items-center gap-6 mt-12 md:mt-16">
+            <P className="text-size-sm text-[#13132E]/80 text-center">
+              <span className="font-semibold">{bottomCta.boldText}</span>
+              <span> {bottomCta.text}</span>
+            </P>
+            <CTALinkOrButton
+              variant="outline-black"
+              url={bottomCta.buttonUrl}
+              className="!font-medium text-size-sm px-5 py-2.5 !rounded-md !border-[rgba(19,19,46,0.3)] !text-[#13132e]"
+            >
+              {bottomCta.buttonText}
+            </CTALinkOrButton>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/website/src/components/lander/course-content/AgiStrategyContent.tsx
+++ b/apps/website/src/components/lander/course-content/AgiStrategyContent.tsx
@@ -58,6 +58,12 @@ export const createAgiStrategyContent = (
         description: 'who want to take big bets on the most impactful research ideas.',
       },
     ],
+    bottomCta: {
+      boldText: "Don't fit these perfectly? Apply anyway.",
+      text: 'Some of our most impactful participants have included teachers, policymakers, engineers, and community leaders. We bet on drive and ambition, not CVs.',
+      buttonText: 'Apply now',
+      buttonUrl: applicationUrlWithUtm,
+    },
   },
 
   curriculum: {

--- a/apps/website/src/components/lander/course-content/BioSecurityContent.tsx
+++ b/apps/website/src/components/lander/course-content/BioSecurityContent.tsx
@@ -58,6 +58,12 @@ export const createBioSecurityContent = (
         description: 'who want to build new pandemic defences.',
       },
     ],
+    bottomCta: {
+      boldText: "Don't fit these perfectly? Apply anyway.",
+      text: 'Some of our most impactful participants have included teachers, policymakers, engineers, and community leaders. We bet on drive and ambition, not CVs.',
+      buttonText: 'Apply now',
+      buttonUrl: applicationUrlWithUtm,
+    },
   },
 
   curriculum: {

--- a/apps/website/src/components/lander/course-content/TechnicalAiSafetyContent.tsx
+++ b/apps/website/src/components/lander/course-content/TechnicalAiSafetyContent.tsx
@@ -59,6 +59,12 @@ export const createTechnicalAiSafetyContent = (
         description: 'who want to drive high-impact safety work.',
       },
     ],
+    bottomCta: {
+      boldText: "Don't fit these perfectly? Apply anyway.",
+      text: 'Some of our most impactful participants have included teachers, policymakers, engineers, and community leaders. We bet on drive and ambition, not CVs.',
+      buttonText: 'Apply now',
+      buttonUrl: applicationUrlWithUtm,
+    },
   },
 
   curriculum: {


### PR DESCRIPTION
# Description
Adds a "bottom CTA" section to the WhoIsThisForSection component on course lander pages. This is meant to encourage users who don't fit the typical audience profiles to apply anyway, with copy highlighting that BlueDot bets on "drive and ambition, not CVs." The new section includes an "Apply now" button that links to the course application URL. The copy is placed in the content sections for each of the respective course landers in case core team wants to customize that copy for each course.

## Issue
#1616 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
<img width="991" height="186" alt="whoiscoursefor-bottomcta" src="https://github.com/user-attachments/assets/eabd8f98-c608-4af4-b9dc-f5b28978defc" />

### Mobile
<img width="320" height="501" alt="whoiscoursefor-bottomcta-mobile" src="https://github.com/user-attachments/assets/29a384ad-5e1b-4abd-8728-027a787e2cda" />
