### PR TITLE
[codex] Refine homepage programs teaser

### DIFF
--- a/apps/website/src/components/homepage/GrantsSection.tsx
+++ b/apps/website/src/components/homepage/GrantsSection.tsx
@@ -1,48 +1,29 @@
 import { CTALinkOrButton, H2, P } from '@bluedot/ui';
 import { ROUTES } from '../../lib/routes';
 
-const RAPID_GRANTS_URL = `${ROUTES.programs.url}/rapid-grants?utm_source=website&utm_campaign=homepage-grants`;
-const PROGRAMS_OVERVIEW_URL = `${ROUTES.programs.url}?utm_source=website&utm_campaign=homepage-grants`;
+const RAPID_GRANTS_URL = `${ROUTES.programs.url}/rapid-grants?utm_source=website&utm_campaign=homepage-programs`;
+const PROGRAMS_OVERVIEW_URL = `${ROUTES.programs.url}?utm_source=website&utm_campaign=homepage-programs`;
 
 const GrantsSection = () => {
   return (
     <section className="w-full bg-white py-[48px] px-5 min-[680px]:py-[64px] min-[680px]:px-8 min-[1024px]:py-[80px] lg:px-12 min-[1280px]:py-[96px] xl:px-16 2xl:px-20">
-      <div className="mx-auto grid max-w-screen-xl gap-10 min-[960px]:grid-cols-[minmax(0,1fr)_420px] min-[960px]:items-center min-[1280px]:gap-14">
-        <div className="max-w-[640px]">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-[#2A5FA8]">
-            Grants
-          </p>
-          <H2 className="mt-4 text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-bluedot-navy">
-            Need funding to keep moving?
+      <div className="mx-auto flex max-w-[760px] flex-col items-center text-center">
+        <div className="max-w-[700px]">
+          <H2 className="text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-bluedot-navy">
+            Go beyond a course
           </H2>
-          <div className="mt-6 flex flex-col gap-5">
-            <P className="text-[16px] min-[680px]:text-[18px] leading-[1.6] text-bluedot-navy/80">
-              Rapid Grants back concrete AI safety work in the BlueDot community: research projects, events, community building, travel, tooling, and more.
-            </P>
-            <P className="text-[16px] min-[680px]:text-[18px] leading-[1.6] text-bluedot-navy/80">
-              Five-minute application, decisions in days, money upfront by default.
-            </P>
-          </div>
-          <div className="mt-8 flex flex-wrap gap-3">
-            <CTALinkOrButton url={RAPID_GRANTS_URL}>
-              Apply for Rapid Grants
+          <P className="mt-6 text-[16px] min-[680px]:text-[18px] leading-[1.6] text-bluedot-navy/80">
+            Funding, structured sprints, or a bigger launchpad for the next stage of your work on making AI go well. Explore what programs we are running currently, or go straight to Rapid Grants if you need money to keep moving.
+          </P>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <CTALinkOrButton url={PROGRAMS_OVERVIEW_URL}>
+              Explore programs
             </CTALinkOrButton>
-            <CTALinkOrButton url={PROGRAMS_OVERVIEW_URL} variant="secondary" withChevron>
-              See all programs
+            <CTALinkOrButton url={RAPID_GRANTS_URL} variant="secondary" withChevron>
+              Rapid Grants
             </CTALinkOrButton>
           </div>
         </div>
-
-        <a
-          href={RAPID_GRANTS_URL}
-          className="group relative block overflow-hidden rounded-[8px] border border-bluedot-navy/10 bg-[#F4F8FD] min-[960px]:justify-self-end"
-        >
-          <img
-            src="/images/community-values/people.png"
-            alt="BlueDot community members in conversation"
-            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
-          />
-        </a>
       </div>
     </section>
   );

--- a/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
@@ -6,51 +6,37 @@ exports[`GrantsSection > renders default as expected 1`] = `
     class="w-full bg-white py-[48px] px-5 min-[680px]:py-[64px] min-[680px]:px-8 min-[1024px]:py-[80px] lg:px-12 min-[1280px]:py-[96px] xl:px-16 2xl:px-20"
   >
     <div
-      class="mx-auto grid max-w-screen-xl gap-10 min-[960px]:grid-cols-[minmax(0,1fr)_420px] min-[960px]:items-center min-[1280px]:gap-14"
+      class="mx-auto flex max-w-[760px] flex-col items-center text-center"
     >
       <div
-        class="max-w-[640px]"
+        class="max-w-[700px]"
       >
-        <p
-          class="text-[12px] font-semibold uppercase tracking-[0.14em] text-[#2A5FA8]"
-        >
-          Grants
-        </p>
         <h2
-          class="bluedot-h2 not-prose mt-4 text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-bluedot-navy"
+          class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-bluedot-navy"
         >
-          Need funding to keep moving?
+          Go beyond a course
         </h2>
-        <div
-          class="mt-6 flex flex-col gap-5"
+        <p
+          class="bluedot-p not-prose mt-6 text-[16px] min-[680px]:text-[18px] leading-[1.6] text-bluedot-navy/80"
         >
-          <p
-            class="bluedot-p not-prose text-[16px] min-[680px]:text-[18px] leading-[1.6] text-bluedot-navy/80"
-          >
-            Rapid Grants back concrete AI safety work in the BlueDot community: research projects, events, community building, travel, tooling, and more.
-          </p>
-          <p
-            class="bluedot-p not-prose text-[16px] min-[680px]:text-[18px] leading-[1.6] text-bluedot-navy/80"
-          >
-            Five-minute application, decisions in days, money upfront by default.
-          </p>
-        </div>
+          Funding, structured sprints, or a bigger launchpad for the next stage of your work on making AI go well. Explore what programs we are running currently, or go straight to Rapid Grants if you need money to keep moving.
+        </p>
         <div
-          class="mt-8 flex flex-wrap gap-3"
+          class="mt-8 flex flex-wrap justify-center gap-3"
         >
           <a
             class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
-            href="/programs/rapid-grants?utm_source=website&utm_campaign=homepage-grants"
+            href="/programs?utm_source=website&utm_campaign=homepage-programs"
             tabindex="0"
           >
-            Apply for Rapid Grants
+            Explore programs
           </a>
           <a
             class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
-            href="/programs?utm_source=website&utm_campaign=homepage-grants"
+            href="/programs/rapid-grants?utm_source=website&utm_campaign=homepage-programs"
             tabindex="0"
           >
-            See all programs
+            Rapid Grants
             <span
               class="cta-button__chevron ml-3"
             >
@@ -72,16 +58,6 @@ exports[`GrantsSection > renders default as expected 1`] = `
           </a>
         </div>
       </div>
-      <a
-        class="group relative block overflow-hidden rounded-[8px] border border-bluedot-navy/10 bg-[#F4F8FD] min-[960px]:justify-self-end"
-        href="/programs/rapid-grants?utm_source=website&utm_campaign=homepage-grants"
-      >
-        <img
-          alt="BlueDot community members in conversation"
-          class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
-          src="/images/community-values/people.png"
-        />
-      </a>
     </div>
   </section>
 </div>


### PR DESCRIPTION
## What changed

This PR tightens the homepage Programs teaser so it fits the new Programs framing more cleanly.

Changes:
- removes the side image and turns the section into a centered text-and-CTA block
- shifts the copy from a grants-specific pitch to a lighter Programs entry point
- makes `Explore programs` the primary CTA and keeps `Rapid Grants` as the secondary path
- removes the eyebrow and final heading period for a cleaner presentation
- updates the snapshot for the section

## Why

After the Programs hub landed, the old teaser still looked like a leftover grants component. It was visually off-center, a little too specific to Rapid Grants, and not fully aligned with the `Go beyond a course` framing now used on the Programs overview.

## Impact

- homepage flow feels more consistent with the rest of the centered sections
- Programs are introduced more clearly as a category
- Rapid Grants is still one click away, but no longer defines the whole block

## Validation

- `cd apps/website && npm test -- src/components/homepage/GrantsSection.test.tsx src/components/homepage/HomeHeroContent.test.tsx src/__tests__/pages/about.test.tsx src/__tests__/pages/join-us.test.tsx`
- `cd apps/website && npm run typecheck`
- `cd apps/website && npx eslint src/components/homepage/GrantsSection.tsx`