### PR TITLE
Schema: Add title field to roundTable

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -569,6 +569,14 @@ export const roundTable = pgAirtable('round', {
   baseId: COURSE_RUNNER_BASE_ID,
   tableId: 'tblu6u7F2NHfCMgsk',
   columns: {
+    /**
+     * Primary field in Airtable, called "Course - Round" there.
+     * Constructed by formula, example: "AGI Strategy (2025 Aug W35) - Intensive"
+     */
+    title: {
+      pgColumn: text(),
+      airtableId: 'fldEBVjEF9l2IEyG7',
+    },
     course: {
       pgColumn: text().notNull(),
       airtableId: 'fldvx7D6Uw0VxMPr0',


### PR DESCRIPTION
# Description

Adds the `title` field to `roundTable` schema. This is for displaying round names in the Facilitated courses section (#1905).

## Issue

#1905

## Developer checklist

N/A

## Screenshot

N/A