### PR TITLE
[feat + fix]: resource list items alignment and layout

### DIFF
--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -242,28 +242,29 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({ resource, re
               href={addQueryParam(resource.resourceLink, 'utm_source', 'bluedot-impact')}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2"
+              className="flex items-start gap-2"
               aria-label={`${resource.resourceName} (opens in new tab)`}
             >
-              <FaviconImage url={resource.resourceLink} displaySize={16} />
+              <FaviconImage url={resource.resourceLink} displaySize={16} className="mt-[3px]" />
               <span className="leading-[140%] font-semibold tracking-[-0.005em] text-inherit no-underline transition-colors hover:text-bluedot-normal hover:underline">
                 {resource.resourceName}
+                {/* External link icon - inline so it flows with text on wrap */}
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                  stroke="#13132E"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="inline-block align-middle ml-2"
+                >
+                  <path d="M9.14286 2.28613H13.7143M13.7143 2.28613V6.85756M13.7143 2.28613L8 8.00042M5.71422 3.42871H4.28564C3.18108 3.42871 2.28564 4.32414 2.28564 5.42871V11.7144C2.28564 12.819 3.18108 13.7144 4.28565 13.7144H10.5714C11.6759 13.7144 12.5714 12.819 12.5714 11.7144V10.2859" />
+                </svg>
               </span>
-              {/* External link icon */}
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 16 16"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                aria-hidden="true"
-                stroke="#13132E"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M9.14286 2.28613H13.7143M13.7143 2.28613V6.85756M13.7143 2.28613L8 8.00042M5.71422 3.42871H4.28564C3.18108 3.42871 2.28564 4.32414 2.28564 5.42871V11.7144C2.28564 12.819 3.18108 13.7144 4.28565 13.7144H10.5714C11.6759 13.7144 12.5714 12.819 12.5714 11.7144V10.2859" />
-              </svg>
             </a>
           ) : (
             resource.resourceName


### PR DESCRIPTION
# Description
Fixes a few bugs (#1962 , #1891) in the course resources list when titles wrap to multiple lines (top-aligning the favicon with the first line of text instead of centering it across all lines + preventing the external link icon from shrinking at smaller viewport widths). Also as @joshestein experimented with, moved the external link icon in-line with the text so it flows more naturally to the end of the last line when titles wrap, rather than floating separately.

## Issue
Fixes #1962 and #1891

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshots

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="321" height="549" alt="before-resource-alignment-mobile" src="https://github.com/user-attachments/assets/4cf05a5d-3920-46d6-9de1-923d80d07cda" /> | <img width="322" height="549" alt="after-resource-alignment-mobile" src="https://github.com/user-attachments/assets/ad0b45c9-e4c3-45ff-b59e-6f2f8a525022" /> |
| 🖥️ | ![before-resource-item-alignment](https://github.com/user-attachments/assets/99054627-0ca6-4dbb-a64d-a91e02d1de58) | ![after-resource-item-alignment](https://github.com/user-attachments/assets/b2c0359b-0e11-4fbc-b4ac-3ed95a64a1ea) |
