### PR TITLE
[fix]: collapse nav dropdown when clicking out

### DIFF
--- a/apps/website/src/components/Nav/Nav.test.tsx
+++ b/apps/website/src/components/Nav/Nav.test.tsx
@@ -215,8 +215,8 @@ describe('Nav', () => {
       expect(mobileNavDrawer!.className).not.toMatch(/max-h-0/);
     });
 
-    // Simulate clicking outside the nav drawer
-    fireEvent.click(document.body);
+    // Simulate clicking outside the nav drawer (useClickOutside uses mousedown)
+    fireEvent.mouseDown(document.body);
 
     // Ensure the nav drawer is closed
     await waitFor(() => {

--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import React, { useState, useEffect } from 'react';
-import ClickAwayListener from 'react-click-away-listener';
 import { useAuthStore } from '@bluedot/ui';
 import { useRouter } from 'next/router';
 
@@ -60,49 +59,41 @@ export const Nav: React.FC = () => {
 
   return (
     <nav className={getNavClasses()}>
-      <ClickAwayListener onClickAway={() => setExpandedSections({
-        about: false,
-        explore: false,
-        mobileNav: false,
-        profile: false,
-      })}
-      >
-        <div className="nav__container section-base">
-          <div className="nav__bar w-full flex justify-between items-center min-h-(--nav-height-mobile) min-[1024px]:min-h-(--nav-height-desktop)">
-            {/* Left side: Logo */}
-            <div className="flex items-center">
-              {/* Mobile & Tablet: Hamburger Button */}
-              <MobileNavLinks
-                expandedSections={expandedSections}
-                updateExpandedSections={updateExpandedSections}
-                isLoggedIn={isLoggedIn}
-                isHomepage={isHomepage}
-              />
+      <div className="nav__container section-base">
+        <div className="nav__bar w-full flex justify-between items-center min-h-(--nav-height-mobile) min-[1024px]:min-h-(--nav-height-desktop)">
+          {/* Left side: Logo */}
+          <div className="flex items-center">
+            {/* Mobile & Tablet: Hamburger Button */}
+            <MobileNavLinks
+              expandedSections={expandedSections}
+              updateExpandedSections={updateExpandedSections}
+              isLoggedIn={isLoggedIn}
+              isHomepage={isHomepage}
+            />
 
-              {/* Logo */}
-              <NavLogo isHomepage={isHomepage} />
-            </div>
+            {/* Logo */}
+            <NavLogo isHomepage={isHomepage} />
+          </div>
 
-            {/* Center/Right side: Nav Links and CTA */}
-            <div className="flex items-center gap-12">
-              {/* Desktop: Nav Links */}
-              <DesktopNavLinks
-                expandedSections={expandedSections}
-                updateExpandedSections={updateExpandedSections}
-                isHomepage={isHomepage}
-              />
+          {/* Center/Right side: Nav Links and CTA */}
+          <div className="flex items-center gap-12">
+            {/* Desktop: Nav Links */}
+            <DesktopNavLinks
+              expandedSections={expandedSections}
+              updateExpandedSections={updateExpandedSections}
+              isHomepage={isHomepage}
+            />
 
-              {/* CTA Buttons */}
-              <NavCta
-                isLoggedIn={isLoggedIn}
-                isHomepage={isHomepage}
-                expandedSections={expandedSections}
-                updateExpandedSections={updateExpandedSections}
-              />
-            </div>
+            {/* CTA Buttons */}
+            <NavCta
+              isLoggedIn={isLoggedIn}
+              isHomepage={isHomepage}
+              expandedSections={expandedSections}
+              updateExpandedSections={updateExpandedSections}
+            />
           </div>
         </div>
-      </ClickAwayListener>
+      </div>
     </nav>
   );
 };

--- a/apps/website/src/components/Nav/_MobileNavLinks.tsx
+++ b/apps/website/src/components/Nav/_MobileNavLinks.tsx
@@ -11,6 +11,7 @@ import {
   ExpandedSectionsState,
 } from './utils';
 import { getLoginUrl } from '../../utils/getLoginUrl';
+import { useClickOutside } from '../../lib/hooks/useClickOutside';
 
 export const MobileNavLinks: React.FC<{
   expandedSections: ExpandedSectionsState;
@@ -25,6 +26,11 @@ export const MobileNavLinks: React.FC<{
 }) => {
   const router = useRouter();
   const joinUrl = getLoginUrl(router.asPath, true);
+  const mobileNavRef = useClickOutside<HTMLDivElement>(
+    () => updateExpandedSections({ mobileNav: false }),
+    expandedSections.mobileNav,
+  );
+
   const getPrimaryButtonClasses = () => {
     const baseClasses = 'px-3 py-[5px] rounded-[5px] text-size-sm font-[450] leading-[160%] items-center justify-center';
 
@@ -43,7 +49,7 @@ export const MobileNavLinks: React.FC<{
   };
 
   return (
-    <div className="mobile-nav-links lg:hidden">
+    <div ref={mobileNavRef} className="mobile-nav-links lg:hidden">
       <IconButton
         open={expandedSections.mobileNav}
         Icon={<HamburgerIcon />}

--- a/apps/website/src/components/Nav/_NavLinks.tsx
+++ b/apps/website/src/components/Nav/_NavLinks.tsx
@@ -6,6 +6,7 @@ import { CgChevronDown } from 'react-icons/cg';
 import { ROUTES } from '../../lib/routes';
 import { useCourses } from '../../lib/hooks/useCourses';
 import { usePrimaryCourseURL } from '../../lib/hooks/usePrimaryCourseURL';
+import { useClickOutside } from '../../lib/hooks/useClickOutside';
 import {
   DRAWER_CLASSES,
   ExpandedSectionsState,
@@ -67,6 +68,7 @@ export const NavLinks: React.FC<{
           mobileNav: expandedSections.mobileNav,
           profile: false,
         })}
+        onClose={() => updateExpandedSections({ explore: false })}
         title="Courses"
         loading={loading}
       />
@@ -79,13 +81,25 @@ export const NavLinks: React.FC<{
       >
         Events
       </A>
-      <A href={ROUTES.blog.url} target="_blank" rel="noopener noreferrer" className={getLinkClasses(isCurrentPath(ROUTES.blog.url))} aria-label="Blog (opens in new tab)">
+      <A
+        href={ROUTES.blog.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={getLinkClasses(isCurrentPath(ROUTES.blog.url))}
+        aria-label="Blog (opens in new tab)"
+      >
         Blog
       </A>
-      <A href={ROUTES.about.url} className={getLinkClasses(isCurrentPath(ROUTES.about.url))}>
+      <A
+        href={ROUTES.about.url}
+        className={getLinkClasses(isCurrentPath(ROUTES.about.url))}
+      >
         About
       </A>
-      <A href={ROUTES.joinUs.url} className={getLinkClasses(isCurrentPath(ROUTES.joinUs.url))}>
+      <A
+        href={ROUTES.joinUs.url}
+        className={getLinkClasses(isCurrentPath(ROUTES.joinUs.url))}
+      >
         Jobs
       </A>
     </div>
@@ -99,6 +113,7 @@ const NavDropdown: React.FC<{
   isHomepage: boolean;
   links: { title: string; url: string; isNew?: boolean | null }[];
   onToggle: () => void;
+  onClose: () => void;
   title: string;
   // Optional
   className?: string;
@@ -109,10 +124,13 @@ const NavDropdown: React.FC<{
   isHomepage,
   links,
   onToggle,
+  onClose,
   title,
   className,
   loading,
 }) => {
+  const dropdownRef = useClickOutside<HTMLDivElement>(onClose, isExpanded);
+
   const getDropdownButtonClasses = () => {
     // Mobile drawer always has white background, so always use dark text
     // Desktop navbar uses white text on homepage, dark text elsewhere
@@ -140,7 +158,7 @@ const NavDropdown: React.FC<{
   };
 
   return (
-    <div className="nav-dropdown">
+    <div ref={dropdownRef} className="nav-dropdown">
       <button
         type="button"
         onClick={onToggle}

--- a/apps/website/src/components/Nav/_ProfileLinks.tsx
+++ b/apps/website/src/components/Nav/_ProfileLinks.tsx
@@ -7,6 +7,7 @@ import { ExpandedSectionsState, DRAWER_CLASSES, DRAWER_Z_PROFILE } from './utils
 import { ROUTES } from '../../lib/routes';
 import { UserSearchModal } from '../admin/UserSearchModal';
 import { trpc } from '../../utils/trpc';
+import { useClickOutside } from '../../lib/hooks/useClickOutside';
 
 export const ProfileLinks: React.FC<{
   expandedSections: ExpandedSectionsState;
@@ -20,6 +21,10 @@ export const ProfileLinks: React.FC<{
   const [isBugReportModalOpen, setIsBugReportModalOpen] = useState(false);
   const [isImpersonateModalOpen, setIsImpersonateModalOpen] = useState(false);
   const { data: isAdmin } = trpc.admin.isAdmin.useQuery();
+  const profileRef = useClickOutside<HTMLDivElement>(
+    () => updateExpandedSections({ profile: false }),
+    expandedSections.profile,
+  );
 
   const onToggleProfile = () => updateExpandedSections({
     about: false,
@@ -37,7 +42,7 @@ export const ProfileLinks: React.FC<{
   };
 
   return (
-    <div className="profile-links">
+    <div ref={profileRef} className="profile-links">
       <IconButton
         className={clsx(
           'profile-links__btn',

--- a/apps/website/src/lib/hooks/useClickOutside.ts
+++ b/apps/website/src/lib/hooks/useClickOutside.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, RefObject } from 'react';
+
+/**
+ * Hook to detect clicks outside of a referenced element.
+ * Useful for closing dropdowns, modals, and popups.
+ */
+export function useClickOutside<T extends HTMLElement = HTMLDivElement>(
+  onClickOutside: () => void,
+  enabled = true,
+): RefObject<T> {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClickOutside();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [enabled, onClickOutside]);
+
+  return ref as RefObject<T>;
+}

--- a/apps/website/src/pages/join-us/[slug].tsx
+++ b/apps/website/src/pages/join-us/[slug].tsx
@@ -133,7 +133,7 @@ export const getStaticProps: GetStaticProps<JobPostingPageProps> = async ({ para
       props: {
         slug,
         job,
-        jobOgImage,
+        ...(jobOgImage && { jobOgImage }),
       },
       revalidate: 300,
     };


### PR DESCRIPTION
# Description
Fixes nav dropdowns (profile, courses, mobile menu) not closing when clicking outside of them: 
- Adds a reusable `useClickOutside`hook and applies it consistently to all dropdown components, replacing the previous `ClickAwayListener` approach which only worked for clicks outside the entire nav
- Clicking anywhere outside a dropdown (including on other nav elements like the logo or links) will properly close it

## Issue
Fixes #1788 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots
### Desktop/Tablet
![nav-dropdown-desktop](https://github.com/user-attachments/assets/0c3bd2fd-6445-4633-bce9-57fa497d1d8e)

![nav-dropdown-680](https://github.com/user-attachments/assets/db33e9e0-537c-454a-96ae-28c3069aa83a)

### Mobile (320)
![nav-dropdown-mobile](https://github.com/user-attachments/assets/ebf121b2-2271-4c3b-8fd4-c424fd7c2c9b)
