### PR TITLE
[codex] Fix course lander crash on client navigation

### DIFF
--- a/apps/website/src/components/lander/AgiStrategyLander.test.tsx
+++ b/apps/website/src/components/lander/AgiStrategyLander.test.tsx
@@ -10,6 +10,7 @@ import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
 
 // Test URL - in production this comes from the database
 const TEST_APPLICATION_URL = 'https://web.miniextensions.com/test';
+const mockLatestUtmParams: { utm_source: string | undefined } = { utm_source: undefined };
 
 // Mock Next.js Head component
 vi.mock('next/head', () => ({
@@ -31,7 +32,7 @@ vi.mock('@bluedot/ui', async () => {
   return {
     ...actual,
     useLatestUtmParams: () => ({
-      latestUtmParams: { utm_source: undefined },
+      latestUtmParams: mockLatestUtmParams,
     }),
   };
 });
@@ -53,6 +54,8 @@ vi.mock('./TestimonialCarousel', () => ({
 
 describe('AgiStrategyLander', () => {
   beforeEach(() => {
+    mockLatestUtmParams.utm_source = undefined;
+
     server.use(trpcMsw.testimonials.getCommunityMembersByCourseSlug.query(() => [
       {
         name: 'Test Person 1', jobTitle: 'Job 1', imageSrc: 'https://example.com/1.jpg', url: 'https://example.com/1', quote: 'Quote 1',
@@ -170,5 +173,22 @@ describe('AgiStrategyLander', () => {
     const titleElement = container.querySelector('title');
     expect(titleElement).toBeTruthy();
     expect(titleElement?.textContent).toBe('AGI Strategy Course | BlueDot Impact');
+  });
+
+  it('does not crash when application URL is temporarily missing during client navigation', () => {
+    mockLatestUtmParams.utm_source = 'programs-overview';
+
+    render(
+      <CourseLander
+        courseSlug="agi-strategy"
+        baseApplicationUrl={undefined}
+        createContentFor={createAgiStrategyContent}
+        courseOgImage="https://bluedot.org/images/courses/link-preview/agi-strategy.png"
+        soonestDeadline={null}
+      />,
+      { wrapper: TrpcProvider },
+    );
+
+    expect(screen.getAllByText('AGI Strategy').length).toBeGreaterThan(0);
   });
 });

--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -69,7 +69,7 @@ export type CourseLanderContent = {
 
 type CourseLanderProps = {
   courseSlug: string;
-  baseApplicationUrl: string;
+  baseApplicationUrl?: string;
   createContentFor: (applicationUrlWithUtm: string, courseSlug: string) => CourseLanderContent;
   courseOgImage: string;
   soonestDeadline: string | null;
@@ -80,10 +80,11 @@ const CourseLander = ({
   courseSlug, baseApplicationUrl, createContentFor, courseOgImage, soonestDeadline, canonicalPath,
 }: CourseLanderProps) => {
   const { latestUtmParams } = useLatestUtmParams();
+  const safeBaseApplicationUrl = baseApplicationUrl ?? '';
 
-  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
-    ? addQueryParam(baseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)
-    : baseApplicationUrl);
+  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source && safeBaseApplicationUrl
+    ? addQueryParam(safeBaseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)
+    : safeBaseApplicationUrl);
 
   const content = createContentFor(applicationUrlWithUtm, courseSlug);
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/libraries/ui/src/utils/addQueryParam.test.ts
+++ b/libraries/ui/src/utils/addQueryParam.test.ts
@@ -42,4 +42,14 @@ describe('addQueryParam', () => {
     const result = addQueryParam('', 'key', 'value');
     expect(result).toBe('?key=value');
   });
+
+  test('handles undefined URL', () => {
+    const result = addQueryParam(undefined, 'key', 'value');
+    expect(result).toBe('?key=value');
+  });
+
+  test('handles null URL', () => {
+    const result = addQueryParam(null, 'key', 'value');
+    expect(result).toBe('?key=value');
+  });
 });

--- a/libraries/ui/src/utils/addQueryParam.ts
+++ b/libraries/ui/src/utils/addQueryParam.ts
@@ -2,15 +2,17 @@
  * Adds or updates (upserts) a query parameter in the given URL.
  * If the key already exists, its value is replaced.
  */
-export const addQueryParam = (url: string, key: string, value: string) => {
+export const addQueryParam = (url: string | null | undefined, key: string, value: string) => {
+  const safeUrl = url ?? '';
+
   // Try to parse as absolute URL first
   try {
-    const urlObj = new URL(url);
+    const urlObj = new URL(safeUrl);
     urlObj.searchParams.set(key, value);
     return urlObj.toString();
   } catch {
     // Handle as relative URL (including empty strings)
-    const [pathAndSearch = '', hash = ''] = url.split('#');
+    const [pathAndSearch = '', hash = ''] = safeUrl.split('#');
     const [path = '', existingSearch = ''] = pathAndSearch.split('?');
 
     const params = new URLSearchParams(existingSearch);


### PR DESCRIPTION
## Summary
Fix a client-side crash when navigating into certain course landers, including Technical AI Safety Project, from another page.

## Root Cause
The lander CTA URL path assumed the application URL was always defined during client navigation. In practice, the value can be briefly missing while the page is transitioning. When that happened, the query-param helper tried to call `.split()` on an undefined URL and the page crashed.

A full refresh worked because the lander then rendered with complete data.

## What Changed
- made `addQueryParam` tolerate `null` and `undefined` input in `libraries/ui/src/utils/addQueryParam.ts`
- made `CourseLander` normalize a missing `baseApplicationUrl` before appending UTM parameters in `apps/website/src/components/lander/CourseLander.tsx`
- added regression coverage for both the helper and the lander crash case

## Impact
- client navigation to `/courses/technical-ai-safety-project` no longer crashes if the application URL is temporarily unavailable
- the shared URL helper is more defensive against similar transient states elsewhere

## Validation
- `npm exec --workspace @bluedot/ui vitest run src/utils/addQueryParam.test.ts`
- `npm exec --workspace apps/website vitest run src/components/lander/AgiStrategyLander.test.tsx`
- `npm exec --workspace apps/website tsc --noEmit`
- `npm exec --workspace apps/website eslint src/components/lander/CourseLander.tsx src/components/lander/AgiStrategyLander.test.tsx`
- `npm exec --workspace @bluedot/ui eslint src/utils/addQueryParam.ts src/utils/addQueryParam.test.ts`