### PR TITLE
[feature] Make hero transparent for about and jobs pages

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AboutPage > should render correctly 1`] = `
       class="relative w-full min-h-[317px] min-[680px]:min-h-[366px]"
     >
       <nav
-        class="nav sticky top-0 z-50 w-full transition-all duration-300 bg-white border-b border-color-divider"
+        class="nav absolute top-0 inset-x-0 z-50 w-full transition-all duration-300 bg-transparent border-b border-white/15"
       >
         <div
           class="nav__container section-base"
@@ -22,7 +22,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 class="mobile-nav-links lg:hidden"
               >
                 <button
-                  class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn"
+                  class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn text-white [&_svg]:text-white"
                   type="button"
                 >
                   <svg
@@ -68,7 +68,7 @@ exports[`AboutPage > should render correctly 1`] = `
                         <button
                           aria-controls="courses-dropdown"
                           aria-expanded="false"
-                          class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                          class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                           type="button"
                         >
                           Courses
@@ -118,7 +118,7 @@ exports[`AboutPage > should render correctly 1`] = `
                       </div>
                       <a
                         aria-label="Events (opens in new tab)"
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                         href="https://lu.ma/bluedotevents?utm_source=website&utm_campaign=nav"
                         rel="noopener noreferrer"
                         tabindex="0"
@@ -128,7 +128,7 @@ exports[`AboutPage > should render correctly 1`] = `
                       </a>
                       <a
                         aria-label="Blog (opens in new tab)"
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                         href="https://blog.bluedot.org"
                         rel="noopener noreferrer"
                         tabindex="0"
@@ -137,14 +137,14 @@ exports[`AboutPage > should render correctly 1`] = `
                         Blog
                       </a>
                       <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                         href="/about"
                         tabindex="0"
                       >
                         About
                       </a>
                       <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                         href="/join-us"
                         tabindex="0"
                       >
@@ -173,7 +173,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 <img
                   alt="BlueDot Impact Logo"
                   class="logo__img h-5 min-[681px]:h-6 mr-auto transition-all duration-300"
-                  src="/images/logo/BlueDot_Impact_Logo.svg"
+                  src="/images/logo/BlueDot_Impact_Logo_White.svg"
                 />
               </a>
             </div>
@@ -189,7 +189,7 @@ exports[`AboutPage > should render correctly 1`] = `
                   <button
                     aria-controls="courses-dropdown"
                     aria-expanded="false"
-                    class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                    class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                     type="button"
                   >
                     Courses
@@ -239,7 +239,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </div>
                 <a
                   aria-label="Events (opens in new tab)"
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                   href="https://lu.ma/bluedotevents?utm_source=website&utm_campaign=nav"
                   rel="noopener noreferrer"
                   tabindex="0"
@@ -249,7 +249,7 @@ exports[`AboutPage > should render correctly 1`] = `
                 </a>
                 <a
                   aria-label="Blog (opens in new tab)"
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                   href="https://blog.bluedot.org"
                   rel="noopener noreferrer"
                   tabindex="0"
@@ -258,14 +258,14 @@ exports[`AboutPage > should render correctly 1`] = `
                   Blog
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                   href="/about"
                   tabindex="0"
                 >
                   About
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                   href="/join-us"
                   tabindex="0"
                 >
@@ -276,14 +276,14 @@ exports[`AboutPage > should render correctly 1`] = `
                 class="nav-cta flex flex-row items-center gap-4"
               >
                 <a
-                  class="cta-button transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm cta-button--secondary bg-transparent nav-cta__secondary-cta flex px-3 py-[5px] rounded-[5px] font-[450] leading-[160%] items-center justify-center border border-color-divider text-color-text hover:text-color-text hover:bg-gray-50"
+                  class="cta-button transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm cta-button--secondary nav-cta__secondary-cta flex px-3 py-[5px] rounded-[5px] font-[450] leading-[160%] items-center justify-center bg-white/15 border border-white/20 text-white hover:text-white hover:bg-white/20 backdrop-blur-sm"
                   href="/login?redirect_to=%2Fabout"
                   tabindex="0"
                 >
                   Sign in
                 </a>
                 <a
-                  class="cta-button transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm cta-button--primary link-on-dark nav-cta__primary-cta hidden min-[680px]:flex px-3 py-[5px] rounded-[5px] font-[450] leading-[160%] items-center justify-center bg-bluedot-normal hover:bg-[#1a3599] text-white hover:text-white"
+                  class="cta-button transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm cta-button--primary link-on-dark nav-cta__primary-cta hidden min-[680px]:flex px-3 py-[5px] rounded-[5px] font-[450] leading-[160%] items-center justify-center bg-white hover:bg-white/90 text-[#02034B] hover:text-[#02034B]"
                   href="/login?register=true&redirect_to=%2Fabout"
                   tabindex="0"
                 >

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
       class="relative w-full min-h-[317px] min-[680px]:min-h-[366px]"
     >
       <nav
-        class="nav sticky top-0 z-50 w-full transition-all duration-300 bg-white border-b border-color-divider"
+        class="nav absolute top-0 inset-x-0 z-50 w-full transition-all duration-300 bg-transparent border-b border-white/15"
       >
         <div
           class="nav__container section-base"
@@ -22,7 +22,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 class="mobile-nav-links lg:hidden"
               >
                 <button
-                  class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn"
+                  class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn text-white [&_svg]:text-white"
                   type="button"
                 >
                   <svg
@@ -68,7 +68,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                         <button
                           aria-controls="courses-dropdown"
                           aria-expanded="false"
-                          class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                          class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                           type="button"
                         >
                           Courses
@@ -112,7 +112,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                       </div>
                       <a
                         aria-label="Events (opens in new tab)"
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                         href="https://lu.ma/bluedotevents?utm_source=website&utm_campaign=nav"
                         rel="noopener noreferrer"
                         tabindex="0"
@@ -122,7 +122,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                       </a>
                       <a
                         aria-label="Blog (opens in new tab)"
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                         href="https://blog.bluedot.org"
                         rel="noopener noreferrer"
                         tabindex="0"
@@ -131,14 +131,14 @@ exports[`JoinUsPage > should render correctly 1`] = `
                         Blog
                       </a>
                       <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                         href="/about"
                         tabindex="0"
                       >
                         About
                       </a>
                       <a
-                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                         href="/join-us"
                         tabindex="0"
                       >
@@ -167,7 +167,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 <img
                   alt="BlueDot Impact Logo"
                   class="logo__img h-5 min-[681px]:h-6 mr-auto transition-all duration-300"
-                  src="/images/logo/BlueDot_Impact_Logo.svg"
+                  src="/images/logo/BlueDot_Impact_Logo_White.svg"
                 />
               </a>
             </div>
@@ -183,7 +183,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                   <button
                     aria-controls="courses-dropdown"
                     aria-expanded="false"
-                    class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                    class="nav-dropdown__btn flex items-center gap-2 cursor-pointer nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                     type="button"
                   >
                     Courses
@@ -227,7 +227,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 </div>
                 <a
                   aria-label="Events (opens in new tab)"
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                   href="https://lu.ma/bluedotevents?utm_source=website&utm_campaign=nav"
                   rel="noopener noreferrer"
                   tabindex="0"
@@ -237,7 +237,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 </a>
                 <a
                   aria-label="Blog (opens in new tab)"
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                   href="https://blog.bluedot.org"
                   rel="noopener noreferrer"
                   tabindex="0"
@@ -246,14 +246,14 @@ exports[`JoinUsPage > should render correctly 1`] = `
                   Blog
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                   href="/about"
                   tabindex="0"
                 >
                   About
                 </a>
                 <a
-                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-color-text hover:text-color-text"
+                  class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle text-white hover:text-white nav-link-animation-dark"
                   href="/join-us"
                   tabindex="0"
                 >
@@ -264,14 +264,14 @@ exports[`JoinUsPage > should render correctly 1`] = `
                 class="nav-cta flex flex-row items-center gap-4"
               >
                 <a
-                  class="cta-button transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm cta-button--secondary bg-transparent nav-cta__secondary-cta flex px-3 py-[5px] rounded-[5px] font-[450] leading-[160%] items-center justify-center border border-color-divider text-color-text hover:text-color-text hover:bg-gray-50"
+                  class="cta-button transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm cta-button--secondary nav-cta__secondary-cta flex px-3 py-[5px] rounded-[5px] font-[450] leading-[160%] items-center justify-center bg-white/15 border border-white/20 text-white hover:text-white hover:bg-white/20 backdrop-blur-sm"
                   href="/login?redirect_to=%2Fjoin-us"
                   tabindex="0"
                 >
                   Sign in
                 </a>
                 <a
-                  class="cta-button transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm cta-button--primary link-on-dark nav-cta__primary-cta hidden min-[680px]:flex px-3 py-[5px] rounded-[5px] font-[450] leading-[160%] items-center justify-center bg-bluedot-normal hover:bg-[#1a3599] text-white hover:text-white"
+                  class="cta-button transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm cta-button--primary link-on-dark nav-cta__primary-cta hidden min-[680px]:flex px-3 py-[5px] rounded-[5px] font-[450] leading-[160%] items-center justify-center bg-white hover:bg-white/90 text-[#02034B] hover:text-[#02034B]"
                   href="/login?register=true&redirect_to=%2Fjoin-us"
                   tabindex="0"
                 >

--- a/apps/website/src/pages/about.tsx
+++ b/apps/website/src/pages/about.tsx
@@ -19,7 +19,7 @@ const CURRENT_ROUTE = ROUTES.about;
 const AboutHero = () => {
   return (
     <section className="relative w-full min-h-[317px] min-[680px]:min-h-[366px]">
-      <Nav />
+      <Nav variant="transparent" />
       <img
         src="/images/homepage/hero.webp"
         alt=""

--- a/apps/website/src/pages/join-us/index.tsx
+++ b/apps/website/src/pages/join-us/index.tsx
@@ -18,7 +18,7 @@ const CURRENT_ROUTE = ROUTES.joinUs;
 const JoinUsHero = () => {
   return (
     <section className="relative w-full min-h-[317px] min-[680px]:min-h-[366px]">
-      <Nav />
+      <Nav variant="transparent" />
       <img
         src="/images/homepage/hero.webp"
         alt=""


### PR DESCRIPTION
# Description
Added transparent navbar styling to the About and Jobs pages so they match the course lander pages. I also made the navbar sticky at the top instead of dismissing when the hero disappears because it doesn't make sense for it to move if it's transparent. 

## Issue
Fixes #1918

## Developer checklist

- [X] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [X] Considered having snapshot tests and/or happy path functional tests
- [X] Considered adding Storybook stories

## Screenshot
Before:
<img width="1508" height="444" alt="image" src="https://github.com/user-attachments/assets/52261944-b2ff-442b-9c9c-4e2817e7060e" />
<img width="1508" height="444" alt="image" src="https://github.com/user-attachments/assets/c1544394-5fa7-4e0a-a96f-31aa2c6bdf65" />


After:
<img width="1508" height="369" alt="image" src="https://github.com/user-attachments/assets/5999a9bb-84da-4e4d-b511-f25ecf267a82" />

<img width="1508" height="444" alt="image" src="https://github.com/user-attachments/assets/f73ad2b6-6c41-4b27-b560-7a4ebc5be468" />


