### PR TITLE
Add visible job title heading to editor page

### DIFF
--- a/apps/editor/src/pages/jobs/[slug].tsx
+++ b/apps/editor/src/pages/jobs/[slug].tsx
@@ -1,6 +1,6 @@
 import {
   ErrorSection,
-  P, A,
+  H2, P, A,
   ProgressDots,
   withAuth,
 } from '@bluedot/ui';
@@ -53,6 +53,7 @@ const JobPostPage = withAuth(({ auth }) => {
       <Head>
         <title>{`${data.job.title} | BlueDot Editor`}</title>
       </Head>
+      <H2>{data.job.title}</H2>
       <BodyEditor auth={auth} onSave={saveJob}>
         {data.job.body ?? undefined}
       </BodyEditor>


### PR DESCRIPTION
## Summary
- The job editor page (`/jobs/[slug]`) only showed the job title in the browser tab — no visible heading on the page itself
- Added an `H2` with the job title between the `<Head>` block and `<BodyEditor>`, so editors can see which job they're editing

## Test plan
- [ ] Navigate to `/jobs/head-of-talent` (or any job slug) and confirm the title appears as a heading above the editor
- [ ] Confirm save and "Return to Airtable" link still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)