### PR TITLE
[fix] Allow newly created Airtable records to correctly sync

### DIFF
--- a/apps/pg-sync-service/src/lib/pg-sync.ts
+++ b/apps/pg-sync-service/src/lib/pg-sync.ts
@@ -279,8 +279,11 @@ async function processSingleUpdate(update: AirtableAction): Promise<boolean> {
         and(
           eq(metaTable.airtableBaseId, update.baseId),
           eq(metaTable.airtableTableId, update.tableId),
-          ...(!update.isDelete
-            ? [inArray(metaTable.airtableFieldId, update.fieldIds ?? [])]
+          // Only filter by fieldIds if they exist and are non-empty
+          // Created records have no fieldIds, so we skip the filter to allow them through
+          // If fieldIds is undefined/empty, we just check if the table is tracked at all
+          ...(!update.isDelete && update.fieldIds && update.fieldIds.length > 0
+            ? [inArray(metaTable.airtableFieldId, update.fieldIds)]
             : []),
         ),
       ).limit(1);


### PR DESCRIPTION
# Description
I noticed while working on making pg-sync-service handle large updates, that newly created rows on Airtable would just get skipped.

This is because when a record is created in Airtable, the webhook produces an action with no `fieldIds` property. The meta table query was using `inArray(metaTable.airtableFieldId, update.fieldIds ?? [])`, would end up matching zero rows and skip inserting/updating. 

## Issue
Fixes #1808 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
No screenshot
