### PR TITLE
Don't show past/present rejected course registrations on course hub

### DIFF
--- a/apps/website/src/pages/settings/courses.tsx
+++ b/apps/website/src/pages/settings/courses.tsx
@@ -62,7 +62,7 @@ const CoursesContent = () => {
     .flat();
 
   // Group courses by status
-  // Upcoming: Future courses (pending or accepted applications)
+  // Upcoming: Future courses (pending, accepted, or rejected applications)
   const upcomingCourses = enrolledCourses
     .filter(({ courseRegistration }) => courseRegistration.roundStatus === 'Future');
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Rejected applicants were seeing courses they weren't enrolled in appearing in their settings. A registration would transition from Future -> Active -> Past, but we only handled the 'Future' case explicilty.

Fix:filter out 'Reject' decisions from the enrolled courses list except when the round is still 'Future', where showing the rejected status is intentional (so users can see their application outcome).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2087 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="1284" height="744" alt="image" src="https://github.com/user-attachments/assets/04281f87-ef52-4282-a244-cd1d3fc9ff30" /> | <img width="1275" height="803" alt="image" src="https://github.com/user-attachments/assets/d215f1b2-4ae5-4f42-8983-271ffc769caf" /> |
