### PR TITLE
Return `null` instead of throwing when participant not found

### DIFF
--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -106,7 +106,7 @@ export const groupDiscussionsRouter = router({
       });
 
       if (!participant) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Participant not found' });
+        return null;
       }
 
       const roundId = participant.round;


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

FoAI do not have any course registration records in the 'Course runner' base. This always throws. The caller in `UnitLayout` already handles a null return value.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2203 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="1123" height="424" alt="image" src="https://github.com/user-attachments/assets/3f92e6cb-de40-41f6-9338-f8173eaaf7f7" /> | <img width="1131" height="429" alt="image" src="https://github.com/user-attachments/assets/3378a57b-a781-45c6-a9fe-c4b5c746b926" /> |
