### PR TITLE
Decouple .notNull() from airtable-ts return types

### DIFF
--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -131,7 +131,7 @@ export type CourseRoundsData = Awaited<ReturnType<typeof getCourseRoundsData>>;
 export function getSoonestDeadline(rounds: CourseRoundsData): string | null {
   const allRounds = [...rounds.intense, ...rounds.partTime];
 
-  const roundsWithDeadlines = allRounds.filter((r): r is typeof r & { applicationDeadlineRaw: string } => r.applicationDeadlineRaw !== null);
+  const roundsWithDeadlines = allRounds.filter((r): r is typeof r & { applicationDeadlineRaw: string } => !!r.applicationDeadlineRaw);
 
   if (roundsWithDeadlines.length === 0) {
     return null;

--- a/libraries/db/src/lib/typeUtils.test.ts
+++ b/libraries/db/src/lib/typeUtils.test.ts
@@ -37,18 +37,20 @@ const booleanNull: BooleanType = null;
 // @ts-expect-error - should not accept strings
 const booleanInvalid: BooleanType = 'test';
 
-// Test that array types are correct
 const textArrayValue: TextArrayType = ['test', 'test2'];
+// @ts-expect-error - should not accept null for arrays
 const textArrayNull: TextArrayType = null;
 // @ts-expect-error - should not accept single strings
 const textArrayInvalid: TextArrayType = 'test';
 
 const numericArrayValue: NumericArrayType = [1, 2, 3];
+// @ts-expect-error - should not accept null for arrays
 const numericArrayNull: NumericArrayType = null;
 // @ts-expect-error - should not accept string arrays
 const numericArrayInvalid: NumericArrayType = ['test'];
 
 const booleanArrayValue: BooleanArrayType = [true, false];
+// @ts-expect-error - should not accept null for arrays
 const booleanArrayNull: BooleanArrayType = null;
 // @ts-expect-error - should not accept string arrays
 const booleanArrayInvalid: BooleanArrayType = ['test'];
@@ -81,9 +83,9 @@ const validItemWithNulls: TestAirtableItem = {
   name: null,
   age: null,
   isActive: null,
-  tags: null,
-  scores: null,
-  flags: null,
+  tags: [],
+  scores: [],
+  flags: [],
 };
 
 // Test that invalid assignments are caught
@@ -128,9 +130,6 @@ describe('DrizzleColumnToTsType type tests', () => {
     expect(textNull).toBeNull();
     expect(numericNull).toBeNull();
     expect(booleanNull).toBeNull();
-    expect(textArrayNull).toBeNull();
-    expect(numericArrayNull).toBeNull();
-    expect(booleanArrayNull).toBeNull();
   });
 
   test('should create valid AirtableItemFromColumnsMap objects', () => {

--- a/libraries/db/src/lib/typeUtils.test.ts
+++ b/libraries/db/src/lib/typeUtils.test.ts
@@ -144,15 +144,18 @@ describe('DrizzleColumnToTsType type tests', () => {
 
 describe('drizzleColumnToTsTypeString', () => {
   test.each([
-    [text(), 'string | null'],
+    // String, boolean, and arrays are always non-null (airtable-ts coerces to '', false, [])
+    [text(), 'string'],
     [text().notNull(), 'string'],
-    [boolean(), 'boolean | null'],
+    [boolean(), 'boolean'],
     [boolean().notNull(), 'boolean'],
+    // Numbers are always nullable (need to distinguish null vs 0)
     [numeric({ mode: 'number' }), 'number | null'],
-    [numeric({ mode: 'number' }).notNull(), 'number'],
-    [text().array(), 'string[] | null'],
+    [numeric({ mode: 'number' }).notNull(), 'number | null'],
+    // Arrays are always non-null (airtable-ts coerces to [])
+    [text().array(), 'string[]'],
     [text().array().notNull(), 'string[]'],
-    [numeric({ mode: 'number' }).array(), 'number[] | null'],
+    [numeric({ mode: 'number' }).array(), 'number[]'],
     [numeric({ mode: 'number' }).array().notNull(), 'number[]'],
   ])('%s -> %s', (column, expectedType) => {
     const result = drizzleColumnToTsTypeString(column);

--- a/libraries/db/src/lib/typeUtils.ts
+++ b/libraries/db/src/lib/typeUtils.ts
@@ -99,11 +99,17 @@ export function drizzleColumnToTsTypeString(pgColumn: AllowedPgColumn): TsTypeSt
 
   const baseType = baseColumnConfig?.dataType ?? columnConfig.dataType;
   const isArray = columnConfig.dataType === 'array';
-  const isNullable = !columnConfig.notNull;
 
   if (!['string', 'number', 'boolean'].includes(baseType)) {
     throw new Error(`Unsupported column type: ${baseType}`);
   }
+
+  // Numbers are always nullable (need to distinguish null vs 0).
+  // Everything else (string, boolean, arrays) is always non-null so that
+  // airtable-ts coerces missing values to '', false, or [].
+  // This decouples .notNull() from airtable-ts behaviour, making it purely
+  // a PostgreSQL constraint. See gh-simpler-not-null/README.md.
+  const isNullable = baseType === 'number' && !isArray;
 
   return `${baseType}${isArray ? '[]' : ''}${isNullable ? ' | null' : ''}` as TsTypeString;
 }

--- a/libraries/db/src/lib/typeUtils.ts
+++ b/libraries/db/src/lib/typeUtils.ts
@@ -31,9 +31,9 @@ export type AllowedPgColumn =
   ReturnType<ReturnType<typeof pgBoolean>['array']>;
 
 export type DrizzleColumnToTsType<T extends AllowedPgColumn> =
-  T extends ReturnType<ReturnType<typeof text>['array']> ? string[] | null :
-    T extends ReturnType<ReturnType<typeof numeric<'number'>>['array']> ? number[] | null :
-      T extends ReturnType<ReturnType<typeof pgBoolean>['array']> ? boolean[] | null :
+  T extends ReturnType<ReturnType<typeof text>['array']> ? string[] :
+    T extends ReturnType<ReturnType<typeof numeric<'number'>>['array']> ? number[] :
+      T extends ReturnType<ReturnType<typeof pgBoolean>['array']> ? boolean[] :
         T extends ReturnType<typeof numeric<'number'>> ? number | null :
           T extends ReturnType<typeof pgBoolean> ? boolean | null :
             string | null;

--- a/libraries/db/src/lib/typeUtils.ts
+++ b/libraries/db/src/lib/typeUtils.ts
@@ -88,8 +88,8 @@ export type BasePgTableType<
 
 /**
  * Maps a drizzle PgColumnBuilderBase to the corresponding airtable-ts TypeScript type string.
- * Currently supports numeric columns -> 'number | null', boolean columns -> 'boolean | null',
- * array columns, defaults to 'string | null'.
+ * Numbers are always nullable ('number | null'). Everything else (string, boolean, arrays)
+ * is always non-null since airtable-ts coerces missing values to '', false, or [].
  */
 export function drizzleColumnToTsTypeString(pgColumn: AllowedPgColumn): TsTypeString {
   // @ts-expect-error
@@ -108,7 +108,7 @@ export function drizzleColumnToTsTypeString(pgColumn: AllowedPgColumn): TsTypeSt
   // Everything else (string, boolean, arrays) is always non-null so that
   // airtable-ts coerces missing values to '', false, or [].
   // This decouples .notNull() from airtable-ts behaviour, making it purely
-  // a PostgreSQL constraint. See gh-simpler-not-null/README.md.
+  // a PostgreSQL constraint. See #2081 for full context.
   const isNullable = baseType === 'number' && !isArray;
 
   return `${baseType}${isArray ? '[]' : ''}${isNullable ? ' | null' : ''}` as TsTypeString;


### PR DESCRIPTION
# Description

Decouples `.notNull()` from airtable-ts behaviour. Instead of airtable-ts changing what it returns based on notNull status, we now set per-type defaults:
- Strings, booleans, arrays: always non-null (coerced to `''`, `false`, `[]`)
- Numbers: always nullable (need to distinguish `null` vs `0`)

Small change (3 files) but broad effect since it feeds into schema generation for every table.

Tested: all CI passes, Playwright spot-checks of courses page, FoAI landing, home page look fine. One code fix needed in `course-rounds.ts` (`!== null` -> `!!`).

Risk: code relying on getting `null` for a string/boolean/array would now get the zero value instead. Unlikely to be user-visible since most code guards with `!!`.

Because of the breadth of this change, I think there is some chance of it causing bugs or slight changes in behaviour. However, it's easy to revert (one full sync of the db will migrate to or from the new behaviour), so it's not a big risk to merge.

## Issue

Fixes #2081

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories