### PR TITLE
[feat] dropout: let participants pick the round they defer to

### DIFF
--- a/apps/website/src/components/courses/DropoutModal.stories.tsx
+++ b/apps/website/src/components/courses/DropoutModal.stories.tsx
@@ -37,6 +37,7 @@ export const Default: Story = {
     handleClose() {},
     applicantId: 'rec123456789',
     courseSlug: 'agi-safety-fundamentals',
+    currentRoundId: null,
   },
   parameters: {
     msw: {
@@ -60,6 +61,7 @@ export const Error: Story = {
     handleClose() {},
     applicantId: 'rec123456789',
     courseSlug: 'agi-safety-fundamentals',
+    currentRoundId: null,
   },
   parameters: {
     msw: {
@@ -78,6 +80,7 @@ export const NoUpcomingRounds: Story = {
     handleClose() {},
     applicantId: 'rec123456789',
     courseSlug: 'agi-safety-fundamentals',
+    currentRoundId: null,
   },
   parameters: {
     msw: {

--- a/apps/website/src/components/courses/DropoutModal.tsx
+++ b/apps/website/src/components/courses/DropoutModal.tsx
@@ -106,10 +106,18 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
 
   const renderSuccess = () => {
     const startDateRaw = selectedRound?.firstDiscussionDateRaw;
-    let contactWeek: string | null = null;
-    if (isDeferral && startDateRaw) {
-      const oneWeekBefore = new Date(new Date(startDateRaw).getTime() - 7 * ONE_DAY_MS);
-      contactWeek = formatMonthAndDay(oneWeekBefore.toISOString());
+    const startFormatted = startDateRaw ? formatMonthAndDay(startDateRaw) : null;
+    const contactWeek = startDateRaw
+      ? formatMonthAndDay(new Date(new Date(startDateRaw).getTime() - 7 * ONE_DAY_MS).toISOString())
+      : null;
+
+    let message: string;
+    if (!isDeferral) {
+      message = 'Your dropout request has been submitted. We\'re sorry to see you go. You should receive a confirmation email soon.';
+    } else if (selectedRound && startFormatted && contactWeek) {
+      message = `Your deferral request has been submitted. We'll move you to the ${selectedRound.intensity?.toLowerCase()} round starting ${startFormatted} and be in touch the week of ${contactWeek}.`;
+    } else {
+      message = 'Your deferral request has been submitted. You should receive a confirmation email soon.';
     }
 
     return (
@@ -118,11 +126,7 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
           <CheckIcon className="text-bluedot-normal" />
         </div>
         <div className="flex max-w-[512px] flex-col items-center gap-4">
-          <P className="text-bluedot-navy/80 text-center">
-            {isDeferral
-              ? `Your deferral request has been submitted.${contactWeek ? ` We'll be in touch in the week of ${contactWeek}.` : ''} You should receive a confirmation email soon.`
-              : 'Your dropout request has been submitted. We\'re sorry to see you go. You should receive a confirmation email soon.'}
-          </P>
+          <P className="text-bluedot-navy/80 text-center">{message}</P>
         </div>
         <CTALinkOrButton className="bg-bluedot-normal w-full" onClick={handleCloseWithInvalidation}>
           Close
@@ -147,36 +151,40 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
       : [];
 
     return (
-      <div className="flex flex-col gap-2">
-        <H1 className="text-size-md font-medium text-black">Format</H1>
-        <Select
-          ariaLabel="Course format"
-          value={effectiveIntensity}
-          onChange={(value) => {
-            setIntensity(value as Intensity);
-            setTargetRoundId(undefined);
-          }}
-          options={INTENSITY_OPTIONS.map((opt) => ({
-            value: opt.value,
-            label: opt.label,
-            disabled: dropoutMutation.isPending,
-          }))}
-        />
+      <div className="border-l-2 border-color-divider pl-4 ml-2 mt-3 flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <span className="text-size-sm font-medium text-bluedot-navy/80">Intensity</span>
+          <Select
+            ariaLabel="Intensity"
+            value={effectiveIntensity}
+            onChange={(value) => {
+              setIntensity(value as Intensity);
+              setTargetRoundId(undefined);
+            }}
+            options={INTENSITY_OPTIONS.map((opt) => ({
+              value: opt.value,
+              label: opt.label,
+              disabled: dropoutMutation.isPending,
+            }))}
+          />
+        </div>
 
-        <H1 className="text-size-md font-medium text-black mt-2">Round</H1>
-        <Select
-          ariaLabel="Round"
-          value={hasRounds ? effectiveTargetRoundId : undefined}
-          onChange={(value) => setTargetRoundId(value)}
-          options={roundOptions}
-          placeholder={hasRounds ? 'Choose a round' : 'No upcoming rounds available'}
-          disabled={!hasRounds || dropoutMutation.isPending}
-        />
-        {!hasRounds && (
-          <P className="text-bluedot-normal">
-            No upcoming rounds for this intensity available. You can select a different intensity or drop out instead.
-          </P>
-        )}
+        <div className="flex flex-col gap-1">
+          <span className="text-size-sm font-medium text-bluedot-navy/80">Round</span>
+          <Select
+            ariaLabel="Round"
+            value={hasRounds ? effectiveTargetRoundId : undefined}
+            onChange={(value) => setTargetRoundId(value)}
+            options={roundOptions}
+            placeholder={hasRounds ? 'Choose a round' : 'No upcoming rounds available'}
+            disabled={!hasRounds || dropoutMutation.isPending}
+          />
+          {!hasRounds && (
+            <P className="text-bluedot-normal text-size-xs mt-1">
+              No upcoming rounds for this intensity available. You can select a different intensity or drop out instead.
+            </P>
+          )}
+        </div>
       </div>
     );
   };
@@ -194,17 +202,14 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
           options={TYPE_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label, disabled: dropoutMutation.isPending }))}
           placeholder="Choose an option"
         />
+        {isDeferral && renderRoundPicker()}
       </div>
 
-      {isDeferral && renderRoundPicker()}
-
       <div className="flex flex-col gap-2">
-        <H1 className="text-size-md font-medium text-black">2. Please tell us why</H1>
-        <P>
-          Your feedback (positive and negative) helps improve our courses. Please share any details about your
-          decision with us.
-        </P>
-        <P>Thank you again for participating.</P>
+        <H1 className="text-size-md font-medium text-black">2. We'd love to hear why</H1>
+        <p className="text-size-xs text-[#666C80]">
+          Your feedback helps us improve the course. Thank you for participating.
+        </p>
         <Textarea
           value={reason}
           onChange={(e) => setReason(e.target.value)}

--- a/apps/website/src/components/courses/DropoutModal.tsx
+++ b/apps/website/src/components/courses/DropoutModal.tsx
@@ -1,7 +1,8 @@
 import {
   CTALinkOrButton, H1, Modal, P, ProgressDots, Select, Textarea,
 } from '@bluedot/ui';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import type { CourseRound, CourseRoundsData } from '../../server/routers/course-rounds';
 import { ONE_DAY_MS } from '../../lib/constants';
 import { formatMonthAndDay } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
@@ -15,15 +16,46 @@ const TYPE_OPTIONS = [
 
 type DropoutType = (typeof TYPE_OPTIONS)[number]['value'];
 
+const INTENSITY_OPTIONS = [
+  { value: 'Part-time', label: 'Part-time' },
+  { value: 'Intensive', label: 'Intensive' },
+] as const;
+
+type Intensity = (typeof INTENSITY_OPTIONS)[number]['value'];
+
+const MAX_ROUNDS_PER_INTENSITY = 3;
+
 type DropoutModalProps = {
   applicantId: string;
   courseSlug: string;
+  currentRoundId: string | null;
   handleClose: () => void;
 };
 
-const DropoutModal: React.FC<DropoutModalProps> = ({ applicantId, courseSlug, handleClose }) => {
+const filterFutureRounds = (rounds: CourseRound[]): CourseRound[] => {
+  const now = new Date();
+  return rounds
+    .filter((r) => r.firstDiscussionDateRaw && new Date(r.firstDiscussionDateRaw) > now)
+    .slice(0, MAX_ROUNDS_PER_INTENSITY);
+};
+
+const intensityOfRound = (
+  courseRounds: CourseRoundsData | undefined,
+  roundId: string | null,
+): Intensity | null => {
+  if (!courseRounds || !roundId) return null;
+  if (courseRounds.intense.some((r) => r.id === roundId)) return 'Intensive';
+  if (courseRounds.partTime.some((r) => r.id === roundId)) return 'Part-time';
+  return null;
+};
+
+const DropoutModal: React.FC<DropoutModalProps> = ({
+  applicantId, courseSlug, currentRoundId, handleClose,
+}) => {
   const [dropoutType, setDropoutType] = useState<DropoutType | undefined>();
   const [reason, setReason] = useState('');
+  const [intensity, setIntensity] = useState<Intensity | undefined>();
+  const [targetRoundId, setTargetRoundId] = useState<string | undefined>();
 
   const utils = trpc.useUtils();
   const dropoutMutation = trpc.dropout.dropoutOrDeferral.useMutation();
@@ -39,125 +71,170 @@ const DropoutModal: React.FC<DropoutModalProps> = ({ applicantId, courseSlug, ha
   const { data: courseRounds } = trpc.courseRounds.getRoundsForCourse.useQuery({ courseSlug });
 
   const isDeferral = dropoutType === 'Deferral';
-  const submitDisabled = !dropoutType || dropoutMutation.isPending;
 
-  const nextRoundInfo = (() => {
-    if (!courseRounds) return null;
-    const allRounds = [...courseRounds.intense, ...courseRounds.partTime];
-    if (allRounds.length === 0) return null;
-    const now = new Date();
-    const sorted = allRounds
-      .filter((r) => r.firstDiscussionDateRaw && new Date(r.firstDiscussionDateRaw) > now)
-      .sort((a, b) => new Date(a.firstDiscussionDateRaw!).getTime() - new Date(b.firstDiscussionDateRaw!).getTime());
-    const earliest = sorted[0];
-    if (!earliest?.firstDiscussionDateRaw) return null;
+  const futureRoundsByIntensity = useMemo(() => ({
+    'Part-time': courseRounds ? filterFutureRounds(courseRounds.partTime) : [],
+    Intensive: courseRounds ? filterFutureRounds(courseRounds.intense) : [],
+  }), [courseRounds]);
 
-    const startDate = new Date(earliest.firstDiscussionDateRaw);
-    const oneWeekBefore = new Date(startDate.getTime() - 7 * ONE_DAY_MS);
-    const contactWeek = formatMonthAndDay(oneWeekBefore.toISOString());
-    const startFormatted = formatMonthAndDay(earliest.firstDiscussionDateRaw);
+  const effectiveIntensity: Intensity = intensity
+    ?? intensityOfRound(courseRounds, currentRoundId)
+    ?? 'Part-time';
+  const roundsForChosenIntensity = futureRoundsByIntensity[effectiveIntensity];
 
-    return { startFormatted, contactWeek };
-  })();
+  // Default the round selection to the first future round of the chosen intensity
+  const effectiveTargetRoundId = targetRoundId
+    ?? roundsForChosenIntensity[0]?.id;
+
+  const selectedRound = roundsForChosenIntensity.find((r) => r.id === effectiveTargetRoundId);
+
+  const submitDisabled = !dropoutType
+    || dropoutMutation.isPending
+    || (isDeferral && !effectiveTargetRoundId);
 
   const handleSubmit = () => {
-    if (!dropoutType) {
-      return;
-    }
+    if (!dropoutType) return;
+    if (isDeferral && !effectiveTargetRoundId) return;
 
     dropoutMutation.mutate({
       applicantId,
       reason: reason.trim(),
       type: dropoutType,
+      newRoundId: isDeferral ? effectiveTargetRoundId : undefined,
     });
   };
 
-  const renderContent = () => {
-    if (dropoutMutation.isSuccess) {
-      return (
-        <div className="flex w-full flex-col items-center justify-center gap-8">
-          <div className="bg-bluedot-normal/10 flex rounded-full p-4">
-            <CheckIcon className="text-bluedot-normal" />
-          </div>
-          <div className="flex max-w-[512px] flex-col items-center gap-4">
-            <P className="text-bluedot-navy/80 text-center">
-              {isDeferral
-                ? `Your deferral request has been submitted. ${nextRoundInfo ? `We'll be in touch in the week of ${nextRoundInfo.contactWeek}. You should receive a confirmation email soon.` : 'We\'ll be in touch about joining a future round. You should receive a confirmation email soon.'}`
-                : 'Your dropout request has been submitted. We\'re sorry to see you go. You should receive a confirmation email soon.'}
-            </P>
-          </div>
-          <CTALinkOrButton className="bg-bluedot-normal w-full" onClick={handleCloseWithInvalidation}>
-            Close
-          </CTALinkOrButton>
-        </div>
-      );
+  const renderSuccess = () => {
+    const startDateRaw = selectedRound?.firstDiscussionDateRaw;
+    let contactWeek: string | null = null;
+    if (isDeferral && startDateRaw) {
+      const oneWeekBefore = new Date(new Date(startDateRaw).getTime() - 7 * ONE_DAY_MS);
+      contactWeek = formatMonthAndDay(oneWeekBefore.toISOString());
     }
 
     return (
-      <>
-        <InformationBanner />
-
-        <div className="flex flex-col gap-2">
-          <H1 className="text-size-md font-medium text-black">1. What would you like to do?</H1>
-          <Select
-            ariaLabel="Action type"
-            value={dropoutType}
-            onChange={(value) => setDropoutType(value as DropoutType)}
-            options={TYPE_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label, disabled: dropoutMutation.isPending }))}
-            placeholder="Choose an option"
-          />
-          {isDeferral && (
-            <P className="text-bluedot-normal">
-              {nextRoundInfo ? (
-                <>
-                  We'll reconsider your application for the next round{' '}
-                  <strong>starting {nextRoundInfo.startFormatted}</strong>. We'll contact you a week beforehand.
-                </>
-              ) : (
-                'We\'ll reconsider your application when the course runs again; we\'ll contact you closer to the time.'
-              )}
-            </P>
-          )}
+      <div className="flex w-full flex-col items-center justify-center gap-8">
+        <div className="bg-bluedot-normal/10 flex rounded-full p-4">
+          <CheckIcon className="text-bluedot-normal" />
         </div>
-
-        <div className="flex flex-col gap-2">
-          <H1 className="text-size-md font-medium text-black">2. Please tell us why</H1>
-          <P>
-            Your feedback (positive and negative) helps improve our courses. Please share any details about your
-            decision with us.
+        <div className="flex max-w-[512px] flex-col items-center gap-4">
+          <P className="text-bluedot-navy/80 text-center">
+            {isDeferral
+              ? `Your deferral request has been submitted.${contactWeek ? ` We'll be in touch in the week of ${contactWeek}.` : ''} You should receive a confirmation email soon.`
+              : 'Your dropout request has been submitted. We\'re sorry to see you go. You should receive a confirmation email soon.'}
           </P>
-          <P>Thank you again for participating.</P>
-          <Textarea
-            value={reason}
-            onChange={(e) => setReason(e.target.value)}
-            placeholder="Share your reason for leaving..."
-            rows={3}
-            className="w-full"
-            disabled={dropoutMutation.isPending}
-          />
         </div>
-
-        {dropoutMutation.isError && (
-          <P className="text-red-600">{dropoutMutation.error?.message || 'An error occurred. Please try again.'}</P>
-        )}
-
-        <CTALinkOrButton
-          className="bg-bluedot-normal w-full disabled:opacity-50"
-          onClick={handleSubmit}
-          disabled={submitDisabled}
-        >
-          {dropoutMutation.isPending ? (
-            <div className="flex items-center gap-2">
-              <ProgressDots className="my-0" dotClassName="bg-white" />
-              Submitting...
-            </div>
-          ) : (
-            <span>Submit</span>
-          )}
+        <CTALinkOrButton className="bg-bluedot-normal w-full" onClick={handleCloseWithInvalidation}>
+          Close
         </CTALinkOrButton>
-      </>
+      </div>
     );
   };
+
+  const renderRoundPicker = () => {
+    if (!courseRounds) {
+      return <ProgressDots />;
+    }
+
+    const hasRounds = roundsForChosenIntensity.length > 0;
+
+    const roundOptions = hasRounds
+      ? roundsForChosenIntensity.map((r) => ({
+        value: r.id,
+        label: r.dateRange,
+        disabled: dropoutMutation.isPending,
+      }))
+      : [];
+
+    return (
+      <div className="flex flex-col gap-2">
+        <H1 className="text-size-md font-medium text-black">Format</H1>
+        <Select
+          ariaLabel="Course format"
+          value={effectiveIntensity}
+          onChange={(value) => {
+            setIntensity(value as Intensity);
+            setTargetRoundId(undefined);
+          }}
+          options={INTENSITY_OPTIONS.map((opt) => ({
+            value: opt.value,
+            label: opt.label,
+            disabled: dropoutMutation.isPending,
+          }))}
+        />
+
+        <H1 className="text-size-md font-medium text-black mt-2">Round</H1>
+        <Select
+          ariaLabel="Round"
+          value={hasRounds ? effectiveTargetRoundId : undefined}
+          onChange={(value) => setTargetRoundId(value)}
+          options={roundOptions}
+          placeholder={hasRounds ? 'Choose a round' : 'No upcoming rounds available'}
+          disabled={!hasRounds || dropoutMutation.isPending}
+        />
+        {!hasRounds && (
+          <P className="text-bluedot-normal">
+            No upcoming rounds for this intensity available. You can select a different intensity or drop out instead.
+          </P>
+        )}
+      </div>
+    );
+  };
+
+  const renderForm = () => (
+    <>
+      <InformationBanner />
+
+      <div className="flex flex-col gap-2">
+        <H1 className="text-size-md font-medium text-black">1. What would you like to do?</H1>
+        <Select
+          ariaLabel="Action type"
+          value={dropoutType}
+          onChange={(value) => setDropoutType(value as DropoutType)}
+          options={TYPE_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label, disabled: dropoutMutation.isPending }))}
+          placeholder="Choose an option"
+        />
+      </div>
+
+      {isDeferral && renderRoundPicker()}
+
+      <div className="flex flex-col gap-2">
+        <H1 className="text-size-md font-medium text-black">2. Please tell us why</H1>
+        <P>
+          Your feedback (positive and negative) helps improve our courses. Please share any details about your
+          decision with us.
+        </P>
+        <P>Thank you again for participating.</P>
+        <Textarea
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Share your reason for leaving..."
+          rows={3}
+          className="w-full"
+          disabled={dropoutMutation.isPending}
+        />
+      </div>
+
+      {dropoutMutation.isError && (
+        <P className="text-red-600">{dropoutMutation.error?.message || 'An error occurred. Please try again.'}</P>
+      )}
+
+      <CTALinkOrButton
+        className="bg-bluedot-normal w-full disabled:opacity-50"
+        onClick={handleSubmit}
+        disabled={submitDisabled}
+      >
+        {dropoutMutation.isPending ? (
+          <div className="flex items-center gap-2">
+            <ProgressDots className="my-0" dotClassName="bg-white" />
+            Submitting...
+          </div>
+        ) : (
+          <span>Submit</span>
+        )}
+      </CTALinkOrButton>
+    </>
+  );
 
   const renderTitle = () => (
     <div className="flex w-full items-center justify-center gap-2">
@@ -177,7 +254,7 @@ const DropoutModal: React.FC<DropoutModalProps> = ({ applicantId, courseSlug, ha
     >
       <div className="w-full md:w-[600px]">
         <form className="flex flex-col gap-8" onSubmit={(e) => e.preventDefault()}>
-          {renderContent()}
+          {dropoutMutation.isSuccess ? renderSuccess() : renderForm()}
         </form>
       </div>
     </Modal>

--- a/apps/website/src/components/courses/InactiveCourseBanners.tsx
+++ b/apps/website/src/components/courses/InactiveCourseBanners.tsx
@@ -77,6 +77,7 @@ const InactiveCourseBanner = ({ applicantId, courseSlug, roundId }: InactiveCour
         <DropoutModal
           applicantId={applicantId}
           courseSlug={courseSlug}
+          currentRoundId={roundId}
           handleClose={() => setDropoutModalOpen(false)}
         />
       )}

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -185,6 +185,7 @@ const CourseDetails = ({
         <DropoutModal
           applicantId={courseRegistration.id}
           courseSlug={course.slug}
+          currentRoundId={courseRegistration.roundId?.[0] ?? null}
           handleClose={() => setDropoutModalOpen(false)}
         />
       )}

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -185,7 +185,7 @@ const CourseDetails = ({
         <DropoutModal
           applicantId={courseRegistration.id}
           courseSlug={course.slug}
-          currentRoundId={courseRegistration.roundId?.[0] ?? null}
+          currentRoundId={courseRegistration.roundId ?? null}
           handleClose={() => setDropoutModalOpen(false)}
         />
       )}

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -30,7 +30,7 @@ export const dropoutRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Course registration not found' });
       }
 
-      const oldRoundId = courseRegistration.roundId?.[0] ?? null;
+      const oldRoundId = courseRegistration.roundId ?? null;
 
       return db.insert(dropoutTable, {
         applicantId: [applicantId],

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -10,9 +10,15 @@ export const dropoutRouter = router({
       applicantId: z.string().min(1),
       reason: z.string().optional(),
       type: z.enum(['Drop out', 'Deferral']),
+      newRoundId: z.string().optional(),
+    }).refine((data) => data.type !== 'Deferral' || !!data.newRoundId, {
+      message: 'newRoundId is required for deferrals',
+      path: ['newRoundId'],
     }))
     .mutation(async ({ ctx, input }) => {
-      const { applicantId, reason, type } = input;
+      const {
+        applicantId, reason, type, newRoundId,
+      } = input;
 
       const courseRegistration = await db.getFirst(courseRegistrationTable, {
         filter: {
@@ -24,10 +30,14 @@ export const dropoutRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Course registration not found' });
       }
 
+      const oldRoundId = courseRegistration.roundId?.[0] ?? null;
+
       return db.insert(dropoutTable, {
         applicantId: [applicantId],
         reason: reason ?? null,
         type,
+        newRoundId: type === 'Deferral' && newRoundId ? [newRoundId] : null,
+        oldRoundId: type === 'Deferral' && oldRoundId ? [oldRoundId] : null,
       });
     }),
 });

--- a/libraries/ui/src/Select.tsx
+++ b/libraries/ui/src/Select.tsx
@@ -18,6 +18,7 @@ export type SelectProps = {
   placeholder?: string;
   className?: string;
   ariaLabel?: string;
+  disabled?: boolean;
 };
 
 export const Select = ({
@@ -27,6 +28,7 @@ export const Select = ({
   placeholder = 'Select an option',
   className,
   ariaLabel,
+  disabled,
 }: SelectProps) => {
   const selectedOption = options.find((op) => op.value === value);
   const isDesktop = useAboveBreakpoint(breakpoints.md);
@@ -66,10 +68,15 @@ export const Select = ({
       <AriaSelect
         selectedKey={value}
         onSelectionChange={handleSelect}
-        isOpen={isDesktop ? isOpen : false}
-        onOpenChange={setIsOpen}
+        isOpen={isDesktop && !disabled ? isOpen : false}
+        onOpenChange={(open) => !disabled && setIsOpen(open)}
+        isDisabled={disabled}
         aria-label={ariaLabel}
-        className={cn('w-full flex flex-col bg-white border border-color-divider rounded-lg transition-all text-size-sm', className)}
+        className={cn(
+          'w-full flex flex-col bg-white border border-color-divider rounded-lg transition-all text-size-sm',
+          disabled && 'opacity-50 cursor-not-allowed bg-gray-50',
+          className,
+        )}
       >
         <Button
           className="w-full gap-3 flex justify-between p-4 items-center cursor-pointer text-left transition-all"


### PR DESCRIPTION
## Summary

- The deferral path on \`/settings/courses\` now lets the participant pick the **Intensity** and the specific **Round** they defer to, instead of being silently auto-placed onto the next round of their current intensity.
- Up to 3 future rounds per intensity are offered. Format and Round default to the participant's current round's intensity + earliest future round of that intensity. If the chosen intensity has no upcoming rounds, the Round dropdown is disabled and points the participant at the other intensity or Drop out.
- The deferral record now carries \`Type = \"Deferral\"\`, \`New round\`, and \`Old round\` — the Airtable automation moves the participant onto the chosen round.

## What changed

1. **\`apps/website/src/components/courses/DropoutModal.tsx\`** — Added the 2-step picker (Intensity → Round) with a left-guide-line visual treatment so the picker reads as a follow-up to the action choice. Helper copy under \"We'd love to hear why\" was tightened to a single subtext line. Success message now names the chosen round (\"We'll move you to the part-time round starting 1 Jun and be in touch the week of 25 May\").
2. **\`apps/website/src/server/routers/dropout.ts\`** — \`dropoutOrDeferral\` mutation now accepts \`newRoundId\`. \`oldRoundId\` is resolved server-side from the registration's current round so the client can't tamper. Both are persisted to \`dropoutTable\` for deferrals only; null for drop outs.
3. **\`apps/website/src/components/settings/CourseDetails.tsx\`** + **\`InactiveCourseBanners.tsx\`** — Pass the registration's current \`roundId\` through to the modal so the picker pre-selects the matching Intensity.
4. **\`libraries/ui/src/Select.tsx\`** — Gained a \`disabled\` prop so the Round dropdown can render in a disabled state when no rounds are available for the chosen intensity.

## Notes on rollout

- The Airtable automation has been switched to fire on \`Type = \"Deferral\"\` and to move the participant onto the chosen \`New round\` (handled outside this PR).
- Tested live in dev with a real account: the picker pre-selects correctly, swapping intensity refreshes the round list, the \"no rounds for this intensity\" message renders, and submitting a deferral writes a Drop out / Deferral record with \`Type\`, \`New round\`, and \`Old round\` populated.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npx vitest run\` — 628 passed (1 unrelated en-GB locale snapshot drift on Congratulations.test.tsx)
- [x] Manual test in dev: deferral submit lands the right \`New round\` / \`Old round\` on the Airtable record (no more \`'r' is not a valid record ID\` error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)