### PR TITLE
Remove temporary debug logging from posthog proxy

### DIFF
--- a/apps/posthog-proxy/src/nginx.template.conf
+++ b/apps/posthog-proxy/src/nginx.template.conf
@@ -1,12 +1,4 @@
 http {
-    # Temporary debug logging to diagnose geolocation issue (#1831)
-    log_format ip_debug '$remote_addr - [$time_local] "$request" '
-                        'remote_addr=$remote_addr '
-                        'xff_sent=$proxy_add_x_forwarded_for '
-                        'real_ip_incoming=$http_x_real_ip '
-                        'cf_connecting_ip=$http_cf_connecting_ip';
-    access_log /dev/stdout ip_debug;
-
     # Define allowed origins - only production, staging, and localhost
     map $http_origin $cors_origin {
         default "";


### PR DESCRIPTION
# Description

Removes the temporary IP debug logging added in #2098. The logging confirmed that the Vultr Load Balancer is replacing the real client IP with its own internal IP (`95.179.136.132`) before traffic reaches ingress-nginx. The posthog-proxy config itself was fine, the real client IP is lost upstream.

## Issue

#1831

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

N/A