### PR TITLE
Preview environments: Use production endpoint to update redirect URIs (part 2: adopt in pre-deploy script)

### DIFF
--- a/DEVELOPMENT_HANDBOOK.md
+++ b/DEVELOPMENT_HANDBOOK.md
@@ -638,12 +638,14 @@ To enable this in the Render dashboard, preview deployments need to be turned on
 - **Start:** `cd apps/website && npm run render-preview -- start`
 
 Required environment variables in Render (in addition to what is generally required):
-- `KEYCLOAK_PREVIEW_CLIENT_ID` — service-account client ID with permission to manage redirect URIs
-- `KEYCLOAK_PREVIEW_CLIENT_SECRET` — corresponding client secret
+- `KEYCLOAK_PREVIEW_AUTH_TOKEN` — shared secret for authenticating with the production endpoint that registers redirect URIs
 - `SITE_ACCESS_PASSWORD` — password gate for preview sites
   - Note: This is in 1password under "Preview env login (bluedot.org)". Unfortunately it can't prefill because the subdomain on preview environments is always different.
 
-The production website also needs `KEYCLOAK_PREVIEW_CLIENT_ID` and `KEYCLOAK_PREVIEW_CLIENT_SECRET` (same values as Render), plus `KEYCLOAK_PREVIEW_AUTH_TOKEN` (a shared secret between Render and production for authenticating the preview redirect URI registration endpoint).
+The production website also needs:
+- `KEYCLOAK_PREVIEW_AUTH_TOKEN` (same shared secret as above)
+- `KEYCLOAK_PREVIEW_CLIENT_ID` — service-account client ID with `manage-clients` role (NOT set on Render preview environments)
+- `KEYCLOAK_PREVIEW_CLIENT_SECRET` — corresponding client secret
 
 ### Deployment Processes
 


### PR DESCRIPTION
# Description

Switches the Render pre-deploy script to register redirect URIs via the production endpoint (added in #2093) instead of talking to Keycloak directly. This means we can remove `KEYCLOAK_PREVIEW_CLIENT_ID` and `KEYCLOAK_PREVIEW_CLIENT_SECRET` from Render, so preview environments no longer have Keycloak admin credentials.

After merging and deploying:
1. Add `KEYCLOAK_PREVIEW_AUTH_TOKEN` to Render env vars (same value as production)
2. Remove `KEYCLOAK_PREVIEW_CLIENT_ID` and `KEYCLOAK_PREVIEW_CLIENT_SECRET` from Render

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2072 (part 2 of 2)

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — N/A
- [x] Considered having snapshot tests and/or happy path functional tests — N/A, script change only
- [x] Considered adding Storybook stories — N/A

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

N/A