### PR TITLE
Ignore paper reading clubs/groups on homepage events

### DIFF
--- a/apps/website/src/server/routers/luma.ts
+++ b/apps/website/src/server/routers/luma.ts
@@ -6,6 +6,7 @@ import env from '../../lib/api/env';
 const CACHE_TTL_MS = 60_000; // 1 minute
 const FAILURE_THRESHOLD = 3; // Alert after N consecutive failures
 const SLACK_ALERT_COOLDOWN_MS = 60_000; // Max 1 alert per minute
+const EXCLUDED_EVENT_TITLE_SUFFIXES = ['paper reading club', 'paper reading group'];
 
 type LumaEvent = {
   name: string;
@@ -111,8 +112,10 @@ async function refreshCache(): Promise<Event[]> {
 
       const events = (data.entries || [])
         .map(({ api_id, event }) => transformEvent(api_id, event))
-        // Ignore paper reading clubs/groups
-        .filter((event) => !event.title.endsWith('Paper Reading Club') && !event.title.endsWith('Paper Reading Group'));
+        .filter((event) => {
+          const titleLower = event.title.toLowerCase();
+          return !EXCLUDED_EVENT_TITLE_SUFFIXES.some((suffix) => titleLower.endsWith(suffix));
+        });
 
       // Success: update cache and reset failure counter
       cachedEvents = events;


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Ignore paper reading clubs/groups on homepage events, they add clutter.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1917

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="1262" height="293" alt="image" src="https://github.com/user-attachments/assets/6bc97b15-de11-459b-a742-dcab07317c20" /> | <img width="1263" height="284" alt="image" src="https://github.com/user-attachments/assets/f231f613-135d-4bb5-a81c-19e535c032a8" /> |
