### PR TITLE
[fix] Patch workspace-mcp OAuth scopes for aggregator

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -18,12 +18,42 @@ const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';
 // Front-door auth for the MCP services uses Google OIDC. Access is restricted to @bluedot.org
 // because the OAuth client (mcpGoogleOauthClientId) lives in a GCP project whose consent screen
 // is configured as "Internal" — Google enforces that server-side. The same client serves both
-// identity (here, scope openid/email/profile) and workspace-mcp's data access (gmail/drive/etc).
+// identity (openid/email/profile) and workspace-mcp's data access (gmail/drive/calendar/etc).
+// Scopes use the broadest variant per service; workspace-mcp's scope hierarchy handles mapping
+// (e.g. gmail.modify implies gmail.readonly). See workspace-mcp auth/scopes.py SCOPE_HIERARCHY.
 const mcpGoogleAuth = {
   issuer: 'https://accounts.google.com',
   clientId: config.requireSecret('mcpGoogleOauthClientId'),
   clientSecret: config.requireSecret('mcpGoogleOauthClientSecret'),
-  scopes: ['openid', 'email', 'profile'],
+  scopes: [
+    // Identity
+    'openid', 'email', 'profile',
+    // Gmail (modify covers readonly/send/compose/labels)
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.settings.basic',
+    // Drive (drive covers drive.readonly and drive.file)
+    'https://www.googleapis.com/auth/drive',
+    // Calendar (calendar covers calendar.readonly and calendar.events)
+    'https://www.googleapis.com/auth/calendar',
+    // Docs
+    'https://www.googleapis.com/auth/documents',
+    // Sheets
+    'https://www.googleapis.com/auth/spreadsheets',
+    // Slides
+    'https://www.googleapis.com/auth/presentations',
+    // Forms
+    'https://www.googleapis.com/auth/forms.body',
+    'https://www.googleapis.com/auth/forms.responses.readonly',
+    // Tasks
+    'https://www.googleapis.com/auth/tasks',
+    // Contacts
+    'https://www.googleapis.com/auth/contacts',
+    // Apps Script
+    'https://www.googleapis.com/auth/script.projects',
+    'https://www.googleapis.com/auth/script.deployments',
+    'https://www.googleapis.com/auth/script.processes',
+    'https://www.googleapis.com/auth/script.metrics',
+  ],
   userClaim: 'email',
 };
 

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -389,6 +389,8 @@ export const services: ServiceDefinition[] = [
   },
   // Google Workspace MCP server (gmail/drive/calendar/docs/sheets/forms/slides/tasks/contacts/appscript).
   // Runs the workspace-mcp PyPI package directly via uvx; users OAuth to their own Google account on first use.
+  // EXTERNAL_OAUTH21_PROVIDER mode: workspace-mcp advertises required scopes via RFC 9728 metadata and
+  // expects the upstream proxy (mcp-aggregator) to handle the Google OAuth flow with full workspace scopes.
   {
     name: 'bluedot-mcp-google-workspace',
     spec: {
@@ -400,6 +402,7 @@ export const services: ServiceDefinition[] = [
           { name: 'WORKSPACE_MCP_PORT', value: '8080' },
           { name: 'WORKSPACE_EXTERNAL_URL', value: `https://${MCP_GOOGLE_HOST}` },
           { name: 'MCP_ENABLE_OAUTH21', value: 'true' },
+          { name: 'EXTERNAL_OAUTH21_PROVIDER', value: 'true' },
           { name: 'GOOGLE_MCP_CREDENTIALS_DIR', value: '/app/data/credentials' },
           { name: 'GOOGLE_OAUTH_CLIENT_ID', valueFrom: envVarSources.mcpGoogleOauthClientId },
           { name: 'GOOGLE_OAUTH_CLIENT_SECRET', valueFrom: envVarSources.mcpGoogleOauthClientSecret },

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -17,17 +17,36 @@ const MCP_ASHBY_HOST = 'mcp-ashby.k8s.bluedot.org';
 const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';
 // Front-door auth for the MCP services uses Google OIDC. Access is restricted to @bluedot.org
 // because the OAuth client (mcpGoogleOauthClientId) lives in a GCP project whose consent screen
-// is configured as "Internal" — Google enforces that server-side. The same client serves both
-// identity (openid/email/profile) and workspace-mcp's data access (gmail/drive/calendar/etc).
-// Scopes use the broadest variant per service; workspace-mcp's scope hierarchy handles mapping
-// (e.g. gmail.modify implies gmail.readonly). See workspace-mcp auth/scopes.py SCOPE_HIERARCHY.
-const mcpGoogleAuth = {
+// is configured as "Internal" — Google enforces that server-side.
+const mcpGoogleOauth = {
   issuer: 'https://accounts.google.com',
   clientId: config.requireSecret('mcpGoogleOauthClientId'),
   clientSecret: config.requireSecret('mcpGoogleOauthClientSecret'),
+  userClaim: 'email',
+};
+
+// Identity-only auth: just verifies the user is @bluedot.org. Used by services that don't need
+// Google Workspace data access (e.g. Ashby MCP).
+const mcpIdentityAuth = {
+  ...mcpGoogleOauth,
+  scopes: [
+    'openid',
+    'email',
+    'profile',
+  ],
+};
+
+// Workspace auth: identity + Google Workspace API scopes. Used by the MCP aggregator (which
+// proxies to workspace-mcp). Scopes use the broadest variant per service; workspace-mcp's scope
+// hierarchy handles mapping (e.g. gmail.modify implies gmail.readonly).
+// See workspace-mcp auth/scopes.py SCOPE_HIERARCHY.
+const mcpWorkspaceAuth = {
+  ...mcpGoogleOauth,
   scopes: [
     // Identity
-    'openid', 'email', 'profile',
+    'openid',
+    'email',
+    'profile',
     // Gmail (modify covers readonly/send/compose/labels)
     'https://www.googleapis.com/auth/gmail.modify',
     'https://www.googleapis.com/auth/gmail.settings.basic',
@@ -54,7 +73,6 @@ const mcpGoogleAuth = {
     'https://www.googleapis.com/auth/script.processes',
     'https://www.googleapis.com/auth/script.metrics',
   ],
-  userClaim: 'email',
 };
 
 export const services: ServiceDefinition[] = [
@@ -412,7 +430,7 @@ export const services: ServiceDefinition[] = [
           name: 'MCP_AUTH_WRAPPER_CONFIG',
           value: jsonStringify({
             command: ['npx', '-y', 'ashby-mcp'],
-            auth: mcpGoogleAuth,
+            auth: mcpIdentityAuth,
             envPerUser: [
               {
                 name: 'ASHBY_API_KEY', label: 'Ashby API Key', description: 'Get this from Ashby admin → Integrations → API keys', secret: true,
@@ -451,7 +469,7 @@ export const services: ServiceDefinition[] = [
         env: [{
           name: 'MCP_AGGREGATOR_CONFIG',
           value: jsonStringify({
-            auth: mcpGoogleAuth,
+            auth: mcpWorkspaceAuth,
             upstreams: [
               { name: 'ashby', url: `https://${MCP_ASHBY_HOST}/mcp` },
               { name: 'google', url: `https://${MCP_GOOGLE_HOST}/mcp` },

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -389,20 +389,31 @@ export const services: ServiceDefinition[] = [
   },
   // Google Workspace MCP server (gmail/drive/calendar/docs/sheets/forms/slides/tasks/contacts/appscript).
   // Runs the workspace-mcp PyPI package directly via uvx; users OAuth to their own Google account on first use.
-  // EXTERNAL_OAUTH21_PROVIDER mode: workspace-mcp advertises required scopes via RFC 9728 metadata and
-  // expects the upstream proxy (mcp-aggregator) to handle the Google OAuth flow with full workspace scopes.
   {
     name: 'bluedot-mcp-google-workspace',
     spec: {
       containers: [{
         name: 'bluedot-mcp-google-workspace',
         image: 'ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca',
-        command: ['uvx', 'workspace-mcp==1.18.0', '--transport', 'streamable-http', '--tools', 'gmail', 'drive', 'calendar', 'docs', 'sheets', 'forms', 'slides', 'tasks', 'contacts', 'appscript'],
+        // workspace-mcp 1.18.0 has a bug: in OAuth 2.1 mode, GoogleProvider's required_scopes is
+        // set to BASE_SCOPES (identity only) instead of all workspace scopes. This means the Google
+        // OAuth flow only requests openid/email/profile — not gmail/drive/calendar/etc. We patch
+        // core/server.py at startup to use provider_valid_scopes (full scopes) as required_scopes.
+        // TODO: remove this patch once upstream fixes https://github.com/taylorwilsdon/google_workspace_mcp
+        command: [
+          'sh',
+          '-c',
+          [
+            'uv pip install --system workspace-mcp==1.18.0',
+            'SITE=$(python -c "import core.server; import os; print(os.path.dirname(core.server.__file__))")',
+            'sed -i \'s/provider_required_scopes: List\\[str\\] = sorted(BASE_SCOPES)/provider_required_scopes: List[str] = provider_valid_scopes/\' "$SITE/server.py"',
+            'workspace-mcp --transport streamable-http --tools gmail drive calendar docs sheets forms slides tasks contacts appscript',
+          ].join(' && '),
+        ],
         env: [
           { name: 'WORKSPACE_MCP_PORT', value: '8080' },
           { name: 'WORKSPACE_EXTERNAL_URL', value: `https://${MCP_GOOGLE_HOST}` },
           { name: 'MCP_ENABLE_OAUTH21', value: 'true' },
-          { name: 'EXTERNAL_OAUTH21_PROVIDER', value: 'true' },
           { name: 'GOOGLE_MCP_CREDENTIALS_DIR', value: '/app/data/credentials' },
           { name: 'GOOGLE_OAUTH_CLIENT_ID', valueFrom: envVarSources.mcpGoogleOauthClientId },
           { name: 'GOOGLE_OAUTH_CLIENT_SECRET', valueFrom: envVarSources.mcpGoogleOauthClientSecret },

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -407,6 +407,7 @@ export const services: ServiceDefinition[] = [
             'uv pip install --system workspace-mcp==1.18.0',
             'SITE=$(python -c "import core.server; import os; print(os.path.dirname(core.server.__file__))")',
             'sed -i \'s/provider_required_scopes: List\\[str\\] = sorted(BASE_SCOPES)/provider_required_scopes: List[str] = provider_valid_scopes/\' "$SITE/server.py"',
+            'grep -q "provider_required_scopes: List\\[str\\] = provider_valid_scopes" "$SITE/server.py" || { echo "ERROR: scope patch not applied — pattern not found in $SITE/server.py" >&2; exit 1; }',
             'workspace-mcp --transport streamable-http --tools gmail drive calendar docs sheets forms slides tasks contacts appscript',
           ].join(' && '),
         ],


### PR DESCRIPTION
## Summary
- Follow-up to #2254 and #2255. The previous changes addressed the wrong layers.
- **Root cause**: workspace-mcp 1.18.0 in OAuth 2.1 mode hardcodes `provider_required_scopes = BASE_SCOPES` (identity only) in `core/server.py:238`. This means the Google OAuth flow only requests `openid/email/profile` — not Gmail, Drive, Calendar, etc.
- **Fix**: Patch `core/server.py` at container startup via `sed` to use `provider_valid_scopes` (the full workspace scopes) as `required_scopes`.
- **Also reverts** `EXTERNAL_OAUTH21_PROVIDER=true` from #2255 (caused 404s — workspace-mcp stops serving OAuth endpoints in that mode, but the aggregator still expects them).
- **Retains** the `mcpIdentityAuth`/`mcpWorkspaceAuth` split from #2254.

## TODO
- Open upstream issue/PR at `taylorwilsdon/google_workspace_mcp` to fix the scope bug, then remove the startup patch.

## Test plan
- [ ] Deploy via Pulumi
- [ ] De-auth and re-auth Google on aggregator
- [ ] Google consent screen should request workspace permissions (Gmail, Drive, Calendar, etc.)
- [ ] Verify `list_calendars`, `search_gmail_messages`, `search_drive_files` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)