### PR TITLE
`eslint.useFlatConifg` should be true after eslint v9 migration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,5 @@
     "cSpell.ignoreRegExpList": [
         "(rec|tbl|app|viw|bli)[0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]{14}"
     ],
-    "eslint.useFlatConfig": false,
+    "eslint.useFlatConfig": true,
 }


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

eslint warnings no longer appear in vscode after v9 migration. This shows them again.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

NA

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA