### PR TITLE
[Bug] Fix un-completing exercises

### DIFF
--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -55,7 +55,7 @@ export const exercisesRouter = router({
           id: exerciseResponse.id,
           exerciseId: input.exerciseId,
           response: input.response,
-          completedAt: completedAt ?? exerciseResponse.completedAt,
+          completedAt: completedAt !== undefined ? completedAt : exerciseResponse.completedAt,
         });
       }
 


### PR DESCRIPTION
# Description

This bug was introduced in #2007. Previously, `input.completed ?? exerciseResponse.completed` correctly handled false vs undefined. The new version `completedAt: completedAt ?? exerciseResponse.completedAt` incorrectly fell back to `exerciseResponse.completedAt` when completedAt was null (it was intended to set it to null).

This PR explicitly checks `=== undefined` to handle all the cases correctly.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2094 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
N/A