### PR TITLE
[Feature] Schema changes for pre-filling availability

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1099,6 +1099,9 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       pgColumn: text(),
       airtableId: 'fldQ9PM3ejhilPFc6',
     },
+    // Format: weekly-availabilities library format (https://github.com/domdomegg/weekly-availabilities)
+    // Days: M=Mon, T=Tue, W=Wed, R=Thu, F=Fri, S=Sat, U=Sun
+    // Example: "M16:00 M18:00, W20:00 R08:00" = Monday 4-6pm UTC, Wednesday 8pm to Thursday 8am UTC
     availabilityIntervalsUTC: {
       pgColumn: text(),
       airtableId: 'fldFpLDHyPPDvnJYg',
@@ -1107,6 +1110,7 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       pgColumn: text(),
       airtableId: 'fldur7dw7JEiAQNFK',
     },
+    // Format: "UTC[+/-]HH:MM", e.g. "UTC+01:00", "UTC-05:00", "UTC00:00"
     availabilityTimezone: {
       pgColumn: text(),
       airtableId: 'fld9Y4WfeafUNMxMH',


### PR DESCRIPTION
# Description

For implementing this:

> URL param workaround to cover the GroupSwitchModal case specifically (~30 mins to implement): Add parameters like ?prefill_availability=...&prefill_timezone=... to the form URL, and update the GroupSwitchModal to include the user's existing availability when linking to the form. This is simple and avoids getting involved with auth, but only works for links we control on the website. It wouldn't help users who arrive at the form via the welcome email. It also creates a long ugly URL.

## Issue

#1833
