### PR TITLE
Revert "Use larger runners (4-core) for CI (#2039)"

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout ${{ github.sha }}


### PR DESCRIPTION
# Description

See [comment here](https://github.com/bluedotimpact/bluedot/issues/1913#issuecomment-3883400181). CI is failing at the moment because it can't find the runner. I'm not sure if the runner hasn't been created, or if this is a separate issue. But either way, reverting to get CI working again. 

## Issue

#1913

## Developer checklist

N/A