### PR TITLE
[chore] Remove "Some of our grantees" section from career-transition-grant page

### DIFF
--- a/apps/website/src/pages/programs/career-transition-grant.tsx
+++ b/apps/website/src/pages/programs/career-transition-grant.tsx
@@ -7,7 +7,6 @@ import GrantCta from '../../components/grants/sections/GrantCta';
 import WhatThisIsForSection from '../../components/career-transition-grant/WhatThisIsForSection';
 import ExpectationsSection from '../../components/career-transition-grant/ExpectationsSection';
 import NextStepsSection from '../../components/career-transition-grant/NextStepsSection';
-import GranteesSection from '../../components/career-transition-grant/GranteesSection';
 import { ROUTES } from '../../lib/routes';
 import { formatAmountUsd } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
@@ -49,7 +48,6 @@ const CareerTransitionGrantPage = () => {
       <WhatThisIsForSection />
       <ExpectationsSection />
       <NextStepsSection />
-      <GranteesSection />
       <GrantFaqSection program="career-transition-grant" />
       <GrantCta program="career-transition-grant" />
     </div>


### PR DESCRIPTION
## Summary
- Strip the `<GranteesSection />` render + its import from `apps/website/src/pages/programs/career-transition-grant.tsx`.
- Component file (`GranteesSection.tsx`) and trpc endpoint (`getAllPublicCareerTransitionGrantees`) intentionally left in place — re-enable later by re-adding one import + one line.
- `GrantStatsStrip` is unaffected (different endpoint).

## Test plan
- [x] `npm run lint` (clean)
- [x] `npm run typecheck` (clean)
- [x] `npm test` — 103 files / 629 tests pass
- [x] Playwright sweep at 320 / 480 / 720 / 1024 / 1440 (headless): no "Some of our grantees" heading, no `.career-transition-grant-grantees-section` element, zero horizontal overflow at any width
- [x] Eyeballed in Arc at `/programs/career-transition-grant` — clean flow from "What happens next" → "Frequently asked questions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)