### PR TITLE
[test] website: cover course-registrations tRPC router

### DIFF
--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -1,0 +1,155 @@
+import {
+  applicationsRoundTable, courseRegistrationTable,
+} from '@bluedot/db';
+import { describe, expect, test } from 'vitest';
+import {
+  createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
+} from '../../__tests__/dbTestUtils';
+import { FOAI_COURSE_ID } from '../../lib/constants';
+
+setupTestDb();
+
+const otherCourseId = 'recOtherCourseId12345';
+
+describe('courseRegistrations.getByCourseId', () => {
+  test('rejects unauthenticated callers', async () => {
+    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.getByCourseId({ courseId: otherCourseId })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  test('returns null when no matching accepted registration exists', async () => {
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.getByCourseId({ courseId: otherCourseId });
+    expect(result).toBeNull();
+  });
+
+  test('returns the accepted registration for the auth email and course', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg1',
+      email: 'test@example.com',
+      courseId: otherCourseId,
+      decision: 'Accept',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.getByCourseId({ courseId: otherCourseId });
+    expect(result?.id).toBe('reg1');
+  });
+
+  test('does not return registrations with a non-Accept decision', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg1', email: 'test@example.com', courseId: otherCourseId, decision: 'Reject',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg2', email: 'test@example.com', courseId: otherCourseId, decision: 'Withdrawn',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.getByCourseId({ courseId: otherCourseId });
+    expect(result).toBeNull();
+  });
+
+  test('does not leak registrations belonging to other users', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg1', email: 'someone-else@example.com', courseId: otherCourseId, decision: 'Accept',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.getByCourseId({ courseId: otherCourseId });
+    expect(result).toBeNull();
+  });
+});
+
+describe('courseRegistrations.getAll', () => {
+  test('rejects unauthenticated callers', async () => {
+    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.getAll())
+      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  test('returns all non-Withdrawn registrations for the auth email, including null-decision rows', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-accept', email: 'test@example.com', courseId: 'a', decision: 'Accept',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-pending', email: 'test@example.com', courseId: 'b', decision: null,
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-withdrawn', email: 'test@example.com', courseId: 'c', decision: 'Withdrawn',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-other', email: 'someone-else@example.com', courseId: 'a', decision: 'Accept',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn).courseRegistrations.getAll();
+    const ids = result.map((r) => r.id).sort();
+    expect(ids).toEqual(['reg-accept', 'reg-pending']);
+  });
+});
+
+describe('courseRegistrations.getRoundStartDates', () => {
+  test('rejects unauthenticated callers', async () => {
+    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.getRoundStartDates({ roundIds: [] }))
+      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  test('returns an empty map when given no round ids (no DB hit)', async () => {
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.getRoundStartDates({ roundIds: [] });
+    expect(result).toEqual({});
+  });
+
+  test('returns roundId → firstDiscussionDate, including null entries', async () => {
+    await testDb.insert(applicationsRoundTable, {
+      id: 'round-1', firstDiscussionDate: '2026-05-01',
+    });
+    await testDb.insert(applicationsRoundTable, {
+      id: 'round-2', firstDiscussionDate: null,
+    });
+    await testDb.insert(applicationsRoundTable, {
+      id: 'round-3', firstDiscussionDate: '2026-06-01',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.getRoundStartDates({ roundIds: ['round-1', 'round-2'] });
+
+    expect(result).toEqual({
+      'round-1': '2026-05-01',
+      'round-2': null,
+    });
+    expect(result['round-3']).toBeUndefined();
+  });
+});
+
+describe('courseRegistrations.ensureExists', () => {
+  test('rejects unauthenticated callers', async () => {
+    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.ensureExists({ courseId: otherCourseId }))
+      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  test('returns the existing registration if one already exists', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-existing', email: 'test@example.com', courseId: otherCourseId, decision: 'Accept',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.ensureExists({ courseId: otherCourseId });
+    expect(result?.id).toBe('reg-existing');
+  });
+
+  test('returns null for non-FOAI courses when no registration exists', async () => {
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.ensureExists({ courseId: otherCourseId });
+    expect(result).toBeNull();
+  });
+
+  test('throws NOT_FOUND for FOAI when no applications_course config row exists', async () => {
+    await expect(createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))
+      .rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  // Note: The "creates a new FOAI registration" path can't be exercised in this test setup.
+  // The router's insert (course-registrations.ts L81-87) omits `courseId`, but the courseId column is `notNull()`
+  // in the pg schema. This either reveals a real bug in the router, or a difference between the
+  // pg test schema and Airtable's actual behaviour (likely a formula/lookup populating courseId from
+  // courseApplicationsBaseId). Flagging as a follow-up rather than asserting against a known failing path.
+});


### PR DESCRIPTION
## Summary
- 14 tests across the 4 procedures in \`src/server/routers/course-registrations.ts\` (\`getByCourseId\`, \`getAll\`, \`getRoundStartDates\`, \`ensureExists\`).
- Reuses the in-memory test DB pattern from \`admin.test.ts\` / \`grants.test.ts\`.

## Why
Part of a focused testing pass on tRPC routers. \`course-registrations.ts\` is on the critical path for course access (FOAI auto-registration, registration lookup) and was completely untested.

## What's covered
- \`getByCourseId\`: rejects logged-out callers, returns null when no Accept registration, returns the right row, ignores non-Accept decisions, isolates by email.
- \`getAll\`: rejects logged-out callers, returns non-Withdrawn rows for the auth email (including null-decision rows), excludes Withdrawn and other users' rows.
- \`getRoundStartDates\`: rejects logged-out callers, short-circuits on empty input, returns roundId → firstDiscussionDate map (including null entries), ignores rounds not requested.
- \`ensureExists\`: rejects logged-out callers, returns existing registration without creating a duplicate, returns null for non-FOAI courses, throws \`NOT_FOUND\` when FOAI applications_course config row is missing.

## What's not covered (intentional, flagged in source)
The "creates a new FOAI registration" branch can't be exercised cleanly. The router's insert omits the \`courseId\` column, but \`courseId\` is \`notNull()\` in the pg schema, so the test fails with a constraint violation. This either reveals a real router bug or a divergence between the test pg schema and Airtable's runtime (likely a formula populating courseId from courseApplicationsBaseId). Worth a separate look — a comment in the test file points at the relevant lines.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npx vitest run src/server/routers/course-registrations.test.ts\` — 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)