### PR TITLE
Schema: Add roundName field to courseRegistrationTable

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1137,6 +1137,14 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       pgColumn: text(),
       airtableId: 'fld9Y4WfeafUNMxMH',
     },
+    /**
+     * Formula field that returns the round name.
+     * Example: "AGI Strategy (2025 Aug W35) - Intensive"
+     */
+    roundName: {
+      pgColumn: text(),
+      airtableId: 'fldQymBa7milTYP9q',
+    },
   },
 });
 


### PR DESCRIPTION
# Description

Adds the `roundName` field to `courseRegistrationTable` schema. This is a formula field in Airtable that returns the round name (e.g. "AGI Strategy (2025 Aug W35) - Intensive").

This is for displaying round names in the Facilitated courses section (#1905). I previously added the field `title` to the `roundTable` (#1932), but I realised this gets the result much more directly. I haven't marked the title field as deprecated as it's the primary field so it's likely to come in handy at some point. 

## Issue

#1905

## Developer checklist

N/A

## Screenshot

N/A