### PR TITLE
Fix date calculation for course units in part-time and intensive formats

### DIFF
--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -73,8 +73,15 @@ export const courseRoundsRouter = router({
 
         if (numberOfUnits && numberOfUnits > 0) {
           const isPartTime = intensity?.toLowerCase() === 'part-time';
-          const unitLengthInDays = isPartTime ? 7 : 1;
-          const daysToAdd = (numberOfUnits - 1) * unitLengthInDays;
+
+          let daysToAdd: number;
+          if (isPartTime) {
+            // Part-time: Add numberOfUnits weeks, then subtract 1 day
+            daysToAdd = (numberOfUnits * 7) - 1;
+          } else {
+            // Intensive: Add (numberOfUnits - 1) days
+            daysToAdd = numberOfUnits - 1;
+          }
 
           computedLast = new Date(first.getTime() + daysToAdd * 24 * 60 * 60 * 1000);
         } else if (lastDate) {


### PR DESCRIPTION
# Description
The date calculations were wrong, such that the "last discussion" date for part-time courses was always 6 days too early. 

A course round will always start on a Monday. If it's a part-time course with 6 units, it will run for 6 weeks until the 6th Sunday. 