### PR TITLE
[Feature] GroupSwitchModal: custom text for discussions that have passed

### DIFF
--- a/apps/website/src/components/courses/GroupSwitchModal.test.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.test.tsx
@@ -432,9 +432,11 @@ describe('GroupSwitchModal', () => {
       expect(fullGroupOption).toHaveClass('opacity-50');
       expect(startedGroupOption).toHaveClass('opacity-50');
 
-      // Verify "No spots left" message appears
+      // Verify "No spots left" message appears for full groups
       const noSpotsMessages = screen.getAllByText('No spots left');
       expect(noSpotsMessages.length).toBeGreaterThan(0);
+      // Verify "This discussion has passed" message appears for started discussions
+      expect(screen.getByText('This discussion has passed')).toBeInTheDocument();
 
       // Open unit selector to check if Unit 2 is disabled
       const unitButton = screen.getByLabelText('Select Unit');

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -85,12 +85,14 @@ const getGroupSwitchDescription = ({
   isTemporarySwitch,
   selectedUnitNumber,
   spotsLeftIfKnown,
+  hasStarted = false,
 }: {
   userIsParticipant?: boolean;
   isSelected: boolean;
   isTemporarySwitch: boolean;
   selectedUnitNumber?: string;
   spotsLeftIfKnown: number | null;
+  hasStarted?: boolean;
 }): React.ReactNode => {
   if (isTemporarySwitch) {
     if (userIsParticipant) {
@@ -112,6 +114,10 @@ const getGroupSwitchDescription = ({
     if (isSelected) {
       return <span className="text-[#0037FF]">You are switching into this group for all upcoming units</span>;
     }
+  }
+
+  if (isTemporarySwitch && hasStarted) {
+    return <span>This discussion has passed</span>;
   }
 
   // Default: N spots left
@@ -319,6 +325,7 @@ const GroupSwitchModal: React.FC<GroupSwitchModalProps> = ({
           isTemporarySwitch: true,
           selectedUnitNumber,
           spotsLeftIfKnown: d.spotsLeftIfKnown,
+          hasStarted: d.hasStarted,
         }),
         onSelect: () => setSelectedDiscussionId(d.discussion.id),
         onConfirm: handleSubmit,


### PR DESCRIPTION
# Description

I went with "This discussion has passed" rather than "This discussion has already happened" because it fits better on small screens + sounds more natural imo.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1692

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <img width="682" height="1492" alt="Screenshot 2025-11-25 at 22 06 57" src="https://github.com/user-attachments/assets/3aec6710-0997-47f9-a9da-a57330f9146d" /> |
| 🖥️ | <!-- **Desktop** before --> | <img width="1392" height="1484" alt="Screenshot 2025-11-25 at 22 07 02" src="https://github.com/user-attachments/assets/f4754f46-3443-4960-a5db-c0a79fa6da2a" /> |
