### PR TITLE
Scale CTALinkOrButton chevron with size prop

### DIFF
--- a/libraries/ui/src/CTALinkOrButton.stories.tsx
+++ b/libraries/ui/src/CTALinkOrButton.stories.tsx
@@ -177,6 +177,15 @@ export const SmallWithChevron: Story = {
   },
 };
 
+export const LargeWithChevron: Story = {
+  args: {
+    children: 'Large With Chevron',
+    variant: 'primary',
+    size: 'large',
+    withChevron: true,
+  },
+};
+
 export const DisabledButton: Story = {
   args: {
     children: 'Disabled Button',

--- a/libraries/ui/src/CTALinkOrButton.test.tsx
+++ b/libraries/ui/src/CTALinkOrButton.test.tsx
@@ -124,6 +124,15 @@ describe('CTALinkOrButton', () => {
     expect(button.className).includes('font-medium');
   });
 
+  test('chevron scales with size', () => {
+    const { rerender } = render(<CTALinkOrButton size="small" withChevron>Click me</CTALinkOrButton>);
+    expect(document.querySelector('.cta-button__chevron-icon')?.className).includes('size-2');
+    rerender(<CTALinkOrButton size="medium" withChevron>Click me</CTALinkOrButton>);
+    expect(document.querySelector('.cta-button__chevron-icon')?.className).includes('size-2');
+    rerender(<CTALinkOrButton size="large" withChevron>Click me</CTALinkOrButton>);
+    expect(document.querySelector('.cta-button__chevron-icon')?.className).includes('size-3');
+  });
+
   // Regression test for the tailwind-merge bug Greptile flagged on the PR that
   // introduced `size="large"`: callers passing a `text-{color}` className were
   // silently dropping `text-size-sm` from the size config because `text-size-*`

--- a/libraries/ui/src/CTALinkOrButton.tsx
+++ b/libraries/ui/src/CTALinkOrButton.tsx
@@ -40,6 +40,7 @@ export const CTALinkOrButton: React.FC<CTALinkOrButtonProps> = ({
   children,
   ...rest
 }) => {
+  const chevronClassName = cn('cta-button__chevron-icon', size === 'large' ? 'size-3' : 'size-2');
   return (
     <ClickTarget
       className={cn(
@@ -53,13 +54,13 @@ export const CTALinkOrButton: React.FC<CTALinkOrButtonProps> = ({
     >
       {withBackChevron && (
         <span className="cta-button__chevron mr-3">
-          <FaChevronLeft className="cta-button__chevron-icon size-2" />
+          <FaChevronLeft className={chevronClassName} />
         </span>
       )}
       {children}
       {withChevron && (
         <span className="cta-button__chevron ml-3">
-          <FaChevronRight className="cta-button__chevron-icon size-2" />
+          <FaChevronRight className={chevronClassName} />
         </span>
       )}
     </ClickTarget>


### PR DESCRIPTION
# Description

The chevron rendered by `withChevron` / `withBackChevron` was hardcoded to `size-2` (8px), which looks fine on the default `medium` CTA but too small next to a `size="large"` hero CTA.

(Noticed while reviewing #2417)

## Issue

N/A

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories