### PR TITLE
Use larger runners (4-core) for CI

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout ${{ github.sha }}

--- a/apps/website/src/lib/constants.ts
+++ b/apps/website/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const WEBSITE_VERSION = '0.1.1';
+export const WEBSITE_VERSION = '0.1.2';
 
 export const FOAI_COURSE_ID = 'rec0Zgize0c4liMl5';
 export const FOAI_COURSE_SLUG = 'future-of-ai';


### PR DESCRIPTION
# Description

Use GitHub's larger runners (4-core) for CI. Re-applies #2039 which was reverted in #2050 because the runner hadn't been set up yet. The runner has now been created by @anglilian.

## Issue

Fixes #1913

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist (N/A)
- [x] Considered having snapshot tests and/or happy path functional tests (N/A)
- [x] Considered adding Storybook stories (N/A)