### PR TITLE
Fine-tune facilitator DB filter

### DIFF
--- a/apps/website/src/server/routers/facilitator-switching.ts
+++ b/apps/website/src/server/routers/facilitator-switching.ts
@@ -28,6 +28,8 @@ const getFacilitator = async (courseSlug: string, facilitatorEmail: string) => {
     filter: {
       email: facilitatorEmail,
       courseId: course.id,
+      roundStatus: 'Active',
+      decision: 'Accept',
     },
   });
   if (!courseRegistration) {


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

To find a facilitator we:

1. Use the course slug to find the course,
2. Find the corresponding course registration
3. Use the course registration ID and facilitator email to lookup the facilitator in the `meetTable`

The problem is that there can be multiple similar records for a facilitator in `meetTable` where the course ID is the same. For example, if a facilitator application was previously denied and now accepted, or a facilitator facilitates multiple rounds, some of which are active, some are not. This means that `getFirst` might return an unexpected record.

I've improved the DB filter to check for 'decision: "Accept"' and 'roundStatus: "Active"'. There are 8 facilitators who still have two records returned when we search for them in the DB.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1965

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
