### PR TITLE
[fix]: missing favicon for bluedot substack links

### DIFF
--- a/apps/website/src/components/courses/FaviconImage.tsx
+++ b/apps/website/src/components/courses/FaviconImage.tsx
@@ -7,6 +7,11 @@ type FaviconImageProps = {
   alt?: string;
 };
 
+// Google's Favicon API can't resolve favicons for some domains (e.g., Substack custom domains)
+const FAVICON_OVERRIDES: Record<string, string> = {
+  'blog.bluedot.org': 'https://bluedot.org/favicon.ico',
+};
+
 /**
  * Component that displays a favicon for a given URL using Google's favicon API
  * Falls back gracefully if the favicon fails to load
@@ -36,9 +41,8 @@ export const FaviconImage: React.FC<FaviconImageProps> = ({
   // API Configuration
   const API_FAVICON_SIZE = 256; // Size requested from Google's API (higher res for quality)
 
-  // Request high-resolution favicon from Google's API
-  // We fetch at 256px for quality, then scale down to displaySize for crisp rendering
-  const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=${API_FAVICON_SIZE}`;
+  const faviconUrl = FAVICON_OVERRIDES[domain]
+    ?? `https://www.google.com/s2/favicons?domain=${domain}&sz=${API_FAVICON_SIZE}`;
 
   return (
     <img


### PR DESCRIPTION
# Description
- **Problem:** Google's Favicon API returns a 404 for `blog.bluedot.org` because Substack serves favicons through CDN URLs that Google can't currently parse. Because of this, it ends up falling back to a generic grey globe icon.
- **Solution:** Added a domain override in `FaviconImage.tsx` to use BlueDot's own favicon for Substack links (simplest solution)!

## Issue
Fixes #1824 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="324" height="600" alt="favicon-before-mobile" src="https://github.com/user-attachments/assets/e450fd4a-7ec7-4e69-bc69-abf3e84f516b" /> | <img width="323" height="606" alt="favicon-after-mobile" src="https://github.com/user-attachments/assets/32704e4e-9c32-48c9-8f72-29fcb7e8b03f" /> |
| 🖥️ | <img width="939" height="429" alt="favicon-before-desktop" src="https://github.com/user-attachments/assets/298aabf9-484e-4753-a25d-5e7831af9a82" /> | <img width="923" height="428" alt="favicon-after-desktop" src="https://github.com/user-attachments/assets/8b64cddb-9a14-4a7d-be35-4ee1e4f60498" /> |
