### PR TITLE
Collapse/expand units when moving between them

### DIFF
--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -48,6 +48,10 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   const formatTime = (min: number) => (min < 60 ? `${min}min` : `${Math.floor(min / 60)}h${min % 60 ? ` ${min % 60}min` : ''}`);
 
   useEffect(() => {
+    setIsExpanded(isCurrentUnit);
+  }, [isCurrentUnit]);
+
+  useEffect(() => {
     if (isExpanded && detailsRef.current) {
       detailsRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }


### PR DESCRIPTION
# Description

- Old behaviour: Navigating between units by clicking or by arrow keys doesn't affect the expanded/collapses state
- New behaviour: Navigating to a different unit closes all other units and expands the unit you are navigating to. This happens both when clicking between them and when using arrow keys. The Issue was about arrow keys, but I thought this behaviour felt the most natural overall.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2120

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
N/A
