### PR TITLE
Changes to make action plan Participant only

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -496,6 +496,10 @@ export const meetPersonTable = pgAirtable('meet_person', {
       pgColumn: text().array(),
       airtableId: 'fldFjRSrXH8Z5sGaQ',
     },
+    role: {
+      pgColumn: text(),
+      airtableId: 'fldcMg0UmqlneGerA',
+    },
     /**
      * A bucket defines a set of groups, where participants are allowed to switch between the
      * groups if requested. This field is an array of all the buckets the person is a member of.


### PR DESCRIPTION
# Description
Action plan v1 was implemented with it everyone having it visible as the rest was out of scope. This is in preparation for only having Participant's required to do it. 

## Issue
Related to https://github.com/bluedotimpact/bluedot/issues/1623
