### PR TITLE
Clean up defensive workarounds from #2268

### DIFF
--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -81,7 +81,7 @@ const CourseLander = ({
 }: CourseLanderProps) => {
   const { latestUtmParams } = useLatestUtmParams();
   const applyUrl = baseApplicationUrl ?? '';
-  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
+  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source && applyUrl
     ? addQueryParam(applyUrl, 'prefill_Source', latestUtmParams.utm_source)
     : applyUrl);
 

--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -80,6 +80,7 @@ const CourseLander = ({
   courseSlug, baseApplicationUrl, createContentFor, courseOgImage, soonestDeadline, canonicalPath,
 }: CourseLanderProps) => {
   const { latestUtmParams } = useLatestUtmParams();
+
   const safeBaseApplicationUrl = baseApplicationUrl ?? '';
   const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source && safeBaseApplicationUrl
     ? addQueryParam(safeBaseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)

--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -80,10 +80,10 @@ const CourseLander = ({
   courseSlug, baseApplicationUrl, createContentFor, courseOgImage, soonestDeadline, canonicalPath,
 }: CourseLanderProps) => {
   const { latestUtmParams } = useLatestUtmParams();
-  const applyUrl = baseApplicationUrl ?? '';
-  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source && applyUrl
-    ? addQueryParam(applyUrl, 'prefill_Source', latestUtmParams.utm_source)
-    : applyUrl);
+  const safeBaseApplicationUrl = baseApplicationUrl ?? '';
+  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source && safeBaseApplicationUrl
+    ? addQueryParam(safeBaseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)
+    : safeBaseApplicationUrl);
 
   const content = createContentFor(applicationUrlWithUtm, courseSlug);
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -80,11 +80,10 @@ const CourseLander = ({
   courseSlug, baseApplicationUrl, createContentFor, courseOgImage, soonestDeadline, canonicalPath,
 }: CourseLanderProps) => {
   const { latestUtmParams } = useLatestUtmParams();
-  const safeBaseApplicationUrl = baseApplicationUrl ?? '';
-
-  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source && safeBaseApplicationUrl
-    ? addQueryParam(safeBaseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)
-    : safeBaseApplicationUrl);
+  const applyUrl = baseApplicationUrl ?? '';
+  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
+    ? addQueryParam(applyUrl, 'prefill_Source', latestUtmParams.utm_source)
+    : applyUrl);
 
   const content = createContentFor(applicationUrlWithUtm, courseSlug);
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -55,8 +55,7 @@ const renderCoursePage = ({
   courseSlug: slug, courseData, courseOgImage, soonestDeadline,
 }: CoursePageProps) => {
   const { course } = courseData;
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const baseApplicationUrl = course?.applyUrl || '';
+  const baseApplicationUrl = course?.applyUrl ?? '';
 
   if (slug === 'future-of-ai') {
     // Future of AI is self-paced, so use the start URL instead of an apply URL

--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -380,7 +380,7 @@ const CourseCard = ({ course }: CourseCardProps) => {
   const { latestUtmParams } = useLatestUtmParams();
 
   const baseApplicationUrl = course.applyUrl ?? '';
-  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
+  const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source && baseApplicationUrl
     ? addQueryParam(baseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)
     : baseApplicationUrl);
 

--- a/apps/website/src/pages/courses/index.tsx
+++ b/apps/website/src/pages/courses/index.tsx
@@ -379,8 +379,7 @@ const CourseCard = ({ course }: CourseCardProps) => {
   const { data: rounds, isLoading: roundsLoading } = trpc.courseRounds.getRoundsForCourse.useQuery({ courseSlug: course.slug });
   const { latestUtmParams } = useLatestUtmParams();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const baseApplicationUrl = course.applyUrl || '';
+  const baseApplicationUrl = course.applyUrl ?? '';
   const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
     ? addQueryParam(baseApplicationUrl, 'prefill_Source', latestUtmParams.utm_source)
     : baseApplicationUrl);

--- a/libraries/ui/src/hooks/useLatestUtmParams.tsx
+++ b/libraries/ui/src/hooks/useLatestUtmParams.tsx
@@ -13,7 +13,7 @@ import posthog from 'posthog-js';
 import { addQueryParam } from '../utils/addQueryParam';
 
 type LatestUtmParamsContextType = {
-  latestUtmParams: Record<string, string>;
+  latestUtmParams: Partial<Record<string, string>>;
   appendLatestUtmParamsToUrl: (url: string) => string;
   /** Whether the provider is still checking the current route for UTM params. */
   isLoading: boolean;

--- a/libraries/ui/src/hooks/useLatestUtmParams.tsx
+++ b/libraries/ui/src/hooks/useLatestUtmParams.tsx
@@ -13,7 +13,7 @@ import posthog from 'posthog-js';
 import { addQueryParam } from '../utils/addQueryParam';
 
 type LatestUtmParamsContextType = {
-  latestUtmParams: Partial<Record<string, string>>;
+  latestUtmParams: Record<string, string>;
   appendLatestUtmParamsToUrl: (url: string) => string;
   /** Whether the provider is still checking the current route for UTM params. */
   isLoading: boolean;

--- a/libraries/ui/src/utils/addQueryParam.test.ts
+++ b/libraries/ui/src/utils/addQueryParam.test.ts
@@ -42,14 +42,4 @@ describe('addQueryParam', () => {
     const result = addQueryParam('', 'key', 'value');
     expect(result).toBe('?key=value');
   });
-
-  test('handles undefined URL', () => {
-    const result = addQueryParam(undefined, 'key', 'value');
-    expect(result).toBe('?key=value');
-  });
-
-  test('handles null URL', () => {
-    const result = addQueryParam(null, 'key', 'value');
-    expect(result).toBe('?key=value');
-  });
 });

--- a/libraries/ui/src/utils/addQueryParam.ts
+++ b/libraries/ui/src/utils/addQueryParam.ts
@@ -2,18 +2,16 @@
  * Adds or updates (upserts) a query parameter in the given URL.
  * If the key already exists, its value is replaced.
  */
-export const addQueryParam = (url: string | null | undefined, key: string, value: string) => {
-  const safeUrl = url ?? '';
-
+export const addQueryParam = (url: string, key: string, value: string) => {
   // Try to parse as absolute URL first
   try {
-    const urlObj = new URL(safeUrl);
+    const urlObj = new URL(url);
     urlObj.searchParams.set(key, value);
     return urlObj.toString();
   } catch {
     // Handle as relative URL (including empty strings)
-    const [pathAndSearch = '', hash = ''] = safeUrl.split('#');
-    const [path = '', existingSearch = ''] = pathAndSearch.split('?');
+    const [pathAndSearch = '', hash] = url.split('#');
+    const [path = '', existingSearch] = pathAndSearch.split('?');
 
     const params = new URLSearchParams(existingSearch);
     params.set(key, value);


### PR DESCRIPTION
Closes #2271

## Summary

PR #2268 fixed a crash in `CourseLander` caused by `baseApplicationUrl` being `undefined` at runtime during client navigation. As part of that fix, `addQueryParam` was made to accept `null | undefined`, and a double guard (`utm_source && baseApplicationUrl`) was added at call sites. This PR removes those workarounds in favour of a cleaner approach.

## What changed

- Reverted `addQueryParam` to `url: string` - callers normalise nullable URLs upfront with `?? ''` before calling, which is clearer about intent
- Replaced `|| ''` with `?? ''` in `courses/index.tsx`, removing the `eslint-disable` comment
- Removed the `null`/`undefined` URL tests from `addQueryParam.test.ts` since those inputs are now type errors

## Notes

The issue title mentions fixing the `latestUtmParams` type (`Record<string, string>` implying all keys always exist). In practice `noUncheckedIndexedAccess` is already enabled, so index access on `Record<string, string>` already returns `string | undefined` - a `Partial` wrapper would be redundant. The original crash was not caused by this type gap; it was caused by `baseApplicationUrl` being typed as a required `string` prop when it could be transiently `undefined` during client navigation, which was fixed in #2268.

Generated with [Claude Code](https://claude.com/claude-code)
