### PR TITLE
Halve event photo heights on desktop

### DIFF
--- a/apps/website/src/components/homepage/EventsSection.tsx
+++ b/apps/website/src/components/homepage/EventsSection.tsx
@@ -362,7 +362,7 @@ const PhotoCarousel = ({ photos }: { photos: Photo[] }) => {
               <img
                 src={photo.src}
                 alt={photo.alt}
-                className="h-[240px] min-[680px]:h-[300px] min-[1024px]:h-[385px] rounded-xl min-[1024px]:rounded-xl border border-bluedot-navy/10 object-cover object-center"
+                className="h-[240px] min-[680px]:h-[150px] min-[1024px]:h-[193px] rounded-xl min-[1024px]:rounded-xl border border-bluedot-navy/10 object-cover object-center"
                 style={{ width: `${photo.width}px` }}
               />
             </a>


### PR DESCRIPTION
## Summary
- Halve event carousel image heights at tablet (300→150px) and desktop (385→193px) breakpoints
- Mobile height (240px) unchanged

## Test plan
- [ ] Check landing page "Join an event near you" section at desktop width — images should be ~half previous height
- [ ] Check at mobile width — images should remain 240px tall

🤖 Generated with [Claude Code](https://claude.com/claude-code)