### PR TITLE
[fix] Enable external OAuth mode for workspace-mcp scopes

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -18,12 +18,42 @@ const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';
 // Front-door auth for the MCP services uses Google OIDC. Access is restricted to @bluedot.org
 // because the OAuth client (mcpGoogleOauthClientId) lives in a GCP project whose consent screen
 // is configured as "Internal" — Google enforces that server-side. The same client serves both
-// identity (here, scope openid/email/profile) and workspace-mcp's data access (gmail/drive/etc).
+// identity (openid/email/profile) and workspace-mcp's data access (gmail/drive/calendar/etc).
+// Scopes use the broadest variant per service; workspace-mcp's scope hierarchy handles mapping
+// (e.g. gmail.modify implies gmail.readonly). See workspace-mcp auth/scopes.py SCOPE_HIERARCHY.
 const mcpGoogleAuth = {
   issuer: 'https://accounts.google.com',
   clientId: config.requireSecret('mcpGoogleOauthClientId'),
   clientSecret: config.requireSecret('mcpGoogleOauthClientSecret'),
-  scopes: ['openid', 'email', 'profile'],
+  scopes: [
+    // Identity
+    'openid', 'email', 'profile',
+    // Gmail (modify covers readonly/send/compose/labels)
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.settings.basic',
+    // Drive (drive covers drive.readonly and drive.file)
+    'https://www.googleapis.com/auth/drive',
+    // Calendar (calendar covers calendar.readonly and calendar.events)
+    'https://www.googleapis.com/auth/calendar',
+    // Docs
+    'https://www.googleapis.com/auth/documents',
+    // Sheets
+    'https://www.googleapis.com/auth/spreadsheets',
+    // Slides
+    'https://www.googleapis.com/auth/presentations',
+    // Forms
+    'https://www.googleapis.com/auth/forms.body',
+    'https://www.googleapis.com/auth/forms.responses.readonly',
+    // Tasks
+    'https://www.googleapis.com/auth/tasks',
+    // Contacts
+    'https://www.googleapis.com/auth/contacts',
+    // Apps Script
+    'https://www.googleapis.com/auth/script.projects',
+    'https://www.googleapis.com/auth/script.deployments',
+    'https://www.googleapis.com/auth/script.processes',
+    'https://www.googleapis.com/auth/script.metrics',
+  ],
   userClaim: 'email',
 };
 

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -389,6 +389,8 @@ export const services: ServiceDefinition[] = [
   },
   // Google Workspace MCP server (gmail/drive/calendar/docs/sheets/forms/slides/tasks/contacts/appscript).
   // Runs the workspace-mcp PyPI package directly via uvx; users OAuth to their own Google account on first use.
+  // EXTERNAL_OAUTH21_PROVIDER mode: workspace-mcp advertises required scopes via RFC 9728 metadata and
+  // expects the upstream proxy (mcp-aggregator) to handle the Google OAuth flow with full workspace scopes.
   {
     name: 'bluedot-mcp-google-workspace',
     spec: {
@@ -400,6 +402,7 @@ export const services: ServiceDefinition[] = [
           { name: 'WORKSPACE_MCP_PORT', value: '8080' },
           { name: 'WORKSPACE_EXTERNAL_URL', value: `https://${MCP_GOOGLE_HOST}` },
           { name: 'MCP_ENABLE_OAUTH21', value: 'true' },
+          { name: 'EXTERNAL_OAUTH21_PROVIDER', value: 'true' },
           { name: 'GOOGLE_MCP_CREDENTIALS_DIR', value: '/app/data/credentials' },
           { name: 'GOOGLE_OAUTH_CLIENT_ID', valueFrom: envVarSources.mcpGoogleOauthClientId },
           { name: 'GOOGLE_OAUTH_CLIENT_SECRET', valueFrom: envVarSources.mcpGoogleOauthClientSecret },

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -17,17 +17,36 @@ const MCP_ASHBY_HOST = 'mcp-ashby.k8s.bluedot.org';
 const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';
 // Front-door auth for the MCP services uses Google OIDC. Access is restricted to @bluedot.org
 // because the OAuth client (mcpGoogleOauthClientId) lives in a GCP project whose consent screen
-// is configured as "Internal" — Google enforces that server-side. The same client serves both
-// identity (openid/email/profile) and workspace-mcp's data access (gmail/drive/calendar/etc).
-// Scopes use the broadest variant per service; workspace-mcp's scope hierarchy handles mapping
-// (e.g. gmail.modify implies gmail.readonly). See workspace-mcp auth/scopes.py SCOPE_HIERARCHY.
-const mcpGoogleAuth = {
+// is configured as "Internal" — Google enforces that server-side.
+const mcpGoogleOauth = {
   issuer: 'https://accounts.google.com',
   clientId: config.requireSecret('mcpGoogleOauthClientId'),
   clientSecret: config.requireSecret('mcpGoogleOauthClientSecret'),
+  userClaim: 'email',
+};
+
+// Identity-only auth: just verifies the user is @bluedot.org. Used by services that don't need
+// Google Workspace data access (e.g. Ashby MCP).
+const mcpIdentityAuth = {
+  ...mcpGoogleOauth,
+  scopes: [
+    'openid',
+    'email',
+    'profile',
+  ],
+};
+
+// Workspace auth: identity + Google Workspace API scopes. Used by the MCP aggregator (which
+// proxies to workspace-mcp). Scopes use the broadest variant per service; workspace-mcp's scope
+// hierarchy handles mapping (e.g. gmail.modify implies gmail.readonly).
+// See workspace-mcp auth/scopes.py SCOPE_HIERARCHY.
+const mcpWorkspaceAuth = {
+  ...mcpGoogleOauth,
   scopes: [
     // Identity
-    'openid', 'email', 'profile',
+    'openid',
+    'email',
+    'profile',
     // Gmail (modify covers readonly/send/compose/labels)
     'https://www.googleapis.com/auth/gmail.modify',
     'https://www.googleapis.com/auth/gmail.settings.basic',
@@ -54,7 +73,6 @@ const mcpGoogleAuth = {
     'https://www.googleapis.com/auth/script.processes',
     'https://www.googleapis.com/auth/script.metrics',
   ],
-  userClaim: 'email',
 };
 
 export const services: ServiceDefinition[] = [
@@ -412,7 +430,7 @@ export const services: ServiceDefinition[] = [
           name: 'MCP_AUTH_WRAPPER_CONFIG',
           value: jsonStringify({
             command: ['npx', '-y', 'ashby-mcp'],
-            auth: mcpGoogleAuth,
+            auth: mcpIdentityAuth,
             envPerUser: [
               {
                 name: 'ASHBY_API_KEY', label: 'Ashby API Key', description: 'Get this from Ashby admin → Integrations → API keys', secret: true,
@@ -451,7 +469,7 @@ export const services: ServiceDefinition[] = [
         env: [{
           name: 'MCP_AGGREGATOR_CONFIG',
           value: jsonStringify({
-            auth: mcpGoogleAuth,
+            auth: mcpWorkspaceAuth,
             upstreams: [
               { name: 'ashby', url: `https://${MCP_ASHBY_HOST}/mcp` },
               { name: 'google', url: `https://${MCP_GOOGLE_HOST}/mcp` },


### PR DESCRIPTION
## Summary
- Follow-up to #2254. The scope change to `mcpWorkspaceAuth` only affected the aggregator's front-door auth — not the upstream Google OAuth flow.
- The root cause is that workspace-mcp in standard OAuth 2.1 mode (`GoogleProvider`) requests only identity scopes (`BASE_SCOPES`) from Google, regardless of what scopes the aggregator config has.
- `EXTERNAL_OAUTH21_PROVIDER=true` switches workspace-mcp to `ExternalOAuthProvider` mode, which advertises full workspace scopes via RFC 9728 metadata. The aggregator then handles the Google OAuth flow directly with the correct scopes.
- Also split `mcpGoogleAuth` into `mcpIdentityAuth` (Ashby) and `mcpWorkspaceAuth` (aggregator) for least-privilege (from #2254 review feedback).

## Test plan
- [ ] Deploy via Pulumi
- [ ] De-auth and re-auth Google on the aggregator (`gateway__unauth` then `gateway__auth`)
- [ ] Google consent screen should now request Gmail, Calendar, Drive, etc. permissions
- [ ] Verify `list_calendars`, `search_gmail_messages`, and `search_drive_files` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)