### PR TITLE
[Bug] Fix double border in course settings page

### DIFF
--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -223,7 +223,7 @@ const CourseDetails = ({
 
   return (
     <>
-      <div className={`bg-white border-x border-b border-charcoal-light ${isLast ? 'rounded-b-xl' : ''}`} role="region" aria-label={`Expanded details for ${course.title}`}>
+      <div className={`bg-white border-x border-charcoal-light ${isLast ? 'border-b rounded-b-xl' : ''}`} role="region" aria-label={`Expanded details for ${course.title}`}>
         <div>
           {/* Section header with tabs */}
           <div className="flex border-b border-charcoal-light">


### PR DESCRIPTION
# Description

Previously, if there was an expanded row above a collapsed row, the borders doubled up where they meet. This fixes that.

## Issue

No issue

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="1252" height="681" alt="Screenshot 2025-12-13 at 22 51 11" src="https://github.com/user-attachments/assets/4f088f81-67a9-4181-b0a1-9e6fba1e5a6f" /> | <img width="1252" height="681" alt="Screenshot 2025-12-13 at 22 50 57" src="https://github.com/user-attachments/assets/ac6e8e3c-bfa1-48b4-b21d-f09e9e978229" /> |
