### PR TITLE
Schema change: Add completedAt field to replace completed in exercise responses

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -204,6 +204,10 @@ export const exerciseResponseTable = pgAirtable('exercise_response', {
       pgColumn: boolean().notNull(),
       airtableId: 'fldz8rocQd7Ws9s2q',
     },
+    completedAt: {
+      pgColumn: text(),
+      airtableId: 'fldmmwUvlAy3Ju2or',
+    },
     autoNumberId: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldjhCZEuocd5eYsb',


### PR DESCRIPTION
# Description

The immediate motivation for this is to support the completed timestamp in participant responses for #1794. Plus overall I think this will come in handy.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2002

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
N/A
