### PR TITLE
[codex] Polish Rapid Grants page

### DIFF
--- a/apps/website/src/components/grants/GrantProgramHero.tsx
+++ b/apps/website/src/components/grants/GrantProgramHero.tsx
@@ -46,7 +46,7 @@ const GrantProgramHero = ({
 
   return (
     <section className="w-full bg-white">
-      <div className="max-w-max-width mx-auto px-5 min-[680px]:px-8 lg:px-spacing-x py-6 min-[680px]:py-8 min-[1280px]:py-10 bg-color-canvas">
+      <div className="max-w-max-width mx-auto px-5 min-[680px]:px-8 lg:px-spacing-x py-6 min-[680px]:py-8 min-[1280px]:py-10">
         <div
           className={cn(
             'relative overflow-hidden rounded-[28px] border border-bluedot-navy/10 shadow-[0_16px_50px_rgba(8,28,68,0.06)]',
@@ -68,49 +68,51 @@ const GrantProgramHero = ({
               </span>
             </div>
 
-            <div className="mt-6 max-w-[860px]">
-              <div style={titleTransitionStyle}>
-                <H1 className="text-[34px] min-[680px]:text-[42px] min-[1024px]:text-[48px] leading-tight font-medium tracking-[-1px] text-bluedot-navy">
-                  {title}
-                </H1>
-              </div>
+            <div className="mt-6 lg:grid lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)] lg:gap-8 xl:gap-12 lg:items-start">
+              <div className="max-w-[760px]">
+                <div style={titleTransitionStyle}>
+                  <H1 className="text-[34px] min-[680px]:text-[42px] min-[1024px]:text-[48px] leading-tight font-medium tracking-[-1px] text-bluedot-navy">
+                    {title}
+                  </H1>
+                </div>
 
-              <p className="mt-5 max-w-[760px] text-size-sm min-[680px]:text-[18px] min-[1024px]:text-[20px] leading-[1.6] tracking-[-0.1px] text-bluedot-navy/74">
-                {description}
-              </p>
+                <p className="mt-5 max-w-[640px] text-size-sm min-[680px]:text-[18px] min-[1024px]:text-[20px] leading-[1.6] tracking-[-0.1px] text-bluedot-navy/74">
+                  {description}
+                </p>
 
-              <div className="mt-7 flex flex-wrap gap-3">
-                <CTALinkOrButton url={primaryCta.url} onClick={primaryCta.onClick}>
-                  {primaryCta.text}
-                </CTALinkOrButton>
-                {secondaryCta && (
-                  <CTALinkOrButton
-                    url={secondaryCta.url}
-                    onClick={secondaryCta.onClick}
-                    variant="secondary"
-                    withChevron
-                  >
-                    {secondaryCta.text}
+                <div className="mt-7 flex flex-wrap gap-3">
+                  <CTALinkOrButton url={primaryCta.url} onClick={primaryCta.onClick}>
+                    {primaryCta.text}
                   </CTALinkOrButton>
-                )}
+                  {secondaryCta && (
+                    <CTALinkOrButton
+                      url={secondaryCta.url}
+                      onClick={secondaryCta.onClick}
+                      variant="secondary"
+                      withChevron
+                    >
+                      {secondaryCta.text}
+                    </CTALinkOrButton>
+                  )}
+                </div>
               </div>
 
+              {!!facts?.length && (
+                <div className="mt-10 grid gap-4 min-[680px]:grid-cols-2 lg:mt-0 lg:self-stretch">
+                  {facts.map((fact) => (
+                    <div key={fact.label} className="rounded-[20px] border border-white/70 bg-white/72 px-5 py-5 backdrop-blur-sm">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-bluedot-navy/44">
+                        {fact.label}
+                      </p>
+                      <p className="mt-2 text-[18px] min-[680px]:text-[19px] font-medium leading-[1.35] text-bluedot-navy">
+                        {fact.value}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
 
-            {!!facts?.length && (
-              <div className="mt-10 grid gap-4 min-[680px]:grid-cols-2">
-                {facts.map((fact) => (
-                  <div key={fact.label} className="rounded-[20px] border border-white/70 bg-white/72 px-5 py-5 backdrop-blur-sm">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-bluedot-navy/44">
-                      {fact.label}
-                    </p>
-                    <p className="mt-2 text-[18px] min-[680px]:text-[19px] font-medium leading-[1.35] text-bluedot-navy">
-                      {fact.value}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/apps/website/src/components/grants/GranteesListSection.test.tsx
+++ b/apps/website/src/components/grants/GranteesListSection.test.tsx
@@ -45,7 +45,7 @@ describe('GranteesListSection', () => {
 
     expect(screen.queryByText('Beta Project')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show all 2 public grants' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show 1 more project' }));
 
     await waitFor(() => {
       expect(screen.getByText('Beta Project')).toBeInTheDocument();

--- a/apps/website/src/components/grants/GranteesListSection.tsx
+++ b/apps/website/src/components/grants/GranteesListSection.tsx
@@ -2,7 +2,10 @@ import {
   cn, ErrorSection, P, ProgressDots,
 } from '@bluedot/ui';
 import type { inferRouterOutputs } from '@trpc/server';
-import { useState } from 'react';
+import {
+  useEffect,
+  useState,
+} from 'react';
 import { RiSearchLine } from 'react-icons/ri';
 import type { AppRouter } from '../../server/routers/_app';
 import { formatAmountUsd } from '../../lib/utils';
@@ -68,6 +71,7 @@ type GranteesListSectionProps = {
   title?: string;
   subtitle?: string;
   limit?: number;
+  previewRows?: number;
 };
 
 const GranteesListSection = ({
@@ -75,10 +79,31 @@ const GranteesListSection = ({
   title,
   subtitle,
   limit,
+  previewRows,
 }: GranteesListSectionProps) => {
   const { data: grantees, isLoading, error } = trpc.grants.getAllPublicGrantees.useQuery();
   const [showAll, setShowAll] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const [viewportWidth, setViewportWidth] = useState(() => {
+    if (typeof window === 'undefined') {
+      return 1120;
+    }
+
+    return window.innerWidth;
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setViewportWidth(window.innerWidth);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   if (error) {
     return <ErrorSection error={error} />;
@@ -99,11 +124,26 @@ const GranteesListSection = ({
     return searchableText.includes(normalizedSearchTerm);
   });
 
-  const shouldLimitResults = !!limit && !showAll && !normalizedSearchTerm;
+  let previewColumns = 1;
+  if (viewportWidth >= 1120) {
+    previewColumns = 3;
+  } else if (viewportWidth >= 680) {
+    previewColumns = 2;
+  }
+
+  const previewLimit = previewRows
+    ? previewRows * previewColumns
+    : undefined;
+  const effectiveLimit = previewLimit ?? limit;
+  const shouldLimitResults = !!effectiveLimit && !showAll && !normalizedSearchTerm;
   const visibleGrantees = shouldLimitResults
-    ? filteredGrantees?.slice(0, limit)
+    ? filteredGrantees?.slice(0, effectiveLimit)
     : filteredGrantees;
-  const hasHiddenGrantees = !!limit && !normalizedSearchTerm && !!filteredGrantees && filteredGrantees.length > limit;
+  const hasHiddenGrantees = !!effectiveLimit && !normalizedSearchTerm && !!filteredGrantees && filteredGrantees.length > effectiveLimit;
+  const hiddenGranteeCount = hasHiddenGrantees && effectiveLimit && filteredGrantees
+    ? filteredGrantees.length - effectiveLimit
+    : 0;
+  const showCollapsedPreview = hasHiddenGrantees && !showAll;
 
   return (
     <section
@@ -156,22 +196,41 @@ const GranteesListSection = ({
             </div>
           )}
           {!!visibleGrantees?.length && (
-            <ul className="list-none grid gap-4 min-[680px]:grid-cols-2 min-[1120px]:grid-cols-3">
-              {visibleGrantees.map((grantee) => (
-                <li key={`${grantee.granteeName}-${grantee.projectTitle}`} className="h-full">
-                  <GranteeListItem grantee={grantee} />
-                </li>
-              ))}
-            </ul>
+            <div className={cn('relative', showCollapsedPreview && 'pb-20 min-[680px]:pb-24')}>
+              <ul className="list-none grid gap-4 min-[680px]:grid-cols-2 min-[1120px]:grid-cols-3">
+                {visibleGrantees.map((grantee) => (
+                  <li key={`${grantee.granteeName}-${grantee.projectTitle}`} className="h-full">
+                    <GranteeListItem grantee={grantee} />
+                  </li>
+                ))}
+              </ul>
+
+              {showCollapsedPreview && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center px-4 pb-2 min-[680px]:pb-3">
+                  <div className="absolute inset-x-0 bottom-0 h-28 min-[680px]:h-32 bg-[linear-gradient(180deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.72)_34%,rgba(255,255,255,0.94)_62%,rgba(255,255,255,1)_100%)]" />
+                  <div className="absolute inset-x-[12%] bottom-11 h-px bg-[linear-gradient(90deg,rgba(8,28,68,0)_0%,rgba(8,28,68,0.12)_18%,rgba(8,28,68,0.12)_82%,rgba(8,28,68,0)_100%)] min-[680px]:bottom-14" />
+                  <button
+                    type="button"
+                    onClick={() => setShowAll(true)}
+                    className="pointer-events-auto relative inline-flex items-center gap-2 rounded-full border border-[#D7E4F5] bg-white/96 px-5 py-3 text-[14px] font-medium text-bluedot-navy shadow-[0_16px_40px_rgba(8,28,68,0.12)] backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:border-[#BED3EE] hover:shadow-[0_20px_44px_rgba(8,28,68,0.14)]"
+                  >
+                    <span aria-hidden="true" className="inline-flex size-6 items-center justify-center rounded-full bg-[#EEF5FD] text-[#2A5FA8]">
+                      ↓
+                    </span>
+                    {`Show ${hiddenGranteeCount} more project${hiddenGranteeCount === 1 ? '' : 's'}`}
+                  </button>
+                </div>
+              )}
+            </div>
           )}
-          {hasHiddenGrantees && (
+          {hasHiddenGrantees && showAll && (
             <button
               type="button"
-              onClick={() => setShowAll((previousValue) => !previousValue)}
-              className="mt-8 inline-flex items-center gap-2 text-[14px] font-medium text-bluedot-navy transition-colors hover:text-[#0A2358]"
+              onClick={() => setShowAll(false)}
+              className="mt-8 inline-flex items-center gap-2 rounded-full border border-bluedot-navy/10 bg-white px-4 py-2.5 text-[14px] font-medium text-bluedot-navy transition-all hover:border-bluedot-navy/16 hover:bg-[#FBFCFE]"
             >
-              {showAll ? 'Show fewer grantees' : `Show all ${grantees?.length ?? 0} public grants`}
-              <span aria-hidden="true">{showAll ? '↑' : '→'}</span>
+              Show fewer projects
+              <span aria-hidden="true">↑</span>
             </button>
           )}
         </div>

--- a/apps/website/src/pages/programs/rapid-grants.tsx
+++ b/apps/website/src/pages/programs/rapid-grants.tsx
@@ -133,7 +133,7 @@ const RapidGrantsPage = () => {
     : '—';
 
   return (
-    <div className="bg-color-canvas">
+    <div className="bg-white">
       <Head>
         <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
         <meta
@@ -151,7 +151,7 @@ const RapidGrantsPage = () => {
         description="Research project, event, community chapter? We fund ambitious people doing concrete work to make AI go well."
         status="Active"
         primaryCta={{ text: 'Apply now', url: RAPID_GRANT_APPLICATION_URL }}
-        secondaryCta={{ text: 'Look at grantees', url: '#grants-made', onClick: scrollToGrantees }}
+        secondaryCta={{ text: 'See funded projects', url: '#grants-made', onClick: scrollToGrantees }}
         facts={[
           { label: 'Typical grants', value: 'Up to $10k' },
           { label: 'Decision time', value: 'Around 5 working days' },
@@ -160,7 +160,7 @@ const RapidGrantsPage = () => {
         ]}
       />
 
-      <Breadcrumbs route={CURRENT_ROUTE} />
+      <Breadcrumbs route={CURRENT_ROUTE} className="bg-white" />
 
       <GrantPageSection
         title="What this program is for"
@@ -276,7 +276,7 @@ const RapidGrantsPage = () => {
 
       <div id="grants-made">
         <GrantPageSection title="Projects we have funded">
-          <GranteesListSection />
+          <GranteesListSection previewRows={2} />
         </GrantPageSection>
       </div>
 


### PR DESCRIPTION
## Summary
- rebalance the Rapid Grants hero so the desktop layout uses the space intentionally and matches the white program-page canvas
- cap the funded projects grid to a two-row responsive preview and add a soft fade with a floating expand control
- align copy and navigation labels around "funded projects" and keep the grants section tests in sync

## Why
The Rapid Grants page had an awkward desktop dead zone in the hero, a mismatched cream background compared with the other program pages, and an abrupt full-length grantee list that felt unfinished. This makes the page feel more polished and easier to scan while keeping the full project list accessible.

## Impact
- cleaner visual hierarchy and less empty space in the hero
- more delightful project browsing with a clearer collapsed/expanded interaction
- more consistent CTA language between the hero and the funded projects section

## Validation
- npm run test:update -- GrantProgramHero GranteesListSection programs
- npm run lint
- npm run typecheck
- npm run test
- npm run build
