### PR TITLE
[feat]: course overview time estimation to hours/mins for better readability

### DIFF
--- a/apps/website/src/components/lander/components/CourseCurriculumSection.tsx
+++ b/apps/website/src/components/lander/components/CourseCurriculumSection.tsx
@@ -21,6 +21,15 @@ type UnitMetadata = {
   exerciseCount: number;
 };
 
+const formatDuration = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+
+  if (hours === 0) return `${mins} min`;
+  if (mins === 0) return `${hours} hr`;
+  return `${hours} hr ${mins} min`;
+};
+
 const SectionWrapper = ({ children, title }: { children: React.ReactNode; title: string }) => (
   <section className="w-full bg-white">
     <div className="max-w-max-width mx-auto px-5 py-12 min-[680px]:px-8 min-[680px]:py-16 md:px-spacing-x min-[1280px]:py-24 xl:py-24">
@@ -65,7 +74,7 @@ const UnitMetadataDisplay = ({
         <>
           <CgTime className="size-[18px] text-[#13132E] opacity-60" />
           <span className="text-[13px] font-medium leading-[1.4] tracking-[-0.065px] text-[#13132E] opacity-60">
-            {duration}min
+            {formatDuration(duration)}
           </span>
         </>
       )}


### PR DESCRIPTION
# Description
Changes the course curriculum time display for all course landers from minutes to hours and minutes format. For example, instead of showing "135 min", the curriculum section now displays "2 hr 15 min" for better readability.

## Issue
Closes #1825 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="322" height="553" alt="hours-minutes-mobile-before" src="https://github.com/user-attachments/assets/bb6bbfa3-4150-4273-a28f-e211ca718c78" /> | <img width="322" height="558" alt="hours-minutes-mobile-after" src="https://github.com/user-attachments/assets/35b0490f-1437-4e96-9257-249349695319" /> |
| 🖥️ | <img width="1016" height="653" alt="hours-minutes-desktop-before" src="https://github.com/user-attachments/assets/9ea26792-8c17-41e5-963d-05977f3c7bff" /> | <img width="1045" height="663" alt="hours-minutes-desktop-after" src="https://github.com/user-attachments/assets/9ce4918d-af61-45c1-a7fe-a330fbc1cc2b" /> |
