### PR TITLE
Run CI on all pull requests, not just PRs targeting master

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   ci:


### PR DESCRIPTION
## Description

Currently CI only runs on PRs targeting `master`. I fairly commonly put up PRs like [this](https://github.com/bluedotimpact/bluedot/pull/2046) which are stacked against another branch, and I want CI to run on these too.

The change removes the branch filter on the `pull_request` trigger so CI runs on all PRs. The CD job already has its own guard (`github.ref == 'refs/heads/master'`) so deploys still only happen on master merges.

## Issue

N/A

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist (for Testing)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories