### PR TITLE
[fix] Correct staging URL in website README

### DIFF
--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -2,7 +2,7 @@
 
 Quick links:
 - [Production version](https://bluedot.org/)
-- [Staging version](https://website.k8s.bluedot.org/)
+- [Staging version](https://website-staging.k8s.bluedot.org/)
 - [Storybook](https://bluedot-storybook.k8s.bluedot.org/)
 - [Designs](https://www.figma.com/design/s4dNR4ELGKPbja6GkHLVJy/Website-Laura's-Working-File)
 


### PR DESCRIPTION
## Summary
- The README listed `https://website.k8s.bluedot.org/` as the staging URL — that host has no ingress and returns nginx 404.
- Actual staging host per `apps/infra/src/k8s/serviceDefinitions.ts:135,144` is `https://website-staging.k8s.bluedot.org/` (returns 200).

## Test plan
- [x] `curl -I https://website-staging.k8s.bluedot.org/` → 200
- [x] `curl -I https://website.k8s.bluedot.org/` → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)