### PR TITLE
[fix] website: pin en-US locale on certificate issued date

### DIFF
--- a/apps/website/src/components/courses/Congratulations.tsx
+++ b/apps/website/src/components/courses/Congratulations.tsx
@@ -203,7 +203,7 @@ const CertificateCardAuthed = ({ courseId, courseSlug, courseTitle }: Certificat
   }
 
   if (certificateData?.status === 'has-certificate') {
-    const formattedDate = new Date(certificateData.issuedAt * 1000).toLocaleDateString(undefined, { dateStyle: 'long' });
+    const formattedDate = new Date(certificateData.issuedAt * 1000).toLocaleDateString('en-US', { dateStyle: 'long' });
     return (
       <ActionCard
         number={3}


### PR DESCRIPTION
# Description

`Congratulations.tsx:206` called `toLocaleDateString` with `undefined` as the locale, so it picked up the host runtime default. On en-GB hosts (e.g. Mac with British locale) the date rendered as \"1 January 2024\"; on en-US (CI Linux default) it rendered as \"January 1, 2024\". The committed snapshot was generated under en-US, so the test failed for any contributor not on en-US.

This PR pins `'en-US'` explicitly to match the convention used everywhere else in the codebase (\`lib/utils.ts\`, \`pages/certification.tsx\`, \`routers/course-rounds.ts\`, etc.).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

No related issue, caught while running tests locally.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with \`npm run test\`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

No visual change for en-US users (CI, US contributors). For en-GB hosts the rendered string switches from \"1 January 2024\" to \"January 1, 2024\" — i.e. it now matches what production users see.