### PR TITLE
Add OG tags for dynamically chunked courses

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -110,7 +110,7 @@ const CourseUnitChunkPage = ({
         <meta key="og:description" property="og:description" content={metaDescription} />
         <meta key="og:site_name" property="og:site_name" content="BlueDot Impact" />
         <meta key="og:type" property="og:type" content="website" />
-        <meta key="og:url" property="og:url" content={`https://bluedot.org/courses/${unit.courseSlug}`} />
+        <meta key="og:url" property="og:url" content={`https://bluedot.org/courses/${unit.courseSlug}/${unitNumber}/${chunkIndex + 1}`} />
         <meta key="og:image" property="og:image" content={courseOgImage || 'https://bluedot.org/images/logo/link-preview-fallback.png'} />
         <meta key="og:image:width" property="og:image:width" content="1200" />
         <meta key="og:image:height" property="og:image:height" content="630" />


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

In https://github.com/bluedotimpact/bluedot/pull/1670 we added new OG tags to course slug indexes, but not for chunks within those courses. That means something like 'https://bluedot.org/courses/my-course' gets a nice preview but 'https://bluedot.org/courses/my-course/1/1' doesn't.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1745

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x]  Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="561" height="431" alt="image" src="https://github.com/user-attachments/assets/7077777d-8414-457c-b19a-b00bc0476476" /> |  |
