### PR TITLE
Do not append PostHog session ID to internal (relative) routes

### DIFF
--- a/apps/website/src/lib/appendPosthogSessionIdPrefill.ts
+++ b/apps/website/src/lib/appendPosthogSessionIdPrefill.ts
@@ -2,11 +2,11 @@ import posthog from 'posthog-js';
 
 export const appendPosthogSessionIdPrefill = (url: string): string => {
   if (!url) return url;
-  const sessionId = posthog.get_session_id?.();
-  if (!sessionId) return url;
-
   // new URL() requires an absolute URL; skip relative paths (e.g. internal nav links)
   if (!url.startsWith('http://') && !url.startsWith('https://')) return url;
+
+  const sessionId = posthog.get_session_id?.();
+  if (!sessionId) return url;
 
   const urlObj = new URL(url);
   urlObj.searchParams.set('prefill_PostHog Session ID', sessionId);


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

The PostHog session ID is appended to external miniextensions form URLs (like https://web.miniextensions.com/...) so that when someone fills out an application form, BlueDot can correlate the form submission back to the user's PostHog session for analytics purposes.

For the future-of-ai page specifically, `baseApplicationUrl` is `/courses/future-of-ai/1/1` — an internal Next.js route, not a miniextensions form. This is an invalid URL, so `appendPosthogSessionIdPrefill` fails when trying to call `new URL(url)`.

Fixing by early returning if we have a relative URL (i.e. doesn't start with 'http' or 'https'). The PostHog session ID isn't useful here anyways.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

[Fixes #
](https://ai-safety-sa.slack.com/archives/C090L5FT139/p1771483833711379)
## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA