### PR TITLE
[fix]: padding in resource feedback

### DIFF
--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -391,7 +391,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource, re
         {auth && isCompleted && (
           <div className="hidden lg:block">
             <div
-              className="hidden lg:flex flex-col transition-all duration-200 pt-[23px] pb-4 px-4 gap-2 w-full bg-[rgba(19,19,46,0.05)] border-[0.5px] border-[rgba(19,19,46,0.15)] rounded-b-[10px] -mt-4 relative z-0"
+              className={`hidden lg:flex flex-col transition-all duration-200 pt-[23px] px-4 gap-2 w-full bg-[rgba(19,19,46,0.05)] border-[0.5px] border-[rgba(19,19,46,0.15)] rounded-b-[10px] -mt-4 relative z-0 ${resourceFeedback !== RESOURCE_FEEDBACK.NO_RESPONSE || feedback ? 'pb-4' : 'pb-[9px]'}`}
               role="region"
               aria-label="Resource feedback section"
             >


### PR DESCRIPTION
# Description
Quickly fixing addtl padding left in #1784!

### Before
<img width="809" height="129" alt="addtl-space" src="https://github.com/user-attachments/assets/17479ef4-319e-4d4b-bcbd-4c89fb55382e" />

### After
<img width="806" height="130" alt="addtl-space-after" src="https://github.com/user-attachments/assets/18ef5d06-10fe-4a14-9d87-40cb6c1718f5" />

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories