### PR TITLE
Homepage: show active programs grid in GrantsSection

### DIFF
--- a/apps/website/src/components/grants/grantPrograms.ts
+++ b/apps/website/src/components/grants/grantPrograms.ts
@@ -3,11 +3,15 @@ import type React from 'react';
 export type GrantProgramStatus = 'Active' | 'On hiatus';
 export type GrantProgramSlug = 'rapid-grants' | 'career-transition-grant' | 'technical-ai-safety-project-sprint' | 'incubator-week';
 
+export type GrantProgramTrack = 'Funding' | 'Build' | 'Launch';
+
 export type GrantProgramDefinition = {
   slug: GrantProgramSlug;
   title: string;
   href: string;
   status: GrantProgramStatus;
+  /** Short track label shown above the program title (e.g. 'Funding', 'Build'). */
+  track: GrantProgramTrack;
   goal: string;
   scope: string;
   scopeLabel?: string;
@@ -21,6 +25,7 @@ export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
     slug: 'rapid-grants',
     title: 'Rapid Grants',
     href: '/programs/rapid-grants',
+    track: 'Funding',
     goal: 'Fund talented people in the BlueDot community to do excellent work on AI safety - research, events, community building, and more.',
     scope: 'Grants up to $10,000 for project costs, events, travel, community building, and other costs that remove barriers. Fast decisions, lightweight process.',
     status: 'Active',
@@ -29,6 +34,7 @@ export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
     slug: 'career-transition-grant',
     title: 'Career Transition Grant',
     href: '/programs/career-transition-grant',
+    track: 'Funding',
     goal: 'Support BlueDot graduates to work full-time on impactful AI safety work.',
     scope: 'Funding plus intros, advising, and community for people ready to go full-time on AI safety.',
     status: 'Active',
@@ -37,6 +43,7 @@ export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
     slug: 'technical-ai-safety-project-sprint',
     title: 'Technical AI Safety Project Sprint',
     href: '/courses/technical-ai-safety-project',
+    track: 'Build',
     goal: 'Help technically minded people ship a concrete AI safety research or engineering project with expert support.',
     scope: 'A 30-hour project sprint with mentorship, public output, and a clear path to portfolio-building.',
     scopeLabel: 'Format',
@@ -46,6 +53,7 @@ export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
     slug: 'incubator-week',
     title: 'Incubator Week',
     href: '/courses/incubator-week',
+    track: 'Launch',
     goal: 'Back founders from our courses to turn strong ideas into organizations that can make AI go well.',
     scope: 'A five-day intensive in London. All expenses paid. Pitch for funding on Friday.',
     scopeLabel: 'Format',

--- a/apps/website/src/components/homepage/GrantsSection.tsx
+++ b/apps/website/src/components/homepage/GrantsSection.tsx
@@ -40,7 +40,7 @@ const GrantsSection = () => {
                   <span className="transition-transform group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5">
                     Learn more
                   </span>
-                  <span aria-hidden="true" className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+                  <span aria-hidden="true" className="opacity-60 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
                     →
                   </span>
                 </span>

--- a/apps/website/src/components/homepage/GrantsSection.tsx
+++ b/apps/website/src/components/homepage/GrantsSection.tsx
@@ -1,28 +1,65 @@
 import { CTALinkOrButton, H2, P } from '@bluedot/ui';
+import Link from 'next/link';
+import { GRANT_PROGRAMS, type GrantProgramSlug } from '../grants/grantPrograms';
 import { ROUTES } from '../../lib/routes';
 
-const RAPID_GRANTS_URL = `${ROUTES.programs.url}/rapid-grants?utm_source=website&utm_campaign=homepage-programs`;
 const PROGRAMS_OVERVIEW_URL = `${ROUTES.programs.url}?utm_source=website&utm_campaign=homepage-programs`;
 
+const TRACK_BY_SLUG: Record<GrantProgramSlug, string> = {
+  'rapid-grants': 'Funding',
+  'career-transition-grant': 'Funding',
+  'technical-ai-safety-project-sprint': 'Build',
+  'incubator-week': 'Launch',
+};
+
 const GrantsSection = () => {
+  const activePrograms = GRANT_PROGRAMS.filter((p) => p.status === 'Active');
+
   return (
     <section className="w-full bg-white py-[48px] px-5 min-[680px]:py-[64px] min-[680px]:px-8 min-[1024px]:py-[80px] lg:px-12 min-[1280px]:py-[96px] xl:px-16 2xl:px-20">
-      <div className="mx-auto flex max-w-[760px] flex-col items-center text-center">
-        <div className="max-w-[700px]">
+      <div className="mx-auto max-w-screen-xl flex flex-col items-center">
+        <div className="max-w-[700px] text-center">
           <H2 className="text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-bluedot-navy">
             Go beyond a course
           </H2>
           <P className="mt-6 text-[16px] min-[680px]:text-[18px] leading-[1.6] text-bluedot-navy/80">
-            Funding, structured sprints, or a bigger launchpad for the next stage of your work on making AI go well. Explore what programs we are running currently, or go straight to Rapid Grants if you need money to keep moving.
+            Funding, structured sprints, or a bigger launchpad for the next stage of your work on making AI go well.
           </P>
-          <div className="mt-8 flex flex-wrap justify-center gap-3">
-            <CTALinkOrButton url={PROGRAMS_OVERVIEW_URL}>
-              Explore programs
-            </CTALinkOrButton>
-            <CTALinkOrButton url={RAPID_GRANTS_URL} variant="secondary" withChevron>
-              Rapid Grants
-            </CTALinkOrButton>
-          </div>
+        </div>
+
+        <ul className="list-none mt-10 min-[680px]:mt-12 grid gap-4 w-full max-w-[1120px] grid-cols-1 min-[680px]:grid-cols-2 min-[1024px]:grid-cols-3">
+          {activePrograms.map((program) => (
+            <li key={program.slug}>
+              <Link
+                href={`${program.href}?utm_source=website&utm_campaign=homepage-programs`}
+                className="group flex h-full flex-col gap-3 rounded-xl border border-bluedot-navy/10 bg-white p-6 transition-colors hover:border-bluedot-navy/20"
+              >
+                <p className="text-[11px] font-semibold uppercase tracking-[0.5px] text-bluedot-normal">
+                  {TRACK_BY_SLUG[program.slug]}
+                </p>
+                <h3 className="text-[18px] min-[680px]:text-[20px] font-semibold leading-tight text-bluedot-navy">
+                  {program.title}
+                </h3>
+                <p className="text-[15px] leading-[1.55] text-bluedot-navy/70">
+                  {program.goal}
+                </p>
+                <span className="mt-auto pt-2 inline-flex items-center gap-1 text-[14px] font-medium text-bluedot-normal">
+                  <span className="transition-transform group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5">
+                    Learn more
+                  </span>
+                  <span aria-hidden="true" className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+                    →
+                  </span>
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-10 min-[680px]:mt-12">
+          <CTALinkOrButton url={PROGRAMS_OVERVIEW_URL} variant="secondary" withChevron>
+            See all programs
+          </CTALinkOrButton>
         </div>
       </div>
     </section>

--- a/apps/website/src/components/homepage/GrantsSection.tsx
+++ b/apps/website/src/components/homepage/GrantsSection.tsx
@@ -1,16 +1,9 @@
 import { CTALinkOrButton, H2, P } from '@bluedot/ui';
 import Link from 'next/link';
-import { GRANT_PROGRAMS, type GrantProgramSlug } from '../grants/grantPrograms';
+import { GRANT_PROGRAMS } from '../grants/grantPrograms';
 import { ROUTES } from '../../lib/routes';
 
 const PROGRAMS_OVERVIEW_URL = `${ROUTES.programs.url}?utm_source=website&utm_campaign=homepage-programs`;
-
-const TRACK_BY_SLUG: Record<GrantProgramSlug, string> = {
-  'rapid-grants': 'Funding',
-  'career-transition-grant': 'Funding',
-  'technical-ai-safety-project-sprint': 'Build',
-  'incubator-week': 'Launch',
-};
 
 const GrantsSection = () => {
   const activePrograms = GRANT_PROGRAMS.filter((p) => p.status === 'Active');
@@ -35,7 +28,7 @@ const GrantsSection = () => {
                 className="group flex h-full flex-col gap-3 rounded-xl border border-bluedot-navy/10 bg-white p-6 transition-colors hover:border-bluedot-navy/20"
               >
                 <p className="text-[11px] font-semibold uppercase tracking-[0.5px] text-bluedot-normal">
-                  {TRACK_BY_SLUG[program.slug]}
+                  {program.track}
                 </p>
                 <h3 className="text-[18px] min-[680px]:text-[20px] font-semibold leading-tight text-bluedot-navy">
                   {program.title}
@@ -44,7 +37,7 @@ const GrantsSection = () => {
                   {program.goal}
                 </p>
                 <span className="mt-auto pt-2 inline-flex items-center gap-1 text-[14px] font-medium text-bluedot-normal">
-                  <span className="transition-transform group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5">
+                  <span className="transition-transform group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5">
                     Learn more
                   </span>
                   <span aria-hidden="true" className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">

--- a/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`GrantsSection > renders default as expected 1`] = `
               class="mt-auto pt-2 inline-flex items-center gap-1 text-[14px] font-medium text-bluedot-normal"
             >
               <span
-                class="transition-transform group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5"
+                class="transition-transform group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5"
               >
                 Learn more
               </span>
@@ -86,7 +86,7 @@ exports[`GrantsSection > renders default as expected 1`] = `
               class="mt-auto pt-2 inline-flex items-center gap-1 text-[14px] font-medium text-bluedot-normal"
             >
               <span
-                class="transition-transform group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5"
+                class="transition-transform group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5"
               >
                 Learn more
               </span>
@@ -123,7 +123,7 @@ exports[`GrantsSection > renders default as expected 1`] = `
               class="mt-auto pt-2 inline-flex items-center gap-1 text-[14px] font-medium text-bluedot-normal"
             >
               <span
-                class="transition-transform group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5"
+                class="transition-transform group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5"
               >
                 Learn more
               </span>

--- a/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`GrantsSection > renders default as expected 1`] = `
     class="w-full bg-white py-[48px] px-5 min-[680px]:py-[64px] min-[680px]:px-8 min-[1024px]:py-[80px] lg:px-12 min-[1280px]:py-[96px] xl:px-16 2xl:px-20"
   >
     <div
-      class="mx-auto flex max-w-[760px] flex-col items-center text-center"
+      class="mx-auto max-w-screen-xl flex flex-col items-center"
     >
       <div
-        class="max-w-[700px]"
+        class="max-w-[700px] text-center"
       >
         <h2
           class="bluedot-h2 not-prose text-[28px] min-[680px]:text-[36px] min-[1024px]:text-[40px] min-[1280px]:text-[48px] leading-tight tracking-[-1px] font-medium text-bluedot-navy"
@@ -19,44 +19,152 @@ exports[`GrantsSection > renders default as expected 1`] = `
         <p
           class="bluedot-p not-prose mt-6 text-[16px] min-[680px]:text-[18px] leading-[1.6] text-bluedot-navy/80"
         >
-          Funding, structured sprints, or a bigger launchpad for the next stage of your work on making AI go well. Explore what programs we are running currently, or go straight to Rapid Grants if you need money to keep moving.
+          Funding, structured sprints, or a bigger launchpad for the next stage of your work on making AI go well.
         </p>
-        <div
-          class="mt-8 flex flex-wrap justify-center gap-3"
-        >
+      </div>
+      <ul
+        class="list-none mt-10 min-[680px]:mt-12 grid gap-4 w-full max-w-[1120px] grid-cols-1 min-[680px]:grid-cols-2 min-[1024px]:grid-cols-3"
+      >
+        <li>
           <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--primary bg-bluedot-normal link-on-dark"
-            href="/programs?utm_source=website&utm_campaign=homepage-programs"
-            tabindex="0"
-          >
-            Explore programs
-          </a>
-          <a
-            class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
+            class="group flex h-full flex-col gap-3 rounded-xl border border-bluedot-navy/10 bg-white p-6 transition-colors hover:border-bluedot-navy/20"
             href="/programs/rapid-grants?utm_source=website&utm_campaign=homepage-programs"
-            tabindex="0"
           >
-            Rapid Grants
-            <span
-              class="cta-button__chevron ml-3"
+            <p
+              class="text-[11px] font-semibold uppercase tracking-[0.5px] text-bluedot-normal"
             >
-              <svg
-                class="cta-button__chevron-icon size-2"
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 320 512"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              Funding
+            </p>
+            <h3
+              class="text-[18px] min-[680px]:text-[20px] font-semibold leading-tight text-bluedot-navy"
+            >
+              Rapid Grants
+            </h3>
+            <p
+              class="text-[15px] leading-[1.55] text-bluedot-navy/70"
+            >
+              Fund talented people in the BlueDot community to do excellent work on AI safety - research, events, community building, and more.
+            </p>
+            <span
+              class="mt-auto pt-2 inline-flex items-center gap-1 text-[14px] font-medium text-bluedot-normal"
+            >
+              <span
+                class="transition-transform group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5"
               >
-                <path
-                  d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
-                />
-              </svg>
+                Learn more
+              </span>
+              <span
+                aria-hidden="true"
+                class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+              >
+                →
+              </span>
             </span>
           </a>
-        </div>
+        </li>
+        <li>
+          <a
+            class="group flex h-full flex-col gap-3 rounded-xl border border-bluedot-navy/10 bg-white p-6 transition-colors hover:border-bluedot-navy/20"
+            href="/programs/career-transition-grant?utm_source=website&utm_campaign=homepage-programs"
+          >
+            <p
+              class="text-[11px] font-semibold uppercase tracking-[0.5px] text-bluedot-normal"
+            >
+              Funding
+            </p>
+            <h3
+              class="text-[18px] min-[680px]:text-[20px] font-semibold leading-tight text-bluedot-navy"
+            >
+              Career Transition Grant
+            </h3>
+            <p
+              class="text-[15px] leading-[1.55] text-bluedot-navy/70"
+            >
+              Support BlueDot graduates to work full-time on impactful AI safety work.
+            </p>
+            <span
+              class="mt-auto pt-2 inline-flex items-center gap-1 text-[14px] font-medium text-bluedot-normal"
+            >
+              <span
+                class="transition-transform group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5"
+              >
+                Learn more
+              </span>
+              <span
+                aria-hidden="true"
+                class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+              >
+                →
+              </span>
+            </span>
+          </a>
+        </li>
+        <li>
+          <a
+            class="group flex h-full flex-col gap-3 rounded-xl border border-bluedot-navy/10 bg-white p-6 transition-colors hover:border-bluedot-navy/20"
+            href="/courses/technical-ai-safety-project?utm_source=website&utm_campaign=homepage-programs"
+          >
+            <p
+              class="text-[11px] font-semibold uppercase tracking-[0.5px] text-bluedot-normal"
+            >
+              Build
+            </p>
+            <h3
+              class="text-[18px] min-[680px]:text-[20px] font-semibold leading-tight text-bluedot-navy"
+            >
+              Technical AI Safety Project Sprint
+            </h3>
+            <p
+              class="text-[15px] leading-[1.55] text-bluedot-navy/70"
+            >
+              Help technically minded people ship a concrete AI safety research or engineering project with expert support.
+            </p>
+            <span
+              class="mt-auto pt-2 inline-flex items-center gap-1 text-[14px] font-medium text-bluedot-normal"
+            >
+              <span
+                class="transition-transform group-hover:-translate-x-0.5 group-focus-visible:-translate-x-0.5"
+              >
+                Learn more
+              </span>
+              <span
+                aria-hidden="true"
+                class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+              >
+                →
+              </span>
+            </span>
+          </a>
+        </li>
+      </ul>
+      <div
+        class="mt-10 min-[680px]:mt-12"
+      >
+        <a
+          class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-sm px-4 py-3 rounded-sm font-[650] cta-button--secondary bg-transparent border border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter"
+          href="/programs?utm_source=website&utm_campaign=homepage-programs"
+          tabindex="0"
+        >
+          See all programs
+          <span
+            class="cta-button__chevron ml-3"
+          >
+            <svg
+              class="cta-button__chevron-icon size-2"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 320 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
+              />
+            </svg>
+          </span>
+        </a>
       </div>
     </div>
   </section>

--- a/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`GrantsSection > renders default as expected 1`] = `
               </span>
               <span
                 aria-hidden="true"
-                class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+                class="opacity-60 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
               >
                 →
               </span>
@@ -92,7 +92,7 @@ exports[`GrantsSection > renders default as expected 1`] = `
               </span>
               <span
                 aria-hidden="true"
-                class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+                class="opacity-60 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
               >
                 →
               </span>
@@ -129,7 +129,7 @@ exports[`GrantsSection > renders default as expected 1`] = `
               </span>
               <span
                 aria-hidden="true"
-                class="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+                class="opacity-60 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
               >
                 →
               </span>

--- a/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/GrantsSection.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`GrantsSection > renders default as expected 1`] = `
             <h3
               class="text-[18px] min-[680px]:text-[20px] font-semibold leading-tight text-bluedot-navy"
             >
-              Career Transition Grant
+              Career Transition Grants
             </h3>
             <p
               class="text-[15px] leading-[1.55] text-bluedot-navy/70"


### PR DESCRIPTION
## Summary

The homepage GrantsSection mentioned only Rapid Grants in prose form. With Career Transition Grants now live, this upgrades the section to surface the full active program portfolio.

## Changes

- Keeps the 'Go beyond a course' heading and a tightened one-sentence prose hook.
- Adds a 3-card grid of active programs below (Rapid Grants, Career Transition Grants, TAISP), sourced from the existing `GRANT_PROGRAMS` array filtered by `status === 'Active'`. Each card = track label + title + one-sentence `goal` + 'Learn more →'.
- Replaces the old 'Rapid Grants' secondary CTA with a single 'See all programs' link — per-program links now live on the cards.
- Preserves `utm_source=website` / `utm_campaign=homepage-programs` tagging on every out-link.

Programs on hiatus (currently Incubator Week) are omitted from the homepage grid so it fills cleanly; they remain visible on /programs.

## Test plan

- [x] `npm run typecheck` + `npm run lint` pass
- [x] Full `npm run test` run — only `GrantsSection` snapshot needed regen; unrelated pre-existing `Congratulations` locale flake is the only other failure (not from this change)
- [ ] Visual QA on staging after merge
- [ ] After merge, tag `website/v2.23.16` off new master HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)