### PR TITLE
Add debug logging to posthog proxy to diagnose geolocation (#1831)

### DIFF
--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -1,4 +1,12 @@
 http {
+    # Temporary debug logging to diagnose geolocation issue (#1831)
+    log_format ip_debug '$remote_addr - [$time_local] "$request" '
+                        'remote_addr=$remote_addr '
+                        'xff_sent=$proxy_add_x_forwarded_for '
+                        'real_ip_incoming=$http_x_real_ip '
+                        'cf_connecting_ip=$http_cf_connecting_ip';
+    access_log /dev/stdout ip_debug;
+
     # Define allowed origins - only production, staging, and localhost
     map $http_origin $cors_origin {
         default "";


### PR DESCRIPTION
# Description

The previous PR (#2097, X-Real-IP fix) didn't fix geolocation, staging still shows Amsterdam for all users.

By sending test events directly to PostHog with various header combinations, I determined that PostHog ignores X-Real-IP entirely and uses the first IP in X-Forwarded-For for GeoIP lookup.

Given that `$proxy_add_x_forwarded_for` should produce `real_client_ip, internal_pod_ip` (with the real client IP first), PostHog should be picking up the correct IP. The fact that it still shows Amsterdam means the real client IP is being lost somewhere upstream of the posthog-proxy.

This PR adds temporary debug logging to the nginx access log so we can see the actual header values in production:
- `remote_addr`: what the posthog-proxy container sees as the source IP
- `xff_sent`: the full X-Forwarded-For chain being sent to PostHog
- `real_ip_incoming`: the X-Real-IP header from ingress-nginx
- `cf_connecting_ip`: Cloudflare's header (expected to be empty since `*.k8s.bluedot.org` is DNS-only)

I'll remove this later today once I've found the issue.

## Issue

#1831

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

N/A