### PR TITLE
[Bug] Remove triple-dot menu on attended discussions for facilitators

### DIFF
--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -91,7 +91,7 @@ const CourseDetailsRow = ({
       variant: 'secondary',
       url: discussionDocLink,
       target: '_blank',
-      isVisible: discussionIsSoonOrLive || isFacilitator,
+      isVisible: !isPast && (discussionIsSoonOrLive || isFacilitator),
       overflowIcon: <DocumentIcon className="mx-auto" />,
     },
     {


### PR DESCRIPTION
# Description

One button was missing the `!isPast` condition, which caused it to show on attended discussions.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1884