### PR TITLE
User impersonation: Show all available users, not just ones with 'test' in the name

### DIFF
--- a/apps/website/src/components/admin/UserSearchModal.tsx
+++ b/apps/website/src/components/admin/UserSearchModal.tsx
@@ -23,9 +23,9 @@ export const UserSearchModal = ({
     }
   }, [isOpen]);
 
-  const searchTerm = searchTermInput.trim() || 'test'; // Fallback to 'test' to show recently used test users
+  const searchTerm = searchTermInput.trim();
   const { data: searchResults, isLoading, error } = trpc.admin.searchUsers.useQuery(
-    { searchTerm },
+    { searchTerm: searchTerm || undefined },
     { enabled: isOpen },
   );
 

--- a/apps/website/src/server/routers/admin.ts
+++ b/apps/website/src/server/routers/admin.ts
@@ -36,41 +36,20 @@ export const adminRouter = router({
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const trimmedSearchTerm = (input.searchTerm || '').trim();
 
-      if (access === 'admin') {
-        // Admins get full user search
-        let whereClause;
-        if (!trimmedSearchTerm) {
-          whereClause = sql`TRUE`;
-        } else {
-          const pattern = `%${trimmedSearchTerm}%`;
-          whereClause = sql`(u.email ILIKE ${pattern} OR u.name ILIKE ${pattern})`;
-        }
+      // Build WHERE clause: scoped users are restricted to their allowed targets
+      const scopeClause = access === 'scoped'
+        ? sql`u.id IN (${sql.join(allowedTargets.map((id) => sql`${id}`), sql`, `)})`
+        : sql`TRUE`;
 
-        const results = await db.pg.execute(sql`
-          SELECT
-            u.id,
-            u.email,
-            u.name,
-            u."lastSeenAt",
-            COALESCE(
-              (SELECT COUNT(*)
-               FROM ${courseRegistrationTable.pg} cr
-               WHERE cr.email = u.email AND (cr."certificateId" IS NOT NULL OR cr.decision = 'Accepted')),
-              0
-            )::int AS "courseCount"
-          FROM ${userTable.pg} u
-          WHERE ${whereClause}
-          ORDER BY
-            CASE WHEN LOWER(u.email) = LOWER(${trimmedSearchTerm}) THEN 0 ELSE 1 END,
-            u."lastSeenAt" DESC NULLS LAST
-          LIMIT 20
-        `);
+      const searchClause = trimmedSearchTerm
+        ? sql`(u.email ILIKE ${`%${trimmedSearchTerm}%`} OR u.name ILIKE ${`%${trimmedSearchTerm}%`})`
+        : sql`TRUE`;
 
-        return results.rows as UserSearchResult[];
-      }
+      // When searching, sort exact email matches first; otherwise sort test users first
+      const orderClause = trimmedSearchTerm
+        ? sql`CASE WHEN LOWER(u.email) = LOWER(${trimmedSearchTerm}) THEN 0 ELSE 1 END, u."lastSeenAt" DESC NULLS LAST`
+        : sql`CASE WHEN u.email ILIKE '%test%' OR u.name ILIKE '%test%' THEN 0 ELSE 1 END, u."lastSeenAt" DESC NULLS LAST`;
 
-      // Scoped users: return only their allowed targets, with optional name/email filtering
-      const idList = sql.join(allowedTargets.map((id) => sql`${id}`), sql`, `);
       const results = await db.pg.execute(sql`
         SELECT
           u.id,
@@ -84,9 +63,9 @@ export const adminRouter = router({
             0
           )::int AS "courseCount"
         FROM ${userTable.pg} u
-        WHERE u.id IN (${idList})
-        ${trimmedSearchTerm ? sql`AND (u.email ILIKE ${`%${trimmedSearchTerm}%`} OR u.name ILIKE ${`%${trimmedSearchTerm}%`})` : sql``}
-        ORDER BY u.name ASC NULLS LAST
+        WHERE ${scopeClause} AND ${searchClause}
+        ORDER BY ${orderClause}
+        LIMIT 20
       `);
 
       return results.rows as UserSearchResult[];


### PR DESCRIPTION
# Description

Previously, when there was no search term, it would just show all users with 'test' in the name. Now we support a specific scoped list of users, this is confusing because it doesn't show all that are available. I've updated it to sort the ones with 'test' first, but then show all available if there are more beyond that.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

N/A