### PR TITLE
Optimistically update MCQ component

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -90,8 +90,8 @@ const Exercise: React.FC<ExerciseProps> = ({
       return { previousResponse, previousCourseProgress };
     },
     onError(_err, _variables, mutationResult) {
-      if (mutationResult?.previousResponse !== undefined) {
-        utils.exercises.getExerciseResponse.setData({ exerciseId }, mutationResult.previousResponse);
+      if (mutationResult) {
+        utils.exercises.getExerciseResponse.setData({ exerciseId }, mutationResult.previousResponse ?? undefined);
       }
 
       rollbackCourseProgress(utils, courseSlug, mutationResult?.previousCourseProgress);
@@ -117,6 +117,8 @@ const Exercise: React.FC<ExerciseProps> = ({
         response: exerciseResponse,
         completed, // undefined means "don't change", backend preserves existing value
       });
+    } catch {
+      // Rollback handled by onError
     } finally {
       isSavingRef.current = false;
     }

--- a/apps/website/src/components/courses/exercises/MultipleChoice.test.tsx
+++ b/apps/website/src/components/courses/exercises/MultipleChoice.test.tsx
@@ -145,7 +145,7 @@ describe('MultipleChoice', () => {
 
   test('shows correct result immediately after submitting correct answer', async () => {
     const user = userEvent.setup();
-    const mockOnExerciseSubmit = vi.fn();
+    const mockOnExerciseSubmit = vi.fn().mockResolvedValue(undefined);
 
     const { getAllByRole, queryByRole } = render(<MultipleChoice {...mockArgs} onExerciseSubmit={mockOnExerciseSubmit} isLoggedIn />);
 

--- a/apps/website/src/components/courses/exercises/MultipleChoice.tsx
+++ b/apps/website/src/components/courses/exercises/MultipleChoice.tsx
@@ -59,13 +59,18 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
   useEffect(() => {
     if (formattedExerciseResponse) {
       setValue('answer', formattedExerciseResponse);
+    } else if (!isEditing) {
+      setValue('answer', '');
+      setIsEditing(true);
     }
+    // Only re-run when the server response changes, not on isEditing transitions
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formattedExerciseResponse, setValue]);
 
   const onSubmit = useCallback(
     (data: FormData) => {
       const isAnswerCorrect = data.answer === formattedAnswer;
-      onExerciseSubmit(data.answer, isAnswerCorrect);
+      void onExerciseSubmit(data.answer, isAnswerCorrect);
       setIsEditing(false);
     },
     [onExerciseSubmit, formattedAnswer],


### PR DESCRIPTION
# Description

Optimistically update the exercise response data so that MCQ feedback is instant, rather than waiting for the server round-trip.

Changes:
- **Exercise.tsx**: Full optimistic update of `getExerciseResponse` query data in `onMutate`, with rollback in `onError`. Moved `invalidate` from `onSuccess` to `onSettled`. Simplified `isCompleted` to derive directly from `responseData` since the optimistic data now keeps it in sync.
- **MultipleChoice.tsx**: Made `onSubmit` synchronous (no `await`), removed `isSubmitting` state and "Checking..." button text, and use `currentAnswer` (local form state) instead of `formattedExerciseResponse` (server state) for correct/incorrect display — so feedback appears before the server responds.

## Issue

Fixes #1607

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

N/A no visual change