### PR TITLE
Add mcp-aggregator with ashby, google workspace, and 6 hosted MCP upstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository has the code for:
 - [storybook](./apps/storybook/) (storybook.k8s.bluedot.org): App to demo and document design system components
 - [website](./apps/website/) (bluedot.org): Public website
 - [website-proxy](./apps/website-proxy/) (bluedot.org): Reverse proxy to split traffic between the new and old website during migration
+- mcp-aggregator (mcp.k8s.bluedot.org): Single [MCP](https://modelcontextprotocol.io/) endpoint behind Keycloak that fronts Ashby, Google Workspace, Slack, Airtable, Notion, PostHog, Granola and Customer.io for use with AI clients (configured in [infra](./apps/infra/src/k8s/serviceDefinitions.ts))
 - [infra](./apps/infra/): Deploying the above applications on Kubernetes
 
 The following key parts of our software are _not_ in this repository because they are built in 3rd party services that are hard to open-source the code for:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository has the code for:
 - [storybook](./apps/storybook/) (storybook.k8s.bluedot.org): App to demo and document design system components
 - [website](./apps/website/) (bluedot.org): Public website
 - [website-proxy](./apps/website-proxy/) (bluedot.org): Reverse proxy to split traffic between the new and old website during migration
-- mcp-aggregator (mcp.k8s.bluedot.org): Single [MCP](https://modelcontextprotocol.io/) endpoint behind Keycloak that fronts Ashby, Google Workspace, Slack, Airtable, Notion, PostHog, Granola and Customer.io for use with AI clients (configured in [infra](./apps/infra/src/k8s/serviceDefinitions.ts))
+- mcp-aggregator (mcp.k8s.bluedot.org): Single [MCP](https://modelcontextprotocol.io/) endpoint behind @bluedot.org Google sign-in that fronts Ashby, Google Workspace, Slack, Airtable, Notion, PostHog, Granola and Customer.io for use with AI clients (configured in [infra](./apps/infra/src/k8s/serviceDefinitions.ts))
 - [infra](./apps/infra/): Deploying the above applications on Kubernetes
 
 The following key parts of our software are _not_ in this repository because they are built in 3rd party services that are hard to open-source the code for:

--- a/apps/infra/Pulumi.prod.yaml
+++ b/apps/infra/Pulumi.prod.yaml
@@ -44,3 +44,11 @@ config:
     secure: v1:3TlW+6Q1YhvmuJ15:rRAcVGJSQiWyYT9Ynrh1+2/nPzecEg67kKyaHe9ovn++vaD4qtR++nG0jHlcTfOePg78435VeZar
   infra:cioHmacSecret:
     secure: v1:wPbUSYK/0qQk8Ney:k/Rusjtz9RuaLWnIT68V+oX7DZ/xFcb18jqSlyn+vVKpLWfSVrbOZSvJjhSFFLKuocEVIXqxluJmlixdVtV9yRl5ov4trNIeJfu8FWaDhsA=
+  infra:mcpAggregatorSecret:
+    secure: v1:y9qSfOFvE69wDwsR:DsNc4IBABgqn249uTJCdbrR2X7VbvwH3piaHN1kHSQMnfMcU+zGHrlPsDKhcxnQPnEvlrvvHmu57iw7D25QYKQ6E6Mn1hHhwNsEZh5dPG24=
+  infra:mcpAuthWrapperSecret:
+    secure: v1:H4FJ9MqBYF2ddbBm:DfZtl1M9zUBUxcNges2VCGl0LoMPSe64qOonjtGgR4ShI8u+vlw/Tgndb1PcNZweRc8JWUAc0EWYB8lEJ7H3HoAbWRZFib5QY42pG2pz/M4=
+  infra:mcpGoogleOauthClientId:
+    secure: v1:rrEk1XQ9LwV+9G6s:KUs0YC8GYniqNrD8Z+xB1l/7S5Lt5B2aZVvaXMCEHmObdtlp15idwrHIJKg6RzqFCQuPXJbZYC+KvCHiA0fURDJ81ABpm4Ax0ex60de4SvuVmx5L1P5P6w==
+  infra:mcpGoogleOauthClientSecret:
+    secure: v1:b5UzcM6qaYfkVVdW:xhm2fxYkE8rZ/hdDf/HxweP6Ey/Xwbb7Yakk+BfCTZ4/RKcOSDvMyHQry7dr9ahBJ2cU

--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -14,10 +14,13 @@ We're currently hosting most things on [Vultr Kubernetes Engine](https://www.vul
 [vultr-object-storage]
 aws_access_key_id=80A66SRD78U8DZX8SBLJ
 # Get from https://my.vultr.com/objectstorage/subs/detail/?id=caa1d747-4302-4b90-b8dd-aca9d9de1a1f#overview
+# Or from 1Password: "Vultr" in the Engineering vault
 aws_secret_access_key=
 ```
 
-3. In `passphrase.prod.txt` add the contents from [1Password](https://start.1password.com/open/i?a=HTUBIRRURRGNNAKFHX5DU3YWRI&v=j3reqistnwqma7zpy5lzdnwvpi&i=fvtnqvlv5mvrer7o5zm4iijsga&h=bluedotimpact.1password.com).
+3. In `passphrase.prod.txt` add the contents from 1Password: **"bluedot/infra: passphrase.prod.txt k8s"** in the **Engineering** vault ([direct link](https://start.1password.com/open/i?a=HTUBIRRURRGNNAKFHX5DU3YWRI&v=j3reqistnwqma7zpy5lzdnwvpi&i=fvtnqvlv5mvrer7o5zm4iijsga&h=bluedotimpact.1password.com)).
+
+   With the 1Password CLI: `op item get --account bluedotimpact.1password.com j4c627x6cmdutnu7wz4nbagboi --fields notesPlain > passphrase.prod.txt`
 
 ## How it works
 

--- a/apps/infra/src/k8s/pvc.ts
+++ b/apps/infra/src/k8s/pvc.ts
@@ -8,3 +8,19 @@ export const minioPvc = new k8s.core.v1.PersistentVolumeClaim('minio-pvc', {
     resources: { requests: { storage: '50Gi' } },
   },
 }, { provider });
+
+export const mcpAggregatorDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-aggregator-data-pvc', {
+  metadata: { name: 'mcp-aggregator-data-pvc' },
+  spec: {
+    accessModes: ['ReadWriteOnce'],
+    resources: { requests: { storage: '100Mi' } },
+  },
+}, { provider });
+
+export const mcpAshbyDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-ashby-data-pvc', {
+  metadata: { name: 'mcp-ashby-data-pvc' },
+  spec: {
+    accessModes: ['ReadWriteOnce'],
+    resources: { requests: { storage: '100Mi' } },
+  },
+}, { provider });

--- a/apps/infra/src/k8s/pvc.ts
+++ b/apps/infra/src/k8s/pvc.ts
@@ -24,3 +24,11 @@ export const mcpAshbyDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-ashby-
     resources: { requests: { storage: '100Mi' } },
   },
 }, { provider });
+
+export const mcpGoogleDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-google-data-pvc', {
+  metadata: { name: 'mcp-google-data-pvc' },
+  spec: {
+    accessModes: ['ReadWriteOnce'],
+    resources: { requests: { storage: '100Mi' } },
+  },
+}, { provider });

--- a/apps/infra/src/k8s/secrets.ts
+++ b/apps/infra/src/k8s/secrets.ts
@@ -25,6 +25,8 @@ const toK8s = [
   'cioTrackApiKey',
   'cioHmacSecret',
   'lumaApiKey',
+  'mcpGoogleOauthClientId',
+  'mcpGoogleOauthClientSecret',
 ] as const;
 
 export const envVarSources = toK8s.reduce((obj, key) => {

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -1,12 +1,19 @@
+import { jsonStringify } from '@pulumi/pulumi';
 import { type core } from '@pulumi/kubernetes/types/input';
 import { envVarSources } from './secrets';
 import { getConnectionDetails, keycloakPg, airtableSyncPg } from './postgres';
-import { minioPvc } from './pvc';
+import { minioPvc, mcpAggregatorDataPvc, mcpAshbyDataPvc } from './pvc';
 import { websiteAssetsBucket } from '../minio';
+import { config } from '../config';
 
 const ALERTS_SLACK_CHANNEL_ID = 'C04SAGM4FN1'; // #update_tech-prod
 const INFO_SLACK_CHANNEL_ID = 'C04SFUECECU'; // #updates_tech-dev
 const CLIENT_ERRORS_SLACK_CHANNEL_ID = 'C0AL75QQ0SC'; // #update_client-errors
+
+const KEYCLOAK_ISSUER = 'https://login.bluedot.org/realms/customers';
+const MCP_AGGREGATOR_HOST = 'mcp.k8s.bluedot.org';
+const MCP_ASHBY_HOST = 'mcp-ashby.k8s.bluedot.org';
+const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';
 
 export const services: ServiceDefinition[] = [
   {
@@ -319,6 +326,106 @@ export const services: ServiceDefinition[] = [
       ],
     },
     hosts: ['storage.k8s.bluedot.org'],
+  },
+  // Google Workspace MCP server (gmail/drive/calendar/docs/sheets/forms/slides/tasks/contacts/appscript).
+  // Runs the workspace-mcp PyPI package directly via uvx; users OAuth to their own Google account on first use.
+  {
+    name: 'bluedot-mcp-google-workspace',
+    spec: {
+      containers: [{
+        name: 'bluedot-mcp-google-workspace',
+        image: 'ghcr.io/astral-sh/uv:python3.13-bookworm-slim',
+        command: ['uvx', 'workspace-mcp', '--transport', 'streamable-http', '--tools', 'gmail', 'drive', 'calendar', 'docs', 'sheets', 'forms', 'slides', 'tasks', 'contacts', 'appscript'],
+        env: [
+          { name: 'WORKSPACE_MCP_PORT', value: '8080' },
+          { name: 'WORKSPACE_EXTERNAL_URL', value: `https://${MCP_GOOGLE_HOST}` },
+          { name: 'MCP_ENABLE_OAUTH21', value: 'true' },
+          { name: 'GOOGLE_OAUTH_CLIENT_ID', valueFrom: envVarSources.mcpGoogleOauthClientId },
+          { name: 'GOOGLE_OAUTH_CLIENT_SECRET', valueFrom: envVarSources.mcpGoogleOauthClientSecret },
+        ],
+      }],
+    },
+    hosts: [MCP_GOOGLE_HOST],
+  },
+  // Ashby MCP server. ashby-mcp itself is stdio-only, so mcp-auth-wrapper exposes it as
+  // streamable-HTTP behind Keycloak; each user supplies their own Ashby API key via a web form.
+  {
+    name: 'bluedot-mcp-ashby',
+    spec: {
+      containers: [{
+        name: 'bluedot-mcp-ashby',
+        image: 'ghcr.io/domdomegg/mcp-auth-wrapper:1.2.0@sha256:fd2fb6d3c952349423b3dfac2c1bb4ecc18cadbe0b37d0c842d6570506695453',
+        env: [{
+          name: 'MCP_AUTH_WRAPPER_CONFIG',
+          value: jsonStringify({
+            command: ['npx', '-y', 'ashby-mcp'],
+            auth: { issuer: KEYCLOAK_ISSUER, clientId: 'mcp-auth-wrapper' },
+            envPerUser: [
+              {
+                name: 'ASHBY_API_KEY', label: 'Ashby API Key', description: 'Get this from Ashby admin → Integrations → API keys', secret: true,
+              },
+            ],
+            storage: '/app/data/mcp.sqlite',
+            issuerUrl: `https://${MCP_ASHBY_HOST}`,
+            port: 8080,
+            secret: config.requireSecret('mcpAuthWrapperSecret'),
+          }),
+        }],
+        volumeMounts: [{
+          name: 'mcp-data-volume',
+          mountPath: '/app/data',
+        }],
+      }],
+      volumes: [{
+        name: 'mcp-data-volume',
+        persistentVolumeClaim: {
+          claimName: mcpAshbyDataPvc.metadata.name,
+        },
+      }],
+    },
+    hosts: [MCP_ASHBY_HOST],
+  },
+  // MCP aggregator: single streamable-HTTP endpoint behind Keycloak that fronts the two
+  // self-hosted servers above plus six vendor-hosted MCPs. See https://github.com/domdomegg/mcp-aggregator
+  {
+    name: 'bluedot-mcp-aggregator',
+    spec: {
+      containers: [{
+        name: 'bluedot-mcp-aggregator',
+        image: 'ghcr.io/domdomegg/mcp-aggregator:2.0.1@sha256:990a63a45a29a5a7258202c2803f8ac8e5717fa90cd4dce1afb8580d0decc3ea',
+        env: [{
+          name: 'MCP_AGGREGATOR_CONFIG',
+          value: jsonStringify({
+            auth: { issuer: KEYCLOAK_ISSUER, clientId: 'mcp-aggregator' },
+            upstreams: [
+              { name: 'ashby', url: `https://${MCP_ASHBY_HOST}/mcp` },
+              { name: 'google', url: `https://${MCP_GOOGLE_HOST}/mcp` },
+              { name: 'slack', url: 'https://mcp.slack.com/mcp' },
+              { name: 'airtable', url: 'https://mcp.airtable.com/mcp' },
+              { name: 'notion', url: 'https://mcp.notion.com/mcp' },
+              { name: 'posthog', url: 'https://mcp-eu.posthog.com/mcp' },
+              { name: 'granola', url: 'https://mcp.granola.ai/mcp' },
+              { name: 'customerio', url: 'https://mcp.customer.io/mcp' },
+            ],
+            storage: '/app/data/mcp-aggregator.sqlite',
+            issuerUrl: `https://${MCP_AGGREGATOR_HOST}`,
+            port: 8080,
+            secret: config.requireSecret('mcpAggregatorSecret'),
+          }),
+        }],
+        volumeMounts: [{
+          name: 'mcp-data-volume',
+          mountPath: '/app/data',
+        }],
+      }],
+      volumes: [{
+        name: 'mcp-data-volume',
+        persistentVolumeClaim: {
+          claimName: mcpAggregatorDataPvc.metadata.name,
+        },
+      }],
+    },
+    hosts: [MCP_AGGREGATOR_HOST],
   },
 ];
 

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -12,7 +12,7 @@ const ALERTS_SLACK_CHANNEL_ID = 'C04SAGM4FN1'; // #update_tech-prod
 const INFO_SLACK_CHANNEL_ID = 'C04SFUECECU'; // #updates_tech-dev
 const CLIENT_ERRORS_SLACK_CHANNEL_ID = 'C0AL75QQ0SC'; // #update_client-errors
 
-const KEYCLOAK_ISSUER = 'https://login.bluedot.org/realms/customers';
+const KEYCLOAK_ISSUER = 'https://login.bluedot.org/realms/master';
 const MCP_AGGREGATOR_HOST = 'mcp.k8s.bluedot.org';
 const MCP_ASHBY_HOST = 'mcp-ashby.k8s.bluedot.org';
 const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -12,10 +12,20 @@ const ALERTS_SLACK_CHANNEL_ID = 'C04SAGM4FN1'; // #update_tech-prod
 const INFO_SLACK_CHANNEL_ID = 'C04SFUECECU'; // #updates_tech-dev
 const CLIENT_ERRORS_SLACK_CHANNEL_ID = 'C0AL75QQ0SC'; // #update_client-errors
 
-const KEYCLOAK_ISSUER = 'https://login.bluedot.org/realms/master';
 const MCP_AGGREGATOR_HOST = 'mcp.k8s.bluedot.org';
 const MCP_ASHBY_HOST = 'mcp-ashby.k8s.bluedot.org';
 const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';
+// Front-door auth for the MCP services uses Google OIDC. Access is restricted to @bluedot.org
+// because the OAuth client (mcpGoogleOauthClientId) lives in a GCP project whose consent screen
+// is configured as "Internal" — Google enforces that server-side. The same client serves both
+// identity (here, scope openid/email/profile) and workspace-mcp's data access (gmail/drive/etc).
+const mcpGoogleAuth = {
+  issuer: 'https://accounts.google.com',
+  clientId: config.requireSecret('mcpGoogleOauthClientId'),
+  clientSecret: config.requireSecret('mcpGoogleOauthClientSecret'),
+  scopes: ['openid', 'email', 'profile'],
+  userClaim: 'email',
+};
 
 export const services: ServiceDefinition[] = [
   {
@@ -361,7 +371,7 @@ export const services: ServiceDefinition[] = [
     hosts: [MCP_GOOGLE_HOST],
   },
   // Ashby MCP server. ashby-mcp itself is stdio-only, so mcp-auth-wrapper exposes it as
-  // streamable-HTTP behind Keycloak; each user supplies their own Ashby API key via a web form.
+  // streamable-HTTP behind Google sign-in; each user supplies their own Ashby API key via a web form.
   {
     name: 'bluedot-mcp-ashby',
     spec: {
@@ -372,7 +382,7 @@ export const services: ServiceDefinition[] = [
           name: 'MCP_AUTH_WRAPPER_CONFIG',
           value: jsonStringify({
             command: ['npx', '-y', 'ashby-mcp'],
-            auth: { issuer: KEYCLOAK_ISSUER, clientId: 'mcp-auth-wrapper' },
+            auth: mcpGoogleAuth,
             envPerUser: [
               {
                 name: 'ASHBY_API_KEY', label: 'Ashby API Key', description: 'Get this from Ashby admin → Integrations → API keys', secret: true,
@@ -398,7 +408,7 @@ export const services: ServiceDefinition[] = [
     },
     hosts: [MCP_ASHBY_HOST],
   },
-  // MCP aggregator: single streamable-HTTP endpoint behind Keycloak that fronts the two
+  // MCP aggregator: single streamable-HTTP endpoint behind Google sign-in that fronts the two
   // self-hosted servers above plus six vendor-hosted MCPs. See https://github.com/domdomegg/mcp-aggregator
   {
     name: 'bluedot-mcp-aggregator',
@@ -409,7 +419,7 @@ export const services: ServiceDefinition[] = [
         env: [{
           name: 'MCP_AGGREGATOR_CONFIG',
           value: jsonStringify({
-            auth: { issuer: KEYCLOAK_ISSUER, clientId: 'mcp-aggregator' },
+            auth: mcpGoogleAuth,
             upstreams: [
               { name: 'ashby', url: `https://${MCP_ASHBY_HOST}/mcp` },
               { name: 'google', url: `https://${MCP_GOOGLE_HOST}/mcp` },

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -2,7 +2,9 @@ import { jsonStringify } from '@pulumi/pulumi';
 import { type core } from '@pulumi/kubernetes/types/input';
 import { envVarSources } from './secrets';
 import { getConnectionDetails, keycloakPg, airtableSyncPg } from './postgres';
-import { minioPvc, mcpAggregatorDataPvc, mcpAshbyDataPvc } from './pvc';
+import {
+  minioPvc, mcpAggregatorDataPvc, mcpAshbyDataPvc, mcpGoogleDataPvc,
+} from './pvc';
 import { websiteAssetsBucket } from '../minio';
 import { config } from '../config';
 
@@ -334,15 +336,26 @@ export const services: ServiceDefinition[] = [
     spec: {
       containers: [{
         name: 'bluedot-mcp-google-workspace',
-        image: 'ghcr.io/astral-sh/uv:python3.13-bookworm-slim',
-        command: ['uvx', 'workspace-mcp', '--transport', 'streamable-http', '--tools', 'gmail', 'drive', 'calendar', 'docs', 'sheets', 'forms', 'slides', 'tasks', 'contacts', 'appscript'],
+        image: 'ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca',
+        command: ['uvx', 'workspace-mcp==1.18.0', '--transport', 'streamable-http', '--tools', 'gmail', 'drive', 'calendar', 'docs', 'sheets', 'forms', 'slides', 'tasks', 'contacts', 'appscript'],
         env: [
           { name: 'WORKSPACE_MCP_PORT', value: '8080' },
           { name: 'WORKSPACE_EXTERNAL_URL', value: `https://${MCP_GOOGLE_HOST}` },
           { name: 'MCP_ENABLE_OAUTH21', value: 'true' },
+          { name: 'GOOGLE_MCP_CREDENTIALS_DIR', value: '/app/data/credentials' },
           { name: 'GOOGLE_OAUTH_CLIENT_ID', valueFrom: envVarSources.mcpGoogleOauthClientId },
           { name: 'GOOGLE_OAUTH_CLIENT_SECRET', valueFrom: envVarSources.mcpGoogleOauthClientSecret },
         ],
+        volumeMounts: [{
+          name: 'mcp-data-volume',
+          mountPath: '/app/data',
+        }],
+      }],
+      volumes: [{
+        name: 'mcp-data-volume',
+        persistentVolumeClaim: {
+          claimName: mcpGoogleDataPvc.metadata.name,
+        },
       }],
     },
     hosts: [MCP_GOOGLE_HOST],


### PR DESCRIPTION
Adds a single MCP endpoint at https://mcp.k8s.bluedot.org that the team can plug into Claude/ChatGPT/Cursor etc. You log in once with your @bluedot.org Google account and get tools for all our main systems in one place, instead of configuring 8 separate connectors per person per AI client.

This is config-only (three new entries in infra's serviceDefinitions plus three small PVCs for token storage). No new app dirs — the containers are upstream images configured via env var, same pattern as the minio entry. Reference setup is my homelab which runs the same thing: https://github.com/domdomegg/homelab

How it's wired:
- [mcp-aggregator](https://github.com/domdomegg/mcp-aggregator) at mcp.k8s.bluedot.org — fronts everything below behind Google sign-in
- [mcp-auth-wrapper](https://github.com/domdomegg/mcp-auth-wrapper) at mcp-ashby.k8s.bluedot.org — wraps the stdio-only `ashby-mcp` package, each user enters their own Ashby API key on first use
- [workspace-mcp](https://github.com/taylorwilsdon/google_workspace_mcp) at mcp-google.k8s.bluedot.org — Gmail/Drive/Calendar/Docs/Sheets/Forms/Slides/Tasks/Contacts/Apps Script (chat and search deliberately left off)

Upstreams the aggregator points at:
- ashby — self-hosted above
- google — self-hosted above
- slack — https://mcp.slack.com/mcp
- airtable — https://mcp.airtable.com/mcp
- notion — https://mcp.notion.com/mcp
- posthog — https://mcp-eu.posthog.com/mcp (EU region)
- granola — https://mcp.granola.ai/mcp
- customerio — https://mcp.customer.io/mcp

## Auth

Front-door login is Google OIDC. Access is restricted to @bluedot.org accounts because the OAuth client lives in a GCP project whose consent screen is set to **Internal** — Google enforces that server-side, so no extra claim-checking is needed in the aggregator. The same OAuth client doubles as workspace-mcp's data-access client (one client, three redirect URIs). Scopes are requested per-flow, so the front-door login only asks for `openid email profile`; the Gmail/Drive/etc consent only appears when a user first connects the google-workspace upstream.

## Before this can deploy

One Google OAuth client (in a GCP project with consent screen User Type = **Internal**):
- APIs & Services → Credentials → Create OAuth client ID → **Web application**
- Three authorised redirect URIs:
  - `https://mcp.k8s.bluedot.org/callback`
  - `https://mcp-ashby.k8s.bluedot.org/callback`
  - `https://mcp-google.k8s.bluedot.org/oauth2callback`
- In the same project, enable: Gmail API, Google Drive API, Google Calendar API, Google Docs API, Google Sheets API, Google Forms API, Google Slides API, Google Tasks API, People API, Apps Script API

Then four Pulumi secrets (in apps/infra: `npm run config:secret <key>`):
- `mcpAggregatorSecret` — random string, e.g. `openssl rand -hex 32`
- `mcpAuthWrapperSecret` — random string, same
- `mcpGoogleOauthClientId` / `mcpGoogleOauthClientSecret` — from the OAuth client above

## Per-service setup on first use

Mostly just OAuth-in-browser when each user first calls a tool, but a couple need admin action:
- Slack: needs a registered Slack app on the workspace
- Customer.io: a workspace admin has to enable "Customer.io MCP" under Settings → Privacy, Data & AI
- Airtable: OAuth (or PAT) per user
- Notion, Granola, PostHog: OAuth per user, no admin setup

## Not in this PR

Wrapping the Nexudus API as an MCP would be useful (room bookings etc.) but there's no existing server for it, so that's a separate piece of work.
