### PR TITLE
fix: remove erroneous url prop causing 404 on attendance confirmation

### DIFF
--- a/apps/meet/src/pages/record-attendance.tsx
+++ b/apps/meet/src/pages/record-attendance.tsx
@@ -66,8 +66,8 @@ const RecordAttendancePage: React.FC<{ groupDiscussionId: string, participantId:
           'Not sure, but I attended',
         ].map((reason) => (
           <CTALinkOrButton
+            key={reason}
             variant="secondary"
-            url="test"
             onClick={() => recordAttendance({ reason })}
           >
             {reason}


### PR DESCRIPTION
Fixes #1948

The CTALinkOrButton components had url="test" which caused navigation to /test (a non-existent page) instead of just executing the onClick handler to record attendance.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
