### PR TITLE
Silence 'Discussions missing unit reference' Slack warning

### DIFF
--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -8,11 +8,9 @@ import {
   zoomAccountTable,
 } from '@bluedot/db';
 import { logger } from '@bluedot/ui/src/api';
-import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import { TRPCError, type inferRouterOutputs } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
-import env from '../../lib/api/env';
 import { protectedProcedure, publicProcedure, router } from '../trpc';
 import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
 


### PR DESCRIPTION
# Description

The discussion in #1557 says that these are cases of past discussions where we've now deleted the unit. When a user loads the https://bluedot.org/settings/courses page it fetches all discussions for all courses they've ever done, so if there are any records like this sitting around in the database, we will get Slack warnings.

I spot-checked about 10 records from recent warnings we've received, and as far as I can tell #1557 is still correct. They are all for old rounds of courses (the most recent affected record is from 2025-10-12), so I think it's just that we periodically delete units and this breaks these old records.

This isn't great as it causes the old discussions to be filtered out in the UI, but it's not critical for anyone enrolled in a current course, so I'm silencing the Slack warning which is very spammy and just keeping the console error.

## Issue

#1557
