### PR TITLE
[chore] db: expose grant date on rapidGrantTable

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -889,6 +889,10 @@ export const rapidGrantTable = pgAirtable('rapid_grant', {
       pgColumn: text(),
       airtableId: 'fldAKj0OmnG43FRSp',
     },
+    grantDate: {
+      pgColumn: text(),
+      airtableId: 'fld1hj1URzMqImRFu',
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

- Expose the existing 'Grant date' column (`fld1hj1URzMqImRFu`) on the `rapid_grant` Airtable table via `@bluedot/db` so it can be read by `db.scan(rapidGrantTable)`.
- Schema-only change. No consumers updated in this PR.

## Why split?

Per the team's pgAirtable convention, schema additions ship in a standalone PR ahead of any consumer code. That gives `pg-sync-service` time to materialise the new column in staging Postgres before the website starts querying it, avoiding a 500 storm on the rapid-grants page.

The website-side change (sort newest-first + render month label + refresh "Who this is for" copy) will land in a follow-up PR once this is deployed.

## Deploy note

After this merges and `pg-sync-service` redeploys, the new column will populate either via the next webhook event for the `rapid_grant` table or via a manual initial sync:

```
npm run start -- --initial-sync-tables rapid_grant
```

If anyone deploying this isn't sure the next webhook event will land soon, run the manual initial sync.

## Test plan

- [x] `cd libraries/db && npm test` — passes (22/22)
- [x] `cd libraries/db && npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)