### PR TITLE
[codex] Fix course hub round and discussion visibility

### DIFF
--- a/apps/website/src/server/routers/course-rounds.test.ts
+++ b/apps/website/src/server/routers/course-rounds.test.ts
@@ -1,0 +1,58 @@
+import {
+  applicationsRoundTable,
+  courseTable,
+} from '@bluedot/db';
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import { setupTestDb, testDb } from '../../__tests__/dbTestUtils';
+import { getCourseRoundsData } from './course-rounds';
+
+setupTestDb();
+
+async function seedCourseAndRound(applicationDeadline: string) {
+  await testDb.insert(courseTable, {
+    id: 'course-1',
+    slug: 'technical-ai-safety',
+    title: 'Technical AI Safety',
+    shortDescription: 'Test course',
+    units: [],
+  });
+
+  await testDb.insert(applicationsRoundTable, {
+    id: 'round-1',
+    courseId: 'course-1',
+    applicationDeadline,
+    intensity: 'Intensive',
+  });
+}
+
+describe('getCourseRoundsData', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('keeps a round visible throughout its deadline day', async () => {
+    vi.setSystemTime(new Date('2026-04-12T23:59:00.000Z'));
+    await seedCourseAndRound('2026-04-12');
+
+    const rounds = await getCourseRoundsData('technical-ai-safety');
+
+    expect(rounds.intense).toHaveLength(1);
+    expect(rounds.intense[0]?.id).toBe('round-1');
+  });
+
+  test('hides a round once the deadline has passed everywhere in the world', async () => {
+    vi.setSystemTime(new Date('2026-04-13T12:00:00.000Z'));
+    await seedCourseAndRound('2026-04-12');
+
+    const rounds = await getCourseRoundsData('technical-ai-safety');
+
+    expect(rounds.intense).toHaveLength(0);
+    expect(rounds.partTime).toHaveLength(0);
+  });
+});

--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -13,9 +13,9 @@ import { ONE_DAY_MS, ONE_HOUR_MS } from '../../lib/constants';
 import { formatMonthAndDay } from '../../lib/utils';
 import { publicProcedure, router } from '../trpc';
 
-function getDeadlineThreshold(): Date {
+function getDeadlineThresholdDate(): string {
   const now = new Date();
-  return new Date(now.getTime() - 12 * ONE_HOUR_MS);
+  return new Date(now.getTime() - 12 * ONE_HOUR_MS).toISOString().slice(0, 10);
 }
 
 function formatDateRange(
@@ -91,7 +91,7 @@ export async function getCourseRoundsData(courseSlug: string) {
 
   // Only show rounds where deadline hasn't passed everywhere in the world
   // Subtract 12 hours from current time to account for UTC-12 (furthest behind timezone)
-  const deadlineThreshold = getDeadlineThreshold();
+  const deadlineThresholdDate = getDeadlineThresholdDate();
 
   const filteredRounds = await db.pg
     .select()
@@ -100,7 +100,7 @@ export async function getCourseRoundsData(courseSlug: string) {
       eq(applicationsRoundTable.pg.courseId, courseId),
       or(
         sql`${applicationsRoundTable.pg.applicationDeadline} IS NULL`,
-        sql`${applicationsRoundTable.pg.applicationDeadline}::timestamp >= ${deadlineThreshold.toISOString()}::timestamp`,
+        sql`${applicationsRoundTable.pg.applicationDeadline}::date >= ${deadlineThresholdDate}::date`,
       ),
     ));
 
@@ -177,7 +177,7 @@ export const courseRoundsRouter = router({
       const courses = allCourses.filter((course) => course.slug !== 'future-of-ai');
 
       // Only show rounds where deadline hasn't passed everywhere in the world
-      const deadlineThreshold = getDeadlineThreshold();
+      const deadlineThresholdDate = getDeadlineThresholdDate();
 
       // Fetch all upcoming rounds for all courses
       const allRounds = await db.pg
@@ -185,7 +185,7 @@ export const courseRoundsRouter = router({
         .from(applicationsRoundTable.pg)
         .where(or(
           sql`${applicationsRoundTable.pg.applicationDeadline} IS NULL`,
-          sql`${applicationsRoundTable.pg.applicationDeadline}::timestamp >= ${deadlineThreshold.toISOString()}::timestamp`,
+          sql`${applicationsRoundTable.pg.applicationDeadline}::date >= ${deadlineThresholdDate}::date`,
         ));
 
       // Create a map of courseId to course info

--- a/apps/website/src/server/routers/group-discussions.test.ts
+++ b/apps/website/src/server/routers/group-discussions.test.ts
@@ -1,0 +1,64 @@
+import {
+  courseRegistrationTable,
+  courseTable,
+  groupDiscussionTable,
+  meetPersonTable,
+} from '@bluedot/db';
+import { describe, expect, test } from 'vitest';
+import {
+  createCaller,
+  setupTestDb,
+  testAuthContextLoggedIn,
+  testDb,
+} from '../../__tests__/dbTestUtils';
+
+setupTestDb();
+
+const caller = createCaller(testAuthContextLoggedIn);
+const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;
+
+describe('groupDiscussions.getByCourseSlug', () => {
+  test('uses expected facilitator discussion ids when indirect round linkage misses the upcoming session', async () => {
+    const futureStartTimeSecs = Math.floor(Date.now() / 1000) + (7 * 24 * 60 * 60);
+    const futureEndTimeSecs = futureStartTimeSecs + (60 * 60);
+
+    await testDb.insert(courseTable, {
+      id: 'course-1',
+      slug: 'technical-ai-safety',
+      title: 'Technical AI Safety',
+      shortDescription: 'Test course',
+      units: [],
+    });
+
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-1',
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      decision: 'Accept',
+    });
+
+    await testDb.insert(meetPersonTable, {
+      id: 'facilitator-1',
+      email: CALLER_EMAIL,
+      applicationsBaseRecordId: 'reg-1',
+      round: 'round-without-discussion',
+      role: 'Facilitator',
+      expectedDiscussionsFacilitator: ['discussion-next-week'],
+    });
+
+    await testDb.insert(groupDiscussionTable, {
+      id: 'discussion-next-week',
+      group: 'group-1',
+      round: 'different-round',
+      startDateTime: futureStartTimeSecs,
+      endDateTime: futureEndTimeSecs,
+      facilitators: [],
+      participantsExpected: [],
+    });
+
+    const result = await caller.groupDiscussions.getByCourseSlug({ courseSlug: 'technical-ai-safety' });
+
+    expect(result?.groupDiscussion?.id).toBe('discussion-next-week');
+    expect(result?.userRole).toBe('facilitator');
+  });
+});

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -123,33 +123,56 @@ export const groupDiscussionsRouter = router({
 
       const roundIds = [...new Set(participants.map((p) => p.round).filter((r): r is string => !!r))];
       const participantIds = [...new Set(participants.map((p) => p.id))];
+      const expectedParticipantDiscussionIds = [
+        ...new Set(participants.flatMap((p) => p.expectedDiscussionsParticipant ?? [])),
+      ];
+      const expectedFacilitatorDiscussionIds = [
+        ...new Set(participants.flatMap((p) => p.expectedDiscussionsFacilitator ?? [])),
+      ];
+      const expectedDiscussionIds = [
+        ...new Set([...expectedParticipantDiscussionIds, ...expectedFacilitatorDiscussionIds]),
+      ];
 
-      if (roundIds.length === 0) {
+      if (roundIds.length === 0 && expectedDiscussionIds.length === 0) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Round not found for participant' });
       }
 
       const currentTimeMs = Date.now();
+      const discussionConditions = [];
 
-      // Query discussions across all rounds where the user is a participant or facilitator
+      if (roundIds.length > 0) {
+        discussionConditions.push(and(
+          inArray(groupDiscussionTable.pg.round, roundIds),
+          sql`(${groupDiscussionTable.pg.participantsExpected} && ARRAY[${sql.join(participantIds.map((id) => sql`${id}`), sql`, `)}]::text[] OR ${groupDiscussionTable.pg.facilitators} && ARRAY[${sql.join(participantIds.map((id) => sql`${id}`), sql`, `)}]::text[])`,
+        ));
+      }
+
+      if (expectedDiscussionIds.length > 0) {
+        discussionConditions.push(inArray(groupDiscussionTable.pg.id, expectedDiscussionIds));
+      }
+
+      // Query discussions through both the direct expected-discussion linkage and the
+      // round-based fallback so the course hub stays aligned with the settings page.
       const groupDiscussions = await db.pg
         .select()
         .from(groupDiscussionTable.pg)
-        .where(and(
-          inArray(groupDiscussionTable.pg.round, roundIds),
-          sql`(${groupDiscussionTable.pg.participantsExpected} && ARRAY[${sql.join(participantIds.map((id) => sql`${id}`), sql`, `)}]::text[] OR ${groupDiscussionTable.pg.facilitators} && ARRAY[${sql.join(participantIds.map((id) => sql`${id}`), sql`, `)}]::text[])`,
-        ))
+        .where(discussionConditions.length === 1 ? discussionConditions[0]! : or(...discussionConditions))
         .orderBy(groupDiscussionTable.pg.startDateTime);
 
+      const dedupedDiscussions = groupDiscussions.filter((discussion, index, discussions) => discussions.findIndex((d) => d.id === discussion.id) === index);
+
       // Get the first discussion that hasn't ended (already ordered by start time)
-      const groupDiscussion = groupDiscussions.find((d) => getDiscussionTimeState({ discussion: d, currentTimeMs }) !== 'ended') ?? null;
+      const groupDiscussion = dedupedDiscussions.find((d) => getDiscussionTimeState({ discussion: d, currentTimeMs }) !== 'ended') ?? null;
 
       // Determine user role and get host key if facilitator
       let userRole: 'participant' | 'facilitator' | undefined;
       let hostKeyForFacilitators: string | undefined;
 
       if (groupDiscussion) {
-        const isFacilitator = participantIds.some((id) => groupDiscussion.facilitators.includes(id));
-        const isParticipant = participantIds.some((id) => groupDiscussion.participantsExpected.includes(id));
+        const isFacilitator = expectedFacilitatorDiscussionIds.includes(groupDiscussion.id)
+          || participantIds.some((id) => groupDiscussion.facilitators.includes(id));
+        const isParticipant = expectedParticipantDiscussionIds.includes(groupDiscussion.id)
+          || participantIds.some((id) => groupDiscussion.participantsExpected.includes(id));
 
         if (isFacilitator) {
           userRole = 'facilitator';


### PR DESCRIPTION
## Summary
Fix two course hub visibility issues:

- keep date-only application deadlines visible through the full deadline day worldwide
- make course hub discussion lookup more robust for facilitators and participants by also honoring direct expected discussion IDs on `meetPerson`

## Root Cause
The missing round bug came from comparing a date-only `applicationDeadline` like `2026-04-12` as a timestamp against `now - 12 hours`. That cast the deadline to midnight at the start of the day, so rounds could disappear during the deadline day instead of after the date had passed everywhere.

The facilitator issue appears to come from the course hub relying on round membership plus discussion participant/facilitator arrays, while the source data can also represent expected discussion linkage directly on `meetPerson`. When that indirect linkage is incomplete or stale, the course hub can miss a still-upcoming session.

## What Changed
- switched course-round filtering from timestamp comparison to date comparison in `apps/website/src/server/routers/course-rounds.ts`
- updated course hub discussion selection in `apps/website/src/server/routers/group-discussions.ts` to consider `expectedDiscussionsParticipant` and `expectedDiscussionsFacilitator` in addition to the round-based query path
- added regression tests for both behaviors

## Impact
- rounds with deadline `today` remain visible for the full intended window
- facilitator and participant banners are less likely to hide valid upcoming discussions because of incomplete indirect linkage

## Validation
- `npm exec --workspace apps/website vitest run src/server/routers/course-rounds.test.ts src/server/routers/group-discussions.test.ts src/lib/group-discussions/utils.test.ts src/components/courses/GroupDiscussionBanner.test.tsx`
- `npm exec --workspace apps/website vitest --run`
- `npm run --workspace apps/website typecheck`
- `npm exec --workspace apps/website eslint src/server/routers/course-rounds.ts src/server/routers/group-discussions.ts src/server/routers/course-rounds.test.ts src/server/routers/group-discussions.test.ts`

## Notes
`npm audit --omit=dev` reports existing repository dependency advisories, but those are pre-existing and not introduced by this PR.