### PR TITLE
[feat]: visual tweaks for giving feedback

### DIFF
--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -34,13 +34,13 @@ type FeedbackSectionProps = {
 };
 
 const FeedbackSection: React.FC<FeedbackSectionProps> = ({ resourceFeedback, onFeedback, variant }) => {
-  const gapClass = variant === 'mobile' ? 'gap-1' : 'gap-[1px]';
+  const gapClass = variant === 'mobile' ? 'gap-1' : 'gap-1';
 
   const renderButton = (feedbackValue: ResourceFeedbackValue) => {
     const isActive = feedbackValue === resourceFeedback;
     const isLikeButton = feedbackValue === RESOURCE_FEEDBACK.LIKE;
 
-    const activeBackground = isLikeButton ? 'bg-[rgba(34,68,187,0.1)]' : 'bg-[rgba(19,19,46,0.1)]';
+    const activeBackground = isLikeButton ? 'bg-[rgba(0,55,255,0.06)]' : 'bg-[rgba(19,19,46,0.1)]';
     const hoverBackground = 'hover:bg-[rgba(19,19,46,0.08)]';
 
     const baseClasses = 'flex flex-row justify-center items-center px-2 py-1.5 h-[30px] rounded-md border-none transition-all duration-200 font-medium text-[13px] leading-[140%] tracking-[-0.005em] cursor-pointer';
@@ -50,7 +50,7 @@ const FeedbackSection: React.FC<FeedbackSectionProps> = ({ resourceFeedback, onF
 
     let textColorClass = 'text-[#13132E]';
     if (isActive && isLikeButton) {
-      textColorClass = 'text-bluedot-normal';
+      textColorClass = 'text-[#2244bb]';
     }
 
     // Flip vertically for dislike (thumbs down) by flipping on Y-axis
@@ -391,11 +391,11 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource, re
         {auth && isCompleted && (
           <div className="hidden lg:block">
             <div
-              className="hidden lg:flex flex-col transition-all duration-200 px-6 pt-[17px] pb-4 gap-3 w-full bg-[rgba(19,19,46,0.05)] border-[0.5px] border-[rgba(19,19,46,0.15)] rounded-b-[10px] -mt-[10px] relative z-0"
+              className="hidden lg:flex flex-col transition-all duration-200 pt-[23px] pb-4 px-4 gap-2 w-full bg-[rgba(19,19,46,0.05)] border-[0.5px] border-[rgba(19,19,46,0.15)] rounded-b-[10px] -mt-4 relative z-0"
               role="region"
               aria-label="Resource feedback section"
             >
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-3 px-2">
                 <P className="font-medium text-[13px] leading-[140%] tracking-[-0.005em] text-[#13132E] opacity-60">
                   Was this resource useful?
                 </P>

--- a/apps/website/src/components/courses/exercises/AutoSaveTextarea.tsx
+++ b/apps/website/src/components/courses/exercises/AutoSaveTextarea.tsx
@@ -156,7 +156,7 @@ const AutoSaveTextarea: React.FC<AutoSaveTextareaProps> = ({
   };
 
   const textareaClasses = cn(
-    'box-border w-full bg-white rounded-[10px] px-6 py-5 z-[1]',
+    'box-border w-full bg-white rounded-[6px] p-4 z-[1]',
     'font-normal text-[14px] leading-[160%] tracking-[-0.002em] text-[#13132E]',
     'resize-y outline-none transition-all duration-200 block',
     'border-[0.5px] border-[rgba(19,19,46,0.25)]',

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
       >
         <textarea
           aria-label="Text input area"
-          class="box-border w-full bg-white rounded-[10px] px-6 py-5 z-[1] font-normal text-[14px] leading-[160%] tracking-[-0.002em] text-[#13132E] resize-y outline-none transition-all duration-200 block border-[0.5px] border-[rgba(19,19,46,0.25)] focus:border-[1.25px] focus:border-[#1641D9] focus:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-resizer]:hidden min-h-[140px]"
+          class="box-border w-full bg-white rounded-[6px] p-4 z-[1] font-normal text-[14px] leading-[160%] tracking-[-0.002em] text-[#13132E] resize-y outline-none transition-all duration-200 block border-[0.5px] border-[rgba(19,19,46,0.25)] focus:border-[1.25px] focus:border-[#1641D9] focus:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-resizer]:hidden min-h-[140px]"
           disabled=""
           placeholder="Create an account to save your answers"
         />
@@ -147,7 +147,7 @@ exports[`FreeTextResponse > renders logged in as expected 1`] = `
         <textarea
           aria-describedby="save-status-message"
           aria-label="Text input area"
-          class="box-border w-full bg-white rounded-[10px] px-6 py-5 z-[1] font-normal text-[14px] leading-[160%] tracking-[-0.002em] text-[#13132E] resize-y outline-none transition-all duration-200 block border-[0.5px] border-[rgba(19,19,46,0.25)] focus:border-[1.25px] focus:border-[#1641D9] focus:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-resizer]:hidden min-h-[140px]"
+          class="box-border w-full bg-white rounded-[6px] p-4 z-[1] font-normal text-[14px] leading-[160%] tracking-[-0.002em] text-[#13132E] resize-y outline-none transition-all duration-200 block border-[0.5px] border-[rgba(19,19,46,0.25)] focus:border-[1.25px] focus:border-[#1641D9] focus:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-resizer]:hidden min-h-[140px]"
           placeholder="Enter your answer here"
         />
         <div
@@ -231,7 +231,7 @@ exports[`FreeTextResponse > renders with saved exercise response 1`] = `
         <textarea
           aria-describedby="save-status-message"
           aria-label="Text input area"
-          class="box-border w-full bg-white rounded-[10px] px-6 py-5 z-[1] font-normal text-[14px] leading-[160%] tracking-[-0.002em] text-[#13132E] resize-y outline-none transition-all duration-200 block border-[0.5px] border-[rgba(19,19,46,0.25)] focus:border-[1.25px] focus:border-[#1641D9] focus:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-resizer]:hidden min-h-[140px]"
+          class="box-border w-full bg-white rounded-[6px] p-4 z-[1] font-normal text-[14px] leading-[160%] tracking-[-0.002em] text-[#13132E] resize-y outline-none transition-all duration-200 block border-[0.5px] border-[rgba(19,19,46,0.25)] focus:border-[1.25px] focus:border-[#1641D9] focus:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-resizer]:hidden min-h-[140px]"
           placeholder="Enter your answer here"
         >
           This is my saved answer.


### PR DESCRIPTION
# Description
Visual tweaks to the resource feedback input field:
- Adjusts the grey feedback box padding to 16px (left, right, bottom)
- Reduces the textarea corner radius from 10px to 6px so it fits better inside the container
- Updates the textarea internal padding from 24px/20px to 16px. 
- Adjusted like/dislike button gap

## Issue
Fixes #1750 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
<!-- If this PR results in visual changes -->

| Before | After |
|---|---|
| <img width="820" height="203" alt="resource-feedback-before" src="https://github.com/user-attachments/assets/ab4b9017-606f-480d-8c6f-b8bdd29e3b52" /> | <img width="778" height="191" alt="resource-feedback-after" src="https://github.com/user-attachments/assets/46dc55a9-77fb-48ac-ba36-2281410f71f8" /> |
| <img width="779" height="190" alt="internal-padding-before" src="https://github.com/user-attachments/assets/a3b44e61-79bc-4ef0-ac89-fb7735d00c9d" /> | <img width="774" height="170" alt="internal-padding-after" src="https://github.com/user-attachments/assets/297d39ef-8107-4e80-8c6f-90d38ac788ab" /> |
