### PR TITLE
Add typedRoutes reference to next-env.d.ts files

### DIFF
--- a/apps/app-template/next-env.d.ts
+++ b/apps/app-template/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/availability/next-env.d.ts
+++ b/apps/availability/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/editor/next-env.d.ts
+++ b/apps/editor/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/frontend-example/next-env.d.ts
+++ b/apps/frontend-example/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/meet/next-env.d.ts
+++ b/apps/meet/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/room/next-env.d.ts
+++ b/apps/room/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Commits the `typedRoutes` reference line that Next.js 15 adds to `next-env.d.ts` files during build
- Prevents local git diffs when `dist/types/routes.d.ts` is regenerated during development

## Context
Next.js 15's `typedRoutes` feature generates typed route definitions in `dist/types/routes.d.ts` and adds a reference to this file in `next-env.d.ts`. Since `dist/` is gitignored, this causes a local diff that doesn't appear in CI. Committing the reference is safe because the build always regenerates the referenced file.

## Test plan
- [x] Verified build succeeds with committed reference
- [x] Verified `tsc --noEmit` works even without the `dist/` folder (reference is optional)