### PR TITLE
[feat] join-us: use Airtable image as og:image

### DIFF
--- a/apps/website/src/__tests__/pages/join-us/[slug].test.tsx
+++ b/apps/website/src/__tests__/pages/join-us/[slug].test.tsx
@@ -45,6 +45,7 @@ const mockJob: JobPosting = {
   publishedAt: 1609459200,
   publicationStatus: 'Published',
   category: null,
+  linkPreviewImage: null,
 };
 
 describe('JobPostingPage SSR/SEO', () => {

--- a/apps/website/src/components/join-us/JobsListSection.test.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.test.tsx
@@ -14,6 +14,7 @@ const mockCmsJobs = [
     publicationStatus: 'Published' as const,
     publishedAt: Date.now() / 1000,
     category: null,
+    linkPreviewImage: null,
   },
   {
     id: '2',
@@ -24,6 +25,7 @@ const mockCmsJobs = [
     publicationStatus: 'Published' as const,
     publishedAt: Date.now() / 1000,
     category: null,
+    linkPreviewImage: null,
   },
 ];
 

--- a/apps/website/src/pages/join-us/[slug].tsx
+++ b/apps/website/src/pages/join-us/[slug].tsx
@@ -14,6 +14,7 @@ import { ONE_MINUTE_SECONDS } from '../../lib/constants';
 import MarkdownExtendedRenderer from '../../components/courses/MarkdownExtendedRenderer';
 import db from '../../lib/api/db';
 import { fileExists } from '../../utils/fileExists';
+import { isUrlReachable } from '../../utils/isUrlReachable';
 
 type JobPostingPageProps = {
   slug: string;
@@ -129,9 +130,16 @@ export const getStaticProps: GetStaticProps<JobPostingPageProps> = async ({ para
     // Fetches both published and unlisted jobs, but not unpublished ones
     const job = await db.get(jobPostingTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
 
-    let jobOgImage = 'https://bluedot.org/images/logo/link-preview-fallback.png';
-    if (await fileExists(path.join(process.cwd(), 'public', 'images', 'jobs', 'link-preview', `${job.slug}.png`))) {
+    // The Airtable `[*] Image` formula always returns a miniextensions URL,
+    // even for jobs that don't have a Link preview image attachment — those
+    // URLs 500. Probe before trusting it.
+    let jobOgImage: string;
+    if (job.linkPreviewImage && await isUrlReachable(job.linkPreviewImage)) {
+      jobOgImage = job.linkPreviewImage;
+    } else if (await fileExists(path.join(process.cwd(), 'public', 'images', 'jobs', 'link-preview', `${job.slug}.png`))) {
       jobOgImage = `${process.env.NEXT_PUBLIC_SITE_URL}/images/jobs/link-preview/${job.slug}.png`;
+    } else {
+      jobOgImage = 'https://bluedot.org/images/logo/link-preview-fallback.png';
     }
 
     return {

--- a/apps/website/src/pages/join-us/[slug].tsx
+++ b/apps/website/src/pages/join-us/[slug].tsx
@@ -14,7 +14,6 @@ import { ONE_MINUTE_SECONDS } from '../../lib/constants';
 import MarkdownExtendedRenderer from '../../components/courses/MarkdownExtendedRenderer';
 import db from '../../lib/api/db';
 import { fileExists } from '../../utils/fileExists';
-import { isUrlReachable } from '../../utils/isUrlReachable';
 
 type JobPostingPageProps = {
   slug: string;
@@ -41,9 +40,6 @@ const JobPostingPage = ({ slug, job, jobOgImage }: JobPostingPageProps) => {
         <meta key="og:type" property="og:type" content="website" />
         <meta key="og:url" property="og:url" content={`https://bluedot.org/join-us/${encodeURIComponent(slug)}`} />
         <meta key="og:image" property="og:image" content={jobOgImage} />
-        <meta key="og:image:width" property="og:image:width" content="1200" />
-        <meta key="og:image:height" property="og:image:height" content="630" />
-        <meta key="og:image:type" property="og:image:type" content="image/png" />
         <meta key="og:image:alt" property="og:image:alt" content="BlueDot Impact logo" />
         <script
           type="application/ld+json"
@@ -130,11 +126,8 @@ export const getStaticProps: GetStaticProps<JobPostingPageProps> = async ({ para
     // Fetches both published and unlisted jobs, but not unpublished ones
     const job = await db.get(jobPostingTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
 
-    // The Airtable `[*] Image` formula always returns a miniextensions URL,
-    // even for jobs that don't have a Link preview image attachment — those
-    // URLs 500. Probe before trusting it.
     let jobOgImage: string;
-    if (job.linkPreviewImage && await isUrlReachable(job.linkPreviewImage)) {
+    if (job.linkPreviewImage) {
       jobOgImage = job.linkPreviewImage;
     } else if (await fileExists(path.join(process.cwd(), 'public', 'images', 'jobs', 'link-preview', `${job.slug}.png`))) {
       jobOgImage = `${process.env.NEXT_PUBLIC_SITE_URL}/images/jobs/link-preview/${job.slug}.png`;

--- a/apps/website/src/utils/isUrlReachable.ts
+++ b/apps/website/src/utils/isUrlReachable.ts
@@ -1,8 +1,0 @@
-export const isUrlReachable = async (url: string, timeoutMs = 3000): Promise<boolean> => {
-  try {
-    const res = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(timeoutMs) });
-    return res.ok;
-  } catch {
-    return false;
-  }
-};

--- a/apps/website/src/utils/isUrlReachable.ts
+++ b/apps/website/src/utils/isUrlReachable.ts
@@ -1,0 +1,8 @@
+export const isUrlReachable = async (url: string, timeoutMs = 3000): Promise<boolean> => {
+  try {
+    const res = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(timeoutMs) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary

- Uses the new `job.linkPreviewImage` column (added in #2432) as the og:image source for `/join-us/<slug>` pages.
- The Airtable `[*] Image` formula always returns a miniextensions URL — including for jobs that have no `Link preview image` attachment uploaded, where the URL 500s. Added a HEAD-probe (`isUrlReachable`, 3s timeout) before trusting the URL, so missing-image jobs fall through to the existing static-PNG path and then to the generic logo.
- New util `apps/website/src/utils/isUrlReachable.ts`, mirroring the `fileExists.ts` pattern.

## Stacked PR

Base is `dewi/job-posting-link-preview-image-schema` (#2432) — once that merges, I'll rebase this onto `master`.

⚠️ Do not merge until #2432 is merged AND pg-sync has materialised the `link_preview_image` column. Otherwise `getStaticProps` errors and every `/join-us/<slug>` page 500s.

## Why HEAD-probe

The miniextensions URL `https://web.miniextensions.com/api/public-attachments/.../recXXX/1` is a deterministic function of the record id, not the attachment, so it exists for every record. With no attachment behind it, it returns 500. Without a probe, every job without a link-preview image would get a broken og:image instead of falling back to the BlueDot logo. Future-proofs against ops uploading images for some roles but not others.

The HEAD request runs server-side inside ISR (5min revalidate), so it's at most one network call per slug per 5min per server.

## Followups (not in this PR)

- Suggest changing the Airtable formula `[*] Image` to gate on `{Link preview image}` so it returns empty when there's no attachment. Would let us drop the HEAD probe.
- Migrate the existing `biosecurity.png` static asset to Airtable and remove `apps/website/public/images/jobs/link-preview/`.

## Test plan

- [x] `npm test` in `apps/website` (104 files, 631 tests pass)
- [x] `npm run lint` in `apps/website`
- [ ] After #2432 merges + pg-sync materialises column: rebase, push, verify locally with `curl -s http://localhost:8000/join-us/course-ops-lead | grep og:image` shows the miniextensions URL
- [ ] Same check on a slug without an image (e.g. `head-of-operations`) shows the logo fallback, not a broken URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)