### PR TITLE
back to blue CTA links on courses page

### DIFF
--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -539,8 +539,7 @@ const SelfPacedSection = ({ course }: SelfPacedSectionProps) => {
           </p>
           <Link
             href={`${course.path}/1/1`}
-            className="mt-3 text-[15px] leading-[1.6] font-medium cursor-pointer"
-            style={{ color: accentColor }}
+            className="mt-3 text-[15px] leading-[1.6] font-medium cursor-pointer text-bluedot-normal"
           >
             Start learning
           </Link>
@@ -562,7 +561,7 @@ const SelfPacedSection = ({ course }: SelfPacedSectionProps) => {
           </div>
         </div>
 
-        <div className="ml-auto flex items-center text-[15px] leading-[1.6] font-medium" style={{ color: accentColor }}>
+        <div className="ml-auto flex items-center text-[15px] leading-[1.6] font-medium text-bluedot-normal">
           <span className="transition-transform group-hover:-translate-x-1 group-focus-visible:-translate-x-1">
             Start learning
           </span>
@@ -656,8 +655,7 @@ const CourseRoundItem = ({ round, course }: CourseRoundItemProps) => {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Apply now (opens in a new tab)"
-            className="mt-3 text-[15px] leading-[1.6] font-medium cursor-pointer"
-            style={{ color: accentColor }}
+            className="mt-3 text-[15px] leading-[1.6] font-medium cursor-pointer text-bluedot-normal"
           >
             Apply now
           </a>
@@ -682,7 +680,7 @@ const CourseRoundItem = ({ round, course }: CourseRoundItemProps) => {
           </div>
         </div>
 
-        <div className="ml-auto flex items-center text-[15px] leading-[1.6] font-medium" style={{ color: accentColor }}>
+        <div className="ml-auto flex items-center text-[15px] leading-[1.6] font-medium text-bluedot-normal">
           <span className="transition-transform group-hover:-translate-x-1 group-focus-visible:-translate-x-1">
             Apply now
           </span>


### PR DESCRIPTION
# Description
This change is for the courses page only for updated design purposes (as discussed in slack). Updates the CTA links "Apply now" and "Start learning" colors on the /courses page back to use the BlueDot blue (#1144cc / text-bluedot-normal) vs their normal identity colors. Replaces the previous course-specific accent colors for these call-to-action links while maintaining the other existing visual identity elsewhere (e.g vertical colored bars still use each course's unique accent color to preserve differentiation, icons, colors).

## Issue
Related to #1897

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
<img width="228" height="328" alt="back-to-blue" src="https://github.com/user-attachments/assets/c1f1de5c-dda8-4980-b0dc-fa06349e75d9" />

