### PR TITLE
Followup for #2038 (show application status): Show info tooltip for accepted applications

### DIFF
--- a/apps/website/src/components/settings/CourseListRow.tsx
+++ b/apps/website/src/components/settings/CourseListRow.tsx
@@ -162,7 +162,7 @@ const CourseListRow = ({
                       <Tooltip content={reasonNotEligibleForCert} ariaLabel="Show certificate eligibility information" />
                     </span>
                   )}
-                  {isFuture && courseRegistration.decision === null && (
+                  {isFuture && courseRegistration.decision !== 'Reject' && (
                     <span className="ml-0.5 inline-flex items-center align-middle">
                       <Tooltip content="We typically finalise all application decisions and group discussion times 1 week before the start of the course." ariaLabel="Show application timeline information" />
                     </span>
@@ -231,7 +231,7 @@ const CourseListRow = ({
                     <Tooltip content={reasonNotEligibleForCert} ariaLabel="Show certificate eligibility information" />
                   </span>
                 )}
-                {isFuture && courseRegistration.decision === null && (
+                {isFuture && courseRegistration.decision !== 'Reject' && (
                   <span className="ml-0.5 inline-flex items-center align-middle">
                     <Tooltip content="We typically finalise all application decisions and group discussion times 1 week before the start of the course." ariaLabel="Show application timeline information" />
                   </span>


### PR DESCRIPTION
# Description

Feedback from Li-Lian: "can we have the info tooltip still visible for people who have been accepted? it will let them know why they don't see their group discussion times yet"

## Issue

#2038

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

N/A, straightforward change