### PR TITLE
[style] website: tidy homepage three-rung ladder

### DIFF
--- a/apps/website/src/components/homepage/CourseValueProps.tsx
+++ b/apps/website/src/components/homepage/CourseValueProps.tsx
@@ -1,14 +1,15 @@
-import {
-  H1, H4, P, Section,
-} from '@bluedot/ui';
+import { H4, P, Section } from '@bluedot/ui';
 import { PiShieldStarLight, PiShootingStarLight, PiUsersThreeLight } from 'react-icons/pi';
 
 const Header = () => (
   <div className="flex flex-col items-center gap-8 max-w-4xl mx-auto text-center">
     <div className="flex flex-col gap-5">
-      <H1 className="text-size-xl bd-md:text-size-2xl font-medium leading-tight tracking-[-1px]">
+      <h2
+        className="text-size-xl bd-md:text-size-2xl font-medium leading-[125%] text-bluedot-navy tracking-[-1px]"
+        style={{ fontFeatureSettings: '\'ss04\' on' }}
+      >
         Start making an impact today
-      </H1>
+      </h2>
       <P className="text-size-sm md:text-size-md leading-[1.55] tracking-[-0.005em] opacity-70 max-w-4xl">
         Do you want to help build an awesome, safe future with AI? Apply to one of our free courses today.
         We'll help you ensure that humanity safely navigates the transition to transformative AI.

--- a/apps/website/src/components/homepage/MergedLadder.test.tsx
+++ b/apps/website/src/components/homepage/MergedLadder.test.tsx
@@ -42,16 +42,44 @@ const mockCourses = [
   }),
 ];
 
+const mockPrograms = [
+  {
+    id: 'program-rapid',
+    name: 'Rapid Grants',
+    description: 'Fund talented people in the BlueDot community.',
+    applicationForm: null,
+    category: 'Funding',
+    slug: 'rapid-grants',
+    order: '1',
+    status: 'Active',
+  },
+  {
+    id: 'program-incubator',
+    name: 'Incubator Week',
+    description: 'Back graduates launching AI safety companies.',
+    applicationForm: null,
+    category: 'Launch',
+    slug: 'incubator-week',
+    order: '2',
+    status: 'Active',
+  },
+];
+
 describe('MergedLadder', () => {
   beforeEach(() => {
-    server.use(trpcMsw.courses.getAll.query(() => mockCourses));
+    server.use(
+      trpcMsw.courses.getAll.query(() => mockCourses),
+      trpcMsw.programs.getAll.query(() => mockPrograms),
+      trpcMsw.grants.getRapidGrantStats.query(() => ({ totalAmountUsd: 0, count: 0 })),
+      trpcMsw.grants.getCareerTransitionGrantStats.query(() => ({ totalAmountUsd: 0, count: 0 })),
+    );
   });
 
   test('renders three rungs once cohort courses load', async () => {
     const { findByText, getByText } = render(<MergedLadder />, { wrapper: TrpcProvider });
 
     expect(getByText('See where AI is going')).toBeDefined();
-    expect(getByText('Pick a specialism')).toBeDefined();
+    expect(getByText('Understand how you can help')).toBeDefined();
     expect(getByText('Start contributing')).toBeDefined();
     expect(getByText('The Future of AI')).toBeDefined();
 
@@ -63,14 +91,14 @@ describe('MergedLadder', () => {
     });
   });
 
-  test('rung 3 grant links carry homepage UTM params', async () => {
+  test('rung 3 program links carry homepage UTM params', async () => {
     const { container } = render(<MergedLadder />, { wrapper: TrpcProvider });
 
     await waitFor(() => {
-      const grantLinks = Array.from(container.querySelectorAll('a'))
+      const programLinks = Array.from(container.querySelectorAll('a'))
         .filter((a) => a.getAttribute('href')?.includes('utm_campaign=homepage-programs'));
-      expect(grantLinks.length).toBeGreaterThan(0);
-      grantLinks.forEach((a) => {
+      expect(programLinks.length).toBeGreaterThan(0);
+      programLinks.forEach((a) => {
         const href = a.getAttribute('href') ?? '';
         expect(href).toContain('utm_source=website');
         expect(href).toContain('utm_campaign=homepage-programs');

--- a/apps/website/src/components/homepage/MergedLadder.tsx
+++ b/apps/website/src/components/homepage/MergedLadder.tsx
@@ -4,8 +4,8 @@ import {
 } from '@bluedot/ui';
 import { trpc } from '../../utils/trpc';
 import { COURSE_COLORS, type CourseColorSlug } from '../../lib/courseColors';
-import { GRANT_PROGRAMS } from '../grants/grantPrograms';
-import { PageListGroup, PageListRow } from '../PageListRow';
+import { ProgramsList } from '../programs/ProgramsList';
+import { ArrowDownIcon } from '../icons';
 
 const FOAI = COURSE_COLORS['future-of-ai'];
 
@@ -30,25 +30,28 @@ type Rung = {
 
 const RUNGS: Rung[] = [
   { step: 'Step one', title: 'See where AI is going' },
-  { step: 'Step two', title: 'Pick a specialism' },
+  { step: 'Step two', title: 'Understand how you can help' },
   { step: 'Step three', title: 'Start contributing' },
 ];
 
 const RungHeader = ({ rung }: { rung: Rung }) => (
-  <div className="flex flex-col gap-3">
+  <div className="flex flex-col gap-3 text-center">
     <P className="text-size-xs font-medium tracking-[1.5px] uppercase text-bluedot-navy/60">
       {rung.step}
     </P>
-    <H3 className="text-size-lg md:text-size-xl lg:text-size-2xl leading-[1.2] tracking-[-0.5px] font-medium text-bluedot-navy">
+    <h2
+      className="text-size-xl bd-md:text-size-2xl font-medium leading-[125%] text-bluedot-navy tracking-[-1px]"
+      style={{ fontFeatureSettings: '\'ss04\' on' }}
+    >
       {rung.title}
-    </H3>
+    </h2>
   </div>
 );
 
 const FoaiRungCard = () => (
   <a
     href="/courses/future-of-ai"
-    className="relative rounded-xl border border-bluedot-navy/10 overflow-hidden group cursor-pointer block"
+    className="relative rounded-xl border border-bluedot-navy/10 overflow-hidden group cursor-pointer block w-full lg:max-w-[50%] mx-auto"
   >
     <div className="absolute inset-0 pointer-events-none" style={{ background: FOAI.gradient }} />
     <div
@@ -60,18 +63,21 @@ const FoaiRungCard = () => (
       }}
     />
     <div className="absolute inset-0 bg-black/30 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
-    <div className="relative z-10 flex flex-col lg:flex-row gap-6 lg:gap-12 p-7 md:p-10 lg:p-12 min-h-[240px] items-start lg:items-center">
-      <div className="size-14 lg:size-20 flex-shrink-0">
-        <img src="/images/courses/future-of-ai-icon.svg" alt="" className="block size-full" />
+    <div className="relative z-10 flex flex-col h-full p-6 md:p-7 min-h-[260px] md:min-h-[300px]">
+      <div className="flex-grow">
+        <div className="size-14 md:size-16">
+          <img src="/images/courses/future-of-ai-icon.svg" alt="" className="block size-full" />
+        </div>
       </div>
-      <div className="flex flex-col gap-3 flex-1">
-        <H3 className="text-size-lg lg:text-size-xl font-medium tracking-[-0.3px] text-white leading-[1.25]">
+      <div className="flex flex-col gap-3 mt-5">
+        <H3 className="text-size-lg font-[450] leading-[1.3] tracking-[-0.3px] text-white">
           The Future of AI
+          <span className="inline-block ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">→</span>
         </H3>
-        <P className="text-size-sm md:text-size-md leading-[1.55] text-white/85 max-w-[520px]">
+        <P className="text-size-sm leading-[1.55] text-white/85">
           Free, self-paced, no application. Finish in an evening with a clearer picture of frontier AI and how to help.
         </P>
-        <div className="flex flex-wrap gap-2 mt-2">
+        <div className="flex flex-wrap gap-2 mt-1">
           {['2 hours', 'Free', 'No application'].map((tag) => (
             <span
               key={tag}
@@ -81,10 +87,6 @@ const FoaiRungCard = () => (
             </span>
           ))}
         </div>
-      </div>
-      <div className="flex items-center gap-2 text-white text-size-md font-medium group-hover:translate-x-1 transition-transform duration-200 flex-shrink-0">
-        Start the course
-        <span aria-hidden="true">→</span>
       </div>
     </div>
   </a>
@@ -180,8 +182,11 @@ const MergedLadder = () => {
   } else if (featuredCohort) {
     rungTwoContent = (
       <div className="flex flex-col gap-5 lg:gap-6">
-        <div className="lg:max-w-[60%]">
+        <div className="lg:max-w-[50%] mx-auto w-full">
           <CohortCard course={featuredCohort} featured />
+        </div>
+        <div className="flex justify-center">
+          <ArrowDownIcon aria-hidden="true" className="text-bluedot-navy/40" />
         </div>
         <div className="grid grid-cols-1 bd-md:grid-cols-3 gap-4 md:gap-5">
           {otherCohorts.slice(0, 3).map((c) => (
@@ -208,18 +213,9 @@ const MergedLadder = () => {
         </div>
 
         {/* Rung 3 — Build something */}
-        <div className="flex flex-col gap-6 lg:gap-8">
+        <div className="flex flex-col gap-6 lg:gap-8 w-full max-w-[730px] mx-auto">
           <RungHeader rung={RUNGS[2]!} />
-          <PageListGroup>
-            {GRANT_PROGRAMS.map((program) => (
-              <PageListRow
-                key={program.slug}
-                href={`${program.href}?utm_source=website&utm_campaign=homepage-programs`}
-                title={program.title}
-                summary={program.goal}
-              />
-            ))}
-          </PageListGroup>
+          <ProgramsList utmCampaign="homepage-programs" />
         </div>
       </div>
     </Section>

--- a/apps/website/src/components/programs/ProgramsList.tsx
+++ b/apps/website/src/components/programs/ProgramsList.tsx
@@ -1,0 +1,56 @@
+import { ErrorSection, ProgressDots } from '@bluedot/ui';
+import { PageListGroup, PageListRow } from '../PageListRow';
+import { trpc } from '../../utils/trpc';
+import { formatAmountUsd } from '../../lib/utils';
+
+const pluralizeGrants = (count: number) => `${count} ${count === 1 ? 'grant' : 'grants'}`;
+
+type ProgramsListProps = {
+  utmCampaign?: string;
+};
+
+export const ProgramsList = ({ utmCampaign }: ProgramsListProps) => {
+  const { data: programs, isLoading, error } = trpc.programs.getAll.useQuery();
+  const { data: rapidStats } = trpc.grants.getRapidGrantStats.useQuery();
+  const { data: ctStats } = trpc.grants.getCareerTransitionGrantStats.useQuery();
+
+  // Per-slug stats overlay. Keeps the live "$50k+ across N grants" copy fresh
+  // without baking stale numbers into Airtable.
+  const getMeta = (slug: string | null): string | null => {
+    if (slug === 'rapid-grants' && rapidStats) {
+      return `${formatAmountUsd(rapidStats.totalAmountUsd)} deployed so far across ${pluralizeGrants(rapidStats.count)}.`;
+    }
+
+    if (slug === 'career-transition-grant' && ctStats) {
+      return `${formatAmountUsd(ctStats.totalAmountUsd)} awarded so far across ${pluralizeGrants(ctStats.count)}.`;
+    }
+
+    return null;
+  };
+
+  if (error) return <ErrorSection error={error} />;
+  if (isLoading) return <ProgressDots />;
+  if (!programs) return null;
+
+  const buildHref = (program: { slug: string | null; applicationForm: string | null }) => {
+    const base = program.slug ? `/programs/${program.slug}` : (program.applicationForm ?? '#');
+    if (!utmCampaign || base === '#') return base;
+    const separator = base.includes('?') ? '&' : '?';
+    return `${base}${separator}utm_source=website&utm_campaign=${utmCampaign}`;
+  };
+
+  return (
+    <PageListGroup>
+      {programs.map((program) => (
+        <PageListRow
+          key={program.id}
+          href={buildHref(program)}
+          title={program.name}
+          summary={program.description}
+          meta={getMeta(program.slug)}
+          ctaLabel="Explore program"
+        />
+      ))}
+    </PageListGroup>
+  );
+};

--- a/apps/website/src/pages/programs.tsx
+++ b/apps/website/src/pages/programs.tsx
@@ -1,35 +1,13 @@
 import {
-  Breadcrumbs, CTALinkOrButton, ErrorSection, ProgressDots,
+  Breadcrumbs, CTALinkOrButton,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import MarketingHero from '../components/MarketingHero';
 import PageNewsletter from '../components/PageNewsletter';
-import { PageListGroup, PageListRow } from '../components/PageListRow';
+import { ProgramsList } from '../components/programs/ProgramsList';
 import { ROUTES } from '../lib/routes';
-import { formatAmountUsd } from '../lib/utils';
-import { trpc } from '../utils/trpc';
-
-const pluralizeGrants = (count: number) => `${count} ${count === 1 ? 'grant' : 'grants'}`;
 
 const ProgramsPage = () => {
-  const { data: programs, isLoading, error } = trpc.programs.getAll.useQuery();
-  const { data: rapidStats } = trpc.grants.getRapidGrantStats.useQuery();
-  const { data: ctStats } = trpc.grants.getCareerTransitionGrantStats.useQuery();
-
-  // Per-slug stats overlay. Keeps the live "$50k+ across N grants" copy fresh
-  // without baking stale numbers into Airtable.
-  const getMeta = (slug: string | null): string | null => {
-    if (slug === 'rapid-grants' && rapidStats) {
-      return `${formatAmountUsd(rapidStats.totalAmountUsd)} deployed so far across ${pluralizeGrants(rapidStats.count)}.`;
-    }
-
-    if (slug === 'career-transition-grant' && ctStats) {
-      return `${formatAmountUsd(ctStats.totalAmountUsd)} awarded so far across ${pluralizeGrants(ctStats.count)}.`;
-    }
-
-    return null;
-  };
-
   return (
     <div>
       <Head>
@@ -49,22 +27,7 @@ const ProgramsPage = () => {
 
       <section className="section section-body">
         <div className="flex flex-col gap-12 lg:gap-14">
-          {error && <ErrorSection error={error} />}
-          {isLoading && <ProgressDots />}
-          {!isLoading && !error && programs && (
-            <PageListGroup>
-              {programs.map((program) => (
-                <PageListRow
-                  key={program.id}
-                  href={program.slug ? `/programs/${program.slug}` : (program.applicationForm ?? '#')}
-                  title={program.name}
-                  summary={program.description}
-                  meta={getMeta(program.slug)}
-                  ctaLabel="Explore program"
-                />
-              ))}
-            </PageListGroup>
-          )}
+          <ProgramsList />
         </div>
 
         <div className="flex justify-center pt-6 bd-md:pt-8 lg:pt-10">


### PR DESCRIPTION
# Description

Quick visual cleanup of the homepage three-rung ladder section. The middle ladder section had inconsistent typography with the rest of the page, the Future of AI card sprawled across the full width, and step 3 hard-coded its program list separately from `/programs`. This PR aligns the section heading style across the homepage, narrows and centres the orientation/featured cards, restores the AGI Strategy → deep-dives downward arrow, retitles step 2, and replaces the hard-coded grant list with the same component used by `/programs`.

The user-visible result: the ladder feels of a piece with the rest of the page, the deep-dive funnel reads more clearly (single featured card → arrow → three options), and any future change to programs in Airtable now flows to both the homepage and `/programs` automatically.

## What changed

1. **`apps/website/src/components/homepage/CourseValueProps.tsx`** — "Start making an impact today" was an `<H1>` (Inter Display, larger, tighter tracking). Swapped to a raw `<h2>` styled to match "Our community" / "Join an event near you" (`text-size-xl bd-md:text-size-2xl font-medium leading-[125%] tracking-[-1px]`, `ss04` font feature). Removes the visual "tier mismatch" with adjacent section headings.
2. **`apps/website/src/components/homepage/MergedLadder.tsx`** — Several changes in one file:
   - Each `RungHeader` now centres its step label and title (`text-center` on the wrapper) and uses the same raw-`<h2>` style as above for visual consistency with the rest of the homepage.
   - `FoaiRungCard` rebuilt to mirror the featured `CohortCard`: vertical layout, `p-6 md:p-7`, `size-14 md:size-16` icon, `text-size-lg` heading. The "Start the course →" pill is gone in favour of the same hover-only `→` the cohort cards use. Constrained to `lg:max-w-[50%] mx-auto` so it stops sprawling on desktop.
   - The featured AGI Strategy `CohortCard` in step 2 also uses `lg:max-w-[50%] mx-auto` (was `lg:max-w-[60%]`) for parity with the FoAI card above it.
   - Restored the `<ArrowDownIcon>` separator between the AGI Strategy featured card and the three deep-dive cohort cards (lost when this section was rebuilt in #2411).
   - Step 2 title: `Pick a specialism` → `Understand how you can help`.
   - Step 3 now renders `<ProgramsList />` instead of mapping `GRANT_PROGRAMS`. Constrained to `max-w-[730px] mx-auto`.
3. **`apps/website/src/components/programs/ProgramsList.tsx`** *(new)* — Extracts the `programs.getAll` + per-slug stats overlay from `pages/programs.tsx` into a reusable component. Takes an optional `utmCampaign` prop so the homepage rung 3 can tag clicks (`?utm_source=website&utm_campaign=homepage-programs`).
4. **`apps/website/src/pages/programs.tsx`** — Replaces the inline tRPC + `PageListGroup` rendering with `<ProgramsList />`. No user-visible change here; just shedding the duplication.
5. **`apps/website/src/components/homepage/MergedLadder.test.tsx`** — Updates the rung-2 heading assertion to `Understand how you can help`, mocks the three new tRPC queries `ProgramsList` depends on (`programs.getAll`, `grants.getRapidGrantStats`, `grants.getCareerTransitionGrantStats`), and renames the UTM test case to "rung 3 program links".

## Notes on `<ProgramsList>` placement

Lives at `apps/website/src/components/programs/`, not co-located with the homepage components. Two consumers (`/` and `/programs`) and likely more in future, so keeping it under a `programs/` folder reads cleanly. No `index.ts` barrel — only one export so far.

## Issue

N/A — visual consistency cleanup, no linked issue.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — semantic `<h2>` for section headings, `aria-hidden` on decorative arrow, alt-empty on decorative card icons (preserved from existing code).
- [x] Considered having snapshot tests / functional tests — updated the existing `MergedLadder.test.tsx` to cover the renamed heading and the tRPC-driven program rows.
- [x] Considered adding Storybook stories — declined; this is a tweak to an existing homepage section, no new reusable primitive worth a story. `<ProgramsList>` could plausibly get one later if it picks up more consumers.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8001` in the `anglilian/homepage-styles` worktree):
- ✅ `/` — eyeballed the three rungs at desktop and mobile; rung headings match "Our community" weight, FoAI + AGI cards centred at 50% width, arrow restored, step 3 programs render from API
- ✅ `/programs` — refactor regression check; renders identically to current production

Type check + lint + full test suite all pass:
\`\`\`
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 622 passed, 1 skipped (run twice for stability)
\`\`\`

## Screenshots

|            | Before                                                                                                                                                          | After                                                                                                                                                         |
| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 📱 Mobile  | <img width="390" src="https://raw.githubusercontent.com/bluedotimpact/bluedot/4d8582f651ecc46c0575d1c9b11fd8e073ae5cde/.github/pr-screenshots/homepage-styles/before-mobile.png">  | <img width="390" src="https://raw.githubusercontent.com/bluedotimpact/bluedot/4d8582f651ecc46c0575d1c9b11fd8e073ae5cde/.github/pr-screenshots/homepage-styles/after-mobile.png">  |
| 🖥️ Desktop | <img width="1280" src="https://raw.githubusercontent.com/bluedotimpact/bluedot/4d8582f651ecc46c0575d1c9b11fd8e073ae5cde/.github/pr-screenshots/homepage-styles/before-desktop.png"> | <img width="1280" src="https://raw.githubusercontent.com/bluedotimpact/bluedot/4d8582f651ecc46c0575d1c9b11fd8e073ae5cde/.github/pr-screenshots/homepage-styles/after-desktop.png"> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)