### PR TITLE
Update start-here copy on homepage

### DIFF
--- a/apps/website/src/components/homepage/CourseSection.tsx
+++ b/apps/website/src/components/homepage/CourseSection.tsx
@@ -431,9 +431,9 @@ const CourseCardsGrid = ({
   otherCourses: Course[];
 }) => (
   <div className="hidden lg:flex flex-col items-center gap-8 w-full max-w-screen-xl mx-auto">
-    {/* "Start here" heading */}
-    <P className="text-[14px] font-medium uppercase tracking-[1.5px] text-bluedot-navy/60">
-      Start here
+    {/* "New to AI Safety? Start here" heading */}
+    <P className="text-[14px] font-medium tracking-[1.5px] text-bluedot-navy/60">
+      New to AI Safety? Start here
     </P>
 
     {/* Featured AGI Strategy card - centered, ~50% width */}
@@ -571,11 +571,6 @@ const CourseTags = ({ course }: { course: Course }) => {
           {tag}
         </span>
       ))}
-      {course.isFeatured && (
-        <span className="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]">
-          Start here
-        </span>
-      )}
     </div>
   );
 };

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -151,9 +151,9 @@ exports[`CourseSection > renders as expected 1`] = `
           class="hidden lg:flex flex-col items-center gap-8 w-full max-w-screen-xl mx-auto"
         >
           <p
-            class="bluedot-p not-prose text-[14px] font-medium uppercase tracking-[1.5px] text-bluedot-navy/60"
+            class="bluedot-p not-prose text-[14px] font-medium tracking-[1.5px] text-bluedot-navy/60"
           >
-            Start here
+            New to AI Safety? Start here
           </p>
           <div
             class="w-full max-w-[50%]"
@@ -228,11 +228,6 @@ exports[`CourseSection > renders as expected 1`] = `
                         class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white/5 border border-white/30 backdrop-blur-[10px] text-white"
                       >
                         Every month
-                      </span>
-                      <span
-                        class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]"
-                      >
-                        Start here
                       </span>
                     </div>
                   </div>
@@ -583,11 +578,6 @@ exports[`CourseSection > renders as expected 1`] = `
                         >
                           Every month
                         </span>
-                        <span
-                          class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]"
-                        >
-                          Start here
-                        </span>
                       </div>
                     </div>
                   </div>
@@ -892,11 +882,6 @@ exports[`CourseSection > renders as expected 1`] = `
                         >
                           Every month
                         </span>
-                        <span
-                          class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]"
-                        >
-                          Start here
-                        </span>
                       </div>
                     </div>
                   </div>
@@ -1200,11 +1185,6 @@ exports[`CourseSection > renders as expected 1`] = `
                           class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white/5 border border-white/30 backdrop-blur-[10px] text-white"
                         >
                           Every month
-                        </span>
-                        <span
-                          class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]"
-                        >
-                          Start here
                         </span>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Changed "START HERE" heading above the featured course to "New to AI Safety? Start here" (mixed case, no longer uppercase)
- Removed the "Start here" badge from inside the AGI strategy course tile

## Test plan
- [ ] Verify homepage renders correctly with the new heading text
- [ ] Confirm the featured course tile no longer shows the "Start here" badge
- [ ] Check snapshot test updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)