### PR TITLE
[fix]: various small course rounds improvements on mobile

### DIFF
--- a/apps/website/src/components/homepage/UpcomingRounds.tsx
+++ b/apps/website/src/components/homepage/UpcomingRounds.tsx
@@ -147,7 +147,7 @@ const RoundItem = ({ round }: RoundItemProps) => {
               aria-label="Apply now (opens in a new tab)"
               className="text-bluedot-normal text-[15px] leading-[1.6] font-medium"
             >
-              Apply now →
+              Apply now
             </a>
           </div>
         </div>

--- a/apps/website/src/components/lander/components/ScheduleRounds.tsx
+++ b/apps/website/src/components/lander/components/ScheduleRounds.tsx
@@ -159,7 +159,7 @@ const RoundItem = ({ round, applicationUrl }: RoundItemProps) => {
               aria-label="Apply now (opens in a new tab)"
               className="text-bluedot-normal text-[15px] leading-[1.6] font-medium"
             >
-              Apply now →
+              Apply now
             </a>
           </div>
         </div>

--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -520,7 +520,7 @@ const SelfPacedSection = ({ course }: SelfPacedSectionProps) => {
     <>
       {/* Mobile Layout */}
       <div className="flex min-[680px]:hidden">
-        <div className="bg-[#1144cc] opacity-20 w-1 flex-shrink-0 rounded-sm" />
+        <div className="bg-[#1144cc] w-1 flex-shrink-0 rounded-sm" />
         <div className="flex flex-col pl-5">
           <p className="text-[15px] leading-[1.6] font-semibold text-[#13132e]">Self-paced learning</p>
           <p className="text-[15px] leading-[1.6] font-normal text-[#13132e] opacity-50">


### PR DESCRIPTION
# Description
- Removes the → arrow from "Apply now" links on mobile for the homepage upcoming rounds and course lander schedule sections to be like the design in `/courses`
- Fixes the self-paced course blue bar on the /courses page to display at full opacity on mobile, consistent with other course rounds

| Before | After |
|---|---|
|  <img width="314" height="404" alt="mobile-not-lit" src="https://github.com/user-attachments/assets/97054f8a-f077-45ae-97d4-fb825bf4823a" /> | <img width="318" height="532" alt="mobile-lit" src="https://github.com/user-attachments/assets/240e6155-f99a-4e47-8d02-07e7b9b1a7bf" /> |
| <img width="319" height="714" alt="homepage-arrow" src="https://github.com/user-attachments/assets/3b3c9c49-dadd-48cc-a1ac-db29e39ca57b" /> | <img width="319" height="689" alt="homepage-no-arrow" src="https://github.com/user-attachments/assets/6cef5248-e5e7-4178-9d09-55b36ec0b2cb" /> |
| <img width="321" height="499" alt="lander-arrow" src="https://github.com/user-attachments/assets/1ed00488-5763-4176-995c-43eed0fbec73" /> | <img width="318" height="496" alt="lander-no-arrow" src="https://github.com/user-attachments/assets/57bd3aa8-2b38-43af-a138-0f59dca16392" /> |


## Issue
#1779 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories