### PR TITLE
Section on removing env variable in ENV_GUIDE

### DIFF
--- a/apps/infra/ADDING_ENV_GUIDE.md
+++ b/apps/infra/ADDING_ENV_GUIDE.md
@@ -26,6 +26,8 @@ Two types of environment variables:
 
 ### Workflow Overview
 
+**Adding a variable:**
+
 ```
 PR #1 (Infra)
   Add secret to Pulumi + configure Kubernetes
@@ -38,6 +40,20 @@ PR #2 (Code)
   Merge → service deploys + pods restart automatically
   Feature goes live
 ```
+
+**Removing a variable** (reverse order!):
+
+```
+PR #1 (Code)
+  Remove from validateEnv + remove usage from code
+  Merge → service deploys, pod no longer expects the variable
+        ↓
+PR #2 (Infra)
+  Remove from serviceDefinitions.ts (+ secrets.ts/Pulumi if secret)
+  Merge → infra deploys
+```
+
+If you remove from infra first, pods will crash on restart because the code still expects the variable.
 
 ---
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Adds 'Removing a variable' workflow to `ADDING_ENV_GUIDE`.

We had an outage because I removed a bunch of inactive uses of `INFO_SLACK_CHANNEL_ID` in #2150. However, I made backend changes to remove the variable defn at the same time as I removed the variable from `validateEnv`. This led to ~6 mins where the website threw an error about an unset env variable because the pod has been restarted with old code that still expected the variable to be set.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

NA

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA