### PR TITLE
feat(db): add course and peer feedback tables to schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ core
 .cursorrules
 CLAUDE.md
 .claude/
+plan.md

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -41,6 +41,8 @@ export {
   testimonialTable,
   grantTable,
   bugReportsTable,
+  courseFeedbackTable,
+  peerFeedbackTable,
 } from './schema';
 
 // Type exports
@@ -81,6 +83,8 @@ export type {
   Testimonial,
   Grant,
   BugReport,
+  CourseFeedback,
+  PeerFeedback,
 } from './schema';
 
 export { getPgAirtableFromIds, PgAirtableTable } from './lib/db-core';

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1419,6 +1419,65 @@ export const bugReportsTable = pgAirtable('bug_reports', {
   },
 });
 
+// Course feedback tables
+export const courseFeedbackTable = pgAirtable('course_feedback', {
+  baseId: COURSE_RUNNER_BASE_ID,
+  tableId: 'tblRFqRF2tKAqh7sp',
+  columns: {
+    person: {
+      pgColumn: text().array(),
+      airtableId: 'fldG4l1tLMXcvoLXB',
+    },
+    round: {
+      pgColumn: text().array(),
+      airtableId: 'fldUrmIIPpfew5KIL',
+    },
+    courseRating: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fld90CnlNH6osIEhm',
+    },
+    courseValue: {
+      pgColumn: text(),
+      airtableId: 'fldhPd7BmdhlG2QKl',
+    },
+    improvements: {
+      pgColumn: text(),
+      airtableId: 'fldi82s0kEUrkhsaM',
+    },
+    completed: {
+      pgColumn: boolean(),
+      airtableId: 'fldwjYVkgTT8407U0',
+    },
+  },
+});
+
+export const peerFeedbackTable = pgAirtable('peer_feedback', {
+  baseId: COURSE_RUNNER_BASE_ID,
+  tableId: 'tbl8KC4Q1i5YlCGhm',
+  columns: {
+    courseFeedback: {
+      pgColumn: text().array(),
+      airtableId: 'fldbxDhfPqnvyFmmf',
+    },
+    feedbackRecipient: {
+      pgColumn: text().array(),
+      airtableId: 'fldnHEXJ0HMDJgiEM',
+    },
+    reasoningQualityRating: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldNXTpmIxyKvYdZH',
+    },
+    initiativeRating: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldUBSY6rZ1Oyf1bd',
+    },
+    feedback: {
+      pgColumn: text(),
+      airtableId: 'fldybGPKyRUcM0D84',
+    },
+  },
+});
+
 // Type exports for all tables
 export type Meta = InferSelectModel<typeof metaTable>;
 export type SyncMetadata = InferSelectModel<typeof syncMetadataTable>;
@@ -1455,3 +1514,5 @@ export type FacilitatorSwitching = InferSelectModel<typeof facilitatorDiscussion
 export type Dropout = InferSelectModel<typeof dropoutTable.pg>;
 export type TeamMember = InferSelectModel<typeof teamMemberTable.pg>;
 export type BugReport = InferSelectModel<typeof bugReportsTable.pg>;
+export type CourseFeedback = InferSelectModel<typeof courseFeedbackTable.pg>;
+export type PeerFeedback = InferSelectModel<typeof peerFeedbackTable.pg>;


### PR DESCRIPTION
Add courseFeedbackTable and peerFeedbackTable to the database schema with their respective Airtable mappings. These tables will store participant feedback on courses and peer evaluations. Also update .gitignore to exclude plan.md file.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
