### PR TITLE
[Feature] Add complete button to exercises on desktop

### DIFF
--- a/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
@@ -108,10 +108,10 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
           </div>
         )}
 
-        {/* Mobile "complete" button */}
+        {/* "Complete" button */}
         {isLoggedIn && (
-          <div className="lg:hidden">
-            <div className="w-full h-0 opacity-20 border-[0.5px] border-[#13132E] mb-4" />
+          <div>
+            <div className="w-full h-0 opacity-20 border-[0.5px] lg:border-none lg:mb-0 border-[#13132E] mb-4" />
 
             {!isCompleted ? (
               <button

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -245,11 +245,9 @@ exports[`FreeTextResponse > renders logged in as expected 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="lg:hidden"
-      >
+      <div>
         <div
-          class="w-full h-0 opacity-20 border-[0.5px] border-[#13132E] mb-4"
+          class="w-full h-0 opacity-20 border-[0.5px] lg:border-none lg:mb-0 border-[#13132E] mb-4"
         />
         <button
           aria-label="Mark exercise as complete"
@@ -372,11 +370,9 @@ exports[`FreeTextResponse > renders with saved exercise response 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="lg:hidden"
-      >
+      <div>
         <div
-          class="w-full h-0 opacity-20 border-[0.5px] border-[#13132E] mb-4"
+          class="w-full h-0 opacity-20 border-[0.5px] lg:border-none lg:mb-0 border-[#13132E] mb-4"
         />
         <button
           aria-label="Mark exercise as complete"


### PR DESCRIPTION
# Description

Following discussion [here](https://github.com/bluedotimpact/bluedot/issues/1793#issuecomment-3715080654).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#1793, I'm still planning to make the change to remove the layout shift on the "Saved" bar, so not fixed yet

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="1584" height="1122" alt="Screenshot 2026-01-09 at 08 57 52" src="https://github.com/user-attachments/assets/31397612-90ba-442e-bd37-521cfa77edda" /> | <img width="1584" height="1238" alt="Screenshot 2026-01-09 at 08 57 24" src="https://github.com/user-attachments/assets/37f319be-5a55-4ffc-be82-3cd9bf57f121" /> |
| | <img width="1584" height="1122" alt="Screenshot 2026-01-09 at 08 57 54" src="https://github.com/user-attachments/assets/766e37ec-01b0-495a-8299-3c7d2a38280f" /> | <img width="1584" height="1238" alt="Screenshot 2026-01-09 at 08 57 34" src="https://github.com/user-attachments/assets/cef10425-e76e-45c6-a980-e183e89998fd" /> |
