### PR TITLE
[feat]: course lander social proof, partners and banners stories

### DIFF
--- a/apps/website/src/components/lander/components/GraduateSection.stories.tsx
+++ b/apps/website/src/components/lander/components/GraduateSection.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import GraduateSection from './GraduateSection';
+
+const meta = {
+  title: 'website/CourseLander/GraduateSection',
+  component: GraduateSection,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'A responsive section displaying an infinite-scrolling carousel of company logos where BlueDot alumni work. Features a fade mask effect and auto-scrolling animation.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof GraduateSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/website/src/components/lander/components/LandingBanner.stories.tsx
+++ b/apps/website/src/components/lander/components/LandingBanner.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LandingBanner from './LandingBanner';
+
+const meta = {
+  title: 'website/CourseLander/LandingBanner',
+  component: LandingBanner,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'A full-width call-to-action banner with a background image, noise texture overlay, icon, title, and CTA button. Used at the bottom of course landers to drive conversions.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      description: 'Main heading text displayed in the banner',
+      control: 'text',
+    },
+    ctaText: {
+      description: 'Text for the call-to-action button',
+      control: 'text',
+    },
+    ctaUrl: {
+      description: 'URL the CTA button links to',
+      control: 'text',
+    },
+    imageSrc: {
+      description: 'Background image URL',
+      control: 'text',
+    },
+    imageAlt: {
+      description: 'Alt text for the background image',
+      control: 'text',
+    },
+    iconSrc: {
+      description: 'URL for the icon displayed above the title',
+      control: 'text',
+    },
+    iconAlt: {
+      description: 'Alt text for the icon',
+      control: 'text',
+    },
+    noiseImageSrc: {
+      description: 'URL for the noise texture overlay image',
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof LandingBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Start building towards a good future today',
+    ctaText: 'Apply now',
+    ctaUrl: 'https://example.com/apply',
+    imageSrc: '/images/agi-strategy/hero-banner-split.png',
+    imageAlt: 'AGI Strategy banner',
+    iconSrc: '/images/agi-strategy/bluedot-icon.svg',
+    iconAlt: 'BlueDot',
+    noiseImageSrc: '/images/agi-strategy/noise.webp',
+  },
+};

--- a/apps/website/src/components/lander/components/PartnerSection.stories.tsx
+++ b/apps/website/src/components/lander/components/PartnerSection.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PartnerSection, { Partner } from './PartnerSection';
+
+const meta = {
+  title: 'website/CourseLander/PartnerSection',
+  component: PartnerSection,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'A section showcasing partner organizations. Features an infinite-scrolling carousel on mobile/tablet and a responsive grid on desktop. Each partner card shows a logo and description.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      description: 'Section heading displayed at the top',
+      control: 'text',
+    },
+    partners: {
+      description: 'Array of partner organizations to display',
+      control: 'object',
+    },
+  },
+} satisfies Meta<typeof PartnerSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const samplePartners: Partner[] = [
+  {
+    name: 'Entrepreneur First',
+    url: 'https://www.joinef.com/',
+    logo: '/images/agi-strategy/ef.svg',
+    descriptionShort: 'We collaborate with EF to host AI safety hackathons.',
+    descriptionFull: 'A London-based startup incubation programme. We collaborate with EF to host AI safety and def/acc hackathons.',
+  },
+  {
+    name: 'Institute for Progress',
+    url: 'https://ifp.org/',
+    logo: '/images/agi-strategy/ifp.svg',
+    descriptionShort: 'We collaborate with IFP to get impactful projects off the ground.',
+    descriptionFull: 'IFP is a science and innovation think tank. We collaborate with IFP to get impactful projects from their Launch Sequence off the ground.',
+  },
+  {
+    name: '50 Years',
+    url: 'https://www.fiftyyears.com/',
+    logo: '/images/agi-strategy/fifty-years.svg',
+    descriptionShort: 'We fast-track entrepreneurs into their 5050 AI cohorts.',
+    descriptionFull: 'A pre-seed and seed VC firm. We fast-track our most promising entrepreneurs into their 5050 AI cohorts, focused on building an aligned AI future.',
+  },
+  {
+    name: 'Seldon Lab',
+    url: 'https://seldonlab.com/',
+    logo: '/images/agi-strategy/seldon-lab.svg',
+    descriptionShort: 'We help community members get ready to join future Seldon batches.',
+    descriptionFull: 'Seldon offers guidance and investments in the next generation of AGI security startups. We help our most entrepreneurial community members get ready to join future Seldon batches.',
+  },
+  {
+    name: 'Halcyon Futures',
+    url: 'https://halcyonfutures.org/',
+    logo: '/images/agi-strategy/halcyon-futures.svg',
+    descriptionShort: 'We introduce our most promising leaders to Halcyon.',
+    descriptionFull: 'Halcyon identifies leaders from business, policy, and academia, and helps them take on new ambitious projects. We introduce our most promising leaders to Halcyon.',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    title: 'Co-created with our network of leading AI industry partners',
+    partners: samplePartners,
+  },
+};

--- a/apps/website/src/components/lander/components/QuoteSection.stories.tsx
+++ b/apps/website/src/components/lander/components/QuoteSection.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import QuoteSection, { QuoteWithUrl } from './QuoteSection';
+
+const meta = {
+  title: 'website/CourseLander/QuoteSection',
+  component: QuoteSection,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'A carousel section displaying quotes from notable figures. Features auto-rotation, swipe gestures on mobile, and keyboard navigation. Font size automatically adjusts based on quote length.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    quotes: {
+      description: 'Array of quotes to display in the carousel',
+      control: 'object',
+    },
+  },
+} satisfies Meta<typeof QuoteSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleQuotes: QuoteWithUrl[] = [
+  {
+    quote: '"We should not underestimate the real threats coming from AI [while] we have a narrowing window of opportunity to guide this technology responsibly."',
+    name: 'Ursula von der Leyen',
+    role: 'President, European Commission',
+    imageSrc: '/images/agi-strategy/ursula.png',
+    url: 'https://neighbourhood-enlargement.ec.europa.eu/news/2023-state-union-address-president-von-der-leyen-2023-09-13_en',
+  },
+  {
+    quote: '"I\'ve always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we\'ve done in the past… The downside is, at some point, that humanity loses control of the technology it\'s developing."',
+    name: 'Sundar Pichai',
+    role: 'CEO, Google',
+    imageSrc: '/images/agi-strategy/sundar.jpg',
+    url: 'https://garrisonlovely.substack.com/p/a-compilation-of-tech-executives',
+  },
+  {
+    quote: '"AI could surpass almost all humans at almost everything shortly after 2027."',
+    name: 'Dario Amodei',
+    role: 'CEO, Anthropic',
+    imageSrc: '/images/lander/foai/dario.jpeg',
+    url: 'https://arstechnica.com/ai/2025/01/anthropic-chief-says-ai-could-surpass-almost-all-humans-at-almost-everything-shortly-after-2027/',
+  },
+  {
+    quote: '"I\'m all in favor of accelerating technological progress, but there is something unsettling about the way OpenAI explicitly declares its mission to be the creation of AGI. AI is a wonderful tool for the betterment of humanity; AGI is a potential successor species … To the extent the mission produces extra motivation for the team to ship good products, it\'s a positive. To the extent it might actually succeed, it\'s a reason for concern."',
+    name: 'David Sacks',
+    role: 'White House AI and Crypto Czar',
+    imageSrc: '/images/agi-strategy/david-sacks.jpg',
+    url: 'https://x.com/HumanHarlan/status/1864858286065111298',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    quotes: sampleQuotes,
+  },
+};
+
+export const ShortQuotes: Story = {
+  args: {
+    quotes: [
+      {
+        quote: '"AI could surpass almost all humans at almost everything shortly after 2027."',
+        name: 'Dario Amodei',
+        role: 'CEO, Anthropic',
+        imageSrc: '/images/lander/foai/dario.jpeg',
+        url: 'https://example.com',
+      },
+      {
+        quote: '"The downside is, at some point, humanity loses control."',
+        name: 'Sundar Pichai',
+        role: 'CEO, Google',
+        imageSrc: '/images/agi-strategy/sundar.jpg',
+        url: 'https://example.com',
+      },
+    ],
+  },
+};
+
+export const LongQuotes: Story = {
+  args: {
+    quotes: [
+      {
+        quote: '"I\'m all in favor of accelerating technological progress, but there is something unsettling about the way OpenAI explicitly declares its mission to be the creation of AGI. AI is a wonderful tool for the betterment of humanity; AGI is a potential successor species … To the extent the mission produces extra motivation for the team to ship good products, it\'s a positive. To the extent it might actually succeed, it\'s a reason for concern."',
+        name: 'David Sacks',
+        role: 'White House AI and Crypto Czar',
+        imageSrc: '/images/agi-strategy/david-sacks.jpg',
+        url: 'https://example.com',
+      },
+      {
+        quote: '"I\'ve always thought of AI as the most profound technology humanity is working on. More profound than fire or electricity or anything that we\'ve done in the past. The downside is, at some point, that humanity loses control of the technology it\'s developing. We need to be thoughtful about how we proceed with this transformative technology that will reshape every aspect of human civilization."',
+        name: 'Sundar Pichai',
+        role: 'CEO, Google',
+        imageSrc: '/images/agi-strategy/sundar.jpg',
+        url: 'https://example.com',
+      },
+    ],
+  },
+};

--- a/apps/website/src/components/lander/components/TestimonialSubSection.stories.tsx
+++ b/apps/website/src/components/lander/components/TestimonialSubSection.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TestimonialSubSection, { Testimonial } from './TestimonialSubSection';
+
+const meta = {
+  title: 'website/CourseLander/TestimonialSubSection',
+  component: TestimonialSubSection,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: 'A responsive grid section displaying testimonial cards from course participants. Adapts from 1 column on mobile to 3 columns on desktop.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    testimonials: {
+      description: 'Array of testimonials to display',
+      control: 'object',
+    },
+    title: {
+      description: 'Optional section heading',
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof TestimonialSubSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleTestimonials: Testimonial[] = [
+  {
+    quote: 'This course completely changed my perspective on AI safety. The frameworks we learned are directly applicable to my work.',
+    name: 'Sarah Chen',
+    role: 'ML Engineer at DeepMind',
+    imageSrc: '/images/graduates/neel.jpeg',
+  },
+  {
+    quote: 'The community I joined through this course has been invaluable. I now have a network of like-minded professionals working on the most important problems.',
+    name: 'Marcus Johnson',
+    role: 'Policy Researcher at RAND',
+    imageSrc: '/images/graduates/marius.jpeg',
+  },
+  {
+    quote: 'After completing the course, I transitioned into AI safety research. The curriculum gave me the foundation I needed to make the switch.',
+    name: 'Elena Rodriguez',
+    role: 'Research Scientist at Anthropic',
+    imageSrc: '/images/graduates/chiara.jpeg',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    testimonials: sampleTestimonials,
+  },
+};


### PR DESCRIPTION
# Description
Stories for `GraduateSection`, `QuoteSection`, `TestimonialSubSection` (still actively used in old landers), `PartnerSection` and `LandingBanner`.

Will add stories for `CommunityMembersSubSection` once #1715 is merged and is consolidated to a single "CommunityCarousel" component for both homepage and course landers.

## Issue
#1686 