### PR TITLE
Increase hook timeout for pg-sync

### DIFF
--- a/apps/pg-sync-service/vitest.config.mjs
+++ b/apps/pg-sync-service/vitest.config.mjs
@@ -3,5 +3,6 @@ import { withDefaultBlueDotVitestConfig } from '@bluedot/utils/src/default-confi
 export default withDefaultBlueDotVitestConfig({
   test: {
     setupFiles: ['./src/test-setup.ts'],
+    hookTimeout: 60_000,
   },
 });


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Increase hook timeout for pg-sync. In https://github.com/bluedotimpact/bluedot/pull/2168 we updated our `package-lock.json`, causing all packages to be marked as changed.

This is a temporary fix. We should probably have a global setup that runs in its own worker that ensures the schema is up to date.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

NA

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->
