### PR TITLE
[feat] Add teamMember table schema for Airtable sync

### DIFF
--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -32,6 +32,7 @@ export {
   resourceCompletionTable,
   facilitatorDiscussionSwitchingTable,
   dropoutTable,
+  teamMemberTable,
   testimonialTable,
 } from './schema';
 
@@ -69,6 +70,7 @@ export type {
   ResourceCompletion,
   FacilitatorSwitching,
   Dropout,
+  TeamMember,
   Testimonial,
 } from './schema';
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1316,6 +1316,18 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
   },
 });
 
+export const teamMemberTable = pgAirtable('team_member', {
+  baseId: WEB_CONTENT_BASE_ID,
+  tableId: 'tblt4A2LhdyhAcBk9',
+  columns: {
+    name: { pgColumn: text().notNull(), airtableId: 'fldjY13g0tuTPJmB3' },
+    jobTitle: { pgColumn: text().notNull(), airtableId: 'fldlJy9D63sCry5Yg' },
+    imageAttachmentUrls: { pgColumn: text(), airtableId: 'fldOo7XlA4hA1glaL' },
+    url: { pgColumn: text(), airtableId: 'fld3ChLLOQHQGDK18' },
+    status: { pgColumn: text(), airtableId: 'fld5nsgLdaDUoMC2N' },
+  },
+});
+
 export const dropoutTable = pgAirtable('dropout', {
   baseId: APPLICATIONS_BASE_ID,
   tableId: 'tblmxqYXX1RaDvunu',
@@ -1368,3 +1380,4 @@ export type User = InferSelectModel<typeof userTable.pg>;
 export type ResourceCompletion = InferSelectModel<typeof resourceCompletionTable.pg>;
 export type FacilitatorSwitching = InferSelectModel<typeof facilitatorDiscussionSwitchingTable.pg>;
 export type Dropout = InferSelectModel<typeof dropoutTable.pg>;
+export type TeamMember = InferSelectModel<typeof teamMemberTable.pg>;


### PR DESCRIPTION
## Summary
- Adds `teamMemberTable` to `@bluedot/db` schema using `pgAirtable()`, pointing at the existing team members table in the Web Content base
- Exports `teamMemberTable` and `TeamMember` type from `@bluedot/db`
- **No runtime impact** — nothing queries this table yet

## Deploy instructions
After merging, redeploy `pg-sync-service`. On startup, `ensureSchemaUpToDate()` will auto-create the `team_member` Postgres table and sync data from Airtable.

## Test plan
- [ ] Merge and redeploy pg-sync-service
- [ ] Verify `team_member` table is created in Postgres with synced data
- [ ] Then merge PR 2 (website changes) to use this data

🤖 Generated with [Claude Code](https://claude.com/claude-code)