### PR TITLE
Replace 'unitResourceIdWrite' and 'unitResourceIdRead' with just 'unitResourceId'

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -224,6 +224,7 @@ export const createMockResourceCompletion = (overrides: Partial<ResourceCompleti
   isCompleted: false,
   rating: null,
   resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
+  unitResourceId: MOCK_RESOURCE_ID,
   unitResourceIdRead: MOCK_RESOURCE_ID,
   unitResourceIdWrite: MOCK_RESOURCE_ID,
   ...overrides,

--- a/apps/website/src/components/courses/ResourceDisplay.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.tsx
@@ -77,7 +77,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
     return <ErrorView error={resourceCompletionsError} />;
   }
 
-  const resourceCompletionMap = new Map(resourceCompletions?.map((rc) => [rc.unitResourceIdRead, rc]));
+  const resourceCompletionMap = new Map(resourceCompletions?.map((rc) => [rc.unitResourceId, rc]));
   const coreResources = filterResourcesByType(resources, 'Core');
   const optionalResources = filterResourcesByType(resources, 'Further');
   const totalCoreResourceTime = calculateResourceTime(coreResources);

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -114,7 +114,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource, re
 
           const { unitResourceId, ...updatedFields } = newData;
 
-          const existingIndex = oldData.findIndex((item) => item.unitResourceIdRead === resource.id);
+          const existingIndex = oldData.findIndex((item) => item.unitResourceId === resource.id);
 
           if (newArray[existingIndex]) {
             // If an existing item is found, update it
@@ -128,6 +128,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource, re
               id: unitResourceId,
               autoNumberId: null,
               email: auth?.email ?? '',
+              unitResourceId,
               unitResourceIdRead: unitResourceId,
               unitResourceIdWrite: unitResourceId,
               rating: updatedFields.rating ?? null,

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -71,7 +71,7 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   const groupedResourceCompletionData = chunks.map((chunk) => {
     const coreChunkResources = filterResourcesByType(chunk.resources, 'Core');
     const coreResourceIds = new Set(coreChunkResources.map((resource) => resource.id));
-    const completedCoreResources = resourceCompletions?.filter((completion) => completion.isCompleted && completion.unitResourceIdRead && coreResourceIds.has(completion.unitResourceIdRead)) || [];
+    const completedCoreResources = resourceCompletions?.filter((completion) => completion.isCompleted && completion.unitResourceId && coreResourceIds.has(completion.unitResourceId)) || [];
 
     return {
       chunkCoreResources: coreChunkResources,

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -15,25 +15,25 @@ export const resourcesRouter = router({
         .from(resourceCompletionTable.pg)
         .where(
           and(
-            inArray(resourceCompletionTable.pg.unitResourceIdRead, input.unitResourceIds),
+            inArray(resourceCompletionTable.pg.unitResourceId, input.unitResourceIds),
             eq(resourceCompletionTable.pg.email, ctx.auth.email),
           ),
         )
         .orderBy(desc(resourceCompletionTable.pg.autoNumberId));
 
-      // Deduplicate by unitResourceIdRead, keeping only the first occurrence.
+      // Deduplicate by unitResourceId, keeping only the first occurrence.
       // Although we should only have one resource completion for a resource per user, it is possible to have multiple
       // (e.g. if a user quickly submits multiple times before the first is saved). We cannot enforce uniqueness in
       // Airtable, so we handle it here.
       const seenIds = new Set<string>();
       const uniqueCompletions = resourceCompletions.filter((completion) => {
-        if (!completion.unitResourceIdRead) {
+        if (!completion.unitResourceId) {
           return false;
         }
-        if (seenIds.has(completion.unitResourceIdRead)) {
+        if (seenIds.has(completion.unitResourceId)) {
           return false;
         }
-        seenIds.add(completion.unitResourceIdRead);
+        seenIds.add(completion.unitResourceId);
         return true;
       });
 
@@ -59,7 +59,7 @@ export const resourcesRouter = router({
     .mutation(async ({ input, ctx }) => {
       const resourceCompletion = await db.getFirst(resourceCompletionTable, {
         filter: {
-          unitResourceIdRead: input.unitResourceId,
+          unitResourceId: input.unitResourceId,
           email: ctx.auth.email,
         },
       });
@@ -71,6 +71,7 @@ export const resourcesRouter = router({
         // Update existing resource completion
         updatedResourceCompletion = await db.update(resourceCompletionTable, {
           id: resourceCompletion.id,
+          unitResourceId: input.unitResourceId,
           unitResourceIdWrite: input.unitResourceId,
           rating: input.rating ?? resourceCompletion.rating,
           isCompleted: input.isCompleted ?? resourceCompletion.isCompleted,
@@ -81,6 +82,7 @@ export const resourcesRouter = router({
         // Create new resource completion
         updatedResourceCompletion = await db.insert(resourceCompletionTable, {
           email: ctx.auth.email,
+          unitResourceId: input.unitResourceId,
           unitResourceIdWrite: input.unitResourceId,
           rating: input.rating ?? null,
           isCompleted: input.isCompleted ?? false,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1155,10 +1155,16 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
   baseId: COURSE_BUILDER_BASE_ID,
   tableId: 'tblu6YnR7Lh0Bsl6v',
   columns: {
+    unitResourceId: {
+      pgColumn: text(),
+      airtableId: 'fldk4dbWAohE312Qn',
+    },
+    /** @deprecated use `unitResourceId` instead */
     unitResourceIdWrite: {
       pgColumn: text(),
       airtableId: 'fldk4dbWAohE312Qn',
     },
+    /** @deprecated use `unitResourceId` instead */
     unitResourceIdRead: {
       pgColumn: text(),
       airtableId: 'fldoTb7xx0QQVHXvM',


### PR DESCRIPTION
# Description

`unitResourceIdWrite` and `unitResourceIdRead` correspond to the fields "[>] Unit resource" and "[>] Unit resource record id" in Airtable. The second one is just a lookup field that extracts the record id of "[>] Unit resource" as a string. This sort of thing is useful sometimes within airtable for doing indirect lookups, but isn't needed in the code as `unitResourceIdWrite` is already a string.

Once I've deployed this and the schema changes have come through, I will delete the old fields.

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
