### PR TITLE
[feat] db: add linkPreviewImage column to job_posting

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -761,6 +761,10 @@ export const jobPostingTable = pgAirtable('job_posting', {
       pgColumn: text(),
       airtableId: 'fldSJh6VeETvtPuDD',
     },
+    linkPreviewImage: {
+      pgColumn: text(),
+      airtableId: 'fldXua1PI4iXLKCKm',
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

- Adds `linkPreviewImage: text()` to `jobPostingTable` (`libraries/db/src/schema.ts:728`), mapped to Airtable field `[*] Image` (`fldXua1PI4iXLKCKm`).
- That Airtable field is a formula that outputs a permanent miniextensions-hosted URL for whatever attachment is in the `Link preview image` field. Same pattern as `imageAttachmentUrls` on `teamMemberTable` (`schema.ts:1480`).
- Schema-first PR. Once merged, pg-sync will materialise the column in staging and prod automatically. A follow-up PR will read `job.linkPreviewImage` in `apps/website/src/pages/join-us/[slug].tsx` and use it as the og:image source.

## Why this column

Today every role page falls back to BlueDot's generic logo link-preview unless someone hand-commits a `public/images/jobs/link-preview/<slug>.png`. Only `biosecurity.png` exists. Wiring this through Airtable lets ops upload a per-role share image without a code change.

## Test plan

- [x] `npm test` in `libraries/db` (4 files, 22 tests pass)
- [x] `npm run lint` in `libraries/db`
- [ ] Reviewer: confirm field name + Airtable id are correct (visible in [the field URL](https://airtable.com/app63L1YChHfS6RJF/tblGv8yisIfJMjT6K/viwk9RrUJNeeOjq1F/fldXua1PI4iXLKCKm))
- [ ] After merge: confirm pg-sync-service auto-backfills `link_preview_image` on next sync (per [reference_pg_sync_auto_backfill](https://github.com/bluedotimpact/bluedot)) before opening the consumer PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)