### PR TITLE
Fix: keep Postgres table name as 'grant' to avoid pushSchema hang

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -838,7 +838,10 @@ export const testimonialTable = pgAirtable('testimonial', {
   },
 });
 
-export const rapidGrantTable = pgAirtable('rapid_grant', {
+// Postgres table name kept as 'grant' (not 'rapid_grant') so drizzle-kit does not
+// interpret the TypeScript rename as a DROP+CREATE, which can hang pushSchema (see
+// drizzle-orm issue #4651). The Airtable source was repointed in the previous PR.
+export const rapidGrantTable = pgAirtable('grant', {
   baseId: WEB_CONTENT_BASE_ID,
   tableId: 'tblSrknIDVIyNySWn',
   columns: {


### PR DESCRIPTION
Renaming the Drizzle pgAirtable name from 'grant' to 'rapid_grant' in PR #2296 caused drizzle-kit's pushSchema to hang trying to reconcile the rename as DROP+CREATE (see drizzle-orm issue #4651), which timed out after 120 seconds and crashed pg-sync-service on startup. As a result the `rapid_grant` table was never created, so the website errored on `select ... from "rapid_grant"`.

Keep the TypeScript variable as `rapidGrantTable` for semantic clarity but point it at Postgres table 'grant'. Columns are identical between old and new schema, so pushSchema sees no physical schema change for this table. The new tables from PR #2296 (career_transition_grant, career_transition_grant_application, rapid_grant_application) are still net-new CREATEs, which push cleanly.

Deploy note: after pg-sync-service restarts with this fix, it'll push the three new tables and reset metaTable field mappings. The existing `grant` table keeps its old rows until a full sync replaces them. If rows are not automatically refreshed, run pg-sync-service with `--initial-sync-tables grant career_transition_grant career_transition_grant_application rapid_grant_application` to force a clean rehydrate.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
