### PR TITLE
Remove n + 1 queries for fetching unit resources/exercises

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -227,8 +227,8 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
     .filter((chunk) => chunk.unitId === unit.id)
     .sort((a, b) => Number(a.chunkOrder) - Number(b.chunkOrder));
 
-  const chunkResourceIds = currentUnitChunks.flatMap((chunk) => chunk.chunkResources || []);
-  const chunkExerciseIds = currentUnitChunks.flatMap((chunk) => chunk.chunkExercises || []);
+  const chunkResourceIds = currentUnitChunks.flatMap((chunk) => chunk.chunkResources ?? []);
+  const chunkExerciseIds = currentUnitChunks.flatMap((chunk) => chunk.chunkExercises ?? []);
 
   const [allResourcesForUnit, allExercisesForUnit] = await Promise.all([
     chunkResourceIds.length > 0
@@ -247,7 +247,7 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
 
   const chunksWithContent = currentUnitChunks.map((chunk) => {
     // Use pre-fetched resources/exercises for the current unit to avoid N+1 queries, filter out any that might be missing, and sort by readingOrder/exerciseNumber
-    const resources = (chunk.chunkResources || [])
+    const resources = (chunk.chunkResources ?? [])
       .map((resourceId) => resourceById.get(resourceId))
       .filter((r): r is UnitResource => r !== undefined)
       .sort((a, b) => {
@@ -256,7 +256,7 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
         return orderA - orderB;
       });
 
-    const exercises = (chunk.chunkExercises || [])
+    const exercises = (chunk.chunkExercises ?? [])
       .map((exerciseId) => exerciseById.get(exerciseId))
       .filter((e): e is Exercise => e !== undefined)
       .sort((a, b) => {


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Since we now fetch all resources and exercises for unit at once it makes sense to streamline our DB call to avoid n + 1 queries. Previously this wasn't much of an issue since we'd only fetch for the expanded chunk, so only a few excess queries would be called

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2037

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
