### PR TITLE
[chore] save-status: replace #1641D9 with bluedot-normal token

### DIFF
--- a/apps/website/src/components/courses/exercises/RichTextAutoSaveEditor.tsx
+++ b/apps/website/src/components/courses/exercises/RichTextAutoSaveEditor.tsx
@@ -247,7 +247,7 @@ const RichTextAutoSaveEditor: React.FC<RichTextAutoSaveEditorProps> = ({
     'resize-y overflow-auto relative cursor-text',
     'box-border w-full bg-white rounded-md z-[1] p-4',
     'border-[0.5px] border-bluedot-navy/25',
-    'focus-within:border-[1.25px] focus-within:border-[#1641D9] focus-within:shadow-[0px_0px_10px_rgba(34,68,187,0.3)]',
+    'focus-within:border-[1.25px] focus-within:border-bluedot-normal focus-within:shadow-[0px_0px_10px_rgba(34,68,187,0.3)]',
     'transition-all duration-200',
     '[&::-webkit-resizer]:hidden',
     disabled && 'cursor-not-allowed opacity-60',

--- a/apps/website/src/components/courses/exercises/SaveStatusIndicator.tsx
+++ b/apps/website/src/components/courses/exercises/SaveStatusIndicator.tsx
@@ -27,7 +27,7 @@ const getStatusConfig = (savedText: string): Record<SaveStatus, {
     text: '', // No typing message shown - auto-saves after 5 seconds
   },
   saving: {
-    icon: <RiLoader4Line className="animate-spin -translate-y-[0.5px]" size={16} style={{ color: '#1641D9' }} />,
+    icon: <RiLoader4Line className="animate-spin -translate-y-[0.5px] text-bluedot-normal" size={16} />,
     text: 'Saving...',
   },
   saved: {

--- a/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
+++ b/apps/website/src/components/courses/exercises/__snapshots__/FreeTextResponse.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FreeTextResponse > renders default as expected 1`] = `
         class="relative w-full z-[1]"
       >
         <div
-          class="resize-y overflow-auto relative box-border w-full bg-white rounded-md z-[1] p-4 border-[0.5px] border-bluedot-navy/25 focus-within:border-[1.25px] focus-within:border-[#1641D9] focus-within:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] transition-all duration-200 [&::-webkit-resizer]:hidden cursor-not-allowed opacity-60 min-h-[140px]"
+          class="resize-y overflow-auto relative box-border w-full bg-white rounded-md z-[1] p-4 border-[0.5px] border-bluedot-navy/25 focus-within:border-[1.25px] focus-within:border-bluedot-normal focus-within:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] transition-all duration-200 [&::-webkit-resizer]:hidden cursor-not-allowed opacity-60 min-h-[140px]"
         >
           <div
             aria-label="Rich text input area"
@@ -121,7 +121,7 @@ exports[`FreeTextResponse > renders logged in as expected 1`] = `
         class="relative w-full z-[1]"
       >
         <div
-          class="resize-y overflow-auto relative cursor-text box-border w-full bg-white rounded-md z-[1] p-4 border-[0.5px] border-bluedot-navy/25 focus-within:border-[1.25px] focus-within:border-[#1641D9] focus-within:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] transition-all duration-200 [&::-webkit-resizer]:hidden min-h-[140px]"
+          class="resize-y overflow-auto relative cursor-text box-border w-full bg-white rounded-md z-[1] p-4 border-[0.5px] border-bluedot-navy/25 focus-within:border-[1.25px] focus-within:border-bluedot-normal focus-within:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] transition-all duration-200 [&::-webkit-resizer]:hidden min-h-[140px]"
         >
           <div
             aria-describedby="save-status-message"
@@ -227,7 +227,7 @@ exports[`FreeTextResponse > renders with saved exercise response 1`] = `
         class="relative w-full z-[1]"
       >
         <div
-          class="resize-y overflow-auto relative cursor-text box-border w-full bg-white rounded-md z-[1] p-4 border-[0.5px] border-bluedot-navy/25 focus-within:border-[1.25px] focus-within:border-[#1641D9] focus-within:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] transition-all duration-200 [&::-webkit-resizer]:hidden min-h-[140px]"
+          class="resize-y overflow-auto relative cursor-text box-border w-full bg-white rounded-md z-[1] p-4 border-[0.5px] border-bluedot-navy/25 focus-within:border-[1.25px] focus-within:border-bluedot-normal focus-within:shadow-[0px_0px_10px_rgba(34,68,187,0.3)] transition-all duration-200 [&::-webkit-resizer]:hidden min-h-[140px]"
         >
           <div
             aria-describedby="save-status-message"


### PR DESCRIPTION
## Summary

The save-status indicator and rich-text editor both used a one-off blue hex `#1641D9` (rgb 22, 65, 217) — visually close to `--bluedot-normal` (#1144CC, rgb 17, 68, 204) but a slightly different shade, so the "saving" spinner and the editor focus border were drifting from the canonical brand blue used everywhere else.

Two swaps:

- `SaveStatusIndicator.tsx`: `style={{ color: '#1641D9' }}` → `className="… text-bluedot-normal"`. Drops the inline style for a className that goes through the design-system token.
- `RichTextAutoSaveEditor.tsx`: `focus-within:border-[#1641D9]` → `focus-within:border-bluedot-normal` (still keeping the 1.25px width + box-shadow halo, which are bespoke focus-state effects).

The `rgba(34, 68, 187, 0.3)` halo shadow elsewhere on the editor is left alone — it's a derived alpha + slightly different blue and would need either a new token or an inline `var(--bluedot-normal)` with `color-mix(...)` to be tokenised cleanly. Separate PR.

## Test plan

- [x] `npx vitest run` (apps/website): 103 files / 629 passed / 1 skipped (3 snapshots updated to reflect class swaps)
- [x] No new visual regressions — colour shift is rgb(22, 65, 217) → rgb(17, 68, 204), imperceptible at the spinner / 1px border level

🤖 Generated with [Claude Code](https://claude.com/claude-code)