### PR TITLE
Fix progress tracking preventing FOAI completion

### DIFF
--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -90,7 +90,7 @@ export const certificatesRouter = router({
           const response = exerciseResponses.find((resp) => resp.exerciseId === exercise.id);
           return !response || !response.completed;
         })
-        .sort((a, b) => Number(a.unitNumber) - Number(b.unitNumber));
+        .sort((a, b) => Number(a.unitNumber || Infinity) - Number(b.unitNumber || Infinity));
 
       if (incompleteExercises.length > 0) {
         const exerciseList = incompleteExercises


### PR DESCRIPTION
# Description
I need to look into why, but I had to change FOAI certificate route from `courseIdRead` to `courseIdWrite`. Also, Unit numbers when returning exercises that still need to be completed are all null. 

I've tested this locally and can confirm that I can complete the course and get a certificate

## Issue
fixes #1789 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
No visible changes
