### PR TITLE
Standardise trpc inputs: add `.min(1)` to slug and auth token inputs

### DIFF
--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -15,7 +15,7 @@ export type CertificateStatus = inferRouterOutputs<AppRouter>['certificates']['g
 export const certificatesRouter = router({
   // This is a public procedure because it's called from an Airtable script, not from within the app
   create: publicProcedure
-    .input(z.object({ courseRegistrationId: z.string(), publicToken: z.string() }))
+    .input(z.object({ courseRegistrationId: z.string(), publicToken: z.string().min(1) }))
     .mutation(async ({ input: { courseRegistrationId, publicToken } }) => {
       // This is similar to the `request` procedure below, but it relies on a shared secret for authentication and
       // allows a certificate to be created even if not all exercises are complete.

--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -161,7 +161,7 @@ export function getSoonestDeadline(rounds: CourseRoundsData): string | null {
 export const courseRoundsRouter = router({
   getRoundsForCourse: publicProcedure
     .input(z.object({
-      courseSlug: z.string(),
+      courseSlug: z.string().min(1),
     }))
     .query(async ({ input }) => {
       return getCourseRoundsData(input.courseSlug);
@@ -244,7 +244,7 @@ export const courseRoundsRouter = router({
     }),
 
   getApplyCTAProps: publicProcedure
-    .input(z.object({ courseSlug: z.string() }))
+    .input(z.object({ courseSlug: z.string().min(1) }))
     .query(async ({ ctx, input }): Promise<ApplyCTAProps | null> => {
       const { courseSlug } = input;
 

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -181,7 +181,7 @@ export const coursesRouter = router({
 
   getBySlug: publicProcedure
     .input(z.object({
-      courseSlug: z.string(),
+      courseSlug: z.string().min(1),
     }))
     .query(async ({ input: { courseSlug } }) => {
       return getCourseData(courseSlug);
@@ -194,7 +194,7 @@ export const coursesRouter = router({
 
   getCurriculumMetadata: publicProcedure
     .input(z.object({
-      courseSlug: z.string(),
+      courseSlug: z.string().min(1),
     }))
     .query(async ({ input: { courseSlug } }) => {
       const course = await db.get(courseTable, { slug: courseSlug });
@@ -253,7 +253,7 @@ export const coursesRouter = router({
     }),
 
   getCourseProgress: protectedProcedure
-    .input(z.object({ courseSlug: z.string() }))
+    .input(z.object({ courseSlug: z.string().min(1) }))
     .query(async ({ input: { courseSlug }, ctx }) => {
       const { units } = await getCourseData(courseSlug);
       const unitIds = units.map((u) => u.id);

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -85,7 +85,7 @@ export const groupDiscussionsRouter = router({
     }),
 
   getByCourseSlug: protectedProcedure
-    .input(z.object({ courseSlug: z.string() }))
+    .input(z.object({ courseSlug: z.string().min(1) }))
     .query(async ({ ctx, input: { courseSlug } }) => {
       const course = await db.get(courseTable, { slug: courseSlug });
       if (!course) {

--- a/apps/website/src/server/routers/meet-person.ts
+++ b/apps/website/src/server/routers/meet-person.ts
@@ -25,7 +25,7 @@ export const meetPersonRouter = router({
     }),
 
   getInactiveCourseRegistrations: protectedProcedure
-    .input(z.object({ courseSlug: z.string().optional() }))
+    .input(z.object({ courseSlug: z.string().min(1).optional() }))
     .query(async ({ ctx, input }) => {
       const results = await db.pg
         .select({

--- a/apps/website/src/server/routers/subscription-preferences.ts
+++ b/apps/website/src/server/routers/subscription-preferences.ts
@@ -76,7 +76,7 @@ export type SubscriptionTopic = {
 
 export const subscriptionPreferencesRouter = router({
   getPreferences: publicProcedure
-    .input(z.object({ cid: z.string(), token: z.string() }))
+    .input(z.object({ cid: z.string().min(1), token: z.string().min(1) }))
     .query(async ({ input }) => {
       if (!verifyToken(input.cid, input.token)) {
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Invalid or expired link' });
@@ -120,8 +120,8 @@ export const subscriptionPreferencesRouter = router({
 
   savePreferences: publicProcedure
     .input(z.object({
-      cid: z.string(),
-      token: z.string(),
+      cid: z.string().min(1),
+      token: z.string().min(1),
       // Record of topic_<id> -> boolean, only for topics shown to the user.
       // Never send false for hidden topics (e.g. hiring topic for non-hiring managers).
       preferences: z.record(z.boolean()),

--- a/apps/website/src/server/routers/testimonials.ts
+++ b/apps/website/src/server/routers/testimonials.ts
@@ -66,7 +66,7 @@ export const testimonialsRouter = router({
   }),
 
   getCommunityMembersByCourseSlug: publicProcedure
-    .input(z.object({ courseSlug: z.string() }))
+    .input(z.object({ courseSlug: z.string().min(1) }))
     .query(async ({ input }) => {
       const all = await db.scan(testimonialTable);
       const filtered = all.filter((t) => t.name


### PR DESCRIPTION
Standardise tRPC input validation across routers. Add `.min(1)` to fields where an empty string is semantically invalid at the boundary: course slugs, auth tokens (publicToken, cid, token). Skip opaque record IDs (courseId, roundId, etc.) where DB layer is the appropriate rejection point.

Closes #1638
