### PR TITLE
[enchancment] Add padding to the bottom of the sidebar

### DIFF
--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -194,7 +194,7 @@ const SideBar: React.FC<SideBarProps> = ({
       </div>
 
       {/* Units */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto pb-6">
         {units.map((unit) => (
           <SideBarCollapsible
             key={unit.id}

--- a/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/SideBar.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`SideBar > renders default as expected 1`] = `
       </div>
     </div>
     <div
-      class="flex-1 overflow-y-auto"
+      class="flex-1 overflow-y-auto pb-6"
     >
       <div
         class="relative"

--- a/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
+++ b/apps/website/src/components/courses/__snapshots__/UnitLayout.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`UnitLayout > renders first unit as expected 1`] = `
         </div>
       </div>
       <div
-        class="flex-1 overflow-y-auto"
+        class="flex-1 overflow-y-auto pb-6"
       >
         <div
           class="relative"


### PR DESCRIPTION
# Description
Adding padding to the bottom of the sidebar while viewing courses

## Issue
Fixes #1903 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
before:
<img width="360" height="793" alt="image" src="https://github.com/user-attachments/assets/589448c3-6dcb-48b3-b153-facb59aff4b1" />
after:
<img width="360" height="793" alt="image" src="https://github.com/user-attachments/assets/067f938a-99f9-458b-a2b7-f5fcf72c9642" />
