### PR TITLE
fix(website): show soonest discussion across all rounds for facilitators

### DIFF
--- a/apps/speed-review/src/pages/index.tsx
+++ b/apps/speed-review/src/pages/index.tsx
@@ -268,7 +268,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
     // Show undo toast
     setUndoToast(current.name);
     if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
-    undoTimerRef.current = setTimeout(() => setUndoToast(null), 3000);
+    undoTimerRef.current = setTimeout(() => setUndoToast(null), 6000);
   }, [state, showMilestone]);
   handleRateRef.current = handleRate;
 
@@ -548,7 +548,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
       )}
 
       {toastName && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 bg-stone-800 text-white text-size-sm px-4 py-2 rounded-full shadow-lg pointer-events-none">
+        <div className={`fixed left-1/2 -translate-x-1/2 bg-stone-800 text-white text-size-sm px-4 py-2 rounded-full shadow-lg pointer-events-none ${undoToast ? 'bottom-16' : 'bottom-6'}`}>
           Moved to back of queue: {toastName}
         </div>
       )}

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -111,9 +111,11 @@ export const groupDiscussionsRouter = router({
         return null;
       }
 
-      // Get meetPerson records for all registrations
-      const participantResults = await Promise.all(courseRegistrations.map((reg) => db.getFirst(meetPersonTable, { filter: { applicationsBaseRecordId: reg.id } })));
-      const participants = participantResults.filter((p): p is NonNullable<typeof p> => p !== null);
+      // Get meetPerson records for all registrations in a single query
+      const participants = await db.pg
+        .select()
+        .from(meetPersonTable.pg)
+        .where(inArray(meetPersonTable.pg.applicationsBaseRecordId, courseRegistrations.map((r) => r.id)));
 
       if (participants.length === 0) {
         return null;

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -5,7 +5,10 @@ import {
   eq,
   groupDiscussionTable,
   groupTable,
+  inArray,
+  isNull,
   meetPersonTable,
+  or,
   sql,
   unitTable,
   zoomAccountTable,
@@ -89,39 +92,49 @@ export const groupDiscussionsRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${courseSlug}` });
       }
 
-      const courseRegistration = await db.getFirst(courseRegistrationTable, {
-        filter: {
-          email: ctx.auth.email,
-          decision: 'Accept',
-          courseId: course.id,
-        },
-      });
+      // Get all accepted course registrations for this course (not just the first),
+      // so facilitators with discussions across multiple rounds see the soonest one
+      const courseRegistrations = await db.pg
+        .select()
+        .from(courseRegistrationTable.pg)
+        .where(and(
+          eq(courseRegistrationTable.pg.email, ctx.auth.email),
+          eq(courseRegistrationTable.pg.courseId, course.id),
+          eq(courseRegistrationTable.pg.decision, 'Accept'),
+          or(
+            eq(courseRegistrationTable.pg.isDuplicate, false),
+            isNull(courseRegistrationTable.pg.isDuplicate),
+          ),
+        ));
 
-      if (!courseRegistration) {
+      if (courseRegistrations.length === 0) {
         return null;
       }
 
-      const participant = await db.getFirst(meetPersonTable, {
-        filter: { applicationsBaseRecordId: courseRegistration.id },
-      });
+      // Get meetPerson records for all registrations
+      const participantResults = await Promise.all(courseRegistrations.map((reg) => db.getFirst(meetPersonTable, { filter: { applicationsBaseRecordId: reg.id } })));
+      const participants = participantResults.filter((p): p is NonNullable<typeof p> => p !== null);
 
-      if (!participant) {
+      if (participants.length === 0) {
         return null;
       }
 
-      const roundId = participant.round;
-      if (!roundId) {
+      const roundIds = [...new Set(participants.map((p) => p.round).filter((r): r is string => !!r))];
+      const participantIds = participants.map((p) => p.id);
+
+      if (roundIds.length === 0) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Round not found for participant' });
       }
 
       const currentTimeMs = Date.now();
 
+      // Query discussions across all rounds where the user is a participant or facilitator
       const groupDiscussions = await db.pg
         .select()
         .from(groupDiscussionTable.pg)
         .where(and(
-          eq(groupDiscussionTable.pg.round, roundId),
-          sql`(${groupDiscussionTable.pg.participantsExpected} @> ARRAY[${participant.id}] OR ${groupDiscussionTable.pg.facilitators} @> ARRAY[${participant.id}])`,
+          inArray(groupDiscussionTable.pg.round, roundIds),
+          sql`(${groupDiscussionTable.pg.participantsExpected} && ARRAY[${sql.join(participantIds.map((id) => sql`${id}`), sql`, `)}]::text[] OR ${groupDiscussionTable.pg.facilitators} && ARRAY[${sql.join(participantIds.map((id) => sql`${id}`), sql`, `)}]::text[])`,
         ))
         .orderBy(groupDiscussionTable.pg.startDateTime);
 
@@ -132,20 +145,25 @@ export const groupDiscussionsRouter = router({
       let userRole: 'participant' | 'facilitator' | undefined;
       let hostKeyForFacilitators: string | undefined;
 
-      if (groupDiscussion?.facilitators.includes(participant.id)) {
-        userRole = 'facilitator';
+      if (groupDiscussion) {
+        const isFacilitator = participantIds.some((id) => groupDiscussion.facilitators.includes(id));
+        const isParticipant = participantIds.some((id) => groupDiscussion.participantsExpected.includes(id));
 
-        if (groupDiscussion.zoomAccount) {
-          try {
-            const zoomAccount = await db.get(zoomAccountTable, { id: groupDiscussion.zoomAccount });
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            hostKeyForFacilitators = zoomAccount.hostKey || undefined;
-          } catch {
-            hostKeyForFacilitators = undefined;
+        if (isFacilitator) {
+          userRole = 'facilitator';
+
+          if (groupDiscussion.zoomAccount) {
+            try {
+              const zoomAccount = await db.get(zoomAccountTable, { id: groupDiscussion.zoomAccount });
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+              hostKeyForFacilitators = zoomAccount.hostKey || undefined;
+            } catch {
+              hostKeyForFacilitators = undefined;
+            }
           }
+        } else if (isParticipant) {
+          userRole = 'participant';
         }
-      } else if (groupDiscussion?.participantsExpected.includes(participant.id)) {
-        userRole = 'participant';
       }
 
       return {

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -122,7 +122,7 @@ export const groupDiscussionsRouter = router({
       }
 
       const roundIds = [...new Set(participants.map((p) => p.round).filter((r): r is string => !!r))];
-      const participantIds = participants.map((p) => p.id);
+      const participantIds = [...new Set(participants.map((p) => p.id))];
 
       if (roundIds.length === 0) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Round not found for participant' });


### PR DESCRIPTION
## Summary
- **Bug:** Facilitators with discussions across multiple rounds only saw discussions from one round. A facilitator could have a call in 10 minutes but the banner would show a call 2 days away (in a different round).
- **Root cause:** `getByCourseSlug` used `getFirst` to pick a single course registration → single meetPerson → single round, missing discussions in other rounds.
- **Fix:** Query all accepted (non-duplicate) course registrations, collect all meetPerson records and their rounds, then find the soonest non-ended discussion across all of them using the `&&` (array overlap) operator.

## Test plan
- [ ] Facilitator with discussions in multiple rounds sees the soonest upcoming call
- [ ] Facilitator with discussions in a single round still sees the correct next call
- [ ] Participant banner still works correctly (single registration case)
- [ ] No banner shown when user has no accepted registrations
- [ ] Role detection (facilitator vs participant) still works correctly for the returned discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)