### PR TITLE
[feat] Drive grant apply URLs from Airtable Programs table

### DIFF
--- a/apps/website/src/components/grants/useGrantApplicationUrl.ts
+++ b/apps/website/src/components/grants/useGrantApplicationUrl.ts
@@ -1,13 +1,17 @@
 import { addQueryParam, useLatestUtmParams } from '@bluedot/ui';
 import { appendPosthogSessionIdPrefill } from '../../lib/appendPosthogSessionIdPrefill';
+import { trpc } from '../../utils/trpc';
 import {
   GRANT_PROGRAM_SECTIONS,
   type ConfigurableGrantProgramSlug,
 } from './grantPrograms';
 
 export const useGrantApplicationUrl = (program: ConfigurableGrantProgramSlug): string => {
-  const { applicationUrl } = GRANT_PROGRAM_SECTIONS[program];
+  const { data: programs } = trpc.programs.getAll.useQuery();
   const { latestUtmParams } = useLatestUtmParams();
+
+  const fromAirtable = programs?.find((p) => p.slug === program)?.applicationForm;
+  const applicationUrl = fromAirtable ?? GRANT_PROGRAM_SECTIONS[program].applicationUrl;
 
   return appendPosthogSessionIdPrefill(latestUtmParams.utm_source
     ? addQueryParam(applicationUrl, 'prefill_Source', latestUtmParams.utm_source)

--- a/apps/website/src/components/rapid-grants/HowItWorksSection.tsx
+++ b/apps/website/src/components/rapid-grants/HowItWorksSection.tsx
@@ -1,12 +1,12 @@
 import { P } from '@bluedot/ui';
 import { pageSectionHeadingClass } from '../PageListRow';
-import { RAPID_GRANT_APPLICATION_URL } from '../grants/grantPrograms';
+import { useGrantApplicationUrl } from '../grants/useGrantApplicationUrl';
 
-const PROCESS_STEPS = [
+const buildProcessSteps = (applicationUrl: string) => [
   {
     number: '01',
     title: 'Apply',
-    url: RAPID_GRANT_APPLICATION_URL,
+    url: applicationUrl,
     body: 'Tell us what you\'re doing, what you need, and how much it costs. Takes five minutes.',
   },
   {
@@ -65,13 +65,16 @@ const StepCardBody = ({ number, title, body, eyebrowClass }: {
 };
 
 const HowItWorksSection = () => {
+  const applicationUrl = useGrantApplicationUrl('rapid-grants');
+  const processSteps = buildProcessSteps(applicationUrl);
+
   return (
     <section className="section section-body rapid-grants-how-section">
       <div className="w-full flex flex-col gap-6">
         <h3 className={pageSectionHeadingClass}>How it works</h3>
 
         <div className="grid gap-4 bd-md:grid-cols-2 min-[960px]:grid-cols-3">
-          {PROCESS_STEPS.map((step) => (
+          {processSteps.map((step) => (
             step.url ? (
               <a
                 key={step.title}

--- a/apps/website/src/components/rapid-grants/WhatThisIsForSection.tsx
+++ b/apps/website/src/components/rapid-grants/WhatThisIsForSection.tsx
@@ -1,6 +1,6 @@
 import { P } from '@bluedot/ui';
 import { pageSectionHeadingClass } from '../PageListRow';
-import { RAPID_GRANT_APPLICATION_URL } from '../grants/grantPrograms';
+import { useGrantApplicationUrl } from '../grants/useGrantApplicationUrl';
 
 const DECISION_CARDS = [
   {
@@ -14,6 +14,8 @@ const DECISION_CARDS = [
 ];
 
 const WhatThisIsForSection = () => {
+  const applicationUrl = useGrantApplicationUrl('rapid-grants');
+
   return (
     <section className="section section-body rapid-grants-what-section">
       <div className="w-full flex flex-col gap-6">
@@ -24,7 +26,7 @@ const WhatThisIsForSection = () => {
           <P>
             If in doubt,{' '}
             <a
-              href={RAPID_GRANT_APPLICATION_URL}
+              href={applicationUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-bluedot-navy underline underline-offset-4"


### PR DESCRIPTION
## Summary

Apply CTAs across the program detail pages (`/programs/{rapid-grants,career-transition-grant,advising,incubator-week}`) now read their destination URL from the `Application form` field on the Programs Airtable table, instead of the hardcoded `RAPID_GRANT_APPLICATION_URL` / `INCUBATOR_WEEK_APPLICATION_URL` etc. constants. UTM + posthog session-id wrapping behaviour is unchanged.

Caught while spot-checking #2405: the Incubator Week constant in code (`web.miniextensions.com/9UQbEOQ10oTYrqpIOwVS`) and the Airtable `Application form` value (`airtable.com/...form`) had drifted apart. Source-of-truth fix: Airtable record updated to the miniextensions URL, hook now reads from Airtable so the next drift can't happen.

## What changed

1. **`apps/website/src/components/grants/useGrantApplicationUrl.ts`** — adds a `trpc.programs.getAll` lookup keyed by slug. Falls back to `GRANT_PROGRAM_SECTIONS[program].applicationUrl` if Airtable doesn't have the program (defensive — covers staging sync gaps and any program added in code before Airtable).
2. **`apps/website/src/components/rapid-grants/WhatThisIsForSection.tsx`** — replaces direct `RAPID_GRANT_APPLICATION_URL` import with the hook so it picks up Airtable.
3. **`apps/website/src/components/rapid-grants/HowItWorksSection.tsx`** — same; PROCESS_STEPS becomes `buildProcessSteps(applicationUrl)`.

`GRANT_PROGRAM_SECTIONS` constants stay in `grantPrograms.tsx` as the fallback path. Same defensive pattern used for hero copy in #2405.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (clean, `--max-warnings=0`)
- [x] `npx vitest run` — 623 passed (103 files), 1 skipped
- [ ] After merge: confirm pg-sync has propagated the Airtable Incubator Week record update (`web.miniextensions.com/9UQbEOQ10oTYrqpIOwVS`) before publishing the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)