### PR TITLE
refactor: remove breadcrumb components from program pages

### DIFF
--- a/apps/website/src/pages/programs.tsx
+++ b/apps/website/src/pages/programs.tsx
@@ -1,7 +1,4 @@
-import {
-  Breadcrumbs,
-  CTALinkOrButton,
-} from '@bluedot/ui';
+import { CTALinkOrButton } from '@bluedot/ui';
 import Head from 'next/head';
 import MarketingHero from '../components/MarketingHero';
 import PageNewsletter from '../components/PageNewsletter';
@@ -100,7 +97,6 @@ const ProgramsPage = () => {
         title="Programs"
         subtitle="Go beyond a course. Build, launch, get funded."
       />
-      <Breadcrumbs route={ROUTES.programs} />
 
       <section className="section section-body bg-white">
         <div className="flex flex-col gap-12 min-[1024px]:gap-14">

--- a/apps/website/src/pages/programs/career-transition-grant.tsx
+++ b/apps/website/src/pages/programs/career-transition-grant.tsx
@@ -1,4 +1,3 @@
-import { Breadcrumbs, type BluedotRoute } from '@bluedot/ui';
 import Head from 'next/head';
 import MarketingHero from '../../components/MarketingHero';
 import GrantStatsStrip from '../../components/grants/sections/GrantStatsStrip';
@@ -11,13 +10,8 @@ import NextStepsSection from '../../components/career-transition-grant/NextSteps
 import GranteesSection from '../../components/career-transition-grant/GranteesSection';
 import { formatAmountUsd } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
-import { ROUTES } from '../../lib/routes';
 
-const CURRENT_ROUTE: BluedotRoute = {
-  title: 'Career Transition Grants',
-  url: '/programs/career-transition-grant',
-  parentPages: [ROUTES.home, ROUTES.programs],
-};
+const PAGE_TITLE = 'Career Transition Grants';
 
 const CareerTransitionGrantPage = () => {
   const { data: stats } = trpc.grants.getCareerTransitionGrantStats.useQuery();
@@ -27,7 +21,7 @@ const CareerTransitionGrantPage = () => {
   return (
     <div>
       <Head>
-        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
+        <title>{`${PAGE_TITLE} | BlueDot Impact`}</title>
         <meta
           name="description"
           content="Funding and support for BlueDot community members ready to work full-time on AI safety."
@@ -37,7 +31,6 @@ const CareerTransitionGrantPage = () => {
         title="Career Transition Grants"
         subtitle="Funding and support to help you work full-time on AI safety."
       />
-      <Breadcrumbs route={CURRENT_ROUTE} />
       <GrantStatsStrip
         program="career-transition-grant"
         stats={[

--- a/apps/website/src/pages/programs/rapid-grants.tsx
+++ b/apps/website/src/pages/programs/rapid-grants.tsx
@@ -1,5 +1,4 @@
 import type React from 'react';
-import { Breadcrumbs, type BluedotRoute } from '@bluedot/ui';
 import Head from 'next/head';
 import MarketingHero from '../../components/MarketingHero';
 import GrantStatsStrip from '../../components/grants/sections/GrantStatsStrip';
@@ -10,13 +9,8 @@ import HowItWorksSection from '../../components/rapid-grants/HowItWorksSection';
 import FundedProjectsSection from '../../components/rapid-grants/FundedProjectsSection';
 import { formatAmountUsd } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
-import { ROUTES } from '../../lib/routes';
 
-const CURRENT_ROUTE: BluedotRoute = {
-  title: 'Rapid Grants',
-  url: '/programs/rapid-grants',
-  parentPages: [ROUTES.home, ROUTES.programs],
-};
+const PAGE_TITLE = 'Rapid Grants';
 
 const RapidGrantsPage = () => {
   const { data: stats } = trpc.grants.getRapidGrantStats.useQuery();
@@ -39,7 +33,7 @@ const RapidGrantsPage = () => {
   return (
     <div>
       <Head>
-        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
+        <title>{`${PAGE_TITLE} | BlueDot Impact`}</title>
         <meta
           name="description"
           content="Fast, flexible grants for BlueDot community members working on AI safety - research, events, community building, and more."
@@ -49,7 +43,6 @@ const RapidGrantsPage = () => {
         title="Rapid Grants"
         subtitle="Funding for the BlueDot community to ship projects, run events, and do other concrete work on AI safety."
       />
-      <Breadcrumbs route={CURRENT_ROUTE} />
       <GrantStatsStrip
         program="rapid-grants"
         compact


### PR DESCRIPTION
Removed unused Breadcrumbs component imports and implementations from the programs page and grant pages (career-transition-grant and rapid-grants). Also simplified route configuration by removing BluedotRoute types and ROUTES imports, replacing them with simple PAGE_TITLE constants where needed.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
