### PR TITLE
[codex] Refine Rapid Grants page and archive

### DIFF
--- a/apps/website/src/components/grants/GranteesListSection.test.tsx
+++ b/apps/website/src/components/grants/GranteesListSection.test.tsx
@@ -17,7 +17,7 @@ import GranteesListSection from './GranteesListSection';
 setupTestDb();
 
 describe('GranteesListSection', () => {
-  test('renders grantees from DB and toggles show all', async () => {
+  test('renders grantees from DB, toggles show all, and filters by search', async () => {
     await testDb.insert(grantTable, {
       granteeName: 'Alice',
       projectTitle: 'Alpha Project',
@@ -50,5 +50,16 @@ describe('GranteesListSection', () => {
     await waitFor(() => {
       expect(screen.getByText('Beta Project')).toBeInTheDocument();
     });
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search projects or grantees' }), {
+      target: { value: 'bob' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('1 result for "bob"')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Alpha Project')).not.toBeInTheDocument();
+    expect(screen.getByText('Beta Project')).toBeInTheDocument();
   });
 });

--- a/apps/website/src/components/grants/GranteesListSection.tsx
+++ b/apps/website/src/components/grants/GranteesListSection.tsx
@@ -3,6 +3,7 @@ import {
 } from '@bluedot/ui';
 import type { inferRouterOutputs } from '@trpc/server';
 import { useState } from 'react';
+import { RiSearchLine } from 'react-icons/ri';
 import type { AppRouter } from '../../server/routers/_app';
 import { formatAmountUsd } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
@@ -11,7 +12,7 @@ type PublicGrant = inferRouterOutputs<AppRouter>['grants']['getAllPublicGrantees
 
 const GranteeListItem = ({ grantee }: { grantee: PublicGrant }) => {
   const amount = grantee.amountUsd !== null ? formatAmountUsd(grantee.amountUsd) : null;
-  const subtitle = amount ? `${grantee.granteeName} • ${amount}` : grantee.granteeName;
+  const subtitle = grantee.granteeName;
   const Container = grantee.link ? 'a' : 'div';
 
   return (
@@ -22,30 +23,40 @@ const GranteeListItem = ({ grantee }: { grantee: PublicGrant }) => {
           target: '_blank',
         } : {})}
       className={cn(
-        'group block rounded-[24px] border border-bluedot-navy/10 bg-white px-6 py-6 min-[680px]:px-8',
-        grantee.link && 'transition-colors hover:border-bluedot-navy/18 hover:bg-white/90',
+        'group block h-full rounded-[8px] border border-bluedot-navy/10 bg-white p-5',
+        grantee.link && 'transition-colors hover:border-bluedot-navy/18 hover:bg-[#FBFCFE]',
       )}
     >
-      <div className="flex flex-col gap-4 min-[960px]:flex-row min-[960px]:items-start min-[960px]:justify-between min-[960px]:gap-8">
-        <div className="min-w-0 max-w-[920px]">
-          <h3 className="text-[20px] min-[680px]:text-[22px] font-semibold leading-[1.2] tracking-[-0.02em] text-bluedot-navy">
+      <div className="flex h-full flex-col">
+        <div className="flex items-start justify-between gap-4">
+          <h3 className="min-w-0 text-[20px] min-[680px]:text-[21px] font-semibold leading-[1.2] tracking-[-0.02em] text-bluedot-navy">
             {grantee.projectTitle}
           </h3>
-          <p className="mt-2 text-[15px] min-[680px]:text-[16px] leading-[1.55] text-bluedot-navy/72">
+          {amount && (
+            <span className="shrink-0 rounded-[8px] border border-[#D7E4F5] bg-[#F4F8FD] px-2.5 py-1 text-[12px] font-semibold text-[#2A5FA8]">
+              {amount}
+            </span>
+          )}
+        </div>
+
+        <div className="mt-3 min-w-0">
+          <p className="text-[14px] min-[680px]:text-[15px] leading-[1.55] text-bluedot-navy/68">
             {subtitle}
           </p>
           {grantee.projectSummary && (
-            <P className="mt-4 max-w-[880px] text-[15px] min-[680px]:text-[16px] leading-[1.65] text-bluedot-navy/74">
+            <P className="mt-4 text-[15px] leading-[1.65] text-bluedot-navy/74">
               {grantee.projectSummary}
             </P>
           )}
         </div>
 
         {grantee.link && (
-          <span className="inline-flex shrink-0 items-center gap-2 text-[14px] font-medium text-bluedot-navy/68 transition-colors group-hover:text-bluedot-navy min-[960px]:pt-1">
-            View project
-            <span aria-hidden="true" className="text-[18px]">→</span>
-          </span>
+          <div className="mt-auto pt-5">
+            <span className="inline-flex items-center gap-2 border-t border-bluedot-navy/10 pt-4 text-[14px] font-medium text-bluedot-navy/68 transition-colors group-hover:text-bluedot-navy">
+              View project
+              <span aria-hidden="true" className="text-[18px]">→</span>
+            </span>
+          </div>
         )}
       </div>
     </Container>
@@ -67,15 +78,32 @@ const GranteesListSection = ({
 }: GranteesListSectionProps) => {
   const { data: grantees, isLoading, error } = trpc.grants.getAllPublicGrantees.useQuery();
   const [showAll, setShowAll] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
 
   if (error) {
     return <ErrorSection error={error} />;
   }
 
-  const visibleGrantees = limit && !showAll
-    ? grantees?.slice(0, limit)
-    : grantees;
-  const hasHiddenGrantees = !!limit && !!grantees && grantees.length > limit;
+  const normalizedSearchTerm = searchTerm.trim().toLowerCase();
+  const filteredGrantees = grantees?.filter((grantee) => {
+    if (!normalizedSearchTerm) {
+      return true;
+    }
+
+    const searchableText = [
+      grantee.projectTitle,
+      grantee.granteeName,
+      grantee.projectSummary ?? '',
+    ].join(' ').toLowerCase();
+
+    return searchableText.includes(normalizedSearchTerm);
+  });
+
+  const shouldLimitResults = !!limit && !showAll && !normalizedSearchTerm;
+  const visibleGrantees = shouldLimitResults
+    ? filteredGrantees?.slice(0, limit)
+    : filteredGrantees;
+  const hasHiddenGrantees = !!limit && !normalizedSearchTerm && !!filteredGrantees && filteredGrantees.length > limit;
 
   return (
     <section
@@ -84,25 +112,49 @@ const GranteesListSection = ({
     >
       <div className="max-w-max-width mx-auto px-5 min-[680px]:px-8 lg:px-spacing-x py-8 min-[680px]:py-10 min-[1280px]:py-12">
         <div className="max-w-[1120px] mx-auto">
-          <div className="mb-8 min-[680px]:mb-10 max-w-[760px]">
-            <h2 className="text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-bluedot-navy">
-              {title}
-            </h2>
-            {subtitle && (
-              <P className="text-[16px] min-[680px]:text-[18px] leading-[160%] text-bluedot-navy/75 mt-4">
-                {subtitle}
-              </P>
-            )}
+          <div className="mb-8 min-[680px]:mb-10 flex flex-col gap-5 min-[960px]:flex-row min-[960px]:items-end min-[960px]:justify-between">
+            <div className="max-w-[760px]">
+              <h2 className="text-[28px] min-[680px]:text-[32px] xl:text-[36px] font-semibold leading-[125%] tracking-[-0.01em] text-bluedot-navy">
+                {title}
+              </h2>
+              {subtitle && (
+                <P className="text-[16px] min-[680px]:text-[18px] leading-[160%] text-bluedot-navy/75 mt-4">
+                  {subtitle}
+                </P>
+              )}
+            </div>
+
+            <label className="flex w-full min-[960px]:max-w-[340px] items-center gap-2 rounded-[8px] border border-bluedot-navy/12 bg-white px-3 py-2.5 font-sans">
+              <RiSearchLine className="shrink-0 text-bluedot-navy/40" size={18} />
+              <input
+                type="search"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Search projects or grantees"
+                className="w-full border-0 bg-transparent font-sans text-[15px] text-bluedot-navy outline-none placeholder:text-bluedot-navy/42"
+                aria-label="Search projects or grantees"
+              />
+            </label>
           </div>
 
           {isLoading && <ProgressDots />}
           {!isLoading && (!grantees || grantees.length === 0) && (
             <P>No grants to show yet.</P>
           )}
+          {!isLoading && !!grantees?.length && normalizedSearchTerm && (
+            <P className="mb-5 text-[14px] text-bluedot-navy/62">
+              {filteredGrantees?.length ?? 0} result{filteredGrantees?.length === 1 ? '' : 's'} for &quot;{searchTerm.trim()}&quot;
+            </P>
+          )}
+          {!isLoading && !!grantees?.length && normalizedSearchTerm && filteredGrantees?.length === 0 && (
+            <div className="rounded-[8px] border border-bluedot-navy/10 bg-white px-5 py-6">
+              <P>No projects match that search yet.</P>
+            </div>
+          )}
           {!!visibleGrantees?.length && (
-            <ul className="list-none flex flex-col gap-4 min-[680px]:gap-5">
+            <ul className="list-none grid gap-4 min-[680px]:grid-cols-2 min-[1120px]:grid-cols-3">
               {visibleGrantees.map((grantee) => (
-                <li key={`${grantee.granteeName}-${grantee.projectTitle}`}>
+                <li key={`${grantee.granteeName}-${grantee.projectTitle}`} className="h-full">
                   <GranteeListItem grantee={grantee} />
                 </li>
               ))}

--- a/apps/website/src/components/grants/grantPrograms.ts
+++ b/apps/website/src/components/grants/grantPrograms.ts
@@ -20,8 +20,8 @@ export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
     slug: 'rapid',
     title: 'Rapid Grants',
     href: '/grants/rapid',
-    goal: 'Remove concrete blockers so promising work that is already underway can move faster.',
-    scope: 'Small grants up to $5,000 for project costs such as compute, research access, software, hosting, or narrowly justified travel. Designed to be fast, clear, and lightweight.',
+    goal: 'Fund talented people in the BlueDot community to do excellent work on AI safety - research, events, community building, and more.',
+    scope: 'Grants up to $10,000 for project costs, events, travel, community building, and other costs that remove barriers. Fast decisions, lightweight process.',
     status: 'Active',
   },
   {

--- a/apps/website/src/globals.css
+++ b/apps/website/src/globals.css
@@ -100,3 +100,26 @@ body {
     transform: translateY(0);
   }
 }
+
+.grant-process-card {
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease,
+    background-color 180ms ease;
+}
+
+.grant-process-card:hover {
+  border-color: rgba(53, 109, 177, 0.28);
+  background: linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(238,245,253,1) 100%);
+  box-shadow: 0 18px 38px rgba(53, 109, 177, 0.08);
+  transform: translateY(-1px);
+}
+
+.grant-process-card:focus-visible {
+  outline: 2px solid rgba(53, 109, 177, 0.42);
+  outline-offset: 3px;
+  border-color: rgba(53, 109, 177, 0.32);
+  background: linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(238,245,253,1) 100%);
+  box-shadow: 0 18px 38px rgba(53, 109, 177, 0.08);
+}

--- a/apps/website/src/pages/grants/rapid.tsx
+++ b/apps/website/src/pages/grants/rapid.tsx
@@ -24,60 +24,45 @@ const CURRENT_ROUTE: BluedotRoute = {
 
 const DECISION_CARDS = [
   {
-    title: 'Strong fit',
-    body: 'You have already started the work, can point to a real blocker, and need a specific project cost covered.',
+    title: 'Good fit',
+    accentClassName: 'bg-[#356DB1]',
+    eyebrowClassName: 'text-[#2A5FA8]',
+    body: 'You are doing something concrete - a research project, an event series, community building, or fieldwork - and a specific cost is the bottleneck. We fund compute and API credits, events and meetups, research access, travel, community chapters, project tooling, and high-impact wildcard projects that do not fit a category yet.',
   },
   {
-    title: 'Usually not a fit',
-    body: 'Salary, living expenses, general-purpose equipment, or open-ended exploration without a concrete project need.',
+    title: 'Use judgment',
+    accentClassName: 'bg-[#7B8EA9]',
+    eyebrowClassName: 'text-[#52637B]',
+    body: 'General-purpose equipment, productivity subscriptions, or vague plans without evidence of work already underway. Stipends and living expenses are not our default, but we consider them for high-impact work - apply and make the argument.',
   },
-];
-
-const FUNDED_EXAMPLES = [
-  'Compute for technical AI safety work, including API credits and evaluation runs.',
-  'Research access, such as paywalled papers, datasets, and project-relevant tools.',
-  'Project-specific software, hosting, or participant recruitment for empirical studies.',
-  'Conference travel when there is a concrete deliverable beyond networking.',
-];
-
-const NOT_FUNDED_EXAMPLES = [
-  'Compensation for your time on the project.',
-  'General-purpose equipment like laptops, phones, or storage devices.',
-  'General productivity subscriptions without a project-specific case.',
-  'Personal or living expenses.',
 ];
 
 const PROCESS_STEPS = [
   {
     number: '01',
-    title: 'Apply with evidence',
-    body: (
-      <>
-        Show what you have already built, tested, or validated, plus the exact cost you want covered, in the{' '}
-        <a
-          href={RAPID_GRANT_APPLICATION_URL}
-          className="font-medium text-bluedot-navy underline underline-offset-4"
-        >
-          application form
-        </a>
-        .
-      </>
-    ),
+    title: 'Apply',
+    url: RAPID_GRANT_APPLICATION_URL,
+    body: 'Tell us what you are doing, what you need, and how much it costs. Five minutes, no lengthy proposals.',
   },
   {
     number: '02',
     title: 'Get a decision',
-    body: 'We usually reply within five working days and tell you what we are willing to fund.',
+    body: 'We usually reply within five working days.',
   },
   {
     number: '03',
-    title: 'Receive funding',
-    body: 'If accepted, we may send the money upfront as a grant or reimburse later, depending on the case.',
+    title: 'Get paid',
+    body: 'We pay upfront by default. In some cases we reimburse after - we will tell you which.',
   },
   {
     number: '04',
-    title: 'Use it for the approved purpose',
-    body: 'Use the funding for the project costs we agreed on, and check with us if the plan changes materially.',
+    title: 'Do the work',
+    body: 'Use the funding for what we agreed on. If your plans change materially, let us know.',
+  },
+  {
+    number: '05',
+    title: 'Share your impact',
+    body: 'A short update when the work is done - what you did, what came of it. No formal report, just close the loop.',
   },
 ];
 
@@ -85,24 +70,40 @@ const FAQ_ITEMS = [
   {
     id: 'unsure',
     question: 'Should I apply if I am not sure the request is a fit?',
-    answer: 'Yes. If the project is already underway and the blocker is concrete, applying is usually better than self-screening out too early.',
+    answer: 'Yes. If the work is underway and the need is concrete, applying is usually better than self-screening out too early.',
+  },
+  {
+    id: 'eligibility',
+    question: 'Who is eligible?',
+    answer: 'BlueDot course participants, alumni, facilitators, and active community members. If you are in our network and doing excellent work on AI safety, you are likely eligible.',
+  },
+  {
+    id: 'events',
+    question: 'Can Rapid Grants fund events or meetups?',
+    answer: 'Yes. We have funded meetup series, venue costs, and community events in multiple countries. Show us the plan and the specific costs.',
   },
   {
     id: 'reimbursement',
     question: 'Do you fund upfront or reimburse later?',
-    answer: 'Both. In many cases we are happy to send the money upfront as a grant, and in other cases we reimburse later.',
+    answer: 'Both. In many cases we send the money upfront as a grant, and in other cases we reimburse later.',
   },
   {
     id: 'travel',
-    question: 'Can Rapid Grants cover conference travel?',
-    answer: 'Sometimes, but the bar is high. We usually want a concrete deliverable such as presenting research or leading a session, not general networking or exploration.',
+    question: 'Can Rapid Grants cover travel?',
+    answer: 'Yes. We fund travel for conferences, collaboration, and fieldwork. Show us why being there matters for the work.',
   },
   {
     id: 'larger-request',
-    question: 'What if I need more than a small reimbursement?',
-    answer: 'Rapid Grants is for relatively small, concrete project costs. If what you need is substantially larger, this is probably the wrong mechanism.',
+    question: 'What if I need more than a few thousand dollars?',
+    answer: 'Rapid Grants typically range from $50 to $10,000. If your need is substantially larger, get in touch - we may be able to help through another program.',
   },
 ];
+
+const COMMUNITY_CARD = {
+  eyebrow: 'Beyond the grant',
+  title: 'Community',
+  body: 'We keep a community of grantees, and depending on the work and timing, we may invite grant recipients into programming, events, or other opportunities.',
+};
 
 const RapidGrantsPage = () => {
   const { data: grantees } = trpc.grants.getAllPublicGrantees.useQuery();
@@ -136,7 +137,7 @@ const RapidGrantsPage = () => {
         <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
         <meta
           name="description"
-          content="Rapid small grants for BlueDot participants and facilitators working on concrete, high-leverage projects."
+          content="Fast, flexible grants for BlueDot community members working on AI safety - research, events, community building, and more."
         />
       </Head>
 
@@ -145,12 +146,12 @@ const RapidGrantsPage = () => {
       <GrantProgramHero
         slug="rapid"
         title="Rapid Grants"
-        description="Fast, practical funding for BlueDot course participants and facilitators working on projects that are already in motion."
+        description="Research project, event, community chapter? We fund ambitious people doing concrete work to make AI go well."
         status="Active"
         primaryCta={{ text: 'Apply now', url: RAPID_GRANT_APPLICATION_URL }}
         secondaryCta={{ text: 'Look at grantees', url: '#grants-made', onClick: scrollToGrantees }}
         facts={[
-          { label: 'Typical grants', value: 'Up to $5k' },
+          { label: 'Typical grants', value: 'Up to $10k' },
           { label: 'Decision time', value: 'Around 5 working days' },
           { label: 'Grants made', value: grantsMadeLabel },
           { label: 'Funding given out', value: fundingGivenOutLabel },
@@ -164,18 +165,34 @@ const RapidGrantsPage = () => {
         contentClassName="flex flex-col gap-4"
       >
         <div className="max-w-[760px] flex flex-col gap-5">
-          <P>After completing the learning phase of our courses, many participants work on independent projects of their choosing. We want these projects to be excellent, and we try to remove barriers wherever we can.</P>
-          <P>One common barrier is lacking the resources to do the project well. Rapid Grants are aimed at people who, without funding, could not reasonably afford what they need for their chosen project.</P>
+          <P>Over the past few months, we have given out nearly $50,000 in small grants to people in the BlueDot community. Now we are going bigger.</P>
+          <P>Rapid Grants fund whatever it takes to remove the barrier between talented people, great ideas and their best work on AI safety. We fund everything from compute for projects, events you want to run, travel to hubs, community building, and more.</P>
+          <P>
+            If you are unsure whether to apply, the default is simple:{' '}
+            <a
+              href={RAPID_GRANT_APPLICATION_URL}
+              className="font-medium text-bluedot-navy underline underline-offset-4"
+            >
+              apply
+            </a>
+            .
+          </P>
         </div>
 
-        <div className="flex flex-col gap-3">
+        <div className="pt-4 min-[680px]:pt-6 min-[960px]:pt-8 grid gap-4 min-[960px]:grid-cols-2">
           {DECISION_CARDS.map((card) => (
-            <div key={card.title} className="rounded-[24px] border border-bluedot-navy/10 bg-white px-6 py-6 lg:px-8">
-              <div className="flex flex-col gap-3 lg:grid lg:grid-cols-[220px_1fr] lg:gap-6">
-                <h3 className="text-[20px] font-semibold leading-[1.2] tracking-[-0.02em] text-bluedot-navy">
-                  {card.title}
-                </h3>
-                <P className="text-[15px] leading-[1.65] text-bluedot-navy/70">
+            <div
+              key={card.title}
+              className="relative overflow-hidden rounded-[24px] border border-bluedot-navy/10 bg-white px-6 py-6 lg:px-8"
+            >
+              <div className="flex flex-col gap-6">
+                <div className="flex items-center gap-3">
+                  <span className={`size-2 rounded-full ${card.accentClassName}`} />
+                  <p className={`text-[12px] font-semibold uppercase tracking-[0.14em] ${card.eyebrowClassName}`}>
+                    {card.title}
+                  </p>
+                </div>
+                <P className="max-w-[46ch] text-[15px] min-[680px]:text-[16px] leading-[1.8] text-bluedot-navy/70">
                   {card.body}
                 </P>
               </div>
@@ -183,78 +200,90 @@ const RapidGrantsPage = () => {
           ))}
         </div>
 
-        <P className="max-w-[760px]">
-          If you are unsure whether to apply, the default is simple:{' '}
-          <a
-            href={RAPID_GRANT_APPLICATION_URL}
-            className="font-medium text-bluedot-navy underline underline-offset-4"
-          >
-            apply
-          </a>
-          .
-        </P>
-      </GrantPageSection>
-
-      <GrantPageSection
-        title="What we fund and what we usually do not"
-        contentClassName="flex flex-col gap-4"
-      >
-        <P className="max-w-[760px]">Rapid Grants has a quality bar. These are examples of the kinds of costs we often fund and usually do not fund, not a promise that every application of that type will be approved.</P>
-
-        <div className="rounded-[24px] border border-[#D7E4F5] bg-[#F4F8FD] px-6 py-6 flex flex-col gap-5">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[#2A5FA8]">
-            Fundable
-          </p>
-          <ul className="flex flex-col gap-4">
-            {FUNDED_EXAMPLES.map((item) => (
-              <li key={item} className="flex items-start gap-3 text-[15px] leading-[1.65] text-bluedot-navy/76">
-                <span className="mt-[8px] size-1.5 shrink-0 rounded-full bg-[#356DB1]" />
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        <div className="rounded-[24px] border border-[#E6D9C6] bg-[#FBF7F1] px-6 py-6 flex flex-col gap-5">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[#8B5A15]">
-            Usually not funded through this program
-          </p>
-          <ul className="flex flex-col gap-4">
-            {NOT_FUNDED_EXAMPLES.map((item) => (
-              <li key={item} className="flex items-start gap-3 text-[15px] leading-[1.65] text-bluedot-navy/76">
-                <span className="mt-[8px] size-1.5 shrink-0 rounded-full bg-[#9F6A2A]" />
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
       </GrantPageSection>
 
       <GrantPageSection
         title="How it works"
-        contentClassName="flex flex-col gap-3"
+        contentClassName="flex flex-col gap-4"
       >
-        {PROCESS_STEPS.map((step) => (
-          <div key={step.title} className="rounded-[24px] border border-bluedot-navy/10 bg-white px-6 py-6 lg:px-8">
-            <div className="flex flex-col gap-3 lg:grid lg:grid-cols-[96px_220px_1fr] lg:gap-6">
-              <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-bluedot-navy/40">
-                {step.number}
-              </p>
-              <h3 className="text-[20px] font-semibold leading-[1.2] tracking-[-0.02em] text-bluedot-navy">
-                {step.title}
-              </h3>
-              <P className="text-[15px] leading-[1.65] text-bluedot-navy/70">
-                {step.body}
-              </P>
+        <div className="relative">
+          <div className="relative z-10 grid gap-4 min-[960px]:grid-cols-3">
+            {PROCESS_STEPS.map((step, index) => (
+              step.url ? (
+                <a
+                  key={step.title}
+                  href={step.url}
+                  className={`${index === 0
+                    ? 'grant-process-card relative overflow-hidden rounded-[8px] border border-[#CFE0F6] bg-[linear-gradient(180deg,rgba(255,255,255,0.98)_0%,rgba(244,248,254,1)_100%)] px-5 py-5 min-h-[188px]'
+                    : 'grant-process-card relative overflow-hidden rounded-[8px] border border-bluedot-navy/10 bg-white px-5 py-5 min-h-[188px]'
+                  } block cursor-pointer`}
+                >
+                  <div className="flex h-full flex-col gap-4">
+                    <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-bluedot-navy/40">
+                      {step.number}
+                    </p>
+                    <div className="max-w-[32ch]">
+                      <h3 className="text-[22px] font-semibold leading-[1.15] tracking-[-0.02em] text-bluedot-navy">
+                        {step.title}
+                      </h3>
+                      <P className="mt-3 text-[15px] leading-[1.65] text-bluedot-navy/70">
+                        {step.body}
+                      </P>
+                    </div>
+                    <span className="mt-auto inline-flex items-center gap-2 pt-2 text-[14px] font-medium text-[#2A5FA8]">
+                      Open application
+                      <span aria-hidden="true" className="text-[18px]">→</span>
+                    </span>
+                  </div>
+                </a>
+              ) : (
+                <div
+                  key={step.title}
+                  className={`${index === 0
+                    ? 'grant-process-card relative overflow-hidden rounded-[8px] border border-[#CFE0F6] bg-[linear-gradient(180deg,rgba(255,255,255,0.98)_0%,rgba(244,248,254,1)_100%)] px-5 py-5 min-h-[188px]'
+                    : 'grant-process-card relative overflow-hidden rounded-[8px] border border-bluedot-navy/10 bg-white px-5 py-5 min-h-[188px]'
+                  } block`}
+                >
+                  <div className="flex h-full flex-col gap-4">
+                    <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-bluedot-navy/40">
+                      {step.number}
+                    </p>
+                    <div className="max-w-[32ch]">
+                      <h3 className="text-[22px] font-semibold leading-[1.15] tracking-[-0.02em] text-bluedot-navy">
+                        {step.title}
+                      </h3>
+                      <P className="mt-3 text-[15px] leading-[1.65] text-bluedot-navy/70">
+                        {step.body}
+                      </P>
+                    </div>
+                  </div>
+                </div>
+              )
+            ))}
+
+            <div className="grant-process-card relative overflow-hidden rounded-[8px] border border-[#D7E4F5] bg-[linear-gradient(180deg,rgba(255,255,255,0.98)_0%,rgba(244,248,254,1)_100%)] px-5 py-5 min-h-[188px]">
+              <div className="flex h-full flex-col gap-4">
+                <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[#2A5FA8]">
+                  {COMMUNITY_CARD.eyebrow}
+                </p>
+                <div className="max-w-[32ch]">
+                  <h3 className="text-[22px] font-semibold leading-[1.15] tracking-[-0.02em] text-bluedot-navy">
+                    {COMMUNITY_CARD.title}
+                  </h3>
+                  <P className="mt-3 text-[15px] leading-[1.65] text-bluedot-navy/70">
+                    {COMMUNITY_CARD.body}
+                  </P>
+                </div>
+              </div>
             </div>
           </div>
-        ))}
+        </div>
       </GrantPageSection>
 
       <GranteesListSection
         id="grants-made"
         title="Projects we have funded"
-        subtitle=""
+        subtitle="Search by project, grantee, or keyword."
         limit={6}
       />
 


### PR DESCRIPTION
## What changed
- refresh the Rapid Grants overview and landing page copy to match the expanded program
- simplify the page structure by merging the funding guidance into the main program section
- redesign the "How it works" area into a cleaner card grid, with the Apply step clickable
- rework the public grantees section into a searchable grid with cleaner cards
- update the Rapid Grants overview card copy and hero facts to reflect the broader scope

## Why
The Rapid Grants page had become redundant and visually uneven as the program scope expanded. This pass makes the positioning clearer, shortens the page, and gives the archive a more usable browsing experience.

## User impact
Visitors get a clearer explanation of who should apply, a faster path through the page, and a much easier way to browse funded projects.

## Validation
- `npm test -- src/components/grants/GrantProgramHero.test.tsx src/components/grants/GranteesListSection.test.tsx`
- `npm run typecheck`
- targeted lint on the grants files passed

## Notes
- full repo lint is currently blocked by unrelated existing issues in `biosechackathon` files and duplicate `* 2.ts` / `* 2.tsx` files
- `npm audit --omit=dev` reports existing repo-level dependency vulnerabilities unrelated to this Rapid Grants change