### PR TITLE
update newsletter gradient reference from optimizations

### DIFF
--- a/apps/website/src/components/homepage/NewsletterBanner.tsx
+++ b/apps/website/src/components/homepage/NewsletterBanner.tsx
@@ -61,7 +61,7 @@ const NewsletterBanner = () => {
         <div
           className="absolute inset-0 min-[680px]:rounded-xl -scale-x-100 bg-cover"
           style={{
-            backgroundImage: 'url(\'/images/homepage/hero.jpg\')',
+            backgroundImage: 'url(\'/images/homepage/hero.webp\')',
             backgroundPosition: '50% 60%',
           }}
         />


### PR DESCRIPTION
# Description
The newsletter banner was showing a grey gradient on staging instead of the blue hero background. This was because:
  - PR #1694 ("Optimise large homepage images") replaced `hero.jpg` with an optimized `hero.webp` version
  - The `NewsletterBanner` component still referenced the old `hero.jpg` path
  - On staging, the image failed to load, leaving only the grey overlay gradient visible

Updated `NewsletterBanner.tsx` to reference `/images/homepage/hero.webp` instead of `/images/homepage/hero.jpg`

## Issue
Related to #1590 and #1700 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="3030" height="792" alt="image" src="https://github.com/user-attachments/assets/8b415ab4-2287-4559-897a-ba91f28c2168" /> | <img width="1512" height="486" alt="newsletter-after" src="https://github.com/user-attachments/assets/f53bfbd9-6c35-42f4-b14f-b3adf0d4b9b9" /> |
