### PR TITLE
fix: stop writing deprecated resource completion rating

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -236,7 +236,6 @@ export const createMockResourceCompletion = (overrides: Partial<ResourceCompleti
   feedback: null,
   id: MOCK_RESOURCE_COMPLETION_ID,
   isCompleted: false,
-  rating: null,
   resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
   unitResourceId: MOCK_RESOURCE_ID,
   ...overrides,

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -140,7 +140,6 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
               autoNumberId: null,
               email: auth?.email ?? '',
               unitResourceId,
-              rating: updatedFields.rating ?? null,
               feedback: updatedFields.feedback ?? '',
               resourceFeedback: updatedFields.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
               isCompleted: updatedFields.isCompleted ?? false,

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -43,7 +43,6 @@ export const resourcesRouter = router({
   saveResourceCompletion: protectedProcedure
     .input(z.object({
       unitResourceId: z.string().min(1),
-      rating: z.number().nullable().optional(),
       isCompleted: z.boolean().optional(),
       feedback: z.string().optional(),
       resourceFeedback: z
@@ -70,7 +69,6 @@ export const resourcesRouter = router({
         updatedResourceCompletion = await db.update(resourceCompletionTable, {
           id: resourceCompletion.id,
           unitResourceId: input.unitResourceId,
-          rating: input.rating ?? resourceCompletion.rating,
           isCompleted: input.isCompleted ?? resourceCompletion.isCompleted,
           feedback: input.feedback ?? resourceCompletion.feedback,
           resourceFeedback: input.resourceFeedback ?? resourceCompletion.resourceFeedback,
@@ -80,7 +78,6 @@ export const resourcesRouter = router({
         updatedResourceCompletion = await db.insert(resourceCompletionTable, {
           email: ctx.auth.email,
           unitResourceId: input.unitResourceId,
-          rating: input.rating ?? null,
           isCompleted: input.isCompleted ?? false,
           feedback: input.feedback ?? '',
           resourceFeedback: input.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1278,10 +1278,6 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
       pgColumn: text(),
       airtableId: 'fldk4dbWAohE312Qn',
     },
-    rating: {
-      pgColumn: numeric({ mode: 'number' }),
-      airtableId: 'fldq6J5taZX4xLDfD',
-    },
     isCompleted: {
       pgColumn: boolean(),
       airtableId: 'fldm74UNAQuC1XkQc',
@@ -1301,6 +1297,13 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
     autoNumberId: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldbT2G8lDkUsuusY',
+    },
+  },
+  deprecatedColumns: {
+    rating: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldq6J5taZX4xLDfD',
+      deprecated: true,
     },
   },
 });


### PR DESCRIPTION
## Summary
- stop writing the legacy resource completion rating field from the website resource save flow
- move the resource_completion.rating schema mapping to deprecatedColumns so this follows the first step of our schema removal process
- keep the current thumbs-based resourceFeedback flow intact

## Why
The Airtable rating field was removed from resource_completion, but the deployed website still attempted to write it on every resource completion save. That caused resources.saveResourceCompletion to fail and the resource completion UI to flash then roll back.

## Checks
- eslint on touched files
- website typecheck
- ResourceListItem.test.tsx
