### PR TITLE
[feat]: newsletter component on course schedule page + page functiona…

### DIFF
--- a/apps/website/src/__tests__/pages/courses/index.test.tsx
+++ b/apps/website/src/__tests__/pages/courses/index.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  describe, expect, test, vi, beforeEach,
+} from 'vitest';
+import { server, trpcMsw } from '../../trpcMswSetup';
+import { TrpcProvider } from '../../trpcProvider';
+import CoursesPage from '../../../pages/courses/index';
+import { createMockCourse } from '../../testUtils';
+
+vi.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/courses',
+    query: {},
+  }),
+}));
+
+const mockCourses = [
+  createMockCourse({
+    id: 'course-foai',
+    slug: 'future-of-ai',
+    title: 'The Future of AI',
+    cadence: 'self-paced',
+    path: '/courses/future-of-ai',
+    displayOnCourseHubIndex: true,
+  }),
+  createMockCourse({
+    id: 'course-gov',
+    slug: 'ai-governance',
+    title: 'AI Governance',
+    cadence: 'Weekly',
+    path: '/courses/ai-governance',
+    displayOnCourseHubIndex: true,
+  }),
+];
+
+const mockRounds = {
+  intense: [
+    {
+      id: 'round-1',
+      intensity: 'intensive' as const,
+      applicationDeadline: '15 Jan',
+      applicationDeadlineRaw: '2025-01-15',
+      firstDiscussionDateRaw: '2025-01-20',
+      dateRange: '20 Jan - 24 Jan',
+      numberOfUnits: 5,
+    },
+  ],
+  partTime: [],
+};
+
+describe('CoursesPage', () => {
+  beforeEach(() => {
+    server.use(
+      trpcMsw.courses.getAll.query(() => mockCourses),
+      trpcMsw.courseRounds.getRoundsForCourse.query(() => mockRounds),
+    );
+  });
+
+  test('renders hero section with title', () => {
+    const { container } = render(<CoursesPage />, { wrapper: TrpcProvider });
+
+    const heroTitle = container.querySelector('h1');
+    expect(heroTitle?.textContent).toBe('Course Schedule');
+  });
+
+  test('renders newsletter banner', async () => {
+    const { container } = render(<CoursesPage />, { wrapper: TrpcProvider });
+
+    await waitFor(() => {
+      const emailInput = container.querySelector('input[type="email"]');
+      expect(emailInput).not.toBeNull();
+    });
+
+    const subscribeButton = container.querySelector('button[type="submit"]');
+    expect(subscribeButton?.textContent).toBe('Subscribe');
+  });
+
+  test('renders breadcrumb navigation', async () => {
+    const { container } = render(<CoursesPage />, { wrapper: TrpcProvider });
+
+    await waitFor(() => {
+      const nav = container.querySelector('nav');
+      expect(nav).not.toBeNull();
+    });
+  });
+
+  test('displays courses when loaded', async () => {
+    render(<CoursesPage />, { wrapper: TrpcProvider });
+
+    await waitFor(() => {
+      expect(screen.queryByText('The Future of AI')).not.toBeNull();
+      expect(screen.queryByText('AI Governance')).not.toBeNull();
+    });
+  });
+});

--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -12,6 +12,7 @@ import { trpc } from '../../utils/trpc';
 import { AGI_STRATEGY_APPLICATION_URL } from '../../components/lander/course-content/AgiStrategyContent';
 import { BIOSECURITY_APPLICATION_URL } from '../../components/lander/course-content/BioSecurityContent';
 import { TECHNICAL_AI_SAFETY_APPLICATION_URL } from '../../components/lander/course-content/TechnicalAiSafetyContent';
+import NewsletterBanner from '../../components/homepage/NewsletterBanner';
 
 type Course = inferRouterOutputs<AppRouter>['courses']['getAll'][number];
 type CourseRounds = inferRouterOutputs<AppRouter>['courseRounds']['getRoundsForCourse'];
@@ -223,7 +224,7 @@ const CoursesPage = () => {
 
       {/* Main Content Area */}
       <div className="w-full mx-auto px-5 min-[680px]:px-8 min-[1024px]:px-12 min-[1280px]:px-16 min-[1440px]:px-20 min-[1920px]:max-w-[1360px] min-[1920px]:px-0">
-        <div className="pt-8 pb-16 min-[680px]:py-16 min-[1280px]:py-24">
+        <div className="pt-8 min-[680px]:pt-16 min-[1280px]:pt-24">
           <div className="flex flex-col min-[1280px]:flex-row min-[1280px]:gap-16">
             {/* Breadcrumb Menu */}
             <BreadcrumbMenu courses={displayedCourses} />
@@ -240,6 +241,11 @@ const CoursesPage = () => {
               )}
             </div>
           </div>
+        </div>
+
+        {/* Newsletter Banner - ml-[316px] aligns with courses list (breadcrumb 252px + gap 64px) */}
+        <div className="-mx-5 mt-16 min-[680px]:mx-0 min-[680px]:mt-12 min-[680px]:mb-16 min-[1024px]:mt-16 min-[1280px]:ml-[316px] min-[1280px]:mt-20 min-[1280px]:mb-24">
+          <NewsletterBanner />
         </div>
       </div>
     </div>


### PR DESCRIPTION
…l tests

# Description
Adds the existing `NewsletterBanner` component CTA to the bottom of the `/courses` page, aligned with the courses list column on desktop. Includes responsive spacing and the same 3 designs at varying breakpoints that matches the homepage implementation.

Also added functional tests for the overall courses schedule page.

## Issue
Part of #1729 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots

### Desktop / Tablet
<img width="1511" height="717" alt="courses-newsletter-desktop" src="https://github.com/user-attachments/assets/ecc12b44-f2c3-4948-b820-00e7092849cc" />

<img width="680" height="599" alt="courses-newsletter-680" src="https://github.com/user-attachments/assets/57c3f585-b35f-4612-a7ff-3cbf08ce7e04" />

### Mobile (320)
<img width="320" height="631" alt="courses-newsletter-mobile" src="https://github.com/user-attachments/assets/0babc8a3-50ae-48fc-bd1a-7ad8ae82d0e8" />
