### PR TITLE
Keep course-backed program URLs stable

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -54,16 +54,6 @@ module.exports = withDefaultBlueDotNextConfig({
         permanent: true,
       },
       {
-        source: '/courses/incubator-week',
-        destination: '/programs/incubator-week',
-        permanent: true,
-      },
-      {
-        source: '/courses/technical-ai-safety-project',
-        destination: '/programs/technical-ai-safety-project-sprint',
-        permanent: true,
-      },
-      {
         source: '/join-us/mentor',
         destination: '/join-us/coach',
         permanent: true,


### PR DESCRIPTION
Summary
Keep course-backed programs on their existing /courses/... URLs by removing the redirects that were forcing those paths over to /programs/....

This fixes the inconsistent behavior where links from the Programs hub or other course surfaces could send users to /courses/technical-ai-safety-project or /courses/incubator-week, but a hard refresh would bounce them to the /programs/... wrapper pages.

Why
We now have a dedicated Programs hub, but Technical AI Safety Project Sprint and Incubator Week are still operationally backed by Airtable course records and course slugs.

That means:

Programs is the category / discovery layer
these two items should still keep their canonical destination pages under /courses/...
Rapid Grants remains a true /programs/... page
The redirects in next.config.js were fighting that model and creating confusing routing behavior.

Changes
remove redirect from /courses/incubator-week to /programs/incubator-week
remove redirect from /courses/technical-ai-safety-project to /programs/technical-ai-safety-project-sprint
Result
After this change:

Technical AI Safety Project Sprint can live in the Programs hub while still resolving and staying on /courses/technical-ai-safety-project
Incubator Week can live in the Programs hub while still resolving and staying on /courses/incubator-week
refresh behavior matches the actual destination users were sent to