### PR TITLE
Show upcoming rounds on final certificate page when user is not enrolled in course

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -1,4 +1,3 @@
-import { render, type RenderResult } from '@testing-library/react';
 import type {
   Chunk,
   Course,
@@ -11,6 +10,8 @@ import type {
   UnitResource,
 } from '@bluedot/db';
 import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
+import { render, type RenderResult } from '@testing-library/react';
+import type { CourseRound } from '../server/routers/course-rounds';
 
 // Re-export from libraries/ui for convenience
 export { createMockOidcResponse } from '@bluedot/ui/src/utils/testUtils';
@@ -228,6 +229,22 @@ export const createMockResource = (overrides: Partial<UnitResource> = {}): UnitR
   autoNumberId: 1,
   ...overrides,
 });
+
+let mockRoundCounter = 0;
+
+export const createMockRound = (overrides: Partial<CourseRound> = {}): CourseRound => {
+  mockRoundCounter += 1;
+  return {
+    id: `round-${mockRoundCounter}`,
+    intensity: 'intensive',
+    applicationDeadline: '15 Jan',
+    applicationDeadlineRaw: '2025-01-15',
+    firstDiscussionDateRaw: '2025-01-20',
+    dateRange: '20 – 24 Jan',
+    numberOfUnits: 5,
+    ...overrides,
+  };
+};
 
 export const createMockResourceCompletion = (overrides: Partial<ResourceCompletion> = {}): ResourceCompletion => ({
   autoNumberId: 1,

--- a/apps/website/src/components/courses/CourseCompletionSection.stories.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.stories.tsx
@@ -1,0 +1,83 @@
+import { loggedInStory, loggedOutStory } from '@bluedot/ui/src/utils/storybook';
+import type { Meta, StoryObj } from '@storybook/react';
+import { createMockRound } from '../../__tests__/testUtils';
+import { trpcStorybookMsw } from '../../__tests__/trpcMswSetup.browser';
+import CourseCompletionSection from './CourseCompletionSection';
+
+const mockApplyCTAProps = {
+  applicationDeadline: '15 Jan',
+  applicationUrl: 'https://bluedot.org/apply',
+  hasApplied: false,
+};
+
+const mockRounds = {
+  intense: [
+    createMockRound({ dateRange: '20 – 24 Jan' }),
+    createMockRound({
+      applicationDeadline: '12 Feb',
+      applicationDeadlineRaw: '2025-02-12',
+      firstDiscussionDateRaw: '2025-02-17',
+      dateRange: '17 – 21 Feb',
+    }),
+  ],
+  partTime: [
+    createMockRound({
+      intensity: 'part-time',
+      applicationDeadlineRaw: '2025-01-15',
+      firstDiscussionDateRaw: '2025-01-20',
+      dateRange: '20 Jan – 24 Feb',
+      numberOfUnits: 6,
+    }),
+  ],
+};
+
+const meta: Meta<typeof CourseCompletionSection> = {
+  title: 'website/courses/CourseCompletionSection',
+  component: CourseCompletionSection,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    courseId: 'course-1',
+    courseTitle: 'AGI Strategy',
+    courseSlug: 'agi-strategy',
+  },
+  ...loggedOutStory(),
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const EnrollmentCTA: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcStorybookMsw.courseRounds.getApplyCTAProps.query(() => mockApplyCTAProps),
+        trpcStorybookMsw.courseRounds.getRoundsForCourse.query(() => mockRounds),
+      ],
+    },
+  },
+};
+
+export const Congratulations: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        trpcStorybookMsw.courseRounds.getApplyCTAProps.query(() => null),
+        trpcStorybookMsw.certificates.getStatus.query(() => ({ status: 'not-eligible' as const })),
+      ],
+    },
+  },
+};
+
+export const AlreadyApplied: Story = {
+  ...loggedInStory(),
+  parameters: {
+    msw: {
+      handlers: [
+        trpcStorybookMsw.courseRounds.getApplyCTAProps.query(() => ({ ...mockApplyCTAProps, hasApplied: true })),
+        trpcStorybookMsw.certificates.getStatus.query(() => ({ status: 'not-eligible' as const })),
+      ],
+    },
+  },
+};

--- a/apps/website/src/components/courses/CourseCompletionSection.test.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.test.tsx
@@ -1,0 +1,100 @@
+import { render, waitFor } from '@testing-library/react';
+import {
+  beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import { createMockRound } from '../../__tests__/testUtils';
+import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
+import { TrpcProvider } from '../../__tests__/trpcProvider';
+import CourseCompletionSection from './CourseCompletionSection';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/courses/agi-strategy/5/2',
+    query: {},
+    asPath: '/courses/agi-strategy/5/2',
+  }),
+}));
+
+const mockApplyCTAProps = {
+  applicationDeadline: '15 Jan',
+  applicationUrl: 'https://bluedot.org/apply',
+  hasApplied: false,
+};
+
+const mockRounds = {
+  intense: [createMockRound({ dateRange: '20 – 24 Jan' })],
+  partTime: [createMockRound({ intensity: 'part-time', dateRange: '17 Feb – 24 Mar', numberOfUnits: 6 })],
+};
+
+const defaultProps = {
+  courseId: 'course-1',
+  courseTitle: 'AGI Strategy',
+  courseSlug: 'agi-strategy',
+};
+
+describe('CourseCompletionSection', () => {
+  beforeEach(() => {
+    server.use(trpcMsw.certificates.getStatus.query(() => ({ status: 'not-eligible' as const })));
+  });
+
+  test('shows ProgressDots while getApplyCTAProps is loading', () => {
+    // No handler - query stays pending
+    const { container } = render(<CourseCompletionSection {...defaultProps} />, { wrapper: TrpcProvider });
+
+    expect(container.querySelector('.progress-dots')).toBeTruthy();
+    expect(container.querySelector('.congratulations')).toBeFalsy();
+  });
+
+  test('shows enrollment CTA when rounds are available and user has not applied', async () => {
+    server.use(
+      trpcMsw.courseRounds.getApplyCTAProps.query(() => mockApplyCTAProps),
+      trpcMsw.courseRounds.getRoundsForCourse.query(() => mockRounds),
+    );
+
+    const { container } = render(<CourseCompletionSection {...defaultProps} />, { wrapper: TrpcProvider });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Enroll today to receive your certificate');
+    });
+
+    expect(container.textContent).toContain('20 – 24 Jan');
+    expect(container.textContent).toContain('17 Feb – 24 Mar');
+    expect(container.querySelector('.congratulations')).toBeFalsy();
+  });
+
+  test('shows Congratulations when getApplyCTAProps returns null', async () => {
+    server.use(trpcMsw.courseRounds.getApplyCTAProps.query(() => null));
+
+    const { container } = render(<CourseCompletionSection {...defaultProps} />, { wrapper: TrpcProvider });
+
+    await waitFor(() => {
+      expect(container.querySelector('.congratulations')).toBeTruthy();
+    });
+    expect(container.textContent).not.toContain('Enroll today');
+  });
+
+  test('shows Congratulations when user has already applied', async () => {
+    server.use(trpcMsw.courseRounds.getApplyCTAProps.query(() => ({ ...mockApplyCTAProps, hasApplied: true })));
+
+    const { container } = render(<CourseCompletionSection {...defaultProps} />, { wrapper: TrpcProvider });
+
+    await waitFor(() => {
+      expect(container.querySelector('.congratulations')).toBeTruthy();
+    });
+    expect(container.textContent).not.toContain('Enroll today');
+  });
+
+  test('shows Congratulations when no rounds are available', async () => {
+    server.use(
+      trpcMsw.courseRounds.getApplyCTAProps.query(() => mockApplyCTAProps),
+      trpcMsw.courseRounds.getRoundsForCourse.query(() => ({ intense: [], partTime: [] })),
+    );
+
+    const { container } = render(<CourseCompletionSection {...defaultProps} />, { wrapper: TrpcProvider });
+
+    await waitFor(() => {
+      expect(container.querySelector('.congratulations')).toBeTruthy();
+    });
+    expect(container.textContent).not.toContain('Enroll today');
+  });
+});

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -37,7 +37,7 @@ export default function CourseCompletionSection({
     { enabled: shouldFetchRounds },
   );
 
-  const isLoading = isApplyCTALoading || (shouldFetchRounds && isRoundsLoading);
+  const isLoading = isApplyCTALoading || (shouldFetchRounds && (isRoundsLoading || !roundsData));
   const hasRounds = Boolean(roundsData && (roundsData.intense.length > 0 || roundsData.partTime.length > 0));
   const showEnrollmentCTA = shouldFetchRounds && !isRoundsLoading && hasRounds && applyCTAProps && roundsData;
 

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -50,10 +50,9 @@ export default function CourseCompletionSection({
   }
 
   if (showEnrollmentCTA) {
-    const applicationUrl = applyCTAProps?.applicationUrl ?? '';
     const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
-      ? addQueryParam(applicationUrl, 'prefill_Source', latestUtmParams.utm_source)
-      : applicationUrl);
+      ? addQueryParam(applyCTAProps.applicationUrl, 'prefill_Source', latestUtmParams.utm_source)
+      : applyCTAProps.applicationUrl);
 
     return (
       <div className={cn('container-lined bg-white p-6', className)}>

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -30,11 +30,6 @@ export default function CourseCompletionSection({
     courseSlug,
   });
 
-  const applicationUrl = applyCTAProps?.applicationUrl ?? '';
-  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
-    ? addQueryParam(applicationUrl, 'prefill_Source', latestUtmParams.utm_source)
-    : applicationUrl);
-
   const shouldFetchRounds = Boolean(applyCTAProps) && !applyCTAProps?.hasApplied;
 
   const { data: roundsData, isLoading: isRoundsLoading } = trpc.courseRounds.getRoundsForCourse.useQuery(
@@ -55,6 +50,11 @@ export default function CourseCompletionSection({
   }
 
   if (showEnrollmentCTA) {
+    const applicationUrl = applyCTAProps?.applicationUrl ?? '';
+    const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
+      ? addQueryParam(applicationUrl, 'prefill_Source', latestUtmParams.utm_source)
+      : applicationUrl);
+
     return (
       <div className={cn('container-lined bg-white p-6', className)}>
         <div className="flex flex-col gap-4 pb-6 min-[680px]:flex-row min-[680px]:items-center">

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -1,0 +1,104 @@
+import {
+  addQueryParam, cn, ProgressDots, useLatestUtmParams,
+} from '@bluedot/ui';
+import { COURSE_CONFIG } from '../../lib/constants';
+import { appendPosthogSessionIdPrefill } from '../../lib/appendPosthogSessionIdPrefill';
+import { trpc } from '../../utils/trpc';
+import RoundGroup from '../shared/RoundGroup';
+import ActionPlanCard from './ActionPlanCard';
+import CertificateLinkCard from './CertificateLinkCard';
+import Congratulations from './Congratulations';
+import { CourseIcon } from './CourseIcon';
+
+type CourseCompletionSectionProps = {
+  courseId: string;
+  courseTitle: string;
+  courseSlug: string;
+  className?: string;
+};
+
+// eslint-disable-next-line react/function-component-definition
+export default function CourseCompletionSection({
+  courseId,
+  courseTitle,
+  courseSlug,
+  className,
+}: CourseCompletionSectionProps) {
+  const { latestUtmParams } = useLatestUtmParams();
+
+  const { data: applyCTAProps, isLoading: isApplyCTALoading } = trpc.courseRounds.getApplyCTAProps.useQuery({
+    courseSlug,
+  });
+
+  const applicationUrl = applyCTAProps?.applicationUrl ?? '';
+  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
+    ? addQueryParam(applicationUrl, 'prefill_Source', latestUtmParams.utm_source)
+    : applicationUrl);
+
+  const shouldFetchRounds = Boolean(applyCTAProps) && !applyCTAProps?.hasApplied;
+
+  const { data: roundsData, isLoading: isRoundsLoading } = trpc.courseRounds.getRoundsForCourse.useQuery(
+    { courseSlug },
+    { enabled: shouldFetchRounds },
+  );
+
+  const isLoading = isApplyCTALoading || (shouldFetchRounds && isRoundsLoading);
+  const hasRounds = Boolean(roundsData && (roundsData.intense.length > 0 || roundsData.partTime.length > 0));
+  const showEnrollmentCTA = shouldFetchRounds && !isRoundsLoading && hasRounds && applyCTAProps && roundsData;
+
+  if (isLoading) {
+    return (
+      <div className={className}>
+        <ProgressDots />
+      </div>
+    );
+  }
+
+  if (showEnrollmentCTA) {
+    return (
+      <div className={cn('container-lined bg-white p-6', className)}>
+        <div className="flex flex-col gap-4 pb-6 min-[680px]:flex-row min-[680px]:items-center">
+          <CourseIcon courseSlug={courseSlug} size="xlarge" className="rounded-[12px]" />
+          <div>
+            <h2 className="text-bluedot-navy text-[24px] leading-[1.4] font-semibold tracking-[-0.5px]">
+              {courseTitle}
+            </h2>
+            <p className="text-[16px]">Enroll today to receive your certificate</p>
+          </div>
+        </div>
+
+        {roundsData.intense.length > 0 && (
+          <RoundGroup
+            type="intensive"
+            rounds={roundsData.intense}
+            applicationUrl={applicationUrlWithUtm}
+            accentColor={COURSE_CONFIG[courseSlug]?.accentColor}
+          />
+        )}
+
+        {roundsData.partTime.length > 0 && (
+          <div className={roundsData.intense.length > 0 ? 'mt-6' : ''}>
+            <RoundGroup
+              type="part-time"
+              rounds={roundsData.partTime}
+              applicationUrl={applicationUrlWithUtm}
+              accentColor={COURSE_CONFIG[courseSlug]?.accentColor}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <Congratulations courseTitle={courseTitle} coursePath={`/courses/${courseSlug}`} courseId={courseId} />
+      <div className="mt-4">
+        <CertificateLinkCard courseId={courseId} />
+      </div>
+      <div className="mt-8 md:mt-6">
+        <ActionPlanCard courseId={courseId} />
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -77,7 +77,7 @@ export default function CourseCompletionSection({
         )}
 
         {roundsData.partTime.length > 0 && (
-          <div className={roundsData.intense.length > 0 ? 'mt-6' : ''}>
+          <div className={cn(roundsData.intense.length > 0 && 'mt-6')}>
             <RoundGroup
               type="part-time"
               rounds={roundsData.partTime}

--- a/apps/website/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website/src/components/courses/UnitLayout.test.tsx
@@ -1,16 +1,16 @@
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/router';
 import {
   describe,
   expect,
   test,
   vi,
 } from 'vitest';
-import { useRouter } from 'next/router';
-import UnitLayout from './UnitLayout';
 import { createMockChunk, createMockUnit } from '../../__tests__/testUtils';
-import { TrpcProvider } from '../../__tests__/trpcProvider';
 import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
+import { TrpcProvider } from '../../__tests__/trpcProvider';
+import UnitLayout from './UnitLayout';
 
 // Mock next/router
 vi.mock('next/router', () => ({

--- a/apps/website/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website/src/components/courses/UnitLayout.test.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router';
 import UnitLayout from './UnitLayout';
 import { createMockChunk, createMockUnit } from '../../__tests__/testUtils';
 import { TrpcProvider } from '../../__tests__/trpcProvider';
+import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
 
 // Mock next/router
 vi.mock('next/router', () => ({
@@ -156,6 +157,9 @@ describe('UnitLayout', () => {
   });
 
   test('renders Congratulations section on final chunk of final unit', async () => {
+    // No upcoming rounds - CourseCompletionSection should show Congratulations
+    server.use(trpcMsw.courseRounds.getApplyCTAProps.query(() => null));
+
     // Update router mock to show last chunk
     vi.mocked(useRouter).mockReturnValue({
       query: { chunk: String(CHUNKS.length - 1) },
@@ -192,13 +196,10 @@ describe('UnitLayout', () => {
       { wrapper: TrpcProvider },
     );
 
-    // Wait for MarkdownExtendedRenderer to complete async rendering
     await waitFor(() => {
-      expect(container.querySelector('.markdown-extended-renderer')).toBeTruthy();
+      expect(container.querySelector('.congratulations')).toBeTruthy();
     });
-
     expect(container.querySelector('.unit__cta-container')).toBeNull();
-    expect(container.querySelector('.congratulations')).toBeTruthy();
   });
 
   test('keyboard navigation component is displayed', async () => {

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -29,14 +29,12 @@ import { buildCourseUnitUrl } from '../../lib/utils';
 import type { BasicChunk } from '../../pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]]';
 import type { CourseProgress } from '../../server/routers/courses';
 import { trpc } from '../../utils/trpc';
-import ActionPlanCard from './ActionPlanCard';
-import CertificateLinkCard from './CertificateLinkCard';
-import Congratulations from './Congratulations';
 import { CourseIcon } from './CourseIcon';
 import GroupDiscussionBanner from './GroupDiscussionBanner';
 import InactiveCourseBanners from './InactiveCourseBanners';
 import KeyboardNavMenu from './KeyboardNavMenu';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
+import CourseCompletionSection from './CourseCompletionSection';
 import { MobileCourseModal } from './MobileCourseModal';
 import { ResourceDisplay } from './ResourceDisplay';
 import SideBar, { type ApplyCTAProps } from './SideBar';
@@ -461,20 +459,12 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
               ) : null}
 
               {(!nextUnit && isLastChunk) ? (
-                <>
-                  <Congratulations
-                    courseTitle={unit.courseTitle}
-                    coursePath={`/courses/${unit.courseSlug}`}
-                    courseId={unit.courseId}
-                    className="mt-8 md:mt-6"
-                  />
-                  <div className="mt-8 md:mt-6">
-                    <ActionPlanCard courseId={unit.courseId} />
-                  </div>
-                  <div className="mt-4">
-                    <CertificateLinkCard courseId={unit.courseId} />
-                  </div>
-                </>
+                <CourseCompletionSection
+                  courseId={unit.courseId}
+                  courseTitle={unit.courseTitle}
+                  courseSlug={courseSlug}
+                  className="mt-8 md:mt-6"
+                />
               ) : (
                 // Margin-bottom is added to accommodate the Circle widget on mobile screens
                 <div className="unit__cta-container flex flex-row justify-center mt-6 mx-1 mb-14 sm:mb-0">

--- a/apps/website/src/components/shared/RoundGroup.stories.tsx
+++ b/apps/website/src/components/shared/RoundGroup.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { createMockRound } from '../../__tests__/testUtils';
+import RoundGroup from './RoundGroup';
+
+const intensiveRounds = [
+  createMockRound({ dateRange: '20 – 24 Jan' }),
+  createMockRound({
+    applicationDeadline: '12 Feb',
+    applicationDeadlineRaw: '2025-02-12',
+    firstDiscussionDateRaw: '2025-02-17',
+    dateRange: '17 – 21 Feb',
+  }),
+  createMockRound({
+    applicationDeadline: '12 Mar',
+    applicationDeadlineRaw: '2025-03-12',
+    firstDiscussionDateRaw: '2025-03-17',
+    dateRange: '17 – 21 Mar',
+  }),
+  createMockRound({
+    applicationDeadline: '9 Apr',
+    applicationDeadlineRaw: '2025-04-09',
+    firstDiscussionDateRaw: '2025-04-14',
+    dateRange: '14 – 18 Apr',
+  }),
+];
+
+const partTimeRounds = [
+  createMockRound({
+    intensity: 'part-time',
+    applicationDeadlineRaw: '2025-01-15',
+    firstDiscussionDateRaw: '2025-01-20',
+    dateRange: '20 Jan – 24 Feb',
+    numberOfUnits: 6,
+  }),
+  createMockRound({
+    intensity: 'part-time',
+    applicationDeadline: '5 Mar',
+    applicationDeadlineRaw: '2025-03-05',
+    firstDiscussionDateRaw: '2025-03-10',
+    dateRange: '10 Mar – 14 Apr',
+    numberOfUnits: 6,
+  }),
+];
+
+const meta: Meta<typeof RoundGroup> = {
+  title: 'website/shared/RoundGroup',
+  component: RoundGroup,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    applicationUrl: 'https://bluedot.org/apply',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Intensive: Story = {
+  args: {
+    type: 'intensive',
+    rounds: intensiveRounds,
+  },
+};
+
+export const PartTime: Story = {
+  args: {
+    type: 'part-time',
+    rounds: partTimeRounds,
+  },
+};
+
+export const Capped: Story = {
+  args: {
+    type: 'intensive',
+    rounds: intensiveRounds,
+    maxRounds: 3,
+  },
+};

--- a/apps/website/src/components/shared/RoundGroup.tsx
+++ b/apps/website/src/components/shared/RoundGroup.tsx
@@ -1,0 +1,48 @@
+import type { inferRouterOutputs } from '@trpc/server';
+import type { AppRouter } from '../../server/routers/_app';
+import { buildRoundApplyUrl, RoundItem } from './RoundItem';
+
+type Round = inferRouterOutputs<AppRouter>['courseRounds']['getRoundsForCourse']['intense'][number];
+
+type RoundGroupProps = {
+  type: 'intensive' | 'part-time';
+  rounds: Round[];
+  applicationUrl: string;
+  accentColor?: string;
+  /** Cap the number of rounds shown. Defaults to showing all. */
+  maxRounds?: number;
+};
+
+// eslint-disable-next-line react/function-component-definition
+export default function RoundGroup({ type, rounds, applicationUrl, accentColor, maxRounds }: RoundGroupProps) {
+  const displayedRounds = maxRounds !== undefined ? rounds.slice(0, maxRounds) : rounds;
+  const firstRound = displayedRounds[0];
+  const numberOfUnits = firstRound?.numberOfUnits;
+
+  const label = type === 'intensive' ? 'Intensive:' : 'Part-time:';
+  const unitLabel = type === 'intensive' ? 'day' : 'week';
+  const perLabel = type === 'intensive' ? '5h/day' : '5h/week';
+  const description = numberOfUnits ? `${numberOfUnits} ${unitLabel} course (${perLabel})` : `${unitLabel} course`;
+
+  return (
+    <div>
+      <div className="text-bluedot-navy mb-6 text-[15px] leading-tight">
+        <span className="font-semibold tracking-[0.45px] uppercase">{label}</span>
+        <span className="ml-1 font-normal opacity-80">{description}</span>
+      </div>
+      <ul className="flex flex-col">
+        {displayedRounds.map((round, index) => (
+          <li key={round.id}>
+            <RoundItem
+              title={round.dateRange}
+              subtitle={`Application closes ${round.applicationDeadline}`}
+              href={buildRoundApplyUrl(applicationUrl, round.id)}
+              accentColor={accentColor}
+            />
+            {index < displayedRounds.length - 1 && <div className="border-bluedot-navy/10 my-4 border-t" />}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/website/src/components/shared/RoundGroup.tsx
+++ b/apps/website/src/components/shared/RoundGroup.tsx
@@ -1,12 +1,9 @@
-import type { inferRouterOutputs } from '@trpc/server';
-import type { AppRouter } from '../../server/routers/_app';
+import type { CourseRound } from '../../server/routers/course-rounds';
 import { buildRoundApplyUrl, RoundItem } from './RoundItem';
-
-type Round = inferRouterOutputs<AppRouter>['courseRounds']['getRoundsForCourse']['intense'][number];
 
 type RoundGroupProps = {
   type: 'intensive' | 'part-time';
-  rounds: Round[];
+  rounds: CourseRound[];
   applicationUrl: string;
   accentColor?: string;
   /** Cap the number of rounds shown. Defaults to showing all. */

--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -13,7 +13,7 @@ import NewsletterBanner from '../../components/homepage/NewsletterBanner';
 import { CourseIcon } from '../../components/courses/CourseIcon';
 import { COURSE_CONFIG } from '../../lib/constants';
 import { appendPosthogSessionIdPrefill } from '../../lib/appendPosthogSessionIdPrefill';
-import { RoundItem, buildRoundApplyUrl } from '../../components/shared/RoundItem';
+import RoundGroup from '../../components/shared/RoundGroup';
 
 const getCourseAccentColor = (courseSlug: string): string => {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -21,8 +21,6 @@ const getCourseAccentColor = (courseSlug: string): string => {
 };
 
 type Course = inferRouterOutputs<AppRouter>['courses']['getAll'][number];
-type CourseRounds = inferRouterOutputs<AppRouter>['courseRounds']['getRoundsForCourse'];
-type Round = CourseRounds['intense'][number];
 
 /* Self-paced courses have no cohort rounds - just open access content */
 const isSelfPacedCourse = (course: Course): boolean => course.slug === 'future-of-ai' || course.slug === 'personal-theory-of-impact';
@@ -414,19 +412,21 @@ const CourseCard = ({ course }: CourseCardProps) => {
         {!roundsLoading && !isSelfPaced && showRounds && (
           <div className="flex flex-col gap-16">
             {hasIntense && (
-              <FormatSection
+              <RoundGroup
                 type="intensive"
                 rounds={rounds.intense}
-                course={course}
-                applicationUrlWithUtm={applicationUrlWithUtm}
+                applicationUrl={applicationUrlWithUtm}
+                accentColor={getCourseAccentColor(course.slug)}
+                maxRounds={3}
               />
             )}
             {hasPartTime && (
-              <FormatSection
+              <RoundGroup
                 type="part-time"
                 rounds={rounds.partTime}
-                course={course}
-                applicationUrlWithUtm={applicationUrlWithUtm}
+                applicationUrl={applicationUrlWithUtm}
+                accentColor={getCourseAccentColor(course.slug)}
+                maxRounds={3}
               />
             )}
           </div>
@@ -552,53 +552,3 @@ const SelfPacedSection = ({ course }: SelfPacedSectionProps) => {
     </>
   );
 };
-
-/* Format Section (Intensive or Part-time) */
-type FormatSectionProps = {
-  type: 'intensive' | 'part-time';
-  rounds: Round[];
-  course: Course;
-  applicationUrlWithUtm: string;
-};
-
-const FormatSection = ({ type, rounds, course, applicationUrlWithUtm }: FormatSectionProps) => {
-  // Limit to display only first 3 rounds
-  const displayedRounds = rounds.slice(0, 3);
-  const firstRound = displayedRounds[0];
-  const numberOfUnits = firstRound?.numberOfUnits;
-  const label = type === 'intensive' ? 'Intensive:' : 'Part-time:';
-  const unitLabel = type === 'intensive' ? 'day' : 'week';
-  const perLabel = type === 'intensive' ? '5h/day' : '5h/week';
-
-  const description = numberOfUnits
-    ? `${numberOfUnits} ${unitLabel} course (${perLabel})`
-    : `${unitLabel} course`;
-
-  const accentColor = getCourseAccentColor(course.slug);
-
-  return (
-    <div className="flex flex-col">
-      <div className="text-[15px] leading-tight text-bluedot-navy mb-6">
-        <span className="font-semibold uppercase tracking-[0.45px]">{label}</span>
-        <span className="ml-1 font-normal opacity-80">{description}</span>
-      </div>
-
-      <ul className="flex flex-col">
-        {displayedRounds.map((round, index) => (
-          <li key={round.id}>
-            <RoundItem
-              title={round.dateRange}
-              subtitle={`Application closes ${round.applicationDeadline}`}
-              href={buildRoundApplyUrl(applicationUrlWithUtm, round.id)}
-              accentColor={accentColor}
-            />
-            {index < displayedRounds.length - 1 && (
-              <div className="my-4 border-t border-bluedot-navy/10" />
-            )}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-};
-

--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -1,12 +1,17 @@
-import { z } from 'zod';
 import {
-  applicationsRoundTable, courseTable, courseRegistrationTable, eq, and, or, sql,
+  and,
+  applicationsRoundTable,
+  courseRegistrationTable,
+  courseTable,
+  eq,
+  or, sql,
 } from '@bluedot/db';
-import { publicProcedure, router } from '../trpc';
-import db from '../../lib/api/db';
-import { formatMonthAndDay } from '../../lib/utils';
+import { z } from 'zod';
 import type { ApplyCTAProps } from '../../components/courses/SideBar';
+import db from '../../lib/api/db';
 import { ONE_DAY_MS, ONE_HOUR_MS } from '../../lib/constants';
+import { formatMonthAndDay } from '../../lib/utils';
+import { publicProcedure, router } from '../trpc';
 
 function getDeadlineThreshold(): Date {
   const now = new Date();
@@ -122,6 +127,7 @@ export async function getCourseRoundsData(courseSlug: string) {
 }
 
 export type CourseRoundsData = Awaited<ReturnType<typeof getCourseRoundsData>>;
+export type CourseRound = CourseRoundsData['intense'][number];
 
 /**
  * Finds the soonest upcoming application deadline across all rounds.


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Changes the final chunk content to conditionally render rounds and apply CTA depending on user status. If the user is logged out or hasn't applied to the course then they see the new Enrolment CTA. Otherwise they see the existing 'Congratulations' cards - to be updated in a future PR.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2234 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="368" height="660" alt="image" src="https://github.com/user-attachments/assets/69bc32b3-30ca-4dc5-8a69-b01860d7e6e1" /> | <img width="364" height="618" alt="image" src="https://github.com/user-attachments/assets/3c2da811-cba1-49dc-abe3-89abc7608bbc" /> |
| 🖥️ | <img width="1448" height="825" alt="image" src="https://github.com/user-attachments/assets/37387ee9-58e8-4159-b233-16820d2a1b0b" /> | <img width="1234" height="1034" alt="image" src="https://github.com/user-attachments/assets/8b9b209b-500e-4389-b488-67fa11e5447e" /> |
