### PR TITLE
Revert "Decouple .notNull() from airtable-ts return types (#2218)"

### DIFF
--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -136,7 +136,7 @@ export type CourseRound = CourseRoundsData['intense'][number];
 export function getSoonestDeadline(rounds: CourseRoundsData): string | null {
   const allRounds = [...rounds.intense, ...rounds.partTime];
 
-  const roundsWithDeadlines = allRounds.filter((r): r is typeof r & { applicationDeadlineRaw: string } => !!r.applicationDeadlineRaw);
+  const roundsWithDeadlines = allRounds.filter((r): r is typeof r & { applicationDeadlineRaw: string } => r.applicationDeadlineRaw !== null);
 
   if (roundsWithDeadlines.length === 0) {
     return null;

--- a/libraries/db/src/lib/typeUtils.test.ts
+++ b/libraries/db/src/lib/typeUtils.test.ts
@@ -37,20 +37,18 @@ const booleanNull: BooleanType = null;
 // @ts-expect-error - should not accept strings
 const booleanInvalid: BooleanType = 'test';
 
+// Test that array types are correct
 const textArrayValue: TextArrayType = ['test', 'test2'];
-// @ts-expect-error - should not accept null for arrays
 const textArrayNull: TextArrayType = null;
 // @ts-expect-error - should not accept single strings
 const textArrayInvalid: TextArrayType = 'test';
 
 const numericArrayValue: NumericArrayType = [1, 2, 3];
-// @ts-expect-error - should not accept null for arrays
 const numericArrayNull: NumericArrayType = null;
 // @ts-expect-error - should not accept string arrays
 const numericArrayInvalid: NumericArrayType = ['test'];
 
 const booleanArrayValue: BooleanArrayType = [true, false];
-// @ts-expect-error - should not accept null for arrays
 const booleanArrayNull: BooleanArrayType = null;
 // @ts-expect-error - should not accept string arrays
 const booleanArrayInvalid: BooleanArrayType = ['test'];
@@ -83,9 +81,9 @@ const validItemWithNulls: TestAirtableItem = {
   name: null,
   age: null,
   isActive: null,
-  tags: [],
-  scores: [],
-  flags: [],
+  tags: null,
+  scores: null,
+  flags: null,
 };
 
 // Test that invalid assignments are caught
@@ -130,6 +128,9 @@ describe('DrizzleColumnToTsType type tests', () => {
     expect(textNull).toBeNull();
     expect(numericNull).toBeNull();
     expect(booleanNull).toBeNull();
+    expect(textArrayNull).toBeNull();
+    expect(numericArrayNull).toBeNull();
+    expect(booleanArrayNull).toBeNull();
   });
 
   test('should create valid AirtableItemFromColumnsMap objects', () => {
@@ -143,18 +144,15 @@ describe('DrizzleColumnToTsType type tests', () => {
 
 describe('drizzleColumnToTsTypeString', () => {
   test.each([
-    // String, boolean, and arrays are always non-null (airtable-ts coerces to '', false, [])
-    [text(), 'string'],
+    [text(), 'string | null'],
     [text().notNull(), 'string'],
-    [boolean(), 'boolean'],
+    [boolean(), 'boolean | null'],
     [boolean().notNull(), 'boolean'],
-    // Numbers are always nullable (need to distinguish null vs 0)
     [numeric({ mode: 'number' }), 'number | null'],
-    [numeric({ mode: 'number' }).notNull(), 'number | null'],
-    // Arrays are always non-null (airtable-ts coerces to [])
-    [text().array(), 'string[]'],
+    [numeric({ mode: 'number' }).notNull(), 'number'],
+    [text().array(), 'string[] | null'],
     [text().array().notNull(), 'string[]'],
-    [numeric({ mode: 'number' }).array(), 'number[]'],
+    [numeric({ mode: 'number' }).array(), 'number[] | null'],
     [numeric({ mode: 'number' }).array().notNull(), 'number[]'],
   ])('%s -> %s', (column, expectedType) => {
     const result = drizzleColumnToTsTypeString(column);

--- a/libraries/db/src/lib/typeUtils.ts
+++ b/libraries/db/src/lib/typeUtils.ts
@@ -31,9 +31,9 @@ export type AllowedPgColumn =
   ReturnType<ReturnType<typeof pgBoolean>['array']>;
 
 export type DrizzleColumnToTsType<T extends AllowedPgColumn> =
-  T extends ReturnType<ReturnType<typeof text>['array']> ? string[] :
-    T extends ReturnType<ReturnType<typeof numeric<'number'>>['array']> ? number[] :
-      T extends ReturnType<ReturnType<typeof pgBoolean>['array']> ? boolean[] :
+  T extends ReturnType<ReturnType<typeof text>['array']> ? string[] | null :
+    T extends ReturnType<ReturnType<typeof numeric<'number'>>['array']> ? number[] | null :
+      T extends ReturnType<ReturnType<typeof pgBoolean>['array']> ? boolean[] | null :
         T extends ReturnType<typeof numeric<'number'>> ? number | null :
           T extends ReturnType<typeof pgBoolean> ? boolean | null :
             string | null;
@@ -88,8 +88,8 @@ export type BasePgTableType<
 
 /**
  * Maps a drizzle PgColumnBuilderBase to the corresponding airtable-ts TypeScript type string.
- * Numbers are always nullable ('number | null'). Everything else (string, boolean, arrays)
- * is always non-null since airtable-ts coerces missing values to '', false, or [].
+ * Currently supports numeric columns -> 'number | null', boolean columns -> 'boolean | null',
+ * array columns, defaults to 'string | null'.
  */
 export function drizzleColumnToTsTypeString(pgColumn: AllowedPgColumn): TsTypeString {
   // @ts-expect-error
@@ -99,17 +99,11 @@ export function drizzleColumnToTsTypeString(pgColumn: AllowedPgColumn): TsTypeSt
 
   const baseType = baseColumnConfig?.dataType ?? columnConfig.dataType;
   const isArray = columnConfig.dataType === 'array';
+  const isNullable = !columnConfig.notNull;
 
   if (!['string', 'number', 'boolean'].includes(baseType)) {
     throw new Error(`Unsupported column type: ${baseType}`);
   }
-
-  // Numbers are always nullable (need to distinguish null vs 0).
-  // Everything else (string, boolean, arrays) is always non-null so that
-  // airtable-ts coerces missing values to '', false, or [].
-  // This decouples .notNull() from airtable-ts behaviour, making it purely
-  // a PostgreSQL constraint. See #2081 for full context.
-  const isNullable = baseType === 'number' && !isArray;
 
   return `${baseType}${isArray ? '[]' : ''}${isNullable ? ' | null' : ''}` as TsTypeString;
 }


### PR DESCRIPTION
# Description

Reverts #2218

Copy of Slack message regarding the bug being fixed here:

It turns out it’s actually a slightly subtle issue. airtable-ts has a bunch of different rules based on the field type in airtable:
```typescript
                date: {
			toAirtable: (value) => dateTimeMapperPair.toAirtable(value)?.slice(0, 10) ?? null,
			fromAirtable: dateTimeMapperPair.fromAirtable,
		},
		dateTime: dateTimeMapperPair,
		createdTime: dateTimeMapperPair,
		lastModifiedTime: dateTimeMapperPair,
		multipleLookupValues: {
			toAirtable: readonly('multipleLookupValues'),
			fromAirtable: coerce('multipleLookupValues', 'string | null'),
		}
```
This specific bug is due to dateTimeMapperPair, and I’ve only been able to fix it by changing the code back to `text() produces string | null, text().notNull() produces string`, i.e. undoing the de-coupling we just did for strings.

I’m inclined to temporarily revert the whole thing, and make sure we can fix this case properly before re-deploying. As noted in the original PR it is safe to revert:
> Because of the breadth of this change, I think there is some chance of it causing bugs or slight changes in behaviour. However, it’s easy to revert (one full sync of the db will migrate to or from the new behaviour), so it’s not a big risk to merge.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->
