### PR TITLE
Pluralize 'Career Transition Grants' for consistency

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`AboutPage > should render correctly 1`] = `
                               href="/programs/career-transition-grant"
                               tabindex="0"
                             >
-                              Career Transition Grant
+                              Career Transition Grants
                             </a>
                             <a
                               class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
@@ -382,7 +382,7 @@ exports[`AboutPage > should render correctly 1`] = `
                         href="/programs/career-transition-grant"
                         tabindex="0"
                       >
-                        Career Transition Grant
+                        Career Transition Grants
                       </a>
                       <a
                         class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                               href="/programs/career-transition-grant"
                               tabindex="0"
                             >
-                              Career Transition Grant
+                              Career Transition Grants
                             </a>
                             <a
                               class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
@@ -382,7 +382,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                         href="/programs/career-transition-grant"
                         tabindex="0"
                       >
-                        Career Transition Grant
+                        Career Transition Grants
                       </a>
                       <a
                         class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`Nav > renders with courses 1`] = `
                           href="/programs/career-transition-grant"
                           tabindex="0"
                         >
-                          Career Transition Grant
+                          Career Transition Grants
                         </a>
                         <a
                           class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
@@ -418,7 +418,7 @@ exports[`Nav > renders with courses 1`] = `
                     href="/programs/career-transition-grant"
                     tabindex="0"
                   >
-                    Career Transition Grant
+                    Career Transition Grants
                   </a>
                   <a
                     class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/components/grants/grantPrograms.ts
+++ b/apps/website/src/components/grants/grantPrograms.ts
@@ -27,7 +27,7 @@ export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
   },
   {
     slug: 'career-transition-grant',
-    title: 'Career Transition Grant',
+    title: 'Career Transition Grants',
     href: '/programs/career-transition-grant',
     goal: 'Support BlueDot graduates to work full-time on impactful AI safety work.',
     scope: 'Funding plus intros, advising, and community for people ready to go full-time on AI safety.',

--- a/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`HomeHeroContent > renders as expected 1`] = `
                             href="/programs/career-transition-grant"
                             tabindex="0"
                           >
-                            Career Transition Grant
+                            Career Transition Grants
                           </a>
                           <a
                             class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
@@ -393,7 +393,7 @@ exports[`HomeHeroContent > renders as expected 1`] = `
                       href="/programs/career-transition-grant"
                       tabindex="0"
                     >
-                      Career Transition Grant
+                      Career Transition Grants
                     </a>
                     <a
                       class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                             href="/programs/career-transition-grant"
                             tabindex="0"
                           >
-                            Career Transition Grant
+                            Career Transition Grants
                           </a>
                           <a
                             class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
@@ -452,7 +452,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                       href="/programs/career-transition-grant"
                       tabindex="0"
                     >
-                      Career Transition Grant
+                      Career Transition Grants
                     </a>
                     <a
                       class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/components/lander/__snapshots__/IncubatorWeekLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/IncubatorWeekLander.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`IncubatorWeekLander > renders the complete page correctly (snapshot) 1`
                             href="/programs/career-transition-grant"
                             tabindex="0"
                           >
-                            Career Transition Grant
+                            Career Transition Grants
                           </a>
                           <a
                             class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"
@@ -452,7 +452,7 @@ exports[`IncubatorWeekLander > renders the complete page correctly (snapshot) 1`
                       href="/programs/career-transition-grant"
                       tabindex="0"
                     >
-                      Career Transition Grant
+                      Career Transition Grants
                     </a>
                     <a
                       class="bluedot-a not-prose nav-link nav-link-animation w-fit no-underline text-size-sm font-[450] leading-[160%] align-middle pt-1 text-[#02034B] hover:text-[#02034B]"

--- a/apps/website/src/pages/programs/career-transition-grant.tsx
+++ b/apps/website/src/pages/programs/career-transition-grant.tsx
@@ -20,7 +20,7 @@ import { formatAmountUsd } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
 
 const CURRENT_ROUTE: BluedotRoute = {
-  title: 'Career Transition Grant',
+  title: 'Career Transition Grants',
   url: '/programs/career-transition-grant',
 };
 
@@ -310,7 +310,7 @@ const CareerTransitionGrantPage = () => {
         ctaText="Apply now"
         ctaUrl={CAREER_TRANSITION_GRANT_APPLICATION_URL}
         imageSrc="/images/courses/courses-gradient.webp"
-        imageAlt="Career Transition Grant banner"
+        imageAlt="Career Transition Grants banner"
         iconSrc="/images/logo/BlueDot_Impact_Icon_White.svg"
         iconAlt="BlueDot icon"
         noiseImageSrc="/images/agi-strategy/noise.webp"


### PR DESCRIPTION
## Summary

Aligns the nav dropdown label, the CT Grants page `<title>`, and the landing banner's image alt text with the plural 'Career Transition Grants' form already used by the /programs listing row and the hero title on the page itself.

## Changes

- `grantPrograms.ts` — nav dropdown title
- `career-transition-grant.tsx` — `CURRENT_ROUTE.title` (browser tab) and `imageAlt`
- 6 nav snapshots regenerated (single-character change per snapshot)

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass
- [x] Full `npm run test` run — 6 affected snapshots regenerated; only unrelated pre-existing locale flake (`Congratulations`) remains failing on local
- [ ] After merge, tag `website/v2.23.15` off new master HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)