### PR TITLE
Dedupe applications in speed-review to prevent rated people reappearing

### DIFF
--- a/apps/speed-review/src/lib/api/airtable.ts
+++ b/apps/speed-review/src/lib/api/airtable.ts
@@ -182,6 +182,10 @@ export const fetchApplications = async (
   offset?: string,
 ): Promise<{ applications: Application[]; nextOffset?: string }> => {
   const collected: Application[] = [];
+  // Airtable pagination can return the same record across internal pages when
+  // the filtered-on field is modified mid-iteration (every rating mutates the
+  // Decision field). Track IDs to drop duplicates before they reach the queue.
+  const seenIds = new Set<string>();
   let currentOffset = offset;
 
   while (collected.length < RESPONSE_PAGE_SIZE) {
@@ -197,7 +201,14 @@ export const fetchApplications = async (
       currentOffset,
     );
 
-    const matching = records.filter((r) => matchesRound(r, roundId)).map(toApplication);
+    const matching = records
+      .filter((r) => matchesRound(r, roundId))
+      .map(toApplication)
+      .filter((a) => {
+        if (seenIds.has(a.id)) return false;
+        seenIds.add(a.id);
+        return true;
+      });
     collected.push(...matching);
     currentOffset = nextOffset;
 

--- a/apps/speed-review/src/pages/index.tsx
+++ b/apps/speed-review/src/pages/index.tsx
@@ -86,9 +86,18 @@ const reduce = (state: SessionState, action: Action): SessionState => {
   }
 
   if (action.type === 'MORE_LOADED' && state.status === 'reviewing') {
+    // Dedupe against seen and queue: Airtable pagination can return the same
+    // record across pages when the filtered-on field is modified mid-iteration,
+    // which happens constantly here because every rating mutates the Decision
+    // field the formula filters on.
+    const known = new Set<string>([
+      ...state.seen.map((a) => a.id),
+      ...state.queue.map((a) => a.id),
+    ]);
+    const fresh = (action.applications ?? []).filter((a) => !known.has(a.id));
     return {
       ...state,
-      queue: [...state.queue, ...(action.applications ?? [])],
+      queue: [...state.queue, ...fresh],
       nextOffset: action.nextOffset,
     };
   }

--- a/apps/speed-review/src/pages/index.tsx
+++ b/apps/speed-review/src/pages/index.tsx
@@ -94,11 +94,17 @@ const reduce = (state: SessionState, action: Action): SessionState => {
       ...state.seen.map((a) => a.id),
       ...state.queue.map((a) => a.id),
     ]);
-    const fresh = (action.applications ?? []).filter((a) => !known.has(a.id));
+    const incoming = action.applications ?? [];
+    const fresh = incoming.filter((a) => !known.has(a.id));
+    // If the server returned records but every one was a duplicate (e.g. an
+    // offset-expired retry re-scanning already-rated records from the top),
+    // stop paginating. Otherwise the prefetch effect would fire again as soon
+    // as nextOffset changes and we'd burn API calls on more stale pages.
+    const nextOffset = incoming.length > 0 && fresh.length === 0 ? undefined : action.nextOffset;
     return {
       ...state,
       queue: [...state.queue, ...fresh],
-      nextOffset: action.nextOffset,
+      nextOffset,
     };
   }
 


### PR DESCRIPTION
## Summary
- Airtable pagination can return the same record across pages when the filtered-on field is modified during iteration. In speed-review, every rating mutates the `Decision` field the filter keys on, which can cause rated people to reappear in the review queue.
- Primary fix: server-side dedupe inside `fetchApplications`'s internal pagination loop, so a single response can't contain the same record twice.
- Secondary fix: client-side dedupe in the `MORE_LOADED` reducer branch against `seen` + `queue`, catching cross-response duplicates (e.g. offset-expired retry).

## Test plan
- [ ] Run a speed-review session against a real round and confirm no already-rated applicant reappears
- [ ] Rate enough applications to trigger at least one `MORE_LOADED` prefetch (queue drops below 10)
- [ ] Verify `npm run lint` and `npm run typecheck` pass in `apps/speed-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)