### PR TITLE
[codex] Refresh incubator week page

### DIFF
--- a/apps/website/src/components/grants/grantPrograms.tsx
+++ b/apps/website/src/components/grants/grantPrograms.tsx
@@ -67,9 +67,9 @@ export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
     href: '/programs/incubator-week',
     track: 'Launch',
     goal: 'Back graduates launching AI safety companies, with seed funding and an intensive week in London.',
-    scope: 'A five-day intensive in London. All expenses paid. Pitch for funding on Friday.',
+    scope: 'Cohort 4 runs in London, 1–5 June. Apply by 26 May for a five-day sprint from idea to funded.',
     scopeLabel: 'Format',
-    status: 'On hiatus',
+    status: 'Active',
   },
 ];
 
@@ -195,7 +195,7 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
       {
         id: 'funding',
         question: 'How does the funding work?',
-        answer: 'Strong pitches on Friday receive initial grants of £50k+ to work on your project full-time. This is designed to help you build momentum in the months after Incubator Week.',
+        answer: 'Strong pitches on Friday get $5k on the spot, up to $45k more after two weeks of progress, and a path to $200k total for the strongest teams. Funding is equity-free.',
       },
       {
         id: 'bluedot',

--- a/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
+++ b/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
@@ -1,0 +1,30 @@
+import { CTALinkOrButton, P } from '@bluedot/ui';
+import { pageSectionHeadingClass } from '../PageListRow';
+
+type Props = {
+  applicationUrl: string;
+  applicationDeadline: string;
+};
+
+const AboutBlueDotSection = ({ applicationUrl, applicationDeadline }: Props) => {
+  return (
+    <section className="section section-body incubator-week-about-bluedot-section">
+      <div className="w-full flex flex-col gap-6">
+        <h3 className={pageSectionHeadingClass}>About BlueDot</h3>
+        <P>
+          BlueDot Impact is a nonprofit based in London and SF, building the workforce and organizations needed to safely navigate AGI. We&apos;ve raised over $35M and trained over 8,000 people since 2022.
+        </P>
+        <CTALinkOrButton
+          variant="primary"
+          withChevron
+          url={applicationUrl}
+          target="_blank"
+        >
+          Apply by {applicationDeadline}
+        </CTALinkOrButton>
+      </div>
+    </section>
+  );
+};
+
+export default AboutBlueDotSection;

--- a/apps/website/src/components/incubator-week/AboutYouSection.tsx
+++ b/apps/website/src/components/incubator-week/AboutYouSection.tsx
@@ -1,0 +1,19 @@
+import { pageSectionHeadingClass } from '../PageListRow';
+
+const AboutYouSection = () => {
+  return (
+    <section className="section section-body incubator-week-about-you-section">
+      <div className="w-full flex flex-col gap-6">
+        <h3 className={pageSectionHeadingClass}>About you</h3>
+        <ul className="list-disc pl-6 flex flex-col gap-2">
+          <li>Technically serious</li>
+          <li>Working in or adjacent to AI safety, biosecurity, cyber, or other catastrophic-risk fields</li>
+          <li>Ready to leave whatever you&apos;re doing now to build</li>
+          <li>You don&apos;t need a polished idea - we will help you find one here</li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default AboutYouSection;

--- a/apps/website/src/components/incubator-week/TheWeekSection.tsx
+++ b/apps/website/src/components/incubator-week/TheWeekSection.tsx
@@ -10,7 +10,7 @@ const SCHEDULE = [
   {
     cadence: 'Tue – Wed',
     title: 'Build interventions',
-    body: 'Build and iterate on interventions, call experts, attend our community social.',
+    body: 'Build and test interventions, call experts, and pressure-test your assumptions with the cohort.',
   },
   {
     cadence: 'Thursday',
@@ -20,7 +20,7 @@ const SCHEDULE = [
   {
     cadence: 'Friday',
     title: 'Pitch for funding',
-    body: 'Pitch to us for funding. Strong pitches receive initial grants of £50k+ to work on your project full-time.',
+    body: 'Pitch to us. Strong pitches get $5k on the spot, up to $45k more after two weeks of progress, and a path to $200k total for the strongest teams.',
   },
 ];
 

--- a/apps/website/src/components/incubator-week/TrackRecordSection.tsx
+++ b/apps/website/src/components/incubator-week/TrackRecordSection.tsx
@@ -1,0 +1,52 @@
+import { P } from '@bluedot/ui';
+import { pageSectionHeadingClass } from '../PageListRow';
+
+const TrackRecordSection = () => {
+  return (
+    <section className="section section-body incubator-week-track-record-section">
+      <div className="w-full flex flex-col gap-6">
+        <h3 className={pageSectionHeadingClass}>Track record</h3>
+
+        <div className="flex flex-col gap-5">
+          <P>
+            Three cohorts in: 23 participants, 11 companies founded, 7 still going, $500k+ raised.
+          </P>
+          <div className="flex flex-col gap-2">
+            <P>Alumni include:</P>
+            <ul className="list-disc pl-6 flex flex-col gap-1">
+              <li>
+                <a href="https://www.exonalab.com/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Exona Lab</a>
+                : quantifying AI risk for the Lloyd&apos;s insurance market; Lloyd&apos;s Lab Cohort 16, paper with Bengio, Reuters feature
+              </li>
+              <li>
+                <a href="https://www.0labs.ai/" target="_blank" rel="noreferrer" className="underline hover:no-underline">0Labs</a>
+                : AI purple teaming — adversarial agents that expose detection gaps before attackers do
+              </li>
+              <li>
+                <a href="https://www.telluvian.ai/about.html" target="_blank" rel="noreferrer" className="underline hover:no-underline">Telluvian</a>
+                : mechanistic interpretability for high-stakes AI; FR8 incubator
+              </li>
+              <li>
+                <a href="https://www.linkedin.com/in/jacob-arbeid/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Jacob Arbeid</a>
+                : quit AISI; raised from Manifund for an automated evals lab (stealth)
+              </li>
+              <li>
+                <a href="https://www.linkedin.com/in/shay-yahal/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Shay Yahal</a>
+                : enterprise AI security (stealth); paying customers, Redwood Research partnership
+              </li>
+              <li>
+                <a href="https://www.linkedin.com/in/z-saber/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Zac Saber</a>
+                : dropped out of EF; building long-horizon evals (stealth)
+              </li>
+            </ul>
+          </div>
+          <P>
+            Plus career transition grants and placements at Andon Labs, ASET, and BlueDot.
+          </P>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TrackRecordSection;

--- a/apps/website/src/pages/programs.tsx
+++ b/apps/website/src/pages/programs.tsx
@@ -66,9 +66,9 @@ const ProgramsPage = () => {
       id: 'incubator-week',
       name: 'Incubator Week',
       href: '/programs/incubator-week',
-      summary: 'A concentrated week for stronger founders and operators testing bigger bets.',
-      detail: 'Five-day London intensive. All expenses paid. Strong teams pitch for funding on Friday.',
-      ctaLabel: 'Learn more',
+      summary: 'Five days from idea to funded for AI safety founders.',
+      detail: 'Cohort 4 runs 1–5 June in London. Apply by 26 May; $50k equity-free if your pitch lands.',
+      ctaLabel: 'Apply by 26 May',
     },
   ];
 

--- a/apps/website/src/pages/programs/incubator-week.tsx
+++ b/apps/website/src/pages/programs/incubator-week.tsx
@@ -2,16 +2,15 @@ import { Breadcrumbs, type BluedotRoute } from '@bluedot/ui';
 import Head from 'next/head';
 import MarketingHero from '../../components/MarketingHero';
 import GrantStatsStrip from '../../components/grants/sections/GrantStatsStrip';
-import GrantFaqSection from '../../components/grants/sections/GrantFaqSection';
-import GrantCta from '../../components/grants/sections/GrantCta';
-import WhatThisIsForSection from '../../components/incubator-week/WhatThisIsForSection';
+import TrackRecordSection from '../../components/incubator-week/TrackRecordSection';
 import TheWeekSection from '../../components/incubator-week/TheWeekSection';
-import WhatYouGetSection from '../../components/incubator-week/WhatYouGetSection';
-import LogisticsSection from '../../components/incubator-week/LogisticsSection';
+import AboutYouSection from '../../components/incubator-week/AboutYouSection';
+import AboutBlueDotSection from '../../components/incubator-week/AboutBlueDotSection';
+import { useGrantApplicationUrl } from '../../components/grants/useGrantApplicationUrl';
 import { ROUTES } from '../../lib/routes';
 
 const PAGE_TITLE = 'Incubator Week';
-
+const APPLICATION_DEADLINE = '26 May';
 const CURRENT_ROUTE: BluedotRoute = {
   title: PAGE_TITLE,
   url: '/programs/incubator-week',
@@ -19,36 +18,43 @@ const CURRENT_ROUTE: BluedotRoute = {
 };
 
 const IncubatorWeekProgramPage = () => {
+  const applicationUrl = useGrantApplicationUrl('incubator-week');
+
   return (
     <div>
       <Head>
         <title>{`${PAGE_TITLE} | BlueDot Impact`}</title>
         <meta
           name="description"
-          content="A 5-day intensive for founders building organizations to make AI go well. Develop threat models, design interventions, pitch for funding. All expenses paid in London."
+          content="Most accelerators take 12 weeks and 7%. We take 5 days and 0%. Fly to London to turn your AI safety idea into a funded org. $50k if your pitch lands. More for the strongest teams. Equity-free."
         />
       </Head>
       <MarketingHero
         title="Incubator Week"
-        subtitle="A five-day intensive that helps top talent become AI safety founders. All expenses paid. Pitch for funding on Friday. 1-5 June in London."
+        subtitle="Most accelerators take 12 weeks and 7%. We take 5 days and 0%. Fly to London to turn your AI safety idea into a funded org. $50k if your pitch lands. More for the strongest teams. Equity-free."
       />
       <Breadcrumbs route={CURRENT_ROUTE} />
       <GrantStatsStrip
         program="incubator-week"
         compact
+        primaryAction={{
+          label: `Apply by ${APPLICATION_DEADLINE}`,
+          url: applicationUrl,
+        }}
         stats={[
-          { label: 'Format', value: '5 days, in person' },
-          { label: 'Location', value: 'London (LISA)' },
-          { label: 'Cost', value: 'All expenses paid' },
-          { label: 'Funding', value: '£50k+ on strong pitches' },
+          { label: 'Cohort', value: 'v4' },
+          { label: 'Runs', value: '1–5 June' },
+          { label: 'Funding', value: '$50k equity-free' },
+          { label: 'Covered', value: 'Flights, stay, meals' },
         ]}
       />
-      <WhatThisIsForSection />
+      <TrackRecordSection />
       <TheWeekSection />
-      <WhatYouGetSection />
-      <LogisticsSection />
-      <GrantFaqSection program="incubator-week" />
-      <GrantCta program="incubator-week" />
+      <AboutYouSection />
+      <AboutBlueDotSection
+        applicationUrl={applicationUrl}
+        applicationDeadline={APPLICATION_DEADLINE}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Refreshes the Incubator Week page around the new 5-day, 0% equity positioning.
- Replaces duplicated sections with a tighter flow: track record, week schedule, about you, and about BlueDot.
- Updates Incubator Week program metadata, funding copy, and the programs listing.

## Validation
- npm --workspace @bluedot/website run typecheck
- npm --workspace @bluedot/website run lint
- npm --workspace @bluedot/website run test -- src/__tests__/pages/programs.test.tsx src/components/homepage/GrantsSection.test.tsx