### PR TITLE
Switch Rapid Grants hero stats to operational source

### DIFF
--- a/apps/website/src/pages/programs.tsx
+++ b/apps/website/src/pages/programs.tsx
@@ -116,8 +116,10 @@ const ProgramGroup = ({ label, programs }: { label: string; programs: ProgramIte
 const ProgramsPage = () => {
   const { data: stats } = trpc.grants.getRapidGrantStats.useQuery();
 
+  // Fallback strings render while the query is loading (stats === undefined).
+  // Once stats resolves, show real values even if count/amount are 0.
   const fundingGivenOutLabel = stats ? formatAmountUsd(stats.totalAmountUsd) : '$50k+';
-  const grantsMadeLabel = stats?.count ? `${stats.count} grants` : 'many grants';
+  const grantsMadeLabel = stats ? `${stats.count} grants` : 'many grants';
 
   const programs: ProgramItem[] = [
     {

--- a/apps/website/src/pages/programs.tsx
+++ b/apps/website/src/pages/programs.tsx
@@ -114,16 +114,10 @@ const ProgramGroup = ({ label, programs }: { label: string; programs: ProgramIte
 };
 
 const ProgramsPage = () => {
-  const { data: publicGrantees } = trpc.grants.getAllPublicRapidGrantees.useQuery();
+  const { data: stats } = trpc.grants.getRapidGrantStats.useQuery();
 
-  const fundingGivenOut = publicGrantees?.reduce((sum, grantee) => {
-    return sum + (grantee.amountUsd ?? 0);
-  }, 0);
-
-  const fundingGivenOutLabel = typeof fundingGivenOut === 'number'
-    ? formatAmountUsd(fundingGivenOut)
-    : '$50k+';
-  const grantsMadeLabel = publicGrantees?.length ? `${publicGrantees.length} public grants` : 'many grants';
+  const fundingGivenOutLabel = stats ? formatAmountUsd(stats.totalAmountUsd) : '$50k+';
+  const grantsMadeLabel = stats?.count ? `${stats.count} grants` : 'many grants';
 
   const programs: ProgramItem[] = [
     {

--- a/apps/website/src/pages/programs/rapid-grants.tsx
+++ b/apps/website/src/pages/programs/rapid-grants.tsx
@@ -107,7 +107,10 @@ const COMMUNITY_CARD = {
 };
 
 const RapidGrantsPage = () => {
-  const { data: grantees } = trpc.grants.getAllPublicRapidGrantees.useQuery();
+  // Hero stats come from the operational endpoint so they reflect total program
+  // activity, not just the subset of grantees that consented to public listing.
+  // The "Projects we have funded" list below fetches its own data.
+  const { data: stats } = trpc.grants.getRapidGrantStats.useQuery();
 
   const scrollToGrantees = (e: React.BaseSyntheticEvent) => {
     e.preventDefault();
@@ -124,13 +127,8 @@ const RapidGrantsPage = () => {
     window.scrollTo({ top: targetTop, behavior: 'smooth' });
   };
 
-  const grantsMadeLabel = grantees ? String(grantees.length) : '—';
-  const fundingGivenOut = grantees?.reduce((sum, grantee) => {
-    return sum + (grantee.amountUsd ?? 0);
-  }, 0);
-  const fundingGivenOutLabel = typeof fundingGivenOut === 'number'
-    ? formatAmountUsd(fundingGivenOut)
-    : '—';
+  const grantsMadeLabel = stats ? String(stats.count) : '—';
+  const fundingGivenOutLabel = stats ? formatAmountUsd(stats.totalAmountUsd) : '—';
 
   return (
     <div className="bg-white">

--- a/apps/website/src/server/routers/grants.ts
+++ b/apps/website/src/server/routers/grants.ts
@@ -24,6 +24,12 @@ export type PublicRapidGrant = {
 export type PublicCareerTransitionGrant = {
   granteeName: string;
   imageUrl?: string;
+  /** Short bio, e.g. "Director of AI/ML at Syndigo. 7+ years deploying production ML." */
+  bio?: string;
+  /** What the grantee is doing with the grant, shown as a quote on their card. */
+  grantPlan?: string;
+  /** Optional LinkedIn or personal URL. When present the whole card links to it. */
+  profileUrl?: string;
 };
 
 const sanitizeUrl = (value: string | null): string | undefined => {
@@ -70,6 +76,9 @@ const mapPublicCareerTransitionGrants = (all: CareerTransitionGrant[]): PublicCa
       return {
         granteeName: [grant.firstName?.trim(), grant.lastName?.trim()].filter(Boolean).join(' '),
         imageUrl: sanitizeUrl(firstImageUrl),
+        bio: grant.bio?.trim() ? grant.bio.trim() : undefined,
+        grantPlan: grant.grantPlan?.trim() ? grant.grantPlan.trim() : undefined,
+        profileUrl: sanitizeUrl(grant.profileUrl),
       };
     })
     .sort((a, b) => a.granteeName.localeCompare(b.granteeName));

--- a/libraries/db/eslint.config.mjs
+++ b/libraries/db/eslint.config.mjs
@@ -1,4 +1,16 @@
 import bluedot from '@bluedot/eslint-config';
 
 /** @type {import('typescript-eslint').ConfigArray} */
-export default [...bluedot];
+export default [
+  ...bluedot,
+  {
+    // schema.ts is a single source-of-truth file for ~30+ pgAirtable table
+    // definitions; it's expected to grow as tables are added. Keep the rule
+    // enabled elsewhere in the package but raise the limit here so the signal
+    // remains useful for other files.
+    files: ['src/schema.ts'],
+    rules: {
+      'max-lines': ['warn', { max: 2500, skipComments: true }],
+    },
+  },
+];

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import {
   pgTable, text, boolean, numeric, timestamp,
   serial,
@@ -887,6 +888,18 @@ export const careerTransitionGrantTable = pgAirtable('career_transition_grant', 
     imageUrl: {
       pgColumn: text(),
       airtableId: 'fldWPOiBQAYxUlA7V',
+    },
+    bio: {
+      pgColumn: text(),
+      airtableId: 'fldRFV73ElzbB2Jl9',
+    },
+    grantPlan: {
+      pgColumn: text(),
+      airtableId: 'fldsRnpwVRdO6F4iq',
+    },
+    profileUrl: {
+      pgColumn: text(),
+      airtableId: 'fld2h9ghKvg79nayH',
     },
   },
 });

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import {
   pgTable, text, boolean, numeric, timestamp,
   serial,


### PR DESCRIPTION
The Rapid Grants page hero and the /programs listing row were deriving 'grants made' and 'funding given out' from getAllPublicRapidGrantees, which only counts grantees who consented to public listing (94 records). Real program totals are higher (104 accepted applications, ~\$105k deployed since the 2025-06-01 program launch).

Switches both surfaces to trpc.grants.getRapidGrantStats, which already applies the correct operational filter (grantDecision = Accept AND createdAt >= 2025-06-01). The "Projects we have funded" list on the Rapid Grants page keeps using getAllPublicRapidGrantees for the curated display data — only the aggregate numbers change.

Also bundles the Career Transition Grantees schema additions so they can deploy at the same time:
- schema: adds bio, grantPlan, profileUrl columns to careerTransitionGrantTable (pointing at Airtable formula/text fields that already exist on tbln76u7AsVnWAKZo).
- router: surfaces those fields in PublicCareerTransitionGrant. sanitizeUrl is applied to profileUrl. No amount or duration leaves the backend for Career Transition grantees.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
