### PR TITLE
Incubator Week: refresh page copy, structure, and FAQ for new program direction

### DIFF
--- a/apps/website/src/components/grants/grantPrograms.tsx
+++ b/apps/website/src/components/grants/grantPrograms.tsx
@@ -21,7 +21,7 @@ export type GrantProgramDefinition = {
 export const RAPID_GRANT_APPLICATION_URL = 'https://airtable.com/appMVNtdBtvtJvu5E/pag9G3oF4DYAyassX/form';
 export const CAREER_TRANSITION_GRANT_APPLICATION_URL = 'https://airtable.com/appMVNtdBtvtJvu5E/pagyKD4M0wd0ci2gH/form';
 export const ONE_ON_ONE_ADVISING_APPLICATION_URL = 'https://web.miniextensions.com/elMoT4tTN0jx49tNB0cS';
-export const INCUBATOR_WEEK_APPLICATION_URL = 'https://web.miniextensions.com/9UQbEOQ10oTYrqpIOwVS';
+export const INCUBATOR_WEEK_APPLICATION_URL = 'https://airtable.com/appnJbsG1eWbAdEvf/pagA7JU8pPkkbDCOJ/form';
 
 export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
   {
@@ -178,11 +178,6 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
     applicationUrl: INCUBATOR_WEEK_APPLICATION_URL,
     faqItems: [
       {
-        id: 'how-to-join',
-        question: 'How do I join Incubator Week?',
-        answer: 'The AGI Strategy Course and Technical AI Safety Course are our primary feeders. We filter the best participants through problem statement quality, then interview before inviting to Incubator Week.',
-      },
-      {
         id: 'solo-or-team',
         question: 'Can I apply solo or do I need a co-founder?',
         answer: 'Both work. Solo founders are welcome — though we\'ve learned that co-founder matching is hard, so coming with a partner (friend, classmate, existing co-founder) is a plus. We\'ll help facilitate connections during the week.',
@@ -195,7 +190,7 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
       {
         id: 'tracks',
         question: 'What tracks do you support?',
-        answer: 'For now we\'re focused on for-profit companies. We\'re keen to explore other areas as well, especially policy entrepreneurship.',
+        answer: 'We support both for-profit and non-profit organizations in fields like AI safety, biosecurity, cybersecurity, and other catastrophic risk reduction. We\'re especially interested in policy entrepreneurship.',
       },
       {
         id: 'funding',

--- a/apps/website/src/components/incubator-week/LogisticsSection.tsx
+++ b/apps/website/src/components/incubator-week/LogisticsSection.tsx
@@ -8,7 +8,7 @@ const LOGISTICS = [
   },
   {
     label: 'Focus areas',
-    body: 'AI safety, biosecurity, cybersecurity, and other catastrophic risk reduction. For now we\'re focused on for-profit companies.',
+    body: 'For-profit and non-profit founders in fields like AI safety, biosecurity, cybersecurity, and other catastrophic risk reduction.',
   },
   {
     label: 'Schedule',

--- a/apps/website/src/components/incubator-week/WhatThisIsForSection.tsx
+++ b/apps/website/src/components/incubator-week/WhatThisIsForSection.tsx
@@ -28,16 +28,39 @@ const WhatThisIsForSection = () => {
   return (
     <section className="section section-body incubator-week-what-section">
       <div className="w-full flex flex-col gap-6">
-        <h3 className={pageSectionHeadingClass}>Who this is for</h3>
+        <h3 className={pageSectionHeadingClass}>What you&apos;ll do</h3>
 
         <div className="flex flex-col gap-5">
           <P>
-            Training isn&apos;t enough. We need new organizations to make AI go well. Incubator Week takes the strongest founders from our courses and backs them to build.
+            Incubator Week is a 5-day sprint for experts considering founding in AI safety.
           </P>
           <P>
-            We select from our AGI Strategy and Technical AI Safety courses. We&apos;re looking for people who can complete this sentence: &ldquo;Last year I built ___ which resulted in ___.&rdquo; Apply to our courses first, and we&apos;ll invite the strongest participants to Incubator Week.
+            We&apos;ll launch you into the field, help you lock in on a problem, find a co-founder. If we like your pitch we will give you $50k equity-free by the end of the week. The week is held at <a href="https://www.safeai.org.uk/" className="underline hover:no-underline">LISA</a> in London.
           </P>
         </div>
+
+        <h3 className={`${pageSectionHeadingClass} pt-4`}>Track record</h3>
+
+        <div className="flex flex-col gap-5">
+          <P>
+            Three cohorts in: 9 companies founded, $500k+ raised, 9-figure aggregate expected this year.
+          </P>
+          <div className="flex flex-col gap-2">
+            <P>Alumni include:</P>
+            <ul className="list-disc pl-6 flex flex-col gap-1">
+              <li>Exona Lab: Founders met during the week; Pre-seed raised, 7-figure round in progress</li>
+              <li>Jacob Arbeid: Quit AISI to found; Funding secured; $2.4M ARR pending</li>
+              <li>Zac Saber: Dropped out of EF; now on long-horizon AI evals; met his co-founder Jacob Arbeid during Incubator Week</li>
+              <li>Shay Yahal: Enterprise AI security; Already has paying customers and partnership with Redwood Research</li>
+              <li>Lysander Mawby: Mechanistic interpretability; Just wrapped up the FR8 incubator ($100k at $5M val)</li>
+            </ul>
+          </div>
+          <P className="text-size-sm leading-[1.6] text-bluedot-navy/80 pt-4">
+            Run by BlueDot Impact. We&apos;ve raised over $35M to build the workforce and organizations needed to safely navigate AGI.
+          </P>
+        </div>
+
+        <h3 className={`${pageSectionHeadingClass} pt-4`}>About you</h3>
 
         <div className="pt-2 grid gap-8 grid-cols-1 bd-md:grid-cols-3">
           {AUDIENCES.map(({ icon: Icon, title, description }) => (

--- a/apps/website/src/pages/programs/incubator-week.tsx
+++ b/apps/website/src/pages/programs/incubator-week.tsx
@@ -30,7 +30,7 @@ const IncubatorWeekProgramPage = () => {
       </Head>
       <MarketingHero
         title="Incubator Week"
-        subtitle="A five-day intensive that backs the strongest founders from our courses to build organizations to make AI go well. All expenses paid. Pitch for funding on Friday. 1-5 June in London."
+        subtitle="A five-day intensive that helps top talent become AI safety founders. All expenses paid. Pitch for funding on Friday. 1-5 June in London."
       />
       <Breadcrumbs route={CURRENT_ROUTE} />
       <GrantStatsStrip


### PR DESCRIPTION
## Summary

Refreshes the Incubator Week landing page ahead of the redesigned program (Q2 2026 cohort).

### Page changes
- New three-block structure: **What you'll do** → **Track record** → **About you**
- Updated intro copy: program is for "experts considering founding in AI safety"; explicit $50k equity-free pitch grant
- Track record block: 9 companies founded across 3 cohorts, 9-figure aggregate raise expected, 5 named alumni examples (Exona Lab, Jacob Arbeid, Zac Saber, Shay Yahal, Lysander Mawby)
- Muted footer line with BlueDot's $35M institutional funding
- Hero subtitle updated to "A five-day intensive that helps top talent become AI safety founders..."

### FAQ changes
- Removed "How do I join Incubator Week?" (course-prerequisite framing no longer applies)
- Updated "What tracks do you support?" to welcome both for-profit and non-profit organizations

### Logistics
- Focus areas no longer says "for now we're focused on for-profit companies"; tightened to "For-profit and non-profit founders in fields like AI safety, biosecurity, cybersecurity, and other catastrophic risk reduction."

### Other
- Application URL updated to new Airtable form

## Test plan
- [x] \`npm test\` (629 tests pass)
- [x] \`npm run lint\` (--max-warnings=0 clean)
- [x] \`npm run typecheck\` clean
- [x] Manually verified locally on http://localhost:8000/programs/incubator-week