### PR TITLE
`preventDefault` `onMouseDown` for exercise buttons

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -202,6 +202,7 @@ const Exercise: React.FC<ExerciseProps> = ({
             <button
               type="button"
               onClick={() => handleExerciseSubmit(editorTextRef.current, !isCompleted)}
+              onMouseDown={(e) => e.preventDefault()}
               disabled={checkboxDisabled}
               onMouseEnter={() => setCheckboxHovered(true)}
               onMouseLeave={() => setCheckboxHovered(false)}

--- a/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
+++ b/apps/website/src/components/courses/exercises/FreeTextResponse.tsx
@@ -83,6 +83,7 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
             <button
               type="button"
               onClick={handleMarkComplete}
+              onMouseDown={(e) => e.preventDefault()}
               disabled={isDisabled}
               className={cn(
                 'flex flex-row justify-center items-center px-2.5 py-1.5 gap-2 h-[30px] rounded-md border-none font-medium text-[13px] leading-[140%] tracking-[-0.005em] transition-all duration-200 bg-bluedot-normal text-white cursor-pointer',
@@ -96,6 +97,7 @@ const FreeTextResponse: React.FC<FreeTextResponseProps> = ({
             <button
               type="button"
               onClick={handleMarkIncomplete}
+              onMouseDown={(e) => e.preventDefault()}
               className="flex items-center gap-2 h-[30px] transition-all duration-200 hover:opacity-70 bg-transparent border-none cursor-pointer p-0"
               aria-label="Mark exercise as incomplete"
             >


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

1. User pastes text into the TipTap editor
2. User clicks "Complete" - this causes the editor to blur first (browser fires blur before click)
3. `RichTextAutoSaveEditor.onBlur` calls `saveValue` -> `onSave` -> `onExerciseSubmit(value, undefined)` in Exercise.tsx
4. That save acquires `isSavingRef.current = true`
5. The click event fires `handleMarkComplete` -> `onExerciseSubmit(answer, true)` in Exercise.tsx
6. `isSavingRef.current` is already true, so the function returns early - the `completed: true` is dropped

By setting `preventDefault` on mouse down we prevent the blur from firing when the button is clicked.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2232

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

