### PR TITLE
Career Transition Grant page: stats in /programs listing + snapshot fix

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -154,6 +154,13 @@ exports[`AboutPage > should render correctly 1`] = `
                             </a>
                             <a
                               class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                              href="/programs/career-transition-grant"
+                              tabindex="0"
+                            >
+                              Career Transition Grant
+                            </a>
+                            <a
+                              class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                               href="/courses/technical-ai-safety-project"
                               tabindex="0"
                             >
@@ -369,6 +376,13 @@ exports[`AboutPage > should render correctly 1`] = `
                         tabindex="0"
                       >
                         Rapid Grants
+                      </a>
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                        href="/programs/career-transition-grant"
+                        tabindex="0"
+                      >
+                        Career Transition Grant
                       </a>
                       <a
                         class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -154,6 +154,13 @@ exports[`JoinUsPage > should render correctly 1`] = `
                             </a>
                             <a
                               class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                              href="/programs/career-transition-grant"
+                              tabindex="0"
+                            >
+                              Career Transition Grant
+                            </a>
+                            <a
+                              class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                               href="/courses/technical-ai-safety-project"
                               tabindex="0"
                             >
@@ -369,6 +376,13 @@ exports[`JoinUsPage > should render correctly 1`] = `
                         tabindex="0"
                       >
                         Rapid Grants
+                      </a>
+                      <a
+                        class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                        href="/programs/career-transition-grant"
+                        tabindex="0"
+                      >
+                        Career Transition Grant
                       </a>
                       <a
                         class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/__tests__/pages/programs.test.tsx
+++ b/apps/website/src/__tests__/pages/programs.test.tsx
@@ -28,15 +28,8 @@ beforeEach(() => {
   (useRouter as unknown as Mock).mockReturnValue(mockRouter);
   server.use(
     trpcMsw.courses.getAll.query(() => []),
-    trpcMsw.grants.getAllPublicRapidGrantees.query(() => [
-      {
-        projectTitle: 'Example grant',
-        projectSummary: 'Helped someone ship useful work.',
-        granteeName: 'Jane Doe',
-        amountUsd: 3200,
-        link: 'https://example.com/grant',
-      },
-    ]),
+    trpcMsw.grants.getRapidGrantStats.query(() => ({ count: 104, totalAmountUsd: 105000 })),
+    trpcMsw.grants.getCareerTransitionGrantStats.query(() => ({ count: 1, totalAmountUsd: 67500 })),
   );
 });
 
@@ -45,8 +38,10 @@ describe('ProgramsPage', () => {
     render(<ProgramsPage />, { wrapper: TrpcProvider });
 
     await waitFor(() => {
-      expect(screen.getByText('Funding', { selector: 'p' })).toBeInTheDocument();
+      // Funding appears twice (Rapid Grants + Career Transition Grant).
+      expect(screen.getAllByText('Funding', { selector: 'p' })).toHaveLength(2);
       expect(screen.getByText('Rapid Grants', { selector: 'p' })).toBeInTheDocument();
+      expect(screen.getByText('Career Transition Grants', { selector: 'p' })).toBeInTheDocument();
       expect(screen.getByText('Build', { selector: 'p' })).toBeInTheDocument();
       expect(screen.getByText('Technical AI Safety Project Sprint', { selector: 'p' })).toBeInTheDocument();
       expect(screen.getByText('Launch', { selector: 'p' })).toBeInTheDocument();

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -170,6 +170,13 @@ exports[`Nav > renders with courses 1`] = `
                         </a>
                         <a
                           class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                          href="/programs/career-transition-grant"
+                          tabindex="0"
+                        >
+                          Career Transition Grant
+                        </a>
+                        <a
+                          class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                           href="/courses/technical-ai-safety-project"
                           tabindex="0"
                         >
@@ -405,6 +412,13 @@ exports[`Nav > renders with courses 1`] = `
                     tabindex="0"
                   >
                     Rapid Grants
+                  </a>
+                  <a
+                    class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                    href="/programs/career-transition-grant"
+                    tabindex="0"
+                  >
+                    Career Transition Grant
                   </a>
                   <a
                     class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
@@ -159,6 +159,13 @@ exports[`HomeHeroContent > renders as expected 1`] = `
                           </a>
                           <a
                             class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                            href="/programs/career-transition-grant"
+                            tabindex="0"
+                          >
+                            Career Transition Grant
+                          </a>
+                          <a
+                            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                             href="/courses/technical-ai-safety-project"
                             tabindex="0"
                           >
@@ -380,6 +387,13 @@ exports[`HomeHeroContent > renders as expected 1`] = `
                       tabindex="0"
                     >
                       Rapid Grants
+                    </a>
+                    <a
+                      class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                      href="/programs/career-transition-grant"
+                      tabindex="0"
+                    >
+                      Career Transition Grant
                     </a>
                     <a
                       class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -218,6 +218,13 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                           </a>
                           <a
                             class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                            href="/programs/career-transition-grant"
+                            tabindex="0"
+                          >
+                            Career Transition Grant
+                          </a>
+                          <a
+                            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                             href="/courses/technical-ai-safety-project"
                             tabindex="0"
                           >
@@ -439,6 +446,13 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                       tabindex="0"
                     >
                       Rapid Grants
+                    </a>
+                    <a
+                      class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                      href="/programs/career-transition-grant"
+                      tabindex="0"
+                    >
+                      Career Transition Grant
                     </a>
                     <a
                       class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/components/lander/__snapshots__/IncubatorWeekLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/IncubatorWeekLander.test.tsx.snap
@@ -218,6 +218,13 @@ exports[`IncubatorWeekLander > renders the complete page correctly (snapshot) 1`
                           </a>
                           <a
                             class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                            href="/programs/career-transition-grant"
+                            tabindex="0"
+                          >
+                            Career Transition Grant
+                          </a>
+                          <a
+                            class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
                             href="/courses/technical-ai-safety-project"
                             tabindex="0"
                           >
@@ -439,6 +446,13 @@ exports[`IncubatorWeekLander > renders the complete page correctly (snapshot) 1`
                       tabindex="0"
                     >
                       Rapid Grants
+                    </a>
+                    <a
+                      class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
+                      href="/programs/career-transition-grant"
+                      tabindex="0"
+                    >
+                      Career Transition Grant
                     </a>
                     <a
                       class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/pages/programs.tsx
+++ b/apps/website/src/pages/programs.tsx
@@ -114,12 +114,17 @@ const ProgramGroup = ({ label, programs }: { label: string; programs: ProgramIte
 };
 
 const ProgramsPage = () => {
-  const { data: stats } = trpc.grants.getRapidGrantStats.useQuery();
+  const { data: rapidStats } = trpc.grants.getRapidGrantStats.useQuery();
+  const { data: ctStats } = trpc.grants.getCareerTransitionGrantStats.useQuery();
 
-  // Fallback strings render while the query is loading (stats === undefined).
+  const pluralizeGrants = (count: number) => `${count} ${count === 1 ? 'grant' : 'grants'}`;
+
+  // Fallback strings render while each query is loading (stats === undefined).
   // Once stats resolves, show real values even if count/amount are 0.
-  const fundingGivenOutLabel = stats ? formatAmountUsd(stats.totalAmountUsd) : '$50k+';
-  const grantsMadeLabel = stats ? `${stats.count} grants` : 'many grants';
+  const rapidFundingLabel = rapidStats ? formatAmountUsd(rapidStats.totalAmountUsd) : '$50k+';
+  const rapidGrantsLabel = rapidStats ? pluralizeGrants(rapidStats.count) : 'many grants';
+  const ctFundingLabel = ctStats ? formatAmountUsd(ctStats.totalAmountUsd) : '$50k+';
+  const ctGrantsLabel = ctStats ? pluralizeGrants(ctStats.count) : 'a handful of grants';
 
   const programs: ProgramItem[] = [
     {
@@ -129,17 +134,17 @@ const ProgramsPage = () => {
       status: 'Active',
       href: '/programs/rapid-grants',
       summary: 'Small, fast funding for concrete AI safety work.',
-      detail: `Five-minute application, decisions in days, money upfront by default. ${fundingGivenOutLabel} deployed so far across ${grantsMadeLabel}.`,
+      detail: `Five-minute application, decisions in days, money upfront by default. ${rapidFundingLabel} deployed so far across ${rapidGrantsLabel}.`,
       ctaLabel: 'Explore program',
     },
     {
       id: 'career-transition-grant',
-      name: 'BlueDot Career Transition Grant',
+      name: 'Career Transition Grants',
       track: 'Funding',
       status: 'Active',
       href: '/programs/career-transition-grant',
-      summary: 'Funding to work full-time on AI safety, plus intros, advising, and community.',
-      detail: 'For BlueDot community members ready to make the jump. Propose a budget and a plan; decisions after a short call.',
+      summary: 'Funding to enable you to work full-time on impactful AI safety work.',
+      detail: `Propose your plan for contributing full-time to AI safety. ${ctFundingLabel} awarded so far across ${ctGrantsLabel}.`,
       ctaLabel: 'Explore program',
     },
     {


### PR DESCRIPTION
## Summary

- Wires the Career Transition Grant row in `/programs` to its own operational stats endpoint (`getCareerTransitionGrantStats`) so the row reads its own count + amount, not the Rapid Grants ones.
- Pluralises the \"N grants\" label so \"1 grant\" agrees.
- Removes an unused `YouTubeEmbed` import that was breaking lint.
- Regenerates 6 stale nav snapshots. When the Career Transition Grant was added to `GRANT_PROGRAMS` (which the top-nav dropdown iterates over), every page snapshot that renders the nav started disagreeing with its stored version. This was the cause of the CI failure on `c0e5b94a` that blocked the production website deploy.

## Context

CI on the prior merge commit (`c0e5b94a`) failed with 7 test files / 6 snapshot mismatches. The failure is purely from the nav dropdown gaining a new entry; no production behaviour changed. Updating the snapshots (only files that render the nav) unblocks the next `website/v*` tag.

## Test plan

- [x] `npm run typecheck` and `npm run lint` pass in `apps/website`
- [x] Snapshot tests pass after regeneration (7/7 files, 24/24 tests)
- [ ] After merge, tag `website/v2.23.11` on the new master HEAD and let `website_deploy_production.yaml` run
- [ ] Verify on prod: `/programs` shows correct CT counts; `/programs/career-transition-grant` renders the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)