### PR TITLE
[Tech debt] Remove dead noise.svg texture reference from NewsletterBanner

### DIFF
--- a/apps/website/src/components/homepage/NewsletterBanner.tsx
+++ b/apps/website/src/components/homepage/NewsletterBanner.tsx
@@ -74,18 +74,6 @@ const NewsletterBanner = () => {
             mixBlendMode: 'overlay', // Tailwind doesn't support mix-blend-mode
           }}
         />
-
-        {/* Noise Texture */}
-        <div
-          className="absolute inset-0 min-[680px]:rounded-xl opacity-50"
-          style={{
-            backgroundImage: 'url(/images/homepage/noise.svg)',
-            backgroundSize: '464.64px 736.56px',
-            backgroundRepeat: 'repeat',
-            backgroundPosition: 'top left',
-            mixBlendMode: 'soft-light', // Tailwind doesn't support mix-blend-mode
-          }}
-        />
       </div>
 
       {/* Content */}


### PR DESCRIPTION
# Description

The noise.svg file was deleted in commit [2e1e2b0c](https://github.com/bluedotimpact/bluedot/commit/2e1e2b0c) but the reference in NewsletterBanner.tsx was not removed, so the texture wasn't being applied. I tried adopting `noise.webp` (which we use elsewhere) instead but I thought it looked a bit un-subtle, so I'm just deleting this overlay altogether.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

No visual change