### PR TITLE
Clean up homepage and footer events links

### DIFF
--- a/apps/website/src/components/homepage/EventsSection.test.tsx
+++ b/apps/website/src/components/homepage/EventsSection.test.tsx
@@ -309,7 +309,7 @@ describe('buildTimeDeltaString', () => {
   });
 });
 
-describe('EventsSection featured events', () => {
+describe('EventsSection', () => {
   const mockEvents: Event[] = [
     {
       id: 'event-1',
@@ -331,7 +331,7 @@ describe('EventsSection featured events', () => {
     },
     {
       id: 'event-3',
-      title: 'Third Chronologically - Featured',
+      title: 'Third Chronologically',
       startAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(),
       endAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000).toISOString(),
       location: 'NEW YORK',
@@ -366,8 +366,8 @@ describe('EventsSection featured events', () => {
     return Array.from(headings).map((h) => h.textContent || '');
   };
 
-  test('displays events in chronological order when no featured URLs provided', async () => {
-    const { container } = render(<EventsSection featuredUrls={[]} />, { wrapper: TrpcProvider });
+  test('displays events in chronological order', async () => {
+    const { container } = render(<EventsSection />, { wrapper: TrpcProvider });
 
     await waitFor(() => {
       expect(screen.getAllByText('First Chronologically').length).toBeGreaterThan(0);
@@ -377,60 +377,19 @@ describe('EventsSection featured events', () => {
     expect(titles).toEqual([
       'First Chronologically',
       'Second Chronologically',
-      'Third Chronologically - Featured',
+      'Third Chronologically',
       'Fourth Chronologically',
     ]);
   });
 
-  test('displays featured event first when featuredUrls is provided', async () => {
-    const { container } = render(
-      <EventsSection featuredUrls={['https://lu.ma/event-3']} />,
-      { wrapper: TrpcProvider },
-    );
-
-    await waitFor(() => {
-      expect(screen.getAllByText('Third Chronologically - Featured').length).toBeGreaterThan(0);
-    });
-
-    const titles = getDesktopEventTitles(container);
-    expect(titles).toEqual([
-      'Third Chronologically - Featured',
-      'First Chronologically',
-      'Second Chronologically',
-      'Fourth Chronologically',
-    ]);
-  });
-
-  test('handles URL normalization (trailing slashes)', async () => {
-    const { container } = render(
-      <EventsSection featuredUrls={['https://lu.ma/event-3/']} />,
-      { wrapper: TrpcProvider },
-    );
-
-    await waitFor(() => {
-      expect(screen.getAllByText('Third Chronologically - Featured').length).toBeGreaterThan(0);
-    });
-
-    const titles = getDesktopEventTitles(container);
-    expect(titles[0]).toBe('Third Chronologically - Featured');
-  });
-
-  test('preserves order of multiple featured events as specified in featuredUrls', async () => {
-    const { container } = render(
-      <EventsSection featuredUrls={['https://lu.ma/event-4', 'https://lu.ma/event-2']} />,
-      { wrapper: TrpcProvider },
-    );
+  test('shows the first four upcoming events', async () => {
+    const { container } = render(<EventsSection />, { wrapper: TrpcProvider });
 
     await waitFor(() => {
       expect(screen.getAllByText('Fourth Chronologically').length).toBeGreaterThan(0);
     });
 
     const titles = getDesktopEventTitles(container);
-    expect(titles).toEqual([
-      'Fourth Chronologically',
-      'Second Chronologically',
-      'First Chronologically',
-      'Third Chronologically - Featured',
-    ]);
+    expect(titles).toHaveLength(4);
   });
 });

--- a/apps/website/src/components/homepage/EventsSection.tsx
+++ b/apps/website/src/components/homepage/EventsSection.tsx
@@ -10,23 +10,6 @@ import { trpc } from '../../utils/trpc';
 import { ROUTES } from '../../lib/routes';
 import type { Event } from '../../server/routers/luma';
 
-// Featured events - these will appear first (if not yet passed)
-// Add Luma event URLs here to prioritize them (e.g., 'https://lu.ma/your-event-slug')
-const FEATURED_EVENT_URLS: string[] = [
-  // Example:
-  // 'https://lu.ma/b5i3zi74',
-];
-
-// Normalize URL for comparison (removes trailing slashes, query params, standardizes protocol)
-const normalizeUrl = (url: string): string => {
-  try {
-    const parsed = new URL(url);
-    return `${parsed.protocol}//${parsed.host}${parsed.pathname.replace(/\/$/, '')}`.toLowerCase();
-  } catch {
-    return url.toLowerCase().replace(/\/$/, '');
-  }
-};
-
 type Photo = {
   id: string;
   src: string;
@@ -317,41 +300,9 @@ const PhotoCarousel = ({ photos }: { photos: Photo[] }) => {
   );
 };
 
-/** Sorts events with featured URLs first, preserving the order specified in featuredUrls */
-const sortEventsWithFeaturedUrls = (events: Event[], featuredUrls: string[]): Event[] => {
-  if (featuredUrls.length === 0) {
-    return events;
-  }
-
-  const normalizedFeaturedUrls = featuredUrls.map(normalizeUrl);
-  const featuredEvents: Event[] = [];
-  const regularEvents: Event[] = [];
-
-  for (const event of events) {
-    const normalizedEventUrl = normalizeUrl(event.url);
-    if (normalizedFeaturedUrls.includes(normalizedEventUrl)) {
-      featuredEvents.push(event);
-    } else {
-      regularEvents.push(event);
-    }
-  }
-
-  // Featured events first (in the order they appear in featuredUrls),
-  // then remaining events in their original chronological order
-  const sortedFeatured = featuredEvents.sort((a, b) => normalizedFeaturedUrls.indexOf(normalizeUrl(a.url)) - normalizedFeaturedUrls.indexOf(normalizeUrl(b.url)));
-
-  return [...sortedFeatured, ...regularEvents];
-};
-
-type EventsSectionProps = {
-  featuredUrls?: string[];
-};
-
-const EventsSection = ({ featuredUrls = FEATURED_EVENT_URLS }: EventsSectionProps) => {
+const EventsSection = () => {
   const { data: events, isLoading } = trpc.luma.getUpcomingEvents.useQuery();
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const sortedEvents = sortEventsWithFeaturedUrls(events || [], featuredUrls);
-  const displayEvents = sortedEvents.slice(0, 4);
+  const displayEvents = (events ?? []).slice(0, 4);
 
   return (
     <section

--- a/libraries/ui/src/Footer.tsx
+++ b/libraries/ui/src/Footer.tsx
@@ -93,7 +93,7 @@ export const Footer: React.FC<FooterProps> = ({
 
   const resourceLinks: FooterLinkItem[] = [
     { url: 'https://blog.bluedot.org', label: 'Blog', target: '_blank' },
-    { url: 'https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer', label: 'Events', target: '_blank' },
+    { url: '/events?utm_source=website&utm_campaign=footer', label: 'Events' },
     { url: '/grants', label: 'Grants' },
     { url: '/privacy-policy', label: 'Privacy Policy' },
     ...(onReportBug ? [{ onClick: onReportBug, label: 'Report a bug' }] : []),

--- a/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
@@ -114,10 +114,8 @@ exports[`Footer > renders default as expected 1`] = `
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>
@@ -232,10 +230,8 @@ exports[`Footer > renders default as expected 1`] = `
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>
@@ -431,10 +427,8 @@ exports[`Footer > renders default as expected 1`] = `
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>
@@ -700,10 +694,8 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>
@@ -826,10 +818,8 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>
@@ -1033,10 +1023,8 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>
@@ -1310,10 +1298,8 @@ exports[`Footer > renders with optional args 1`] = `
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>
@@ -1428,10 +1414,8 @@ exports[`Footer > renders with optional args 1`] = `
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>
@@ -1627,10 +1611,8 @@ exports[`Footer > renders with optional args 1`] = `
               <li>
                 <a
                   class="bluedot-a not-prose text-size-sm leading-[19px] text-[#CCD7FF] hover:text-white no-underline font-normal"
-                  href="https://luma.com/bluedotevents?utm_source=website&utm_campaign=footer"
-                  rel="noopener noreferrer"
+                  href="/events?utm_source=website&utm_campaign=footer"
                   tabindex="0"
-                  target="_blank"
                 >
                   Events
                 </a>


### PR DESCRIPTION
- EventsSection.tsx now just uses the same chronological getUpcomingEvents feed as /events, with no featured URL override logic.
- Footer.tsx now points Events to /events?utm_source=website&utm_campaign=footer instead of Luma, and we refreshed Footer.test.tsx.snap.