### PR TITLE
Restore MCP PVCs at 5Gi with skipAwait

### DIFF
--- a/apps/infra/src/k8s/pvc.ts
+++ b/apps/infra/src/k8s/pvc.ts
@@ -8,3 +8,38 @@ export const minioPvc = new k8s.core.v1.PersistentVolumeClaim('minio-pvc', {
     resources: { requests: { storage: '50Gi' } },
   },
 }, { provider });
+
+// MCP token-store PVCs. skipAwait stops Pulumi blocking the Deployment on the PVC binding,
+// so a slow-to-provision volume can never red-flag CD — the pod just waits for the volume.
+export const mcpAggregatorDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-aggregator-data-pvc', {
+  metadata: {
+    name: 'mcp-aggregator-data-pvc',
+    annotations: { 'pulumi.com/skipAwait': 'true' },
+  },
+  spec: {
+    accessModes: ['ReadWriteOnce'],
+    resources: { requests: { storage: '5Gi' } },
+  },
+}, { provider });
+
+export const mcpAshbyDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-ashby-data-pvc', {
+  metadata: {
+    name: 'mcp-ashby-data-pvc',
+    annotations: { 'pulumi.com/skipAwait': 'true' },
+  },
+  spec: {
+    accessModes: ['ReadWriteOnce'],
+    resources: { requests: { storage: '5Gi' } },
+  },
+}, { provider });
+
+export const mcpGoogleDataPvc = new k8s.core.v1.PersistentVolumeClaim('mcp-google-data-pvc', {
+  metadata: {
+    name: 'mcp-google-data-pvc',
+    annotations: { 'pulumi.com/skipAwait': 'true' },
+  },
+  spec: {
+    accessModes: ['ReadWriteOnce'],
+    resources: { requests: { storage: '5Gi' } },
+  },
+}, { provider });

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -2,7 +2,9 @@ import { jsonStringify } from '@pulumi/pulumi';
 import { type core } from '@pulumi/kubernetes/types/input';
 import { envVarSources } from './secrets';
 import { getConnectionDetails, keycloakPg, airtableSyncPg } from './postgres';
-import { minioPvc } from './pvc';
+import {
+  minioPvc, mcpAggregatorDataPvc, mcpAshbyDataPvc, mcpGoogleDataPvc,
+} from './pvc';
 import { websiteAssetsBucket } from '../minio';
 import { config } from '../config';
 
@@ -359,11 +361,11 @@ export const services: ServiceDefinition[] = [
           mountPath: '/app/data',
         }],
       }],
-      // emptyDir for now — Vultr block-storage quota is maxed out. Swap to PVCs once the limit is raised
-      // (tokens are lost on pod restart until then, which means users re-auth — acceptable for MVP)
       volumes: [{
         name: 'mcp-data-volume',
-        emptyDir: {},
+        persistentVolumeClaim: {
+          claimName: mcpGoogleDataPvc.metadata.name,
+        },
       }],
     },
     hosts: [MCP_GOOGLE_HOST],
@@ -399,7 +401,9 @@ export const services: ServiceDefinition[] = [
       }],
       volumes: [{
         name: 'mcp-data-volume',
-        emptyDir: {},
+        persistentVolumeClaim: {
+          claimName: mcpAshbyDataPvc.metadata.name,
+        },
       }],
     },
     hosts: [MCP_ASHBY_HOST],
@@ -439,7 +443,9 @@ export const services: ServiceDefinition[] = [
       }],
       volumes: [{
         name: 'mcp-data-volume',
-        emptyDir: {},
+        persistentVolumeClaim: {
+          claimName: mcpAggregatorDataPvc.metadata.name,
+        },
       }],
     },
     hosts: [MCP_AGGREGATOR_HOST],


### PR DESCRIPTION
Follow-up to #2250. Adds the three MCP PVCs back at 5Gi (matching the smallest existing volume in the cluster — the keycloak/grafana CNPG clusters) with `pulumi.com/skipAwait` so PVC binding can never block CD.

Merge after #2250. The stuck PVCs will already be gone, so these provision fresh with no backoff.

No `replaceOnChanges`/`deleteBeforeReplace` — those would make any future spec change wipe the volume.