### PR TITLE
Rename Postgres table: grant -> rapid_grant (2/2, drop old table)

### DIFF
--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -37,7 +37,6 @@ export {
   dropoutTable,
   teamMemberTable,
   testimonialTable,
-  grantLegacyTable,
   rapidGrantTable,
   careerTransitionGrantTable,
   careerTransitionGrantApplicationTable,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -838,21 +838,6 @@ export const testimonialTable = pgAirtable('testimonial', {
   },
 });
 
-// Kept so drizzle-kit sees an unambiguous CREATE TABLE rapid_grant rather than
-// the rename/drop-and-create ambiguity that hangs headless pg-sync-service (see
-// drizzle-orm issue #4651). A plain pgTable (not pgAirtable) — this stops
-// syncing from Airtable, but the table is dropped in the follow-up PR anyway.
-// Columns match what pgAirtable('grant', ...) previously produced so drizzle
-// detects no physical change.
-export const grantLegacyTable = pgTable('grant', {
-  id: text('id').primaryKey(),
-  granteeName: text(),
-  projectTitle: text(),
-  amountUsd: numeric({ mode: 'number' }),
-  projectSummary: text(),
-  link: text(),
-});
-
 export const rapidGrantTable = pgAirtable('rapid_grant', {
   baseId: WEB_CONTENT_BASE_ID,
   tableId: 'tblSrknIDVIyNySWn',


### PR DESCRIPTION
# Description

Removes the `grantLegacyTable` placeholder now that `rapid_grant` is live and `grant` is no longer referenced anywhere.

Do not merge until #2300 is merged AND released to production.

## Issue

N/A (follow-up to #2296 / #2299, continues #2300)

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories