### PR TITLE
[feat] website: emit Event JSON-LD on the biosecurity hackathon page

### DIFF
--- a/apps/website/src/pages/biosechackathon.tsx
+++ b/apps/website/src/pages/biosechackathon.tsx
@@ -49,6 +49,52 @@ const BiosecHackathonPage = () => {
         <meta property="og:type" content="website" />
         <meta property="og:site_name" content="BlueDot Impact" />
         <meta property="og:url" content={`${SITE_URL}/biosechackathon`} />
+
+        {/* Schema.org Event markup so the hackathon qualifies for Event rich results in Google */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Event',
+              name: 'Biosecurity Hackathon',
+              startDate: '2026-04-24',
+              endDate: '2026-04-26',
+              eventAttendanceMode: 'https://schema.org/MixedEventAttendanceMode',
+              eventStatus: 'https://schema.org/EventScheduled',
+              description: 'A 48-hour hackathon for people working at the intersection of AI and biosecurity. Online plus in-person hubs in Boston, SF, London, and Cambridge.',
+              url: `${SITE_URL}/biosechackathon`,
+              location: [
+                {
+                  '@type': 'VirtualLocation',
+                  url: ONLINE_SIGN_UP_URL,
+                },
+              ],
+              organizer: [
+                {
+                  '@type': 'Organization',
+                  name: 'BlueDot Impact',
+                  url: SITE_URL,
+                },
+                {
+                  '@type': 'Organization',
+                  name: 'Apart Research',
+                  url: 'https://apartresearch.com/',
+                },
+                {
+                  '@type': 'Organization',
+                  name: 'Cambridge Biosecurity Hub',
+                  url: 'https://www.cambiohub.org/',
+                },
+              ],
+              offers: {
+                '@type': 'Offer',
+                category: 'Free',
+                url: ONLINE_SIGN_UP_URL,
+              },
+            }),
+          }}
+        />
       </Head>
 
       <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-black px-6 text-center">


### PR DESCRIPTION
## Summary
- Adds Schema.org \`Event\` JSON-LD inside the \`<Head>\` of \`biosechackathon.tsx\` so the 24-26 April 2026 biosecurity hackathon qualifies for Event rich results in Google search.
- Covers the canonical \`/biosechackathon\` plus the two aliases that re-export it (\`/events/hackathon\`, \`/events/special-event\`).
- Uses \`MixedEventAttendanceMode\` since the hackathon has both an online sign-up flow and (tbc) in-person hubs in Boston, SF, London, and Cambridge.
- Lists BlueDot Impact, Apart Research, and Cambridge Biosecurity Hub as co-organisers.

## Why
\`Organization\` is already on the homepage, \`JobPosting\` is on \`/join-us/[slug]\`, and \`Course\` lands in #2341. Event was the remaining gap, and the biosec hackathon is the most active live-event surface BlueDot is promoting right now.

## Notes
- I described the event as "A 48-hour hackathon for people working at the intersection of AI and biosecurity. Online plus in-person hubs in Boston, SF, London, and Cambridge." Worth replacing with a description that's been written in your own voice — happy to defer to you on copy.
- \`/events/index.tsx\` (the events listing page) could also emit an \`ItemList\` of Event entries. Skipped here to keep this PR focused; worth a follow-up if there's more than one live event on that page.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 526/526 pass
- [ ] Validator check post-merge: paste the built \`/biosechackathon\` page through Google's Rich Results Test (https://search.google.com/test/rich-results) to confirm Event is recognised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)