### PR TITLE
[schema] Use perm headshot url column instead

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -824,7 +824,7 @@ export const testimonialTable = pgAirtable('testimonial', {
     },
     headshotAttachmentUrls: {
       pgColumn: text().array(),
-      airtableId: 'fldRtvMPQ4T79vqC1',
+      airtableId: 'flddgVxCSMALkqyUl',
     },
     jobTitle: {
       pgColumn: text(),


### PR DESCRIPTION
# Description
Previously, I synced the attachment URLs directly from Airtable. I've now added a new Airtable web extension and a permanent attachment URL column to the testimonial table. Note that changes to attachments may take up to 5 hours to reflect (limitation is from web-extension and not pg-sync-service) 

## Issue
Related to #1915

## Developer checklist
Not relevant

## Screenshot
No visual changes
