### PR TITLE
Add `submittedAt` field to `course_feedback` schema

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1401,6 +1401,10 @@ export const courseFeedbackTable = pgAirtable('course_feedback', {
       pgColumn: text().array(),
       airtableId: 'fldf1vkZDkPDpWdRX',
     },
+    submittedAt: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldU1lnBjth2Fxban',
+    },
   },
 });
 


### PR DESCRIPTION
# Description

Per [Figma comment](https://www.figma.com/design/aOBsGcUoP0CPIzCdrySLRi?node-id=14-815&m=dev#1724230721) on the new facilitator feedback form:

> It would simplify things a lot to create a stub "Course feedback" row once the first "Peer feedback" is saved, as the peer feedback needs to link back to the course feedback. 

> This would require adding a `submittedAt` field to course feedback so we can distinguish between draft and submitted rows.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2277
