### PR TITLE
Fix drizzle-kit bundling breaking Next.js API routes

### DIFF
--- a/apps/website/src/components/homepage/CourseSection.tsx
+++ b/apps/website/src/components/homepage/CourseSection.tsx
@@ -431,8 +431,8 @@ const CourseCardsGrid = ({
   otherCourses: Course[];
 }) => (
   <div className="hidden lg:flex flex-col items-center gap-8 w-full max-w-screen-xl mx-auto">
-    {/* "New to AI Safety? Start here" heading */}
-    <P className="text-[14px] font-medium tracking-[1.5px] text-bluedot-navy/60">
+    {/* "NEW TO AI SAFETY? START HERE" heading */}
+    <P className="text-[14px] font-medium uppercase tracking-[1.5px] text-bluedot-navy/60">
       New to AI Safety? Start here
     </P>
 
@@ -455,9 +455,9 @@ const CourseCardsGrid = ({
       </svg>
     </div>
 
-    {/* "Deep-dives" heading */}
+    {/* "Ready to contribute?" heading */}
     <P className="text-[14px] font-medium uppercase tracking-[1.5px] text-bluedot-navy/60">
-      Deep-dives
+      Ready to contribute?
     </P>
 
     {/* 3 deep-dive cards in a row */}

--- a/apps/website/src/components/homepage/CourseSection.tsx
+++ b/apps/website/src/components/homepage/CourseSection.tsx
@@ -431,9 +431,9 @@ const CourseCardsGrid = ({
   otherCourses: Course[];
 }) => (
   <div className="hidden lg:flex flex-col items-center gap-8 w-full max-w-screen-xl mx-auto">
-    {/* "Start here" heading */}
-    <P className="text-[14px] font-medium uppercase tracking-[1.5px] text-bluedot-navy/60">
-      Start here
+    {/* "New to AI Safety? Start here" heading */}
+    <P className="text-[14px] font-medium tracking-[1.5px] text-bluedot-navy/60">
+      New to AI Safety? Start here
     </P>
 
     {/* Featured AGI Strategy card - centered, ~50% width */}
@@ -571,11 +571,6 @@ const CourseTags = ({ course }: { course: Course }) => {
           {tag}
         </span>
       ))}
-      {course.isFeatured && (
-        <span className="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]">
-          Start here
-        </span>
-      )}
     </div>
   );
 };

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`CourseSection > renders as expected 1`] = `
           class="hidden lg:flex flex-col items-center gap-8 w-full max-w-screen-xl mx-auto"
         >
           <p
-            class="bluedot-p not-prose text-[14px] font-medium tracking-[1.5px] text-bluedot-navy/60"
+            class="bluedot-p not-prose text-[14px] font-medium uppercase tracking-[1.5px] text-bluedot-navy/60"
           >
             New to AI Safety? Start here
           </p>
@@ -259,7 +259,7 @@ exports[`CourseSection > renders as expected 1`] = `
           <p
             class="bluedot-p not-prose text-[14px] font-medium uppercase tracking-[1.5px] text-bluedot-navy/60"
           >
-            Deep-dives
+            Ready to contribute?
           </p>
           <div
             class="grid grid-cols-3 gap-8 w-full"

--- a/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/CourseSection.test.tsx.snap
@@ -151,9 +151,9 @@ exports[`CourseSection > renders as expected 1`] = `
           class="hidden lg:flex flex-col items-center gap-8 w-full max-w-screen-xl mx-auto"
         >
           <p
-            class="bluedot-p not-prose text-[14px] font-medium uppercase tracking-[1.5px] text-bluedot-navy/60"
+            class="bluedot-p not-prose text-[14px] font-medium tracking-[1.5px] text-bluedot-navy/60"
           >
-            Start here
+            New to AI Safety? Start here
           </p>
           <div
             class="w-full max-w-[50%]"
@@ -228,11 +228,6 @@ exports[`CourseSection > renders as expected 1`] = `
                         class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white/5 border border-white/30 backdrop-blur-[10px] text-white"
                       >
                         Every month
-                      </span>
-                      <span
-                        class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]"
-                      >
-                        Start here
                       </span>
                     </div>
                   </div>
@@ -583,11 +578,6 @@ exports[`CourseSection > renders as expected 1`] = `
                         >
                           Every month
                         </span>
-                        <span
-                          class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]"
-                        >
-                          Start here
-                        </span>
                       </div>
                     </div>
                   </div>
@@ -892,11 +882,6 @@ exports[`CourseSection > renders as expected 1`] = `
                         >
                           Every month
                         </span>
-                        <span
-                          class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]"
-                        >
-                          Start here
-                        </span>
                       </div>
                     </div>
                   </div>
@@ -1200,11 +1185,6 @@ exports[`CourseSection > renders as expected 1`] = `
                           class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white/5 border border-white/30 backdrop-blur-[10px] text-white"
                         >
                           Every month
-                        </span>
-                        <span
-                          class="px-[10px] py-[5px] text-[10px] font-medium leading-[1.4] tracking-[0.5px] uppercase rounded bg-white text-[#001140]"
-                        >
-                          Start here
                         </span>
                       </div>
                     </div>

--- a/libraries/db/src/lib/test-db.ts
+++ b/libraries/db/src/lib/test-db.ts
@@ -4,8 +4,6 @@ import { drizzle } from 'drizzle-orm/pglite';
 import {
   type Table, getTableName, isTable, sql,
 } from 'drizzle-orm';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { pushSchema } from 'drizzle-kit/api';
 import { type PgAirtableDb, type PgDatabase } from './client';
 import { MockAirtableTs } from './mock-airtable-ts';
 import { PgAirtableTable } from './db-core';
@@ -48,6 +46,9 @@ function collectPgTables() {
 }
 
 export async function pushTestSchema(db: PgAirtableDb): Promise<void> {
+  // Dynamic import to avoid bundling drizzle-kit (which requires 'fs') into Next.js server bundles
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  const { pushSchema } = await import('drizzle-kit/api');
   const pgTables = collectPgTables();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { apply } = await pushSchema(pgTables, db.pg as any);

--- a/libraries/db/src/lib/test-db.ts
+++ b/libraries/db/src/lib/test-db.ts
@@ -4,6 +4,8 @@ import { drizzle } from 'drizzle-orm/pglite';
 import {
   type Table, getTableName, isTable, sql,
 } from 'drizzle-orm';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { pushSchema } from 'drizzle-kit/api';
 import { type PgAirtableDb, type PgDatabase } from './client';
 import { MockAirtableTs } from './mock-airtable-ts';
 import { PgAirtableTable } from './db-core';
@@ -46,9 +48,6 @@ function collectPgTables() {
 }
 
 export async function pushTestSchema(db: PgAirtableDb): Promise<void> {
-  // Dynamic import to avoid bundling drizzle-kit (which requires 'fs') into Next.js server bundles
-  // eslint-disable-next-line import/no-extraneous-dependencies
-  const { pushSchema } = await import('drizzle-kit/api');
   const pgTables = collectPgTables();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { apply } = await pushSchema(pgTables, db.pg as any);


### PR DESCRIPTION
## Summary
- Moved `drizzle-kit/api` from a static top-level import to a dynamic `import()` inside `pushTestSchema()` in `@bluedot/db`
- This prevents drizzle-kit (which uses `require('fs')`) from being bundled into the Next.js server runtime, where dynamic requires aren't supported
- Root cause: `@bluedot/db` re-exports test utilities from its main entry point, and `test-db.ts` statically imported `drizzle-kit/api`

## Test plan
- [x] `next build` succeeds (was failing with `Dynamic require of "fs" is not supported`)
- [ ] Dev server serves API routes without 500 errors
- [ ] Tests that use `pushTestSchema()` still work (dynamic import is functionally equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)