### PR TITLE
[feature] Chunk URLs have link previews

### DIFF
--- a/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitNumber].test.tsx
+++ b/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitNumber].test.tsx
@@ -69,6 +69,7 @@ describe('CourseUnitPage', () => {
         chunks={mockChunksWithContent}
         courseSlug="test-course"
         unitNumber="0"
+        courseOgImage="https://bluedot.org/images/logo/link-preview-fallback.png"
       />,
       { wrapper: TrpcProvider },
     );
@@ -108,6 +109,7 @@ describe('CourseUnitPage', () => {
         chunks={mockChunksWithContent}
         courseSlug="test-course"
         unitNumber="3"
+        courseOgImage="https://bluedot.org/images/logo/link-preview-fallback.png"
       />,
       { wrapper: TrpcProvider },
     );
@@ -147,6 +149,7 @@ describe('CourseUnitPage', () => {
         chunks={mockChunksWithContent}
         courseSlug="test-course"
         unitNumber="3"
+        courseOgImage="https://bluedot.org/images/logo/link-preview-fallback.png"
       />,
       { wrapper: TrpcProvider },
     );
@@ -185,6 +188,7 @@ describe('CourseUnitPage', () => {
         chunks={mockChunksWithContent}
         courseSlug="test-course"
         unitNumber="3"
+        courseOgImage="https://bluedot.org/images/logo/link-preview-fallback.png"
       />,
       { wrapper: TrpcProvider },
     );
@@ -225,6 +229,7 @@ describe('CourseUnitPage', () => {
           chunks={mockChunksWithContent}
           courseSlug="test-course"
           unitNumber="3"
+          courseOgImage="https://bluedot.org/images/logo/link-preview-fallback.png"
         />
       </TrpcProvider>,
     );

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -117,7 +117,7 @@ const CourseUnitChunkPage = ({
         <meta key="og:image:width" property="og:image:width" content="1200" />
         <meta key="og:image:height" property="og:image:height" content="630" />
         <meta key="og:image:type" property="og:image:type" content="image/png" />
-        <meta key="og:image:alt" property="og:image:alt" content="BlueDot Impact logo" />
+        <meta key="og:image:alt" property="og:image:alt" content={`${unit.courseTitle} course preview`} />
 
         {/* Twitter Card meta tags */}
         <meta name="twitter:card" content="summary_large_image" />
@@ -152,7 +152,7 @@ export const getServerSideProps: GetServerSideProps<CourseUnitChunkPageProps> = 
     const unitWithContent = await getUnitWithChunks(courseSlug, unitNumber);
 
     // Check for course-specific OG image, fallback to default BlueDot logo
-    let courseOgImage = `${process.env.NEXT_PUBLIC_SITE_URL}/images/logo/link-preview-fallback.png`;
+    let courseOgImage = 'https://bluedot.org/images/logo/link-preview-fallback.png';
     if (await fileExists(path.join(process.cwd(), 'public', 'images', 'courses', 'link-preview', `${courseSlug}.png`))) {
       courseOgImage = `${process.env.NEXT_PUBLIC_SITE_URL}/images/courses/link-preview/${courseSlug}.png`;
     }


### PR DESCRIPTION
# Description
Added open graph and Twitter meta tags to course chunk pages so they display link previews when shared on social media. We previously only the root course pages (e.g., `/courses/technical-ai-safety`) had OG tags, but the actual content pages (e.g., `/courses/technical-ai-safety/1/1`) were missing them entirely.

I followed existing pattern from the standard course page, using `fileExists` to check for course-specific OG images in `getServerSideProps`, then falling back to the BlueDot logo if no custom image exists. Both the course-specific image and fallback use `process.env.NEXT_PUBLIC_SITE_URL`.

Fallback logic is centralized in `getServerSideProps` (single source of truth) rather than duplicated in the component, making it easier to maintain despite seeing patterns in both places.

## Issue

Fixes #1745 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories