### PR TITLE
[fix] cd: run postinstall on node_modules cache hit

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -244,6 +244,10 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --audit false --fund false
 
+      - name: Run postinstall scripts (cache hit)
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        run: npm run postinstall --workspaces --if-present
+
       - name: Cache Next.js build (website)
         if: matrix.app == '@bluedot/website'
         uses: actions/cache@v4

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -54,6 +54,10 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --audit false --fund false
 
+      - name: Run postinstall scripts (cache hit)
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        run: npm run postinstall --workspaces --if-present
+
       - name: Cache Next.js build
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary

- Every cd matrix job on master is failing at **Set production secrets** since #2329, with `sed: can't read apps/website/.env.local: No such file or directory` (run [24966847110](https://github.com/bluedotimpact/bluedot/actions/runs/24966847110)).
- Root cause: #2329 made `npm ci` conditional on a `node_modules` cache miss in the `cd` job and `website_deploy_production`. On cache hit, postinstall hooks don't fire — including `apps/website`'s `shx cp -n .env.local.template .env.local` — so the file the next step `sed`s into doesn't exist. Multiple workspaces (`apps/website`, `apps/editor`, `apps/meet`, `apps/availability`, `apps/room`, `apps/speed-review`, `apps/course-demos`, `apps/app-template`, `apps/frontend-example`, `apps/infra`) rely on postinstall to materialise files used downstream.
- Fix: add a cache-hit-gated `npm run postinstall --workspaces --if-present` step in both workflows so the on-disk state matches a fresh `npm ci`. Cheap, idempotent (`shx cp -n` won't clobber), and preserves the perf win from caching.

## Why this approach over the alternatives

- **Always `npm ci`** — drops the perf gain from #2329; warm registry installs are still ~30–45s.
- **Pre-step that copies the website template only** — plugs the immediate symptom but misses other workspaces with postinstalls (`apps/infra`'s Pulumi passphrase file, etc).
- **Cache `.env.local` files alongside `node_modules`** — fragile; couples cache key to template contents.

## Out of scope

- `Set production secrets` runs unconditionally for every matrix app (no `if: matrix.app == '@bluedot/website'`). That's a pre-existing oddity, not the cause here. Worth a follow-up but changing it would alter deploy behaviour for non-website apps and isn't needed to unblock master.

## Test plan

- [ ] Merge to master and watch the next `cd` run hit the cache-hit path (it will, given the cache is now populated). Confirm **Set production secrets** passes for `@bluedot/website` *and* a non-website matrix app (e.g. `@bluedot/editor`).
- [ ] If you want to validate before merge, dispatch `website_deploy_production.yaml` with `skip_ci_check: true` against this branch — same conditional install, same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)