### PR TITLE
[fix] facilitator follow-up: 'schedule call' → '1-1 advising'

### DIFF
--- a/apps/website/src/components/courses/ParticipantFeedbackModal.test.tsx
+++ b/apps/website/src/components/courses/ParticipantFeedbackModal.test.tsx
@@ -62,7 +62,7 @@ describe('ParticipantFeedbackModal', () => {
     fireEvent.click(screen.getByText('Regularly engaged critically')); // 4
     expect(getDoneButton()).toBeDisabled(); // still need a follow-up
 
-    fireEvent.click(screen.getByText('Schedule a call within the week (high priority)'));
+    fireEvent.click(screen.getByText('Flag for 1-1 advising with BlueDot team'));
     expect(getDoneButton()).toBeEnabled();
 
     fireEvent.change(screen.getByLabelText(/In 2-3 sentences/), { target: { value: 'Strong cohort member.' } });
@@ -74,7 +74,7 @@ describe('ParticipantFeedbackModal', () => {
         showUpRating: 4,
         engageRating: 4,
         investmentNote: 'Strong cohort member.',
-        followUps: ['Schedule follow-up call with BlueDot team within ~1 week (high-priority)'],
+        followUps: ['Flag for 1-1 advising with BlueDot team'],
       });
     });
 
@@ -85,7 +85,7 @@ describe('ParticipantFeedbackModal', () => {
       initiativeRating: 4,
       reasoningQualityRating: 4,
       feedback: 'Strong cohort member.',
-      nextSteps: ['Schedule follow-up call with BlueDot team within ~1 week (high-priority)'],
+      nextSteps: ['Flag for 1-1 advising with BlueDot team'],
     });
   });
 

--- a/apps/website/src/lib/facilitatorFollowUps.ts
+++ b/apps/website/src/lib/facilitatorFollowUps.ts
@@ -2,7 +2,7 @@
 export const FOLLOW_UP_OPTIONS = [
   { id: 'No further action needed', label: 'No further action needed' },
   { id: 'Add to talent pipeline [keep warm for future opportunities/check-ins]', label: 'Add to talent pipeline (keep warm) — for future opportunities' },
-  { id: 'Schedule follow-up call with BlueDot team within ~1 week (high-priority)', label: 'Schedule a call within the week (high priority)' },
+  { id: 'Flag for 1-1 advising with BlueDot team', label: 'Flag for 1-1 advising with BlueDot team' },
   { id: 'Flag as candidate for funding (career transition/project)', label: 'Potential funding candidate — career transition or project support' },
   { id: 'Recommend to facilitate', label: 'Invite to apply as a facilitator' },
 ] as const;
@@ -15,7 +15,7 @@ export const FOLLOW_UP_IDS = FOLLOW_UP_OPTIONS.map((o) => o.id) as [
 export type FollowUpId = typeof FOLLOW_UP_OPTIONS[number]['id'];
 
 export const ACTIONABLE_FOLLOW_UP_IDS = [
-  'Schedule follow-up call with BlueDot team within ~1 week (high-priority)',
+  'Flag for 1-1 advising with BlueDot team',
   'Flag as candidate for funding (career transition/project)',
   'Recommend to facilitate',
 ] as const;


### PR DESCRIPTION
## Summary

- The Airtable `nextSteps` multi-select on Course Runner had its options updated: `Schedule follow-up call with BlueDot team within ~1 week (high-priority)` was removed; `Flag for 1-1 advising with BlueDot team` was added in its place.
- The website's facilitator feedback form hardcodes these option strings in `apps/website/src/lib/facilitatorFollowUps.ts`. Without this update, picking that option would fail to write to Airtable (multipleSelects rejects unknown choice names).
- Updates the lib + the one test that asserted the old string.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run src/components/courses/ParticipantFeedbackModal.test.tsx` — 3 passed
- [x] Full website test suite — 628 passed (one pre-existing en-GB locale snapshot in `Congratulations.test.tsx` fails locally; passes on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)