### PR TITLE
[fix]: course details discussions tabs container now sizes naturally …

### DIFF
--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -291,7 +291,7 @@ const CourseDetails = ({
             {isLoading ? (
               <ProgressDots className="py-8" />
             ) : (
-              <div className="min-h-[200px]">
+              <div>
                 {activeTab === 'upcoming' && (
                   // Show only expected discussions where end datetime hasn't passed
                   upcomingDiscussions.length > 0 ? (


### PR DESCRIPTION
…based on its content

# Description
Removes the fixed `min-h-[200px]` constraint from the discussion content area in `CourseDetails`, which results in large amounts of empty space below discussion tabs. The container now sizes naturally based on its content. 

## Issue
Fixes #1878 

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="312" height="473" alt="white-space-mobile-before" src="https://github.com/user-attachments/assets/a551a5a1-7c1f-41d6-b769-2013516d5a55" /> | <img width="321" height="346" alt="white-space-mobile-after" src="https://github.com/user-attachments/assets/bead443c-ca51-4794-a4fd-aae7b600d5ac" /> |
| 🖥️ | <img width="978" height="400" alt="whitespace-desktop-before" src="https://github.com/user-attachments/assets/141c125f-5846-4868-9534-28fc9430afb0" /> | <img width="964" height="296" alt="whitespace-desktop-after" src="https://github.com/user-attachments/assets/903c023f-33ad-4029-828c-698ea8a6bbef" /> |
