### PR TITLE
Fix clipped confetti on speed-review session complete

### DIFF
--- a/apps/speed-review/src/components/SessionComplete.tsx
+++ b/apps/speed-review/src/components/SessionComplete.tsx
@@ -42,6 +42,14 @@ export const SessionComplete: React.FC<SessionCompleteProps> = ({
   const [resetIds, setResetIds] = useState<Set<string>>(new Set());
   const [editingId, setEditingId] = useState<string | null>(null);
   const [roundStats, setRoundStats] = useState<{ total: number; evaluated: number; accepted: number } | null>(null);
+  const [confettiSize, setConfettiSize] = useState<{ width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    const update = () => setConfettiSize({ width: window.innerWidth, height: window.innerHeight });
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
 
   useEffect(() => {
     authFetch(`/api/round-stats?round=${encodeURIComponent(roundId)}`)
@@ -157,13 +165,19 @@ export const SessionComplete: React.FC<SessionCompleteProps> = ({
 
   return (
     <div className="space-y-6 overflow-hidden">
-      {roundComplete && (
+      {roundComplete && confettiSize && (
         <Confetti
           recycle={false}
           numberOfPieces={500}
-          width={typeof window !== 'undefined' ? window.innerWidth : undefined}
-          height={typeof window !== 'undefined' ? window.innerHeight : undefined}
-          style={{ position: 'fixed', top: 0, left: 0, pointerEvents: 'none', zIndex: 50 }}
+          width={confettiSize.width}
+          height={confettiSize.height}
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            pointerEvents: 'none',
+            zIndex: 50,
+          }}
         />
       )}
       <div>

--- a/apps/speed-review/src/components/SessionComplete.tsx
+++ b/apps/speed-review/src/components/SessionComplete.tsx
@@ -157,7 +157,15 @@ export const SessionComplete: React.FC<SessionCompleteProps> = ({
 
   return (
     <div className="space-y-6 overflow-hidden">
-      {roundComplete && <Confetti recycle={false} numberOfPieces={500} />}
+      {roundComplete && (
+        <Confetti
+          recycle={false}
+          numberOfPieces={500}
+          width={typeof window !== 'undefined' ? window.innerWidth : undefined}
+          height={typeof window !== 'undefined' ? window.innerHeight : undefined}
+          style={{ position: 'fixed', top: 0, left: 0, pointerEvents: 'none', zIndex: 50 }}
+        />
+      )}
       <div>
         <h1 className="text-2xl font-bold text-stone-100">
           {roundComplete ? 'You\'ve evaluated all the applications for the round!' : 'Session complete'}


### PR DESCRIPTION
Confetti canvas was bounded by the overflow-hidden wrapper inside a max-w-3xl column. Render it as position: fixed so it covers the viewport.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
