### PR TITLE
Fix duplicate course registrations due to UTM params on FoAI course

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -94,7 +94,7 @@ const CourseUnitChunkPage = ({
     if (shouldRecordCourseRegistration && !isUtmLoading && !isEnsureExistsPending) {
       createCourseRegistrationMutation({ courseId: unit.courseId, source: latestUtmParams.utm_source });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps isEnsureExistsPending intentionally excluded to avoid re-fire loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- isEnsureExistsPending intentionally excluded to avoid re-fire loop
   }, [auth, unit.courseId, latestUtmParams.utm_source, createCourseRegistrationMutation, isUtmLoading]);
 
   useEffect(() => {


### PR DESCRIPTION
# Description

There are quite a few duplicate course registrations for the FoAI course, which are being generated by `courseRegistrations.ensureExists` firing while there is already one instance in flight.

It looks like the most common cause of this (~75% of cases) was a bug due to `useLatestUtmParams`: `latestUtmParams.utm_source` is undefined on the first render, then populates on a second render if there are utm params. This triggered ensureExists to fire twice in quick succession. I've fixed this narrow problem here.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2191 , the remaining fix is to delete the existing duplicates (making sure to get the right one)

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->