### PR TITLE
[perf] ci: parallelise typecheck/lint/test, cache deps + .next + .turbo

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -6,15 +6,24 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  ci:
+  setup:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
+    outputs:
+      node_version: ${{ steps.setup-node.outputs.node-version }}
+      turbo_filter: ${{ steps.get_affected_apps.outputs.turbo_filter }}
+      affected_deployable_apps: ${{ steps.get_affected_deployable_apps.outputs.deploy_array }}
     steps:
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 10  # Fetch more history to be likely to find a successful commit when identifying affected apps
+
       - name: Use Node.js
         id: setup-node
         uses: actions/setup-node@v4
@@ -22,6 +31,7 @@ jobs:
           node-version: 22
           cache: 'npm'
           registry-url: https://registry.npmjs.org/
+
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v4
@@ -34,8 +44,8 @@ jobs:
 
       - name: Install NPM dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci --audit false --fund false
-        
+        run: npm ci --prefer-offline --audit false --fund false
+
       - name: Get affected apps
         id: get_affected_apps
         env:
@@ -45,15 +55,6 @@ jobs:
         run: |
           TURBO_FILTER=$(npm run turbo_filter --silent --workspace @bluedot/affected-packages)
           echo "turbo_filter=$TURBO_FILTER" >> $GITHUB_OUTPUT
-          
-      - name: Typecheck affected apps
-        run: npx turbo typecheck ${{ steps.get_affected_apps.outputs.turbo_filter }}
-
-      - name: Lint affected apps
-        run: npx turbo lint ${{ steps.get_affected_apps.outputs.turbo_filter }}
-
-      - name: Test affected apps
-        run: npx turbo test ${{ steps.get_affected_apps.outputs.turbo_filter }}
 
       - name: Get affected deployable apps
         id: get_affected_deployable_apps
@@ -64,8 +65,147 @@ jobs:
         run: |
           DEPLOY_ARRAY=$(npm run deploy_array --silent --workspace @bluedot/affected-packages)
           echo "deploy_array=$DEPLOY_ARRAY" >> $GITHUB_OUTPUT
+
+  typecheck:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Restore node_modules
+        id: cache-node-modules
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            libraries/*/node_modules
+          key: ${{ runner.os }}-node-${{ needs.setup.outputs.node_version }}-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install NPM dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --audit false --fund false
+
+      - name: Cache turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-typecheck-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-typecheck-
+
+      - name: Typecheck affected apps
+        run: npx turbo typecheck ${{ needs.setup.outputs.turbo_filter }}
+
+  lint:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Restore node_modules
+        id: cache-node-modules
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            libraries/*/node_modules
+          key: ${{ runner.os }}-node-${{ needs.setup.outputs.node_version }}-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install NPM dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --audit false --fund false
+
+      - name: Cache turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-lint-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-lint-
+
+      - name: Lint affected apps
+        run: npx turbo lint ${{ needs.setup.outputs.turbo_filter }}
+
+  test:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Restore node_modules
+        id: cache-node-modules
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            libraries/*/node_modules
+          key: ${{ runner.os }}-node-${{ needs.setup.outputs.node_version }}-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install NPM dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --audit false --fund false
+
+      - name: Cache turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-test-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-test-
+
+      - name: Test affected apps
+        run: npx turbo test ${{ needs.setup.outputs.turbo_filter }}
+
+  ci:
+    # Aggregator job: branch protection requires a check named "ci", so we keep
+    # this name and have it gate on the parallel jobs above. Removing or
+    # renaming this job would break PR merges.
+    needs: [setup, typecheck, lint, test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
-      affected_deployable_apps: ${{ steps.get_affected_deployable_apps.outputs.deploy_array }}
+      affected_deployable_apps: ${{ needs.setup.outputs.affected_deployable_apps }}
+    steps:
+      - name: Verify all checks passed
+        run: |
+          if [[ "${{ needs.setup.result }}" != "success" \
+             || "${{ needs.typecheck.result }}" != "success" \
+             || "${{ needs.lint.result }}" != "success" \
+             || "${{ needs.test.result }}" != "success" ]]; then
+            echo "setup=${{ needs.setup.result }}, typecheck=${{ needs.typecheck.result }}, lint=${{ needs.lint.result }}, test=${{ needs.test.result }}"
+            exit 1
+          fi
 
   cd:
     needs: ci
@@ -83,13 +223,43 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Node.js
+        id: setup-node
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
           registry-url: https://registry.npmjs.org/
 
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            libraries/*/node_modules
+          key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-modules-${{ hashFiles('package-lock.json') }}
+
       - name: Install NPM dependencies
-        run: npm ci --audit false --fund false
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --audit false --fund false
+
+      - name: Cache Next.js build (website)
+        if: matrix.app == '@bluedot/website'
+        uses: actions/cache@v4
+        with:
+          path: apps/website/.next/cache
+          key: ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/website/**/*.{js,jsx,ts,tsx,mdx,md,json,css}') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-
+
+      - name: Cache turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-cd-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-cd-
 
       - name: Configure infra deployment
         if: matrix.app == '@bluedot/infra'

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -249,7 +249,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: apps/website/.next/cache
-          key: ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/website/**/*.{js,jsx,ts,tsx,mdx,md,json,css}') }}
+          key: ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/website/**/*.{js,jsx,ts,tsx,mdx,md,json,css}', '!apps/website/node_modules/**', '!apps/website/.next/**', '!apps/website/dist/**') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-
 
@@ -257,9 +257,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-cd-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-cd-${{ matrix.app }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-cd-
+            ${{ runner.os }}-turbo-cd-${{ matrix.app }}-
 
       - name: Configure infra deployment
         if: matrix.app == '@bluedot/infra'

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -29,22 +29,46 @@ jobs:
               core.setFailed(`CI/CD has not passed for ${context.sha} (status: ${run?.status ?? 'not found'}, conclusion: ${run?.conclusion ?? 'N/A'})`);
             }
 
-      - name: Install turbo
-        id: install_turbo
-        run: |
-          npm install --global turbo
-
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
 
       - name: Use Node.js
+        id: setup-node
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
           registry-url: https://registry.npmjs.org/
 
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            libraries/*/node_modules
+          key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-modules-${{ hashFiles('package-lock.json') }}
+
       - name: Install NPM dependencies
-        run: npm ci
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --audit false --fund false
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: apps/website/.next/cache
+          key: ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/website/**/*.{js,jsx,ts,tsx,mdx,md,json,css}') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-
+
+      - name: Cache turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-website-prod-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-website-prod-
 
       - name: Configure k8s deployment
         run: |

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: apps/website/.next/cache
-          key: ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/website/**/*.{js,jsx,ts,tsx,mdx,md,json,css}') }}
+          key: ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/website/**/*.{js,jsx,ts,tsx,mdx,md,json,css}', '!apps/website/node_modules/**', '!apps/website/.next/**', '!apps/website/dist/**') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-
 


### PR DESCRIPTION
## Summary

CI/CD on master push currently takes **9-12 min**, PR runs **4-7 min**. This PR is the no-infra quick-win bundle:

- **Splits `ci` into parallel jobs** (`setup` → `typecheck` / `lint` / `test`) sharing a `node_modules` cache. Aggregator job kept named `ci` so branch protection (`required_status_checks.contexts: ["ci"]`) still passes.
- **Caches `node_modules` in `cd`** and `website_deploy_production` (was reinstalling from scratch every run, ~44s).
- **Caches `apps/website/.next/cache`** between deploys for faster `next build`.
- **Caches `.turbo`** so unchanged tasks short-circuit even without remote cache.
- **`concurrency: cancel-in-progress`** on PR runs so stacked pushes don't all run to completion.
- **`npm ci --prefer-offline`** wherever we install fresh.

## Baseline (run [`24964029299`](https://github.com/bluedotimpact/bluedot/actions/runs/24964029299), master push)

| Job | Step | Time |
|---|---|---|
| `ci` (4m19s, sequential) | Tests | 2m41s |
|  | Lint | 0m50s |
|  | Typecheck | 0m15s |
|  | Setup + npm cache | ~30s |
| `cd` (4m55s) | `npm ci` (no cache) | 0m44s |
|  | `next build` + docker + push + rollout | 4m01s |

## Expected impact

- **PR runs:** 4-7m → ~2-3m (CI critical path = max(typecheck, lint, test) ≈ test ~3m, vs. serial 4m19s today; cancel-in-progress kills stacked runs).
- **Master push:** 9-12m → ~5-6m (cd starts 1m earlier, then warm `node_modules` saves 40s, warm `.next/cache` saves 30-90s on `next build`).
- **Steady-state cache hits** (no app code changed): turbo's local cache lets typecheck/lint/test no-op; saved further.

## Branch protection

Verified `gh api repos/bluedotimpact/bluedot/branches/master/protection` requires the check named `ci`. Aggregator job preserves this. **No branch-protection changes needed.**

## Out of scope (deliberate, follow-up)

- Turbo remote cache (Vercel free tier or self-hosted on R2/S3) — biggest remaining lever.
- Decoupling `cd` from `test` (run deploy in parallel with tests on master). Requires confirming PR-level test-gate is sufficient.
- `vitest --shard` test parallelisation across runners.
- Refactoring `deploy:cd` to use `turbo build --filter` instead of bare `npm run build`.

## Test plan

Workflow files are not covered by `npm test`; they're validated by GitHub Actions itself. To verify in this PR:

- [ ] First CI run: confirm 4 jobs (`setup`, `typecheck`, `lint`, `test`) appear and `typecheck`/`lint`/`test` start in parallel after `setup`. Aggregator `ci` runs last.
- [ ] Push a whitespace tweak to this branch: confirm earlier run is cancelled by `cancel-in-progress`.
- [ ] After first successful run, re-run via `gh run rerun`: `npm ci` should be skipped (cache hit), total time should drop further.
- [ ] On merge to master: confirm `cd` runs, `node_modules` and `.next/cache` restore, deploy succeeds. Compare wall clock against baseline.
- [ ] Next production tag (`website/v*`): confirm `website_deploy_production.yaml` still passes with new caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)