### PR TITLE
Demo: Setting up a permanent redirect

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -1,6 +1,15 @@
 const { withDefaultBlueDotNextConfig } = require('@bluedot/ui/src/default-config/next');
 
 module.exports = withDefaultBlueDotNextConfig({
+  async redirects() {
+    return [
+      {
+        source: '/running-versions-of-our-courses',
+        destination: '/blog/running-versions-of-our-courses',
+        permanent: true, // 301 redirect
+      },
+    ];
+  },
   headers: [
     {
       source: '/fonts/:path*',


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Steps to deploy:
- [ ] Create the blog version of this page at `/blog/running-versions-of-our-courses`
- [ ] Add this redirect
  - If you want to test it on prod you can set `permanent: false` at first which will make it easier to undo. `permanent: true` means browsers and search engines will cache this so will keep redirecting for some time even if we remove this