### PR TITLE
Attempt to fix geolocation in posthog: Forward X-Real-IP exactly

### DIFF
--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -40,7 +40,7 @@ http {
             proxy_set_header Host $posthog_upstream;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Real-IP $http_x_real_ip;
 
             # Pass through important headers
             proxy_set_header Referer $http_referer;


### PR DESCRIPTION
## Description

Based on local testing (running posthog-proxy in Docker), I think the proxy was forwarding the internal K8s pod IP as X-Real-IP instead of the real client IP. This would explain why the locations were all set to Amsterdam. 

I changed X-Real-IP to pass through the value set by ingress-nginx ($http_x_real_ip). I'm not 100% sure this will fix it. If it doesn't my guess is that it's because ingress-nginx doesn't set this value, in which case we'll have to try again (e.g. parsing a value out of x-forwarded-for). But it will be obvious after deploying this whether it has worked because the data will start showing up. 

Also: the GeoIP Enricher transformation was actually paused in production, which explains why we were only getting wrong values on dev and no values in prod. I have unpaused it (and it's free, so that's not an issue, I guess it was paused because it wasn't working).

## Issue

#1831

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

N/A