### PR TITLE
[feat] career-transition-grant: add FAQ on Master's/PhD funding

### DIFF
--- a/apps/website/src/components/grants/grantPrograms.tsx
+++ b/apps/website/src/components/grants/grantPrograms.tsx
@@ -167,6 +167,11 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
         question: 'What if I secure a full-time role or my circumstances change during the grant?',
         answer: 'Please let us know. Any remaining funds would be returned to BlueDot.',
       },
+      {
+        id: 'masters-phd',
+        question: 'Will you fund a Master\'s or PhD?',
+        answer: 'Generally, no. For most people, a Master\'s or PhD isn\'t the most direct route to impactful AI safety work. There are exceptions. Mention it in your application if you think yours is one.',
+      },
     ],
   },
   'incubator-week': {


### PR DESCRIPTION
## Summary
- Adds an FAQ to the Career Transition Grants page clarifying that BlueDot generally does not fund Master's/PhD programmes, since this is rarely the most direct route to impactful AI safety work.

## Test plan
- [x] FAQ renders on `/programs/career-transition-grant` (verified via dev server)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (--max-warnings=0)
- [x] Full test suite — 628 passed, 1 pre-existing snapshot failure unrelated to this change (en-GB locale rendering "1 January 2024" vs en-US CI snapshot "January 1, 2024")

🤖 Generated with [Claude Code](https://claude.com/claude-code)