### PR TITLE
Use larger runners (4-core) for CI

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-4core
     timeout-minutes: 20
     steps:
       - name: Checkout ${{ github.sha }}


### PR DESCRIPTION
# Description

Use GitHub's larger runners (4-core) for CI.

This requires manual setup in the GitHub organization settings before the PR can be merged, see [the setup instructions on #1913](https://github.com/bluedotimpact/bluedot/issues/1913#issuecomment-3872127760) for details.

## Issue

Fixes #1913

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

N/A
