### PR TITLE
Server-side filter out passed discussions, never show on frontend

### DIFF
--- a/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
@@ -60,7 +60,6 @@ const mockAvailableGroupsAndDiscussions: DiscussionsAvailable = {
       }),
       userIsParticipant: true,
       spotsLeftIfKnown: 0,
-      isTooLateToSwitchTo: false,
     },
     {
       group: createMockGroup({
@@ -70,7 +69,6 @@ const mockAvailableGroupsAndDiscussions: DiscussionsAvailable = {
       }),
       userIsParticipant: false,
       spotsLeftIfKnown: 3,
-      isTooLateToSwitchTo: false,
     },
     {
       group: createMockGroup({
@@ -80,7 +78,6 @@ const mockAvailableGroupsAndDiscussions: DiscussionsAvailable = {
       }),
       userIsParticipant: false,
       spotsLeftIfKnown: 0,
-      isTooLateToSwitchTo: false,
     },
   ],
   discussionsAvailable: {

--- a/apps/website/src/components/courses/GroupSwitchModal.test.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.test.tsx
@@ -85,7 +85,6 @@ const mockAvailableGroupsAndDiscussions: DiscussionsAvailable = {
       }),
       userIsParticipant: true,
       spotsLeftIfKnown: 0,
-      isTooLateToSwitchTo: false,
     },
     {
       group: createMockGroup({
@@ -95,7 +94,6 @@ const mockAvailableGroupsAndDiscussions: DiscussionsAvailable = {
       }),
       userIsParticipant: false,
       spotsLeftIfKnown: 3,
-      isTooLateToSwitchTo: false,
     },
   ],
   discussionsAvailable: {

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -217,7 +217,7 @@ export default function GroupSwitchModal({
         id: g.group.id,
         groupName: g.group.groupName ?? 'Group [Unknown]',
         dateTime: g.group.startTimeUtc,
-        isDisabled: g.spotsLeftIfKnown === 0 || g.isTooLateToSwitchTo,
+        isDisabled: g.spotsLeftIfKnown === 0,
         isSelected,
         isRecurringTime: true,
         description: getGroupSwitchDescription({

--- a/apps/website/src/server/routers/group-switching.test.ts
+++ b/apps/website/src/server/routers/group-switching.test.ts
@@ -99,7 +99,7 @@ describe('calculateGroupAvailability', () => {
       participantId: mockParticipantId,
     });
 
-    expect(result.groupsAvailable[0]?.isTooLateToSwitchTo).toBe(false);
+    expect(result.groupsAvailable[0]).toBeDefined();
     expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]).toHaveLength(1);
   });
 
@@ -125,8 +125,6 @@ describe('calculateGroupAvailability', () => {
       participantId: mockParticipantId,
     });
 
-    // Group should show isTooLateToSwitchTo as false (mixed)
-    expect(result.groupsAvailable[0]?.isTooLateToSwitchTo).toBe(false);
     // Group spotsLeftIfKnown should be the minimum of available spots from non-started discussions
     expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBe(3); // 5 max - 2 participants from future discussion
   });

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -44,7 +44,6 @@ export function calculateGroupAvailability({
     group: Group;
     spotsLeftIfKnown: number | null;
     userIsParticipant: boolean;
-    isTooLateToSwitchTo: boolean;
   }> = {};
 
   const currentTimeMs = Date.now();
@@ -87,21 +86,15 @@ export function calculateGroupAvailability({
       // Update group data
       const groupId = discussion.group;
       if (!groupData[groupId]) {
-      // First time seeing this group
+        // First time seeing this group
         groupData[groupId] = {
           group,
-          spotsLeftIfKnown: isTooLateToSwitchTo ? null : spotsLeftIfKnown,
+          spotsLeftIfKnown,
           userIsParticipant: group.participants.includes(participantId),
-          isTooLateToSwitchTo,
         };
       } else {
-        // Update existing group data
+        // Update existing group data - take minimum spots across all discussions
         const existing = groupData[groupId];
-
-        // It's too late to switch into the group if it's too late to switch into *all* of the discussions
-        existing.isTooLateToSwitchTo = existing.isTooLateToSwitchTo && isTooLateToSwitchTo;
-
-        // Update spotsLeftIfKnown
         if (existing.spotsLeftIfKnown !== null && spotsLeftIfKnown !== null) {
           existing.spotsLeftIfKnown = Math.min(existing.spotsLeftIfKnown, spotsLeftIfKnown);
         } else if (spotsLeftIfKnown !== null) {


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

1. Backend filters out passed discussions
2. Frontend never receives discussions with `isTooLateToSwitchTo` - all discussions in payload are eligible

I also updated the group switch modal stories to avoid authentication problems by properly mocking all tRPC queries.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1984

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="636" height="345" alt="image" src="https://github.com/user-attachments/assets/b935f6a2-1351-465c-8972-d23d4e6c0333" /> | <img width="633" height="292" alt="image" src="https://github.com/user-attachments/assets/5efc9ae2-240c-415e-ad7c-11e5ecb85f3c" /> |
