### PR TITLE
Add /petr redirect for YouTube sponsorship tracking

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -43,6 +43,11 @@ module.exports = withDefaultBlueDotNextConfig({
         destination: '/join-us/facilitate',
         permanent: true,
       },
+      {
+        source: '/petr',
+        destination: '/?utm_source=petr&utm_medium=youtube&utm_campaign=petr',
+        permanent: false,
+      },
     ];
   },
   headers: [


### PR DESCRIPTION
## Summary
- Adds a temporary (302) redirect from `/petr` to `/?utm_source=petr&utm_medium=youtube&utm_campaign=petr`
- For attribution tracking from Petr's upcoming YouTube video mentioning BlueDot
- UTM params will be captured automatically by PostHog + GTM

## Notes
- Uses `permanent: false` (302) so the destination can be changed later (e.g. to a landing page) without browsers caching a stale redirect
- Follows the same pattern as existing redirects in `next.config.js`
- **Needs manual production deploy after merge**

## Test plan
- [ ] Run `npm run dev` in website app, visit `localhost/petr`
- [ ] Confirm 302 redirect to `/?utm_source=petr&utm_medium=youtube&utm_campaign=petr`
- [ ] After deploy: visit `bluedot.org/petr` and confirm PostHog captures UTM params

🤖 Generated with [Claude Code](https://claude.com/claude-code)