### PR TITLE
Capture PostHog session ID in application form URLs

### DIFF
--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { addQueryParam, useLatestUtmParams } from '@bluedot/ui';
+import { appendPosthogSessionIdPrefill } from '../../lib/appendPosthogSessionIdPrefill';
 import { Nav } from '../Nav/Nav';
 import TestimonialCarousel, { type TestimonialMember } from './TestimonialCarousel';
 import GraduateSection from './components/GraduateSection';
@@ -69,9 +70,9 @@ const CourseLander = ({
 }: CourseLanderProps) => {
   const { latestUtmParams } = useLatestUtmParams();
 
-  const applicationUrlWithUtm = latestUtmParams.utm_source
+  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
     ? addQueryParam(baseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)
-    : baseApplicationUrl;
+    : baseApplicationUrl);
 
   const content = createContentFor(applicationUrlWithUtm, courseSlug);
 

--- a/apps/website/src/lib/appendPosthogSessionIdPrefill.ts
+++ b/apps/website/src/lib/appendPosthogSessionIdPrefill.ts
@@ -1,0 +1,11 @@
+import posthog from 'posthog-js';
+
+export const appendPosthogSessionIdPrefill = (url: string): string => {
+  if (!url) return url;
+  const sessionId = posthog.get_session_id?.();
+  if (!sessionId) return url;
+  const urlObj = new URL(url);
+  urlObj.searchParams.set('prefill_PostHog Session ID', sessionId);
+  // URLSearchParams encodes spaces as '+', but miniextensions requires '%20'
+  return urlObj.toString().replace('prefill_PostHog+Session+ID', 'prefill_PostHog%20Session%20ID');
+};

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -12,6 +12,7 @@ import { type GetStaticProps, type GetStaticPaths } from 'next';
 import path from 'path';
 
 import { ROUTES } from '../../../lib/routes';
+import { appendPosthogSessionIdPrefill } from '../../../lib/appendPosthogSessionIdPrefill';
 import MarkdownExtendedRenderer from '../../../components/courses/MarkdownExtendedRenderer';
 import AiSafetyOpsLander from '../../../components/lander/AiSafetyOpsLander';
 import CourseLander from '../../../components/lander/CourseLander';
@@ -152,7 +153,7 @@ const registerInterestUrl = 'https://web.miniextensions.com/aGd0mXnpcN1gfqlnYNZc
 
 const StandardCoursePage = ({ courseData, courseOgImage }: { courseData: CourseAndUnits; courseOgImage: string }) => {
   const { latestUtmParams } = useLatestUtmParams();
-  const registerInterestUrlWithUtm = latestUtmParams.utm_source ? addQueryParam(registerInterestUrl, 'prefill_Source', latestUtmParams.utm_source) : registerInterestUrl;
+  const registerInterestUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source ? addQueryParam(registerInterestUrl, 'prefill_Source', latestUtmParams.utm_source) : registerInterestUrl);
 
   return (
     <div>

--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -12,6 +12,7 @@ import { trpc } from '../../utils/trpc';
 import NewsletterBanner from '../../components/homepage/NewsletterBanner';
 import { CourseIcon } from '../../components/courses/CourseIcon';
 import { COURSE_CONFIG } from '../../lib/constants';
+import { appendPosthogSessionIdPrefill } from '../../lib/appendPosthogSessionIdPrefill';
 
 const getCourseAccentColor = (courseSlug: string): string => {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -578,9 +579,9 @@ const CourseRoundItem = ({ round, course }: CourseRoundItemProps) => {
   const baseApplicationUrl = course.applyUrl || '';
 
   // Add UTM source prefill if available
-  const applicationUrlWithUtm = latestUtmParams.utm_source
+  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
     ? addQueryParam(baseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)
-    : baseApplicationUrl;
+    : baseApplicationUrl);
 
   // Add round prefill - manually construct to use %20 encoding (miniextensions requires this format)
   const separator = applicationUrlWithUtm.includes('?') ? '&' : '?';


### PR DESCRIPTION
# Description

Appends the PostHog session ID as a prefill parameter (`prefill_PostHog%20Session%20ID`) on miniextensions application form URLs, this prefills a new field I created to track this.

Note: this only covers the miniextensions form path. The FoAI auto-registration required a bigger code change and I thought it wasn't worth it given that there is no meaningful start -> finish completion right there anyway. 

## Issue

Fixes #2059

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
  - Not added: trivial inline change, same pattern as existing UTM prefill
- [x] Considered adding Storybook stories

## Screenshot

N/A