### PR TITLE
Capture Core Web Vitals in Posthog

### DIFF
--- a/apps/website/src/components/analytics/PostHogProvider.tsx
+++ b/apps/website/src/components/analytics/PostHogProvider.tsx
@@ -16,6 +16,7 @@ const ActivePostHogProvider: React.FC<React.PropsWithChildren> = ({ children }) 
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
       api_host: 'https://analytics.k8s.bluedot.org',
+      capture_performance: true,
       loaded: (instance) => {
         // Can't specify debug reliably via config :(
         // https://github.com/PostHog/posthog-js/issues/1387


### PR DESCRIPTION
# Description

These will start appearing in the ["Web analytics"](https://eu.posthog.com/project/21762/web/web-vitals?path_cleaning=true&filter_test_accounts=false&compare_filter=%7B%22compare%22%3Atrue%7D&percentile=p90&tile_visualizations=%7B%7D) section of posthog once this is deployed.

FYI for the BlueDot team (cc @anglilian): This will add more events in posthog, which we may be billed for. Napkin maths says this will add something like ~100k events per month, which would cost $5 at posthog's standard pricing, or free if we still fit within the 1M/mo free tier (we currently hover around 800k).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1823

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] N/A Considered having snapshot tests and/or happy path functional tests
- [X] N/A Considered adding Storybook stories
