### PR TITLE
Fix incorrect prefill for round field

### DIFF
--- a/apps/website/src/components/homepage/UpcomingRounds.test.tsx
+++ b/apps/website/src/components/homepage/UpcomingRounds.test.tsx
@@ -56,7 +56,7 @@ describe('UpcomingRounds', () => {
     const href = firstLink?.getAttribute('href') || '';
 
     expect(href).toContain(mockApplyUrl);
-    expect(href).toContain(`prefill_%5B%3E%5D%20Round=${mockRoundId}`);
+    expect(href).toContain(`prefill_Round=${mockRoundId}`);
   });
 
   it('does not render apply link when applyUrl is null', () => {

--- a/apps/website/src/components/shared/RoundItem.tsx
+++ b/apps/website/src/components/shared/RoundItem.tsx
@@ -1,7 +1,7 @@
 export function buildRoundApplyUrl(baseUrl: string, roundId: string): string {
   if (!baseUrl) return '';
   const separator = baseUrl.includes('?') ? '&' : '?';
-  return `${baseUrl}${separator}prefill_%5B%3E%5D%20Round=${roundId}`;
+  return `${baseUrl}${separator}prefill_Round=${roundId}`;
 }
 
 type RoundItemProps = {


### PR DESCRIPTION
The field name is just 'Round', not '[>] Round'

Fixes #2224

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="652" height="507" alt="image" src="https://github.com/user-attachments/assets/b22f08db-6433-4931-9d6c-15b5b1e45b90" /> | <img width="638" height="403" alt="image" src="https://github.com/user-attachments/assets/023290f2-722c-431d-a1dd-44040b555da1" /> |
