### PR TITLE
Remove course curriculum overview from landers

### DIFF
--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -9,7 +9,6 @@ import WhoIsThisForSection, { WhoIsThisForSectionProps } from './components/WhoI
 import HeroSection, { HeroSectionProps } from './components/HeroSection';
 import QuoteSection, { QuoteSectionProps } from './components/QuoteSection';
 import CourseInformationSection, { CourseInformationSectionProps } from './components/CourseInformationSection';
-import CourseCurriculumSection, { CourseCurriculumSectionProps } from './components/CourseCurriculumSection';
 import FAQSection, { FAQSectionProps } from './components/FAQSection';
 import LandingBanner, { LandingBannerProps } from './components/LandingBanner';
 
@@ -22,7 +21,6 @@ export type CourseLanderContent = {
   meta: CourseLanderMeta;
   hero: HeroSectionProps;
   whoIsThisFor: WhoIsThisForSectionProps;
-  curriculum?: CourseCurriculumSectionProps;
   courseBenefits?: CourseBenefitsSectionProps;
   courseInformation: CourseInformationSectionProps;
   quotes?: QuoteSectionProps;
@@ -85,13 +83,6 @@ const CourseLander = ({
       <div className="border-t-hairline border-color-divider" />
 
       <WhoIsThisForSection {...content.whoIsThisFor} />
-
-      {content.curriculum && (
-        <>
-          <div className="border-t-hairline border-color-divider" />
-          <CourseCurriculumSection {...content.curriculum} />
-        </>
-      )}
 
       {content.courseBenefits && (
         <>

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -650,38 +650,6 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
         class="max-w-max-width mx-auto px-5 py-12 min-[680px]:px-8 min-[680px]:py-16 md:px-spacing-x min-[1280px]:py-24 xl:py-24"
       >
         <h2
-          class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-12 md:mb-16 tracking-[-0.01em]"
-        >
-          Curriculum Overview
-        </h2>
-        <div
-          class="progress-dots my-6 flex items-center justify-center space-x-2"
-        >
-          <span
-            class="size-2 bg-bluedot-normal rounded-full animate-bounce"
-            style="animation-delay: 0ms;"
-          />
-          <span
-            class="size-2 bg-bluedot-normal rounded-full animate-bounce"
-            style="animation-delay: 150ms;"
-          />
-          <span
-            class="size-2 bg-bluedot-normal rounded-full animate-bounce"
-            style="animation-delay: 300ms;"
-          />
-        </div>
-      </div>
-    </section>
-    <div
-      class="border-t-hairline border-color-divider"
-    />
-    <section
-      class="w-full bg-white"
-    >
-      <div
-        class="max-w-max-width mx-auto px-5 py-12 min-[680px]:px-8 min-[680px]:py-16 md:px-spacing-x min-[1280px]:py-24 xl:py-24"
-      >
-        <h2
           class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] text-[#13132E] text-center mb-16 tracking-[-0.01em]"
         >
           How this course will benefit you

--- a/apps/website/src/components/lander/course-content/AgiStrategyContent.tsx
+++ b/apps/website/src/components/lander/course-content/AgiStrategyContent.tsx
@@ -80,11 +80,6 @@ export const createAgiStrategyContent = (
     },
   },
 
-  curriculum: {
-    title: 'Curriculum Overview',
-    courseSlug,
-  },
-
   courseBenefits: {
     title: 'How this course will benefit you',
     benefits: [

--- a/apps/website/src/components/lander/course-content/BioSecurityContent.tsx
+++ b/apps/website/src/components/lander/course-content/BioSecurityContent.tsx
@@ -78,11 +78,6 @@ export const createBioSecurityContent = (
     },
   },
 
-  curriculum: {
-    title: 'Curriculum Overview',
-    courseSlug,
-  },
-
   courseBenefits: {
     title: 'How this course will benefit you',
     benefits: [

--- a/apps/website/src/components/lander/course-content/FutureOfAiContent.tsx
+++ b/apps/website/src/components/lander/course-content/FutureOfAiContent.tsx
@@ -74,11 +74,6 @@ export const createFutureOfAiContent = (
     },
   },
 
-  curriculum: {
-    title: 'Curriculum Overview',
-    courseSlug,
-  },
-
   courseBenefits: {
     title: 'How this course will benefit you',
     benefits: [

--- a/apps/website/src/components/lander/course-content/TechnicalAiSafetyContent.tsx
+++ b/apps/website/src/components/lander/course-content/TechnicalAiSafetyContent.tsx
@@ -81,11 +81,6 @@ export const createTechnicalAiSafetyContent = (
     },
   },
 
-  curriculum: {
-    title: 'Curriculum Overview',
-    courseSlug,
-  },
-
   courseBenefits: {
     title: 'How this course will benefit you',
     benefits: [

--- a/apps/website/src/components/lander/course-content/TechnicalAiSafetyProjectContent.tsx
+++ b/apps/website/src/components/lander/course-content/TechnicalAiSafetyProjectContent.tsx
@@ -66,11 +66,6 @@ export const createTechnicalAiSafetyProjectContent = (
     },
   },
 
-  curriculum: {
-    title: 'Curriculum Overview',
-    courseSlug,
-  },
-
   courseBenefits: {
     title: 'How this course will benefit you',
     benefits: [


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

This component doesn't add much value to the user. It's more useful for them to just browse the curriculum.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | 
<img width="2304" height="12353" alt="CleanShot 2026-01-07 at 14 56 24@2x" src="https://github.com/user-attachments/assets/f0bc66de-3087-4c21-b839-18cb1dff333c" /> |
