### PR TITLE
[DevEx] Fix flaky Login test

### DIFF
--- a/libraries/ui/src/Login.test.tsx
+++ b/libraries/ui/src/Login.test.tsx
@@ -212,12 +212,15 @@ describe('LoginOauthCallbackPage', () => {
     const { getByText } = render(<LoginOauthCallbackPage loginPreset={mockLoginPreset} />);
 
     await waitFor(() => {
-      expect(getByText('Bad login response: No user returned')).toBeInTheDocument();
+      expect(OidcClient).toHaveBeenCalledTimes(1);
     });
 
     expect(mockProcessSigninResponse).toHaveBeenCalledTimes(1);
     expect(mockSetAuth).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(getByText('Bad login response: No user returned')).toBeInTheDocument();
+    });
   });
 
   test('should throw error if user.expires_at is missing', async () => {
@@ -228,12 +231,15 @@ describe('LoginOauthCallbackPage', () => {
     const { getByText } = render(<LoginOauthCallbackPage loginPreset={mockLoginPreset} />);
 
     await waitFor(() => {
-      expect(getByText('Bad login response: user.expires_at is missing or not a number')).toBeInTheDocument();
+      expect(OidcClient).toHaveBeenCalledTimes(1);
     });
 
     expect(mockProcessSigninResponse).toHaveBeenCalledTimes(1);
     expect(mockSetAuth).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(getByText('Bad login response: user.expires_at is missing or not a number')).toBeInTheDocument();
+    });
   });
 
   test('should throw error if user.id_token is missing', async () => {
@@ -243,12 +249,15 @@ describe('LoginOauthCallbackPage', () => {
     const { getByText } = render(<LoginOauthCallbackPage loginPreset={mockLoginPreset} />);
 
     await waitFor(() => {
-      expect(getByText('Bad login response: user.id_token is missing or not a string')).toBeInTheDocument();
+      expect(OidcClient).toHaveBeenCalledTimes(1);
     });
 
     expect(mockProcessSigninResponse).toHaveBeenCalledTimes(1);
     expect(mockSetAuth).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(getByText('Bad login response: user.id_token is missing or not a string')).toBeInTheDocument();
+    });
   });
 
   test('should throw error if user.profile.email is missing', async () => {
@@ -258,12 +267,15 @@ describe('LoginOauthCallbackPage', () => {
     const { getByText } = render(<LoginOauthCallbackPage loginPreset={mockLoginPreset} />);
 
     await waitFor(() => {
-      expect(getByText('Bad login response: user.profile.email is missing or not a string')).toBeInTheDocument();
+      expect(OidcClient).toHaveBeenCalledTimes(1);
     });
 
     expect(mockProcessSigninResponse).toHaveBeenCalledTimes(1);
     expect(mockSetAuth).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(getByText('Bad login response: user.profile.email is missing or not a string')).toBeInTheDocument();
+    });
   });
 
   test('should redirect to "/" when userState.redirectTo is missing', async () => {


### PR DESCRIPTION
# Description

This test [failed](https://github.com/bluedotimpact/bluedot/actions/runs/21687677359/job/62541779118) a couple of times after merging #2027. There was a genuine race condition in the test, so I think it's probably just that the NextJS version bump slightly changed some internals which made it hit the failing case more often. 

## Issue

N/A

## Developer checklist

N/A

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

N/A