### PR TITLE
Delete deprecated unitResourceIdWrite and unitResourceIdRead fields

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -225,7 +225,5 @@ export const createMockResourceCompletion = (overrides: Partial<ResourceCompleti
   rating: null,
   resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
   unitResourceId: MOCK_RESOURCE_ID,
-  unitResourceIdRead: MOCK_RESOURCE_ID,
-  unitResourceIdWrite: MOCK_RESOURCE_ID,
   ...overrides,
 });

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -129,8 +129,6 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource, re
               autoNumberId: null,
               email: auth?.email ?? '',
               unitResourceId,
-              unitResourceIdRead: unitResourceId,
-              unitResourceIdWrite: unitResourceId,
               rating: updatedFields.rating ?? null,
               feedback: updatedFields.feedback ?? '',
               resourceFeedback: updatedFields.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -72,7 +72,6 @@ export const resourcesRouter = router({
         updatedResourceCompletion = await db.update(resourceCompletionTable, {
           id: resourceCompletion.id,
           unitResourceId: input.unitResourceId,
-          unitResourceIdWrite: input.unitResourceId,
           rating: input.rating ?? resourceCompletion.rating,
           isCompleted: input.isCompleted ?? resourceCompletion.isCompleted,
           feedback: input.feedback ?? resourceCompletion.feedback,
@@ -83,7 +82,6 @@ export const resourcesRouter = router({
         updatedResourceCompletion = await db.insert(resourceCompletionTable, {
           email: ctx.auth.email,
           unitResourceId: input.unitResourceId,
-          unitResourceIdWrite: input.unitResourceId,
           rating: input.rating ?? null,
           isCompleted: input.isCompleted ?? false,
           feedback: input.feedback ?? '',

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1159,16 +1159,6 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
       pgColumn: text(),
       airtableId: 'fldk4dbWAohE312Qn',
     },
-    /** @deprecated use `unitResourceId` instead */
-    unitResourceIdWrite: {
-      pgColumn: text(),
-      airtableId: 'fldk4dbWAohE312Qn',
-    },
-    /** @deprecated use `unitResourceId` instead */
-    unitResourceIdRead: {
-      pgColumn: text(),
-      airtableId: 'fldoTb7xx0QQVHXvM',
-    },
     rating: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldq6J5taZX4xLDfD',


### PR DESCRIPTION
# Description

#1828 combined these into `unitResourceId`. To allow clients to update, I won't merge this straight away, but will do so in a couple of days.

If you are reading this after 2025-12-19 you can merge this!