### PR TITLE
[fix] Use permanent URLs for team member images

### DIFF
--- a/apps/website/src/server/routers/teamMembers.ts
+++ b/apps/website/src/server/routers/teamMembers.ts
@@ -22,11 +22,11 @@ export const teamMembersRouter = router({
       });
 
       return all
-        .filter((m) => m.name && getFirstImageUrl(m.imageAttachmentUrls))
+        .filter((m) => m.name && getFirstImageUrl(m.imagePublicUrls))
         .map((m) => ({
           name: m.name,
           jobTitle: m.jobTitle,
-          imageUrl: getFirstImageUrl(m.imageAttachmentUrls),
+          imageUrl: getFirstImageUrl(m.imagePublicUrls),
           url: m.url ?? undefined,
         }))
         .sort((a, b) => a.name.localeCompare(b.name));

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1323,6 +1323,7 @@ export const teamMemberTable = pgAirtable('team_member', {
     name: { pgColumn: text().notNull(), airtableId: 'fldjY13g0tuTPJmB3' },
     jobTitle: { pgColumn: text().notNull(), airtableId: 'fldlJy9D63sCry5Yg' },
     imageAttachmentUrls: { pgColumn: text(), airtableId: 'fldOo7XlA4hA1glaL' },
+    imagePublicUrls: { pgColumn: text(), airtableId: 'fldmN54i5qJObcwuN' },
     url: { pgColumn: text(), airtableId: 'fld3ChLLOQHQGDK18' },
     status: { pgColumn: text(), airtableId: 'fld5nsgLdaDUoMC2N' },
   },


### PR DESCRIPTION
## Summary
- Team member images on `/about` are broken (HTTP 410) because raw Airtable attachment URLs expire after ~2 hours
- Added `imagePublicUrls` field to `teamMemberTable` schema, syncing from MiniExtensions formula field `fldmN54i5qJObcwuN` which generates permanent public URLs
- Switched `teamMembers` router to use `imagePublicUrls` instead of `imageAttachmentUrls`

This follows the same pattern already used for testimonial images.

## Test plan
- [ ] After deploy, verify pg-sync populates the new `image_public_urls` column with `web.miniextensions.com` URLs
- [ ] Visit `/about` and confirm team member images load (network tab shows 200s)
- [ ] Check that no team members are missing from the page due to null `imagePublicUrls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)