### PR TITLE
Filter out private Luma events

### DIFF
--- a/apps/website/src/server/routers/luma-utils.ts
+++ b/apps/website/src/server/routers/luma-utils.ts
@@ -1,0 +1,15 @@
+export type LumaEvent = {
+  name: string;
+  start_at: string; // ISO 8601 Datetime, already in UTC
+  end_at: string; // ISO 8601 Datetime, already in UTC
+  visibility?: string;
+  geo_address_json?: {
+    city?: string;
+  };
+  timezone: string; // IANA timezone, e.g. "America/New_York"
+  url: string;
+};
+
+export function isPublicLumaEvent(event: LumaEvent) {
+  return event.visibility?.toLowerCase() === 'public';
+}

--- a/apps/website/src/server/routers/luma.test.ts
+++ b/apps/website/src/server/routers/luma.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import { isPublicLumaEvent } from './luma-utils';
+
+describe('isPublicLumaEvent', () => {
+  test('returns true for public events', () => {
+    expect(isPublicLumaEvent({
+      name: 'Public event',
+      start_at: '2026-03-18T15:00:00Z',
+      end_at: '2026-03-18T16:00:00Z',
+      timezone: 'UTC',
+      url: 'https://lu.ma/public-event',
+      visibility: 'public',
+    })).toBe(true);
+  });
+
+  test('returns false for private events', () => {
+    expect(isPublicLumaEvent({
+      name: 'Private event',
+      start_at: '2026-03-18T15:00:00Z',
+      end_at: '2026-03-18T16:00:00Z',
+      timezone: 'UTC',
+      url: 'https://lu.ma/private-event',
+      visibility: 'private',
+    })).toBe(false);
+  });
+
+  test('returns false when visibility is missing', () => {
+    expect(isPublicLumaEvent({
+      name: 'Unknown visibility event',
+      start_at: '2026-03-18T15:00:00Z',
+      end_at: '2026-03-18T16:00:00Z',
+      timezone: 'UTC',
+      url: 'https://lu.ma/unknown-event',
+    })).toBe(false);
+  });
+});

--- a/apps/website/src/server/routers/luma.ts
+++ b/apps/website/src/server/routers/luma.ts
@@ -2,22 +2,12 @@ import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import { publicProcedure, router } from '../trpc';
 import env from '../../lib/api/env';
 import { ONE_MINUTE_MS } from '../../lib/constants';
+import { isPublicLumaEvent, type LumaEvent } from './luma-utils';
 
 // In-memory cache for Luma API responses - reduces API calls, improves response time, and handles intermittent API failures
 const CACHE_TTL_MS = ONE_MINUTE_MS;
 const FAILURE_THRESHOLD = 3; // Alert after N consecutive failures
 const EXCLUDED_EVENT_TITLE_SUFFIXES = ['paper reading club', 'paper reading group'];
-
-type LumaEvent = {
-  name: string;
-  start_at: string; // ISO 8601 Datetime, already in UTC
-  end_at: string; // ISO 8601 Datetime, already in UTC
-  geo_address_json?: {
-    city?: string;
-  };
-  timezone: string; // IANA timezone, e.g. "America/New_York"
-  url: string;
-};
 
 function transformEvent(api_id: string, event: LumaEvent) {
   return {
@@ -113,6 +103,7 @@ async function refreshCache(): Promise<Event[]> {
       };
 
       const events = (data.entries || [])
+        .filter(({ event }) => isPublicLumaEvent(event))
         .map(({ api_id, event }) => transformEvent(api_id, event))
         .filter((event) => {
           const titleLower = event.title.toLowerCase();


### PR DESCRIPTION
## Summary
- filter Luma calendar events to only include items with `visibility` set to `public`
- move the visibility check into a small helper for targeted coverage
- add a focused test for public, private, and missing-visibility cases

## Verification
- npm run test --workspace @bluedot/website -- src/server/routers/luma.test.ts
- verified the local app tRPC route returned a public-only event list while the upstream Luma API still returned both `public` and `private` events
