### PR TITLE
Switch from exercise 'completed' boolean to 'completedAt' timestamp

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -52,7 +52,7 @@ const Exercise: React.FC<ExerciseProps> = ({
   // objects, this is just a simple workaround for this one field.
   const isCompleted = (!saveResponseMutation.isError && saveResponseMutation.variables?.completed !== undefined)
     ? saveResponseMutation.variables.completed
-    : (responseData?.completed ?? false);
+    : (responseData?.completedAt != null);
 
   const handleExerciseSubmit = async (exerciseResponse: string, completed?: boolean) => {
     if (isSavingRef.current) return;

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -98,7 +98,7 @@ export const certificatesRouter = router({
       const incompleteExercises = allExercises
         .filter((exercise) => {
           // Workaround for duplicate exercise responses
-          const hasCompletedResponse = exerciseResponses.some((resp) => resp.exerciseId === exercise.id && resp.completed);
+          const hasCompletedResponse = exerciseResponses.some((resp) => resp.exerciseId === exercise.id && resp.completedAt != null);
           return !hasCompletedResponse;
         })
         .sort((a, b) => Number(a.unitNumber || Infinity) - Number(b.unitNumber || Infinity));

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -27,6 +27,13 @@ export const exercisesRouter = router({
       completed: z.boolean().optional(),
     }))
     .mutation(async ({ input, ctx }) => {
+      let completedAt: string | null | undefined;
+      if (input.completed === true) {
+        completedAt = new Date().toISOString();
+      } else if (input.completed === false) {
+        completedAt = null;
+      } // else undefined = "don't change"
+
       const exerciseResponse = await db.getFirst(exerciseResponseTable, {
         filter: { exerciseId: input.exerciseId, email: ctx.auth.email },
       });
@@ -36,7 +43,7 @@ export const exercisesRouter = router({
           id: exerciseResponse.id,
           exerciseId: input.exerciseId,
           response: input.response,
-          completed: input.completed ?? exerciseResponse.completed,
+          completedAt: completedAt ?? exerciseResponse.completedAt,
         });
       }
 
@@ -44,7 +51,7 @@ export const exercisesRouter = router({
         email: ctx.auth.email,
         exerciseId: input.exerciseId,
         response: input.response,
-        completed: input.completed ?? false,
+        completedAt: completedAt ?? null,
       });
     }),
 });

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -200,10 +200,6 @@ export const exerciseResponseTable = pgAirtable('exercise_response', {
       pgColumn: text().notNull(),
       airtableId: 'fld7Qa3JDnRNwCTlH',
     },
-    completed: {
-      pgColumn: boolean().notNull(),
-      airtableId: 'fldz8rocQd7Ws9s2q',
-    },
     completedAt: {
       pgColumn: text(),
       airtableId: 'fldmmwUvlAy3Ju2or',
@@ -211,6 +207,13 @@ export const exerciseResponseTable = pgAirtable('exercise_response', {
     autoNumberId: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldjhCZEuocd5eYsb',
+    },
+  },
+  deprecatedColumns: {
+    completed: {
+      pgColumn: boolean(),
+      airtableId: 'fldz8rocQd7Ws9s2q',
+      deprecated: true,
     },
   },
 });


### PR DESCRIPTION
# Description

From the issue:
>https://github.com/bluedotimpact/bluedot/issues/1794 calls for a timestamp of when a user completed an exercise to show to facilitators. We don't currently track this. The simplest way to support it without duplicating any state is to use a completedAt instead of completed (boolean), and deprecate the old field

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2002

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
No visual or functionality change at this point