### PR TITLE
[codex] Fix project sprint links from course surfaces

### DIFF
--- a/apps/website/src/components/homepage/CourseSection.tsx
+++ b/apps/website/src/components/homepage/CourseSection.tsx
@@ -6,7 +6,7 @@ import {
   useEffect, useRef, useCallback, useState, useMemo,
 } from 'react';
 import { PiShieldStarLight, PiShootingStarLight, PiUsersThreeLight } from 'react-icons/pi';
-import { usePrimaryCourseURL } from '../../lib/hooks/usePrimaryCourseURL';
+import { getDefaultCourseURL, usePrimaryCourseURL } from '../../lib/hooks/usePrimaryCourseURL';
 import { withClickTracking } from '../../lib/withClickTracking';
 import { trpc } from '../../utils/trpc';
 
@@ -394,7 +394,7 @@ const CourseCarousel = ({
                 key={uniqueKey}
                 trackingEventParams={{
                   course_title: course.title,
-                  course_url: `/courses/${course.slug}`, // Always use lander rather than getPrimaryCourseURL(course.slug) to simplify analytics
+                  course_url: getDefaultCourseURL(course.slug),
                 }}
                 course={course}
                 className="flex-shrink-0 w-[276px] md:w-[400px]"

--- a/apps/website/src/lib/hooks/usePrimaryCourseURL.test.tsx
+++ b/apps/website/src/lib/hooks/usePrimaryCourseURL.test.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from '@bluedot/ui';
 import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
 import { TrpcProvider } from '../../__tests__/trpcProvider';
 import { createMockCourse, createMockCourseRegistration } from '../../__tests__/testUtils';
-import { usePrimaryCourseURL } from './usePrimaryCourseURL';
+import { getDefaultCourseURL, usePrimaryCourseURL } from './usePrimaryCourseURL';
 import { ONE_HOUR_MS } from '../constants';
 
 vi.mock('@bluedot/ui', async () => {
@@ -36,6 +36,25 @@ describe('usePrimaryCourseURL', () => {
 
     await waitFor(() => {
       expect(result.current.getPrimaryCourseURL('unknown-course')).toBe('/courses/unknown-course');
+    });
+  });
+
+  it('returns the program URL for the technical AI safety project sprint by default', async () => {
+    const mockCourse = createMockCourse({
+      id: 'course-1',
+      slug: 'technical-ai-safety-project',
+      title: 'Technical AI Safety Project',
+    });
+
+    server.use(trpcMsw.courses.getAll.query(() => [mockCourse]));
+    server.use(trpcMsw.courseRegistrations.getAll.query(() => []));
+
+    const { result } = renderHook(() => usePrimaryCourseURL(), {
+      wrapper: TrpcProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.getPrimaryCourseURL('technical-ai-safety-project')).toBe('/programs/technical-ai-safety-project-sprint');
     });
   });
 
@@ -127,5 +146,15 @@ describe('usePrimaryCourseURL', () => {
       // Not enrolled in course-2
       expect(result.current.getPrimaryCourseURL('course-2')).toBe('/courses/course-2');
     });
+  });
+});
+
+describe('getDefaultCourseURL', () => {
+  it('maps the technical AI safety project to its program page', () => {
+    expect(getDefaultCourseURL('technical-ai-safety-project')).toBe('/programs/technical-ai-safety-project-sprint');
+  });
+
+  it('falls back to the course lander for standard courses', () => {
+    expect(getDefaultCourseURL('future-of-ai')).toBe('/courses/future-of-ai');
   });
 });

--- a/apps/website/src/lib/hooks/usePrimaryCourseURL.ts
+++ b/apps/website/src/lib/hooks/usePrimaryCourseURL.ts
@@ -2,6 +2,14 @@ import { useCallback } from 'react';
 import { useAuthStore } from '@bluedot/ui';
 import { trpc } from '../../utils/trpc';
 
+const SPECIAL_COURSE_DESTINATIONS: Record<string, string> = {
+  'technical-ai-safety-project': '/programs/technical-ai-safety-project-sprint',
+};
+
+export const getDefaultCourseURL = (courseSlug: string): string => {
+  return SPECIAL_COURSE_DESTINATIONS[courseSlug] ?? `/courses/${courseSlug}`;
+};
+
 /**
  * Provides a function `getPrimaryCourseURL` to get the primary URL for any course.
  * - In progress -> /courses/{slug}/1/1 (course content)
@@ -20,7 +28,7 @@ export const usePrimaryCourseURL = () => {
 
     // Fallback to lander url while loading
     if (!course) {
-      return `/courses/${courseSlug}`;
+      return getDefaultCourseURL(courseSlug);
     }
 
     const registration = registrations?.find((r) => r.courseId === course.id);
@@ -30,7 +38,7 @@ export const usePrimaryCourseURL = () => {
       return `/courses/${courseSlug}/1/1`;
     }
 
-    return `/courses/${courseSlug}`;
+    return getDefaultCourseURL(courseSlug);
   }, [coursesData, registrations]);
 
   return { getPrimaryCourseURL };

--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -13,6 +13,7 @@ import NewsletterBanner from '../../components/homepage/NewsletterBanner';
 import { CourseIcon } from '../../components/courses/CourseIcon';
 import { COURSE_CONFIG } from '../../lib/constants';
 import { appendPosthogSessionIdPrefill } from '../../lib/appendPosthogSessionIdPrefill';
+import { getDefaultCourseURL } from '../../lib/hooks/usePrimaryCourseURL';
 import RoundGroup from '../../components/shared/RoundGroup';
 
 const getCourseAccentColor = (courseSlug: string): string => {
@@ -110,7 +111,7 @@ const CoursesPage = () => {
                       name: 'BlueDot Impact',
                       sameAs: 'https://bluedot.org',
                     },
-                    url: `https://bluedot.org/courses/${course.slug}`,
+                    url: `https://bluedot.org${getDefaultCourseURL(course.slug)}`,
                     offers: [{
                       '@type': 'Offer',
                       category: 'Free',
@@ -437,7 +438,7 @@ const CourseCard = ({ course }: CourseCardProps) => {
           <div className="flex items-center min-h-[48px] border-l-4 border-bluedot-navy/20 pl-5">
             <p className="text-[15px] leading-[1.6] font-normal text-bluedot-navy opacity-50">
               No upcoming rounds.{' '}
-              <Link href={`/courses/${course.slug}`} className="text-bluedot-normal font-medium hover:underline cursor-pointer">
+              <Link href={getDefaultCourseURL(course.slug)} className="text-bluedot-normal font-medium hover:underline cursor-pointer">
                 Learn more about this course
               </Link>
             </p>
@@ -454,6 +455,8 @@ type CourseHeaderProps = {
 };
 
 const CourseHeader = ({ course }: CourseHeaderProps) => {
+  const courseUrl = getDefaultCourseURL(course.slug);
+
   return (
     <>
       {/* Mobile Layout */}
@@ -464,7 +467,7 @@ const CourseHeader = ({ course }: CourseHeaderProps) => {
         </div>
 
         <Link
-          href={`/courses/${course.slug}`}
+          href={courseUrl}
           className="group flex items-center gap-2 cursor-pointer"
         >
           <h2 className="text-[24px] leading-[1.4] font-semibold tracking-[-0.5px] text-bluedot-navy">
@@ -481,7 +484,7 @@ const CourseHeader = ({ course }: CourseHeaderProps) => {
         <CourseIcon courseSlug={course.slug} size="xlarge" className="rounded-[12px]" />
 
         <Link
-          href={`/courses/${course.slug}`}
+          href={courseUrl}
           className="group flex items-center gap-2 pt-[15px] cursor-pointer"
         >
           <h2 className="text-[24px] leading-[1.4] font-semibold tracking-[-0.5px] text-bluedot-navy">


### PR DESCRIPTION
## What changed

This PR fixes course-surface links that still sent the Technical AI Safety Project entry to the old `/courses/technical-ai-safety-project` path instead of its new Programs page.

Changes:
- adds a shared default URL mapping for special cases like `technical-ai-safety-project`
- updates the `/courses` page to use that destination for visible links
- updates homepage course-card tracking URLs to use the same canonical destination
- updates course index structured data to point at the correct public URL
- adds regression tests for the special-case routing

## Why

After moving the Technical AI Safety Project Sprint under Programs, some shared course-linking logic still assumed that every course-like item should live under `/courses/{slug}`. That left broken or misleading destinations on the courses hub and related surfaces.

## Impact

- the Technical AI Safety Project entry on `/courses` now routes to `/programs/technical-ai-safety-project-sprint`
- any other surface using the shared primary/default course URL logic will now send users to the right page
- tracking and metadata are aligned with the visible destination

## Validation

- `cd apps/website && npm test -- src/lib/hooks/usePrimaryCourseURL.test.tsx src/__tests__/pages/courses/index.test.tsx src/components/homepage/CourseSection.test.tsx`
- `cd apps/website && npm run typecheck`
- `cd apps/website && npx eslint src/lib/hooks/usePrimaryCourseURL.ts src/lib/hooks/usePrimaryCourseURL.test.tsx src/pages/courses/index.tsx src/components/homepage/CourseSection.tsx`