### PR TITLE
Return `null` instead of throwing if no course registration found

### DIFF
--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -98,7 +98,7 @@ export const groupDiscussionsRouter = router({
       });
 
       if (!courseRegistration) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Course registration not found' });
+        return null;
       }
 
       const participant = await db.getFirst(meetPersonTable, {


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

This prevents an error being shown for users who are simply browsing courses they are not registered for. `getByCourseSlug` was throwing a `NOT_FOUND` error when a signed-in user visited a course they weren't registered for. This is expected behavior (not an error), so the procedure now returns `null` instead. The frontend already handles a nullish result by not rendering the group discussion banner.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2156

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="1186" height="792" alt="image" src="https://github.com/user-attachments/assets/bda966dd-d264-46e6-a248-44f9e9d29797" /> | <img width="1180" height="805" alt="image" src="https://github.com/user-attachments/assets/52bb39e1-8d07-4f52-8e54-fe6ac1210a3a" /> |
