### PR TITLE
infra: bump mcp-aggregator to 2.2.1 + Slack OAuth creds for DCR-less auth

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -470,7 +470,7 @@ export const services: ServiceDefinition[] = [
     spec: {
       containers: [{
         name: 'bluedot-mcp-ashby',
-        image: 'ghcr.io/domdomegg/mcp-auth-wrapper:1.2.0@sha256:fd2fb6d3c952349423b3dfac2c1bb4ecc18cadbe0b37d0c842d6570506695453',
+        image: 'ghcr.io/domdomegg/mcp-auth-wrapper:1.3.0@sha256:4319f73b2b2080f9acd274ba9bacd0ed51f72751882598df494a7d1994b479f5',
         env: [{
           name: 'MCP_AUTH_WRAPPER_CONFIG',
           value: jsonStringify({
@@ -510,7 +510,7 @@ export const services: ServiceDefinition[] = [
     spec: {
       containers: [{
         name: 'bluedot-mcp-aggregator',
-        image: 'ghcr.io/domdomegg/mcp-aggregator:2.0.1@sha256:990a63a45a29a5a7258202c2803f8ac8e5717fa90cd4dce1afb8580d0decc3ea',
+        image: 'ghcr.io/domdomegg/mcp-aggregator:2.2.1@sha256:65947be79e35172db59dfbe8cd811b36115d17e6fc8fbdc76d92cb392dd34243',
         env: [{
           name: 'MCP_AGGREGATOR_CONFIG',
           value: jsonStringify({
@@ -518,7 +518,14 @@ export const services: ServiceDefinition[] = [
             upstreams: [
               { name: 'ashby', url: `https://${MCP_ASHBY_HOST}/mcp` },
               { name: 'google', url: `https://${MCP_GOOGLE_HOST}/mcp` },
-              { name: 'slack', url: 'https://mcp.slack.com/mcp' },
+              {
+                name: 'slack',
+                url: 'https://mcp.slack.com/mcp',
+                // Slack's MCP server doesn't support Dynamic Client Registration, so we pass a
+                // pre-registered Slack app's credentials and the aggregator skips DCR (v2.2.0+).
+                clientId: config.requireSecret('mcpSlackOauthClientId'),
+                clientSecret: config.requireSecret('mcpSlackOauthClientSecret'),
+              },
               { name: 'airtable', url: 'https://mcp.airtable.com/mcp' },
               { name: 'notion', url: 'https://mcp.notion.com/mcp' },
               { name: 'posthog', url: 'https://mcp-eu.posthog.com/mcp' },

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -521,10 +521,9 @@ export const services: ServiceDefinition[] = [
               {
                 name: 'slack',
                 url: 'https://mcp.slack.com/mcp',
-                // Slack's MCP server doesn't support Dynamic Client Registration, so we pass a
-                // pre-registered Slack app's credentials and the aggregator skips DCR (v2.2.0+).
-                clientId: config.requireSecret('mcpSlackOauthClientId'),
-                clientSecret: config.requireSecret('mcpSlackOauthClientSecret'),
+                // Slack doesn't support DCR, and uses PKCE (public client) so only the client_id
+                // is needed. See https://adamjones.me/blog/slack-mcp-custom-client/
+                clientId: '3048373368743.10898791060215',
               },
               { name: 'airtable', url: 'https://mcp.airtable.com/mcp' },
               { name: 'notion', url: 'https://mcp.notion.com/mcp' },


### PR DESCRIPTION
Slack's hosted MCP server doesn't support Dynamic Client Registration, so the aggregator (currently 2.0.1, DCR-only) can't authenticate against it — the slack upstream from #2247 has never actually worked.

mcp-aggregator [v2.2.0](https://github.com/domdomegg/mcp-aggregator/commit/6820342) adds per-upstream `clientId`/`clientSecret` so DCR can be skipped; [v2.2.1](https://github.com/domdomegg/mcp-aggregator/commit/a14cfb7) reads `scopes_supported` from the upstream's discovery metadata and passes them in the authorize URL (Slack rejects authorize requests with no scope).

The Slack app's client ID is hardcoded — it uses PKCE so it's a public client (ID isn't sensitive, no secret needed). Setup details: https://adamjones.me/blog/slack-mcp-custom-client/

Also bumps mcp-auth-wrapper 1.2.0 → 1.3.0 (adds a landing page with install link / web sign-in flow, otherwise no behaviour change).

## Not in this PR

The other vendor upstreams (airtable/notion/posthog/granola/customerio) still rely on DCR. If any of those turn out to also lack DCR support they'll need the same treatment, but Slack is the only one confirmed broken.