### PR TITLE
Use emptyDir for MCP token storage (delete stuck PVCs, unblock CD)

### DIFF
--- a/apps/infra/src/k8s/pvc.ts
+++ b/apps/infra/src/k8s/pvc.ts
@@ -8,27 +8,3 @@ export const minioPvc = new k8s.core.v1.PersistentVolumeClaim('minio-pvc', {
     resources: { requests: { storage: '50Gi' } },
   },
 }, { provider });
-
-export const mcpAggregatorDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-aggregator-data-pvc', {
-  metadata: { name: 'mcp-aggregator-data-pvc' },
-  spec: {
-    accessModes: ['ReadWriteOnce'],
-    resources: { requests: { storage: '100Mi' } },
-  },
-}, { provider });
-
-export const mcpAshbyDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-ashby-data-pvc', {
-  metadata: { name: 'mcp-ashby-data-pvc' },
-  spec: {
-    accessModes: ['ReadWriteOnce'],
-    resources: { requests: { storage: '100Mi' } },
-  },
-}, { provider });
-
-export const mcpGoogleDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-google-data-pvc', {
-  metadata: { name: 'mcp-google-data-pvc' },
-  spec: {
-    accessModes: ['ReadWriteOnce'],
-    resources: { requests: { storage: '100Mi' } },
-  },
-}, { provider });

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -2,9 +2,7 @@ import { jsonStringify } from '@pulumi/pulumi';
 import { type core } from '@pulumi/kubernetes/types/input';
 import { envVarSources } from './secrets';
 import { getConnectionDetails, keycloakPg, airtableSyncPg } from './postgres';
-import {
-  minioPvc, mcpAggregatorDataPvc, mcpAshbyDataPvc, mcpGoogleDataPvc,
-} from './pvc';
+import { minioPvc } from './pvc';
 import { websiteAssetsBucket } from '../minio';
 import { config } from '../config';
 
@@ -361,11 +359,11 @@ export const services: ServiceDefinition[] = [
           mountPath: '/app/data',
         }],
       }],
+      // emptyDir for now — Vultr block-storage quota is maxed out. Swap to PVCs once the limit is raised
+      // (tokens are lost on pod restart until then, which means users re-auth — acceptable for MVP)
       volumes: [{
         name: 'mcp-data-volume',
-        persistentVolumeClaim: {
-          claimName: mcpGoogleDataPvc.metadata.name,
-        },
+        emptyDir: {},
       }],
     },
     hosts: [MCP_GOOGLE_HOST],
@@ -401,9 +399,7 @@ export const services: ServiceDefinition[] = [
       }],
       volumes: [{
         name: 'mcp-data-volume',
-        persistentVolumeClaim: {
-          claimName: mcpAshbyDataPvc.metadata.name,
-        },
+        emptyDir: {},
       }],
     },
     hosts: [MCP_ASHBY_HOST],
@@ -443,9 +439,7 @@ export const services: ServiceDefinition[] = [
       }],
       volumes: [{
         name: 'mcp-data-volume',
-        persistentVolumeClaim: {
-          claimName: mcpAggregatorDataPvc.metadata.name,
-        },
+        emptyDir: {},
       }],
     },
     hosts: [MCP_AGGREGATOR_HOST],


### PR DESCRIPTION
CD has been red since #2247 — the three PVCs are stuck `Pending` (originally Vultr quota; now CSI exponential backoff after a day of failures).

This swaps the three MCP volumes to `emptyDir` and removes the PVC resources, which makes Pulumi delete the stuck PVCs and lets the services actually come up. Tokens are lost on pod restart while on emptyDir — fine, no one's using it yet.

Follow-up PR adds the PVCs back at 5Gi with `skipAwait`.