### PR TITLE
Set fsGroup=1000 on mcp-aggregator + mcp-ashby (fix PVC write permissions)

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -405,6 +405,8 @@ export const services: ServiceDefinition[] = [
           claimName: mcpAshbyDataPvc.metadata.name,
         },
       }],
+      // fsGroup so the node user (uid 1000) can write to the PVC mount
+      securityContext: { fsGroup: 1000 },
     },
     hosts: [MCP_ASHBY_HOST],
   },
@@ -447,6 +449,7 @@ export const services: ServiceDefinition[] = [
           claimName: mcpAggregatorDataPvc.metadata.name,
         },
       }],
+      securityContext: { fsGroup: 1000 },
     },
     hosts: [MCP_AGGREGATOR_HOST],
   },


### PR DESCRIPTION
Both services 503 after #2252 — containers run as `USER node` (uid 1000) but the Vultr CSI volume mounts root:root, so the SQLite open at boot fails with EACCES → CrashLoopBackOff. `mcp-google` is fine because the uv image runs as root.

`fsGroup: 1000` makes kubelet chown the volume to gid 1000 on mount.

Confirm with: `kubectl logs deploy/bluedot-mcp-aggregator-deployment | tail` — should show EACCES/SQLITE_CANTOPEN before this lands.