### PR TITLE
[codex] Add calendar downloads for course discussions

### DIFF
--- a/apps/website/src/__tests__/pages/api/calendar/discussions/[discussionId].test.ts
+++ b/apps/website/src/__tests__/pages/api/calendar/discussions/[discussionId].test.ts
@@ -1,0 +1,184 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  createMockCourseRegistration,
+  createMockGroupDiscussion,
+  createMockMeetPerson,
+  createMockUnit,
+} from '../../../../testUtils';
+import { ONE_HOUR_SECONDS } from '../../../../../lib/constants';
+
+vi.mock('@bluedot/ui', async () => {
+  const actual = await vi.importActual('@bluedot/ui');
+  return {
+    ...actual,
+    loginPresets: {
+      keycloak: {
+        verifyAndDecodeToken: vi.fn(),
+      },
+    },
+  };
+});
+
+vi.mock('../../../../../../lib/api/env', () => ({
+  default: {
+    APP_NAME: 'website',
+    ALERTS_SLACK_BOT_TOKEN: 'slack-token',
+    ALERTS_SLACK_CHANNEL_ID: 'channel-id',
+    CLIENT_ERRORS_SLACK_CHANNEL_ID: 'client-errors',
+    PG_URL: 'postgres://localhost/test',
+    AIRTABLE_PERSONAL_ACCESS_TOKEN: 'airtable-token',
+    KEYCLOAK_CLIENT_ID: 'keycloak-client',
+    KEYCLOAK_CLIENT_SECRET: 'keycloak-secret',
+  },
+}));
+
+vi.mock('../../../../../lib/api/db', () => ({
+  default: {
+    get: vi.fn(),
+    scan: vi.fn(),
+  },
+}));
+
+import { loginPresets } from '@bluedot/ui';
+import handler from '../../../../../pages/api/calendar/discussions/[discussionId]';
+import db from '../../../../../lib/api/db';
+
+const unfoldIcs = (content: string) => content.replaceAll('\r\n ', '');
+
+function createMockReqRes(overrides: Partial<NextApiRequest> = {}) {
+  const req = {
+    method: 'GET',
+    query: { discussionId: 'discussion-1' },
+    headers: {
+      host: 'bluedot.org',
+      authorization: 'Bearer valid-token',
+    },
+    ...overrides,
+  } as NextApiRequest;
+
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    setHeader: vi.fn(),
+  } as unknown as NextApiResponse;
+
+  return { req, res };
+}
+
+describe('calendar discussion download api', () => {
+  const mockAuth = {
+    iss: 'https://auth.example.com',
+    aud: 'bluedot-website',
+    exp: Date.now() / 1000 + ONE_HOUR_SECONDS,
+    sub: 'user-1',
+    email: 'ash@example.com',
+    email_verified: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 405 for non-GET requests', async () => {
+    const { req, res } = createMockReqRes({ method: 'POST' });
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method not allowed' });
+  });
+
+  it('returns 401 when the user is not authenticated', async () => {
+    const { req, res } = createMockReqRes({
+      headers: { host: 'bluedot.org' },
+    });
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing access token' });
+  });
+
+  it('returns 403 when the authenticated user is not attached to the discussion', async () => {
+    const { req, res } = createMockReqRes();
+
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(mockAuth);
+    vi.mocked(db.get).mockResolvedValueOnce(createMockGroupDiscussion({
+      id: 'discussion-1',
+      participantsExpected: ['meet-person-1'],
+    }));
+    vi.mocked(db.scan)
+      .mockResolvedValueOnce([createMockMeetPerson({
+        id: 'meet-person-1',
+        email: 'someone-else@example.com',
+        applicationsBaseRecordId: 'course-registration-1',
+      })])
+      .mockResolvedValueOnce([createMockCourseRegistration({
+        id: 'course-registration-1',
+        email: 'someone-else@example.com',
+      })]);
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'You do not have access to this discussion' });
+  });
+
+  it('returns a calendar file for an attached user', async () => {
+    const { req, res } = createMockReqRes();
+
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(mockAuth);
+    vi.mocked(db.get)
+      .mockResolvedValueOnce(createMockGroupDiscussion({
+        id: 'discussion-1',
+        unitNumber: 2,
+        startDateTime: 1774954800,
+        endDateTime: 1774958400,
+        participantsExpected: ['meet-person-1'],
+        zoomLink: 'https://zoom.us/j/123456789?pwd=abc123',
+        activityDoc: 'https://docs.google.com/document/d/abc123',
+      }))
+      .mockResolvedValueOnce(createMockUnit({
+        id: 'unit-2',
+        unitNumber: '2',
+        title: 'Key Concepts',
+        courseTitle: 'Introduction to AI Safety',
+        path: '/courses/ai-safety/2',
+      }));
+    vi.mocked(db.scan)
+      .mockResolvedValueOnce([createMockMeetPerson({
+        id: 'meet-person-1',
+        email: 'ash@example.com',
+        applicationsBaseRecordId: 'course-registration-1',
+      })])
+      .mockResolvedValueOnce([createMockCourseRegistration({
+        id: 'course-registration-1',
+        email: 'ash@example.com',
+      })]);
+
+    await handler(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/calendar; charset=utf-8');
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      expect.stringContaining('introduction-to-ai-safety-unit-2-key-concepts.ics'),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledTimes(1);
+
+    const [sentIcs] = vi.mocked(res.send).mock.calls[0]!;
+    const unfoldedIcs = unfoldIcs(sentIcs as string);
+
+    expect(unfoldedIcs).toContain('BEGIN:VCALENDAR');
+    expect(unfoldedIcs).toContain('Join Zoom: https://zoom.us/j/123456789?pwd=abc123');
+    expect(unfoldedIcs).toContain('Course page: https://bluedot.org/courses/ai-safety/2');
+  });
+});

--- a/apps/website/src/components/settings/CourseDetails.test.tsx
+++ b/apps/website/src/components/settings/CourseDetails.test.tsx
@@ -16,6 +16,7 @@ import {
   createMockGroupDiscussion,
   createMockUnit,
 } from '../../__tests__/testUtils';
+import { downloadDiscussionCalendarFile } from '../../lib/downloadCalendarFile';
 import CourseDetails from './CourseDetails';
 
 // Mock GroupSwitchModal to avoid testing it here
@@ -27,6 +28,10 @@ vi.mock('../courses/GroupSwitchModal', () => ({
       <button type="button" onClick={handleClose}>Close Modal</button>
     </div>
   ),
+}));
+
+vi.mock('../../lib/downloadCalendarFile', () => ({
+  downloadDiscussionCalendarFile: vi.fn(),
 }));
 
 describe('CourseDetails', () => {
@@ -409,6 +414,52 @@ describe('CourseDetails: Participant view', () => {
     expect(discussionDocLink).toBeInTheDocument();
     expect(discussionDocLink).toHaveAttribute('href', 'https://docs.google.com/document/d/abc123');
     expect(discussionDocLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('shows and wires up "Download calendar file" in the overflow menu for upcoming discussions', async () => {
+    const user = userEvent.setup();
+    const currentTimeMs = Date.now();
+
+    const upcomingDiscussions = [
+      {
+        ...createMockGroupDiscussion({
+          id: 'discussion-calendar-download',
+          unitNumber: 2,
+          startDateTime: Math.floor(currentTimeMs / 1000) + 2 * 60 * 60,
+          endDateTime: Math.floor(currentTimeMs / 1000) + 3 * 60 * 60,
+        }),
+        unitRecord: createMockUnit({ unitNumber: '2', title: 'Unit Two' }),
+        groupDetails: createMockGroup(),
+      },
+    ];
+
+    vi.mocked(downloadDiscussionCalendarFile).mockResolvedValue(undefined);
+
+    render(<CourseDetails
+      course={mockCourse}
+      courseRegistration={mockCourseRegistration}
+      upcomingDiscussions={upcomingDiscussions}
+      attendedDiscussions={[]}
+      facilitatedDiscussions={[]}
+      isLoading={false}
+    />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Prepare for discussion' })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'More actions' }));
+    });
+
+    const downloadCalendarItem = screen.getByRole('menuitem', { name: 'Download calendar file' });
+    expect(downloadCalendarItem).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(downloadCalendarItem);
+    });
+
+    expect(downloadDiscussionCalendarFile).toHaveBeenCalledWith('discussion-calendar-download');
   });
 
   it('does not show "Open discussion doc" when activityDoc is null', async () => {

--- a/apps/website/src/components/settings/DiscussionList.tsx
+++ b/apps/website/src/components/settings/DiscussionList.tsx
@@ -5,9 +5,11 @@ import {
 } from '@bluedot/ui';
 import { useState } from 'react';
 import { FaArrowRightArrowLeft, FaRightToBracket } from 'react-icons/fa6';
+import { PiCalendarDots } from 'react-icons/pi';
 import {
   buildGroupSlackChannelUrl, formatDateMonthAndDay, formatDateTimeRelative, formatTime12HourClock,
 } from '../../lib/utils';
+import { downloadDiscussionCalendarFile } from '../../lib/downloadCalendarFile';
 import type { GroupDiscussionWithGroupAndUnit } from '../../server/routers/group-discussions';
 import type { SwitchType } from '../courses/GroupSwitchModal';
 import type { FacilitatorModalType } from '../courses/FacilitatorSwitchModal';
@@ -106,6 +108,8 @@ const DiscussionListRow = ({
   onOpenDropoutModal,
 }: DiscussionListRowProps) => {
   const currentTimeMs = useCurrentTimeMs();
+  const [isDownloadingCalendar, setIsDownloadingCalendar] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
 
   const discussionTimeState = getDiscussionTimeState({ discussion, currentTimeMs });
   const discussionIsSoonOrLive = discussionTimeState === 'live' || discussionTimeState === 'soon';
@@ -120,6 +124,22 @@ const DiscussionListRow = ({
   const slackChannelLink = discussion.slackChannelId ? buildGroupSlackChannelUrl(discussion.slackChannelId) : '';
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const discussionDocLink = discussion.activityDoc || '';
+
+  const handleDownloadCalendarFile = async () => {
+    if (isDownloadingCalendar) {
+      return;
+    }
+
+    try {
+      setDownloadError(null);
+      setIsDownloadingCalendar(true);
+      await downloadDiscussionCalendarFile(discussion.id);
+    } catch {
+      setDownloadError('Could not download the calendar file. Please try again.');
+    } finally {
+      setIsDownloadingCalendar(false);
+    }
+  };
 
   const buttons: ButtonOrMenuItem[] = [
     // Primary CTA
@@ -198,6 +218,14 @@ const DiscussionListRow = ({
       isVisible: !isFacilitator && !isPast,
       onClick: onOpenDropoutModal,
       overflowIcon: <FaRightToBracket className="mx-auto size-[14px]" />,
+    },
+    {
+      id: 'download-calendar',
+      label: isDownloadingCalendar ? 'Downloading calendar file...' : 'Download calendar file',
+      variant: 'secondary',
+      onClick: handleDownloadCalendarFile,
+      isVisible: !isPast,
+      overflowIcon: <PiCalendarDots className="mx-auto" size={20} />,
     },
   ];
   const visibleButtons = buttons.filter((button) => button.isVisible);
@@ -279,6 +307,15 @@ const DiscussionListRow = ({
           </div>
         </div>
       </div>
+      {downloadError && (
+        <p
+          className="text-red-600 text-size-sm mt-2"
+          role="alert"
+          aria-live="polite"
+        >
+          {downloadError}
+        </p>
+      )}
     </div>
   );
 };

--- a/apps/website/src/lib/calendar.test.ts
+++ b/apps/website/src/lib/calendar.test.ts
@@ -1,0 +1,60 @@
+import {
+  describe, expect, it, vi,
+} from 'vitest';
+import { createDiscussionCalendarIcs } from './calendar';
+
+const unfoldIcs = (content: string) => content.replaceAll('\r\n ', '');
+
+describe('calendar utilities', () => {
+  it('creates an ics payload with discussion metadata and escaped links', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-31T12:00:00Z'));
+
+    const { filename, content, summary } = createDiscussionCalendarIcs({
+      discussionId: 'discussion-123',
+      courseTitle: 'Introduction to AI Safety',
+      coursePath: 'https://bluedot.org/courses/ai-safety/2',
+      unitNumber: 2,
+      unitTitle: 'Key Concepts',
+      unitFallback: null,
+      startDateTime: 1774954800,
+      endDateTime: 1774958400,
+      zoomLink: 'https://zoom.us/j/123456789?pwd=abc123',
+      activityDoc: 'https://docs.google.com/document/d/abc123',
+    });
+
+    expect(summary).toBe('Introduction to AI Safety - Unit 2: Key Concepts');
+    expect(filename).toBe('introduction-to-ai-safety-unit-2-key-concepts.ics');
+    const unfoldedContent = unfoldIcs(content);
+
+    expect(unfoldedContent).toContain('BEGIN:VCALENDAR');
+    expect(unfoldedContent).toContain('UID:discussion-123@bluedot.org');
+    expect(unfoldedContent).toContain('DTSTAMP:20260331T120000Z');
+    expect(unfoldedContent).toContain('DTSTART:20260331T110000Z');
+    expect(unfoldedContent).toContain('DTEND:20260331T120000Z');
+    expect(unfoldedContent).toContain('SUMMARY:Introduction to AI Safety - Unit 2: Key Concepts');
+    expect(unfoldedContent).toContain('Join Zoom: https://zoom.us/j/123456789?pwd=abc123');
+    expect(unfoldedContent).toContain('Discussion doc: https://docs.google.com/document/d/abc123');
+    expect(unfoldedContent).toContain('Course page: https://bluedot.org/courses/ai-safety/2');
+
+    vi.useRealTimers();
+  });
+
+  it('folds long ics lines with continuation prefixes', () => {
+    const { content } = createDiscussionCalendarIcs({
+      discussionId: 'discussion-123',
+      courseTitle: 'Introduction to AI Safety',
+      coursePath: 'https://bluedot.org/courses/ai-safety/2',
+      unitNumber: 2,
+      unitTitle: 'Key Concepts',
+      unitFallback: null,
+      startDateTime: 1774954800,
+      endDateTime: 1774958400,
+      zoomLink: 'https://zoom.us/j/123456789?pwd=abc123&reallyLongParameter=this-should-force-the-url-line-to-fold-across-multiple-lines-for-calendar-clients',
+      activityDoc: 'https://docs.google.com/document/d/abc123',
+    });
+
+    expect(content).toContain('\r\n ');
+    expect(content).toContain('URL:https://zoom.us/j/123456789?pwd=abc123&reallyLongParameter=');
+  });
+});

--- a/apps/website/src/lib/calendar.ts
+++ b/apps/website/src/lib/calendar.ts
@@ -1,0 +1,125 @@
+type DiscussionCalendarData = {
+  discussionId: string;
+  courseTitle?: string | null;
+  coursePath?: string | null;
+  unitNumber?: number | null;
+  unitTitle?: string | null;
+  unitFallback?: string | null;
+  startDateTime: number;
+  endDateTime: number;
+  zoomLink?: string | null;
+  activityDoc?: string | null;
+};
+
+const BLUEDOT_ORGANIZER_EMAIL = 'team@bluedot.org';
+const BLUEDOT_ORGANIZER_NAME = 'BlueDot Impact';
+const MAX_ICS_LINE_LENGTH = 75;
+
+const escapeIcsText = (value: string) => value
+  .replaceAll('\\', '\\\\')
+  .replaceAll('\n', '\\n')
+  .replaceAll(';', '\\;')
+  .replaceAll(',', '\\,');
+
+const formatUtcDateTime = (timestampSeconds: number) => {
+  const isoString = new Date(timestampSeconds * 1000).toISOString();
+  return isoString.replaceAll('-', '').replaceAll(':', '').replace('.000', '');
+};
+
+const foldIcsLine = (line: string) => {
+  if (line.length <= MAX_ICS_LINE_LENGTH) {
+    return [line];
+  }
+
+  const foldedLines = [line.slice(0, MAX_ICS_LINE_LENGTH)];
+  let remaining = line.slice(MAX_ICS_LINE_LENGTH);
+
+  while (remaining.length > 0) {
+    foldedLines.push(` ${remaining.slice(0, MAX_ICS_LINE_LENGTH - 1)}`);
+    remaining = remaining.slice(MAX_ICS_LINE_LENGTH - 1);
+  }
+
+  return foldedLines;
+};
+
+const parseUnitFallback = (unitFallback?: string | null) => {
+  if (!unitFallback) {
+    return null;
+  }
+
+  const separatorIndex = unitFallback.indexOf(':');
+  if (separatorIndex === -1) {
+    return { number: null as number | null, title: unitFallback.trim() };
+  }
+
+  const possibleNumber = Number(unitFallback.slice(0, separatorIndex).trim());
+  return {
+    number: Number.isFinite(possibleNumber) ? possibleNumber : null,
+    title: unitFallback.slice(separatorIndex + 1).trim(),
+  };
+};
+
+export const getDiscussionCalendarSummary = ({
+  courseTitle,
+  unitNumber,
+  unitTitle,
+  unitFallback,
+}: Pick<DiscussionCalendarData, 'courseTitle' | 'unitNumber' | 'unitTitle' | 'unitFallback'>) => {
+  const parsedFallback = parseUnitFallback(unitFallback);
+  const resolvedUnitNumber = unitNumber ?? parsedFallback?.number ?? null;
+  const resolvedUnitTitle = unitTitle ?? parsedFallback?.title ?? null;
+
+  let discussionLabel = 'Discussion';
+
+  if (resolvedUnitNumber && resolvedUnitTitle) {
+    discussionLabel = `Unit ${resolvedUnitNumber}: ${resolvedUnitTitle}`;
+  } else if (resolvedUnitTitle) {
+    discussionLabel = resolvedUnitTitle;
+  } else if (resolvedUnitNumber) {
+    discussionLabel = `Unit ${resolvedUnitNumber}`;
+  }
+
+  return `${courseTitle ?? 'BlueDot Impact'} - ${discussionLabel}`;
+};
+
+export const getDiscussionCalendarFilename = (summary: string) => `${summary
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-+|-+$/g, '') || 'bluedot-discussion'}.ics`;
+
+export const createDiscussionCalendarIcs = (discussion: DiscussionCalendarData) => {
+  const summary = getDiscussionCalendarSummary(discussion);
+  const descriptionLines = [
+    `${summary} with BlueDot Impact.`,
+    discussion.zoomLink ? `Join Zoom: ${discussion.zoomLink}` : null,
+    discussion.activityDoc ? `Discussion doc: ${discussion.activityDoc}` : null,
+    discussion.coursePath ? `Course page: ${discussion.coursePath}` : null,
+  ].filter((line): line is string => Boolean(line));
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//BlueDot Impact//Course Discussions//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${discussion.discussionId}@bluedot.org`,
+    `DTSTAMP:${formatUtcDateTime(Math.floor(Date.now() / 1000))}`,
+    `DTSTART:${formatUtcDateTime(discussion.startDateTime)}`,
+    `DTEND:${formatUtcDateTime(discussion.endDateTime)}`,
+    `SUMMARY:${escapeIcsText(summary)}`,
+    `DESCRIPTION:${escapeIcsText(descriptionLines.join('\n'))}`,
+    'STATUS:CONFIRMED',
+    discussion.zoomLink ? `URL:${discussion.zoomLink}` : null,
+    discussion.zoomLink ? 'LOCATION:Zoom' : 'LOCATION:Online',
+    `ORGANIZER;CN=${escapeIcsText(BLUEDOT_ORGANIZER_NAME)}:mailto:${BLUEDOT_ORGANIZER_EMAIL}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].filter((line): line is string => Boolean(line));
+
+  return {
+    filename: getDiscussionCalendarFilename(summary),
+    content: `${lines.flatMap(foldIcsLine).join('\r\n')}\r\n`,
+    summary,
+  };
+};

--- a/apps/website/src/lib/downloadCalendarFile.ts
+++ b/apps/website/src/lib/downloadCalendarFile.ts
@@ -1,0 +1,32 @@
+import { getHeadersWithValidToken } from '../utils/trpc';
+
+const getFilenameFromContentDisposition = (contentDisposition: string | null) => {
+  if (!contentDisposition) {
+    return null;
+  }
+
+  const filenameMatch = /filename="([^"]+)"/i.exec(contentDisposition);
+  return filenameMatch?.[1] ?? null;
+};
+
+export const downloadDiscussionCalendarFile = async (discussionId: string) => {
+  const response = await fetch(`/api/calendar/discussions/${encodeURIComponent(discussionId)}`, {
+    headers: await getHeadersWithValidToken(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download calendar file (${response.status})`);
+  }
+
+  const blob = await response.blob();
+  const downloadUrl = URL.createObjectURL(blob);
+  const downloadLink = document.createElement('a');
+  downloadLink.href = downloadUrl;
+  downloadLink.download = getFilenameFromContentDisposition(response.headers.get('content-disposition')) ?? `bluedot-discussion-${discussionId}.ics`;
+  downloadLink.style.display = 'none';
+
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  downloadLink.remove();
+  URL.revokeObjectURL(downloadUrl);
+};

--- a/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
+++ b/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
@@ -1,0 +1,113 @@
+import createHttpError from 'http-errors';
+import type { NextApiResponse } from 'next';
+import { StreamingResponseSchema } from '@bluedot/ui/src/api';
+import {
+  courseRegistrationTable,
+  groupDiscussionTable,
+  meetPersonTable,
+  unitTable,
+} from '@bluedot/db';
+import db from '../../../../lib/api/db';
+import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
+import { createDiscussionCalendarIcs } from '../../../../lib/calendar';
+
+function getDiscussionId(queryValue: string | string[] | undefined) {
+  if (typeof queryValue === 'string' && queryValue.trim().length > 0) {
+    return queryValue;
+  }
+
+  throw new createHttpError.BadRequest('Missing discussion id');
+}
+
+function getSiteOrigin(host: string | undefined, forwardedProto: string | string[] | undefined) {
+  if (!host) {
+    return 'https://bluedot.org';
+  }
+
+  let protocol = 'https';
+
+  if (typeof forwardedProto === 'string') {
+    protocol = forwardedProto.split(',')[0]!.trim();
+  } else if (host.startsWith('localhost') || host.startsWith('127.0.0.1')) {
+    protocol = 'http';
+  }
+
+  return `${protocol}://${host}`;
+}
+
+export default makeApiRoute({
+  responseBody: StreamingResponseSchema,
+}, async (_body, {
+  auth,
+  raw: { req, res: rawRes },
+}) => {
+  if (req.method !== 'GET') {
+    throw new createHttpError.MethodNotAllowed('Method not allowed');
+  }
+
+  const res = rawRes as unknown as NextApiResponse<string>;
+  const discussionId = getDiscussionId(req.query.discussionId);
+
+  const discussion = await db.get(groupDiscussionTable, { id: discussionId });
+  if (!discussion) {
+    throw new createHttpError.NotFound('Discussion not found');
+  }
+
+  const relatedMeetPersonIds = [...new Set([
+    ...discussion.participantsExpected,
+    ...discussion.facilitators,
+  ])];
+
+  const meetPeople = relatedMeetPersonIds.length > 0
+    ? await db.scan(meetPersonTable, {
+      OR: relatedMeetPersonIds.map((id) => ({ id })),
+    })
+    : [];
+
+  const courseRegistrationIds = [...new Set(meetPeople
+    .map((meetPerson) => meetPerson.applicationsBaseRecordId)
+    .filter((id): id is string => Boolean(id)))];
+
+  const courseRegistrations = courseRegistrationIds.length > 0
+    ? await db.scan(courseRegistrationTable, {
+      OR: courseRegistrationIds.map((id) => ({ id })),
+    })
+    : [];
+
+  const allowedEmails = new Set([
+    ...meetPeople.map((meetPerson) => meetPerson.email).filter((email): email is string => Boolean(email)),
+    ...courseRegistrations.map((registration) => registration.email).filter((email): email is string => Boolean(email)),
+  ]);
+
+  if (!allowedEmails.has(auth.email)) {
+    throw new createHttpError.Forbidden('You do not have access to this discussion');
+  }
+
+  const unit = discussion.courseBuilderUnitRecordId
+    ? await db.get(unitTable, { id: discussion.courseBuilderUnitRecordId })
+    : null;
+
+  const siteOrigin = getSiteOrigin(req.headers.host, req.headers['x-forwarded-proto']);
+  const coursePath = unit?.path
+    ? new URL(unit.path, siteOrigin).toString()
+    : null;
+
+  const { filename, content } = createDiscussionCalendarIcs({
+    discussionId: discussion.id,
+    courseTitle: unit?.courseTitle,
+    coursePath,
+    unitNumber: discussion.unitNumber,
+    unitTitle: unit?.title,
+    unitFallback: discussion.unitFallback,
+    startDateTime: discussion.startDateTime,
+    endDateTime: discussion.endDateTime,
+    zoomLink: discussion.zoomLink,
+    activityDoc: discussion.activityDoc,
+  });
+
+  res.setHeader('Content-Type', 'text/calendar; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  res.status(200).send(content);
+
+  return null;
+});


### PR DESCRIPTION
## What changed
- add a protected API endpoint that generates per-discussion .ics calendar files for eligible users
- add a download helper and settings UI action for upcoming course discussions
- add test coverage for the calendar generator, API access checks, and the discussion menu action

## Why
Calendar invites occasionally fail to sync for course discussions. This gives participants a reliable self-serve fallback from `/settings/courses`.

## User impact
Users can download a calendar file for an upcoming discussion directly from the overflow menu on the course discussion list.

## Validation
- npm --workspace apps/website run test:update
- npm --workspace apps/website run lint
- npm --workspace apps/website run typecheck
- npm --workspace apps/website run build
- npm audit --workspace apps/website --audit-level=moderate

## Notes
- `npm audit` reports existing workspace dependency advisories, including high-severity issues in `next`, `axios`, and `@trpc/server`, plus a critical advisory in `happy-dom`. These were not introduced by this PR.
- manually verified the UX locally and confirmed an exported .ics imports into calendar successfully.