### PR TITLE
Workaround for bug with camelcase fetchPriority

### DIFF
--- a/apps/website/src/components/homepage/HomeHeroContent.tsx
+++ b/apps/website/src/components/homepage/HomeHeroContent.tsx
@@ -14,7 +14,8 @@ const HomeHeroContent: React.FC<{ className?: string }> = ({ className }) => (
           src="/images/homepage/hero.webp"
           alt=""
           className="absolute inset-0 size-full object-cover"
-          fetchPriority="high"
+          // Workaround for bug with camelcase `fetchPriority`: https://github.com/facebook/react/issues/25682
+          {...{ fetchpriority: 'high' }}
         />
 
         {/* Nav spacer */}

--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -247,7 +247,8 @@ const CoursesHero = () => {
         src="/images/homepage/hero.webp"
         alt=""
         className="absolute inset-0 size-full object-cover -scale-x-100"
-        fetchPriority="high"
+        // Workaround for bug with camelcase `fetchPriority`: https://github.com/facebook/react/issues/25682
+        {...{ fetchpriority: 'high' }}
       />
 
       {/* Content Container */}


### PR DESCRIPTION
# Description

I'm getting errors like this when I load the home page locally:
```
Warning: React does not recognize the `fetchPriority` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `fetchpriority` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at img
    at div
    at div
    at HomeHeroContent (/Users/wh/Documents/code/bluedot/apps/website/src/components/homepage/HomeHeroContent.tsx:6:62)
    at div
    at HomePage
    at main
    at div
```

I can't see any errors like this in prod, so it's possible this is only happening for me. If other people are experiencing it we can merge this workaround. If not, I'll try and work out what local version issue could be causing this. 