### PR TITLE
Hotfix: keep Rapid Grants Postgres table name as 'grant'

### DIFF
--- a/apps/website/src/server/routers/grants.ts
+++ b/apps/website/src/server/routers/grants.ts
@@ -23,8 +23,7 @@ export type PublicRapidGrant = {
 
 export type PublicCareerTransitionGrant = {
   granteeName: string;
-  amountUsd: number | null;
-  grantDuration?: string;
+  imageUrl?: string;
 };
 
 const sanitizeUrl = (value: string | null): string | undefined => {
@@ -65,13 +64,14 @@ const mapPublicRapidGrants = (all: RapidGrant[]): PublicRapidGrant[] => {
 const mapPublicCareerTransitionGrants = (all: CareerTransitionGrant[]): PublicCareerTransitionGrant[] => {
   return all
     .filter((grant) => Boolean(grant.firstName?.trim()) && Boolean(grant.lastName?.trim()))
-    .map((grant: CareerTransitionGrant) => ({
-      granteeName: [grant.firstName?.trim(), grant.lastName?.trim()].filter(Boolean).join(' '),
-      amountUsd: grant.amountUsd ?? null,
-      grantDuration: grant.grantDuration?.trim()
-        ? grant.grantDuration.trim()
-        : undefined,
-    }))
+    .map((grant: CareerTransitionGrant) => {
+      // Formula concatenates up to 5 permanent URLs space-separated; take the first.
+      const firstImageUrl = grant.imageUrl?.trim().split(/\s+/)[0] ?? null;
+      return {
+        granteeName: [grant.firstName?.trim(), grant.lastName?.trim()].filter(Boolean).join(' '),
+        imageUrl: sanitizeUrl(firstImageUrl),
+      };
+    })
     .sort((a, b) => a.granteeName.localeCompare(b.granteeName));
 };
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -838,7 +838,12 @@ export const testimonialTable = pgAirtable('testimonial', {
   },
 });
 
-export const rapidGrantTable = pgAirtable('rapid_grant', {
+// Postgres table name is kept as 'grant' (not 'rapid_grant') because drizzle-kit's
+// pushSchema cannot disambiguate a rename from a drop+create without interactive
+// input, which hangs headless pg-sync-service (see drizzle-orm issue #4651).
+// The TypeScript variable is named for semantic clarity; only the physical table
+// name stays put. The Airtable source is still the new Rapid grants table.
+export const rapidGrantTable = pgAirtable('grant', {
   baseId: WEB_CONTENT_BASE_ID,
   tableId: 'tblSrknIDVIyNySWn',
   columns: {

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -882,13 +882,11 @@ export const careerTransitionGrantTable = pgAirtable('career_transition_grant', 
       pgColumn: text(),
       airtableId: 'fldKQXPr9ZiQq9DVT',
     },
-    amountUsd: {
-      pgColumn: numeric({ mode: 'number' }),
-      airtableId: 'fldbObYsPX0lEK2fi',
-    },
-    grantDuration: {
+    // Formula field that outputs a permanent (miniextension-hosted) URL for the Photo attachment.
+    // Concatenates up to 5 URLs space-separated; consumers should take the first.
+    imageUrl: {
       pgColumn: text(),
-      airtableId: 'fldblFNC8n6nhWlag',
+      airtableId: 'fldWPOiBQAYxUlA7V',
     },
   },
 });


### PR DESCRIPTION
PR #2296 changed the Drizzle pgAirtable name from 'grant' to 'rapid_grant', which renames the physical Postgres table. On deploy, drizzle-kit's pushSchema cannot tell the difference between a rename and a drop+create without interactive input. pg-sync-service runs headless, so the prompt hung for 120 seconds, the service crashed, and the 'rapid_grant' table was never created. The website now errors on queries against a non-existent table.

This reverts only the Postgres table name to 'grant' (keeping the existing synced table in place). The TypeScript variable remains 'rapidGrantTable', and the Airtable source (tblSrknIDVIyNySWn, the new Rapid grants table) is unchanged. Columns are identical between the old and new schema, so pushSchema sees no physical table change for the grant table and does not hang. The three net-new operational tables (career_transition_grant, career_transition_grant_application, rapid_grant_application) will still be CREATEd cleanly on the next pg-sync-service restart, and schemaChangesDetected will trigger a full sync to hydrate them.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
