### PR TITLE
[feat] forward UTM source on grant program application CTAs

### DIFF
--- a/apps/website/src/components/grants/sections/GrantCta.tsx
+++ b/apps/website/src/components/grants/sections/GrantCta.tsx
@@ -1,15 +1,13 @@
 import { CTALinkOrButton } from '@bluedot/ui';
-import {
-  GRANT_PROGRAM_SECTIONS,
-  type ConfigurableGrantProgramSlug,
-} from '../grantPrograms';
+import { type ConfigurableGrantProgramSlug } from '../grantPrograms';
+import { useGrantApplicationUrl } from '../useGrantApplicationUrl';
 
 type Props = {
   program: ConfigurableGrantProgramSlug;
 };
 
 const GrantCta = ({ program }: Props) => {
-  const { applicationUrl } = GRANT_PROGRAM_SECTIONS[program];
+  const applicationUrl = useGrantApplicationUrl(program);
 
   return (
     <div className={`${program}-cta w-full max-w-max-width mx-auto px-spacing-x mt-spacing-y mb-16 flex justify-center`}>

--- a/apps/website/src/components/grants/sections/GrantStatsStrip.tsx
+++ b/apps/website/src/components/grants/sections/GrantStatsStrip.tsx
@@ -1,9 +1,7 @@
 import type React from 'react';
 import { CTALinkOrButton } from '@bluedot/ui';
-import {
-  GRANT_PROGRAM_SECTIONS,
-  type ConfigurableGrantProgramSlug,
-} from '../grantPrograms';
+import { type ConfigurableGrantProgramSlug } from '../grantPrograms';
+import { useGrantApplicationUrl } from '../useGrantApplicationUrl';
 
 export type GrantStat = {
   label: string;
@@ -33,7 +31,7 @@ const GrantStatsStrip = ({
   secondaryAction,
   compact = false,
 }: Props) => {
-  const { applicationUrl } = GRANT_PROGRAM_SECTIONS[program];
+  const applicationUrl = useGrantApplicationUrl(program);
   const primary = primaryAction ?? { label: 'Apply now', url: applicationUrl };
 
   const outerLayoutClass = compact

--- a/apps/website/src/components/grants/useGrantApplicationUrl.ts
+++ b/apps/website/src/components/grants/useGrantApplicationUrl.ts
@@ -1,0 +1,15 @@
+import { addQueryParam, useLatestUtmParams } from '@bluedot/ui';
+import { appendPosthogSessionIdPrefill } from '../../lib/appendPosthogSessionIdPrefill';
+import {
+  GRANT_PROGRAM_SECTIONS,
+  type ConfigurableGrantProgramSlug,
+} from './grantPrograms';
+
+export const useGrantApplicationUrl = (program: ConfigurableGrantProgramSlug): string => {
+  const { applicationUrl } = GRANT_PROGRAM_SECTIONS[program];
+  const { latestUtmParams } = useLatestUtmParams();
+
+  return appendPosthogSessionIdPrefill(latestUtmParams.utm_source
+    ? addQueryParam(applicationUrl, 'prefill_Source', latestUtmParams.utm_source)
+    : applicationUrl);
+};


### PR DESCRIPTION
# Description

The `/courses/*` landing pages already forward `utm_source` (and the PostHog session ID) into the application form's `prefill_Source` field so each form can attribute applicants to their entry channel. The `/programs/*` grant pages — advising, rapid-grants, career-transition-grant, incubator-week — did not. Their "Apply now" CTAs linked straight to the raw form URL, dropping the visitor's UTM context.

This change ports the same recipe from `CourseLander.tsx` into the shared `GrantCta` and `GrantStatsStrip` components via a small new hook, so every configurable grant page picks it up uniformly.

## What changed

1. **`apps/website/src/components/grants/useGrantApplicationUrl.ts`** — new hook. Reads the program's `applicationUrl` from `GRANT_PROGRAM_SECTIONS`, appends `prefill_Source=<utm_source>` when the visitor has one, and runs the result through `appendPosthogSessionIdPrefill`. Mirrors the inline logic in `CourseLander.tsx`.
2. **`apps/website/src/components/grants/sections/GrantCta.tsx`** — replaces the direct `GRANT_PROGRAM_SECTIONS[program].applicationUrl` read with `useGrantApplicationUrl(program)`.
3. **`apps/website/src/components/grants/sections/GrantStatsStrip.tsx`** — same swap. The existing `primaryAction.url` override prop still wins when callers pass it.

## Notes on scope

- Forwarding works for all four configurable grant programs (advising, rapid-grants, career-transition-grant, incubator-week) since they share these components.
- The advising form on miniextensions already has prefill enabled for the "Source" field; the other three forms are on Airtable where `prefill_Source` is native.
- Inline links to the application form that live inside FAQ answer copy (e.g. on `/programs/rapid-grants`) are out of scope — those are hardcoded `<a>` tags in static copy, not routed through `GrantCta`/`GrantStatsStrip`.

## Issue

N/A — internal request, no linked issue.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — no visible UI changes; URL output only.
- [x] Considered having snapshot tests / functional tests — declined. Neither component had a dedicated test before this change, and adding one would require mocking `LatestUtmParamsProvider` and PostHog. Behaviour is browser-verified below.
- [x] Considered adding Storybook stories — declined; existing `GrantSections.stories.tsx` already covers these components, and the URL output is not a visual concern.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8001` on the `anglilian/advising-utm-prefill` worktree):

- ✅ `/programs/advising?utm_source=testchannel` — both Apply CTAs (top stats strip + bottom CTA) carry `prefill_Source=testchannel` and `prefill_PostHog%20Session%20ID`.
- ✅ `/programs/advising` (no UTM) — only `prefill_PostHog Session ID` appended; no spurious `prefill_Source`.
- ✅ `/programs/rapid-grants?utm_source=testchannel` — both Apply CTAs prefilled.
- ✅ `/programs/career-transition-grant?utm_source=testchannel` — both Apply CTAs prefilled.

Type check + lint + full test suite all pass:

\`\`\`
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 628 passed; only failure is a pre-existing en-GB
                    # locale snapshot flake on Congratulations.test.tsx,
                    # unrelated to this change
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)