### PR TITLE
[feature] Add user agent tracking to API request metrics to help identify the source of traffic spikes (1k+ QPS)

### DIFF
--- a/apps/website/src/server/context.ts
+++ b/apps/website/src/server/context.ts
@@ -7,10 +7,11 @@ import { checkAdminAccess } from './trpc';
 
 export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) => {
   const authHeader = req.headers.authorization;
+  const userAgent = req.headers['user-agent'];
 
   // Only attempt to verify if we have a valid Bearer token format
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return { auth: null, impersonation: null };
+    return { auth: null, impersonation: null, userAgent };
   }
 
   const token = authHeader.slice('Bearer '.length).trim();
@@ -31,15 +32,16 @@ export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) 
         return {
           auth: { ...auth, email: targetUser.email },
           impersonation: { adminEmail: auth.email, targetEmail: targetUser.email },
+          userAgent,
         };
       }
     }
 
-    return { auth, impersonation: null };
+    return { auth, impersonation: null, userAgent };
   } catch (error) {
     // Token verification failed - return null and let protectedProcedure handle it
     logger.error('Error verifying token', error);
-    return { auth: null, impersonation: null };
+    return { auth: null, impersonation: null, userAgent };
   }
 };
 

--- a/apps/website/src/server/trpc.ts
+++ b/apps/website/src/server/trpc.ts
@@ -50,10 +50,13 @@ const openTelemetryMiddleware = t.middleware(async (opts) => {
   if (type === 'query') method = 'GET';
   else if (type === 'mutation') method = 'POST';
 
+  const userAgent = ctx.userAgent ?? 'unknown';
+
   const activeSpan = trace.getActiveSpan();
   activeSpan?.setAttribute('http.method', method);
   activeSpan?.setAttribute('http.url', path);
   activeSpan?.setAttribute('user.email', ctx.auth?.email ?? 'anonymous');
+  activeSpan?.setAttribute('user.agent', userAgent);
 
   let statusCode = 200;
 
@@ -67,6 +70,7 @@ const openTelemetryMiddleware = t.middleware(async (opts) => {
       method,
       path,
       status_code: statusCode.toString(),
+      user_agent: userAgent,
     });
 
     return result;
@@ -97,6 +101,7 @@ const openTelemetryMiddleware = t.middleware(async (opts) => {
       method,
       path,
       status_code: statusCode.toString(),
+      user_agent: userAgent,
     });
 
     throw finalError;

--- a/libraries/ui/src/utils/makeMakeApiRoute.ts
+++ b/libraries/ui/src/utils/makeMakeApiRoute.ts
@@ -59,11 +59,13 @@ export const makeMakeApiRoute = <AuthResult extends BaseAuthResult>({ env, verif
       // Extract method and path for instrumentation
       const method = req.method || 'UNKNOWN';
       const path = req.url || 'UNKNOWN';
+      const userAgent = req.headers['user-agent'] ?? 'unknown';
 
       // Get the current active span
       const activeSpan = trace.getActiveSpan();
       activeSpan?.setAttribute('http.method', method);
       activeSpan?.setAttribute('http.url', path);
+      activeSpan?.setAttribute('user.agent', userAgent);
 
       let statusCode = 200;
 
@@ -114,6 +116,7 @@ export const makeMakeApiRoute = <AuthResult extends BaseAuthResult>({ env, verif
           method,
           path,
           status_code: statusCode.toString(),
+          user_agent: userAgent,
         });
       } catch (err: unknown) {
         if (createHttpError.isHttpError(err) && err.expose) {
@@ -125,6 +128,7 @@ export const makeMakeApiRoute = <AuthResult extends BaseAuthResult>({ env, verif
             method,
             path,
             status_code: err.statusCode.toString(),
+            user_agent: userAgent,
           });
 
           logger.warn('Client error handling request:', err);
@@ -142,6 +146,7 @@ export const makeMakeApiRoute = <AuthResult extends BaseAuthResult>({ env, verif
           method,
           path,
           status_code: statusCode.toString(),
+          user_agent: userAgent,
         });
 
         logger.error('Internal error handling request:', err);


### PR DESCRIPTION
# Description
Add user agent tracking to API request metrics to help identify the source of traffic spikes (1k+ QPS),

When we see bursts of API requests, we currently have no way to identify what's causing them (e.g., which bots, browsers, or scrapers). This PR adds the `user_agent` label to our `api_requests_total` Prometheus metric so we can query in
Grafana to see which user agents are responsible for traffic spikes.

**Note on cardinality:** We're using full user agent strings rather than normalized categories. I had implemented a normalized version but then got worried that it's not going to provide enough information. Will adjust as needed


## Issue
Fixes #1023 

## Developer checklist
Not relevant

## Screenshot
No functional changes
