### PR TITLE
Revert font size change in #2054

### DIFF
--- a/apps/website/src/components/settings/CourseListRow.tsx
+++ b/apps/website/src/components/settings/CourseListRow.tsx
@@ -160,7 +160,7 @@ const CourseListRow = ({
         <div className="p-4 sm:px-8 sm:py-6">
           <div className="flex items-start sm:items-center gap-3 sm:gap-4">
             <div className="flex-1 min-w-0">
-              <h3 className="font-semibold text-size-md sm:text-size-base text-black sm:text-gray-900 text-pretty sm:leading-normal">
+              <h3 className="font-semibold text-size-md sm:text-size-sm text-black sm:text-gray-900 text-pretty sm:leading-normal">
                 {course.title}{' '}
                 {reasonNotEligibleForCert && (
                   <span className="ml-0.5 inline-flex items-center align-middle">

--- a/apps/website/src/components/settings/__snapshots__/CourseListRow.test.tsx.snap
+++ b/apps/website/src/components/settings/__snapshots__/CourseListRow.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`CourseListRow > renders completed course correctly (snapshot) 1`] = `
             class="flex-1 min-w-0"
           >
             <h3
-              class="font-semibold text-size-md sm:text-size-base text-black sm:text-gray-900 text-pretty sm:leading-normal"
+              class="font-semibold text-size-md sm:text-size-sm text-black sm:text-gray-900 text-pretty sm:leading-normal"
             >
               Introduction to AI Safety
                
@@ -148,7 +148,7 @@ exports[`CourseListRow > renders in-progress course correctly (snapshot) 1`] = `
             class="flex-1 min-w-0"
           >
             <h3
-              class="font-semibold text-size-md sm:text-size-base text-black sm:text-gray-900 text-pretty sm:leading-normal"
+              class="font-semibold text-size-md sm:text-size-sm text-black sm:text-gray-900 text-pretty sm:leading-normal"
             >
               Introduction to AI Safety
                


### PR DESCRIPTION
# Description

#2054 introduced an accidental change in font size, this reverts it.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2055

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
(How it looked before #2054)