### PR TITLE
env vars for ALERTS_SLACK_CHANNEL_ID, ALERTS_SLACK_BOT_TOKEN

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -218,6 +218,8 @@ export const services: ServiceDefinition[] = [
         env: [
           { name: 'AIRTABLE_PERSONAL_ACCESS_TOKEN', valueFrom: envVarSources.airtablePat },
           { name: 'PG_URL', valueFrom: getConnectionDetails(airtableSyncPg).uri },
+          { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
+          { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
         ],
       }],
     },

--- a/apps/speed-review/src/lib/api/env.ts
+++ b/apps/speed-review/src/lib/api/env.ts
@@ -5,6 +5,8 @@ const env = validateEnv({
     'APP_NAME',
     'AIRTABLE_PERSONAL_ACCESS_TOKEN',
     'PG_URL',
+    'ALERTS_SLACK_CHANNEL_ID',
+    'ALERTS_SLACK_BOT_TOKEN',
   ],
 });
 

--- a/apps/speed-review/src/lib/api/makeApiRoute.ts
+++ b/apps/speed-review/src/lib/api/makeApiRoute.ts
@@ -3,10 +3,6 @@ import { makeMakeApiRoute } from '@bluedot/ui/src/api';
 import env from './env';
 
 export const makeApiRoute = makeMakeApiRoute({
-  env: {
-    ...env,
-    ALERTS_SLACK_BOT_TOKEN: '',
-    ALERTS_SLACK_CHANNEL_ID: '',
-  },
+  env,
   verifyAndDecodeToken: loginPresets.keycloak.verifyAndDecodeToken,
 });


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

The `speed-review` app imports many things from @bluedot/db which in turn calls `validateEnv` with the following variables:

```
    'APP_NAME',
    'PG_URL',
    'AIRTABLE_PERSONAL_ACCESS_TOKEN',
    'ALERTS_SLACK_CHANNEL_ID',
    'ALERTS_SLACK_BOT_TOKEN',
```

Since 'ALERTS_SLACK_CHANNEL_ID' and 'ALERTS_SLACK_BOT_TOKEN' were not included in the service definition for the app it is crashing.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

NA
<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
