### PR TITLE
[Draft] Enable PROXY protocol for real client IPs (#1831)

### DIFF
--- a/apps/infra/src/k8s/ingress.ts
+++ b/apps/infra/src/k8s/ingress.ts
@@ -25,9 +25,19 @@ export const ingressNginx = new k8s.helm.v3.Release('ingress-nginx', {
         // https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes
         // https://github.com/kubernetes/ingress-nginx/issues/11176
         'strict-validate-path-type': false,
+
+        // Enable PROXY protocol so ingress-nginx can read the real client IP
+        // from the Vultr Load Balancer (which otherwise NATs the connection)
+        'use-proxy-protocol': 'true',
       },
       ingressClassResource: {
         default: 'true',
+      },
+      service: {
+        annotations: {
+          // Tell the Vultr Load Balancer to send PROXY protocol headers
+          'service.beta.kubernetes.io/vultr-loadbalancer-proxy-protocol': 'true',
+        },
       },
     },
     // This enables public connections to the airtable-sync-pg database


### PR DESCRIPTION
# Description

_This is a draft PR to document the fix, in fact I think this is not worth doing_

PostHog geolocation shows all users in Amsterdam (#1831). After investigation, it turns out the real client IP is lost at the Vultr load balancer, before it reaches our code (confirmed with this debug logging: #2098).

This could probably be fixed by enabling the [PROXY protocol](https://docs.vultr.com/how-to-use-proxy-protocol-with-vultr-load-balancers) on both sides. I'm not sure exactly how to set this up but this is what Claude thought:
- **Vultr LB: annotation**: `service.beta.kubernetes.io/vultr-loadbalancer-proxy-protocol: "true"` tells the Vultr Cloud Controller Manager to enable PROXY protocol on the load balancer
- **ingress-nginx**: config `use-proxy-protocol: "true"` tells ingress-nginx to read the PROXY protocol header to extract the real client IP

This would affect all services, and has some risk of causing downtime if there's an overlap period where one of the load balancer or ingress controller has switched to PROXY but the other hasn't. IMO this isn't worth it to resolve the geolocation issue, so I'm just putting this up to document it and then closing the issue as won't fix.

## Issue

#1831

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

N/A