### PR TITLE
Add temporary banner for Airtable outage

### DIFF
--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -29,8 +29,8 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: AppProps) => {
   const getAnnouncementBanner = () => {
     return (
       <>
-        <AnnouncementBanner hideAfter={new Date('2025-02-21T18:00:00+00:00')}>
-          <b>We're currently experiencing technical difficulties.</b> Some features (e.g. saving exercise answers, completing exercises) may not work. We're working on resolving this and will update you shortly.
+        <AnnouncementBanner hideAfter={new Date('2026-02-21T18:00:00+00:00')}>
+          <b>We're currently experiencing technical difficulties due to an outage in our database provider (Airtable).</b> Some features (e.g. saving exercises) may not work.
         </AnnouncementBanner>
         {fromSite && (
           <AnnouncementBanner ctaText="Learn more" ctaUrl="/blog/course-website-consolidation">


### PR DESCRIPTION
# Description

There is an ongoing outage causing writes to fail: https://status.airtable.com/


## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
N/A