### PR TITLE
Fix FoAI certificate requests: workaround duplicate exercises

### DIFF
--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -97,8 +97,9 @@ export const certificatesRouter = router({
       // Check if all exercises have been completed
       const incompleteExercises = allExercises
         .filter((exercise) => {
-          const response = exerciseResponses.find((resp) => resp.exerciseId === exercise.id);
-          return !response || !response.completed;
+          // Workaround for duplicate exercise responses
+          const hasCompletedResponse = exerciseResponses.some((resp) => resp.exerciseId === exercise.id && resp.completed);
+          return !hasCompletedResponse;
         })
         .sort((a, b) => Number(a.unitNumber || Infinity) - Number(b.unitNumber || Infinity));
 


### PR DESCRIPTION
# Description

When you complete an exercise in the FoAI course (and possibly other courses), duplicate exercise completion records end up in the database: one completed, one uncompleted. Previously the code here would take the first matching exercise completion for each exercise, and so would say you're not eligible because it would find some that are uncompleted.

The change in this PR makes it makes it count an exercise is completed as long as there is any exercise completion record with `completed = true`. I suspect the underlying problem is due to the recent changes here: #1793, I haven't yet found the issue though so I'm merging this first to fix the acute problem.

Once I've done that I'll try to fix whatever's generating the duplicate records and then go in and dedupe the records in Airtable manually.

## Issue
N/A

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

N/A
