### PR TITLE
[fix] join-us: proxy og:image through bluedot.org for social scrapers

### DIFF
--- a/apps/website/src/pages/api/og-image/[slug].ts
+++ b/apps/website/src/pages/api/og-image/[slug].ts
@@ -3,6 +3,8 @@ import { jobPostingTable } from '@bluedot/db';
 import db from '../../../lib/api/db';
 
 const FALLBACK_PATH = '/images/logo/link-preview-fallback.png';
+const ALLOWED_UPSTREAM_HOSTNAMES = new Set(['web.miniextensions.com']);
+const MAX_BYTES = 10 * 1024 * 1024;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const slug = typeof req.query.slug === 'string' ? req.query.slug : '';
@@ -24,19 +26,51 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
+  // Constrain the upstream URL to a known image host. Without this, anyone
+  // with Airtable write access could redirect this server to fetch arbitrary
+  // (e.g. internal) URLs.
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(imageUrl);
+  } catch {
+    res.redirect(302, FALLBACK_PATH);
+    return;
+  }
+
+  if (!ALLOWED_UPSTREAM_HOSTNAMES.has(parsedUrl.hostname)) {
+    res.redirect(302, FALLBACK_PATH);
+    return;
+  }
+
   // Proxy the image bytes through our origin so social scrapers (LinkedIn,
   // Facebook, Twitter) that miniextensions blocks by User-Agent can fetch it.
   try {
-    const upstream = await fetch(imageUrl, { signal: AbortSignal.timeout(10_000) });
+    const upstream = await fetch(parsedUrl, { signal: AbortSignal.timeout(10_000) });
     if (!upstream.ok || !upstream.body) {
       res.redirect(302, FALLBACK_PATH);
       return;
     }
 
     const contentType = upstream.headers.get('content-type') ?? 'image/png';
+    if (!contentType.startsWith('image/')) {
+      res.redirect(302, FALLBACK_PATH);
+      return;
+    }
+
+    const contentLength = Number(upstream.headers.get('content-length'));
+    if (Number.isFinite(contentLength) && contentLength > MAX_BYTES) {
+      res.redirect(302, FALLBACK_PATH);
+      return;
+    }
+
+    const buffer = Buffer.from(await upstream.arrayBuffer());
+    if (buffer.byteLength > MAX_BYTES) {
+      res.redirect(302, FALLBACK_PATH);
+      return;
+    }
+
     res.setHeader('Content-Type', contentType);
     res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=86400');
-    const buffer = Buffer.from(await upstream.arrayBuffer());
     res.status(200).send(buffer);
   } catch {
     res.redirect(302, FALLBACK_PATH);

--- a/apps/website/src/pages/api/og-image/[slug].ts
+++ b/apps/website/src/pages/api/og-image/[slug].ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { jobPostingTable } from '@bluedot/db';
+import db from '../../../lib/api/db';
+
+const FALLBACK_PATH = '/images/logo/link-preview-fallback.png';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const slug = typeof req.query.slug === 'string' ? req.query.slug : '';
+  if (!slug) {
+    res.redirect(302, FALLBACK_PATH);
+    return;
+  }
+
+  let imageUrl: string | null = null;
+  try {
+    const job = await db.get(jobPostingTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
+    imageUrl = job.linkPreviewImage;
+  } catch {
+    // Job not found or db error — fall through to fallback
+  }
+
+  if (!imageUrl) {
+    res.redirect(302, FALLBACK_PATH);
+    return;
+  }
+
+  // Proxy the image bytes through our origin so social scrapers (LinkedIn,
+  // Facebook, Twitter) that miniextensions blocks by User-Agent can fetch it.
+  try {
+    const upstream = await fetch(imageUrl, { signal: AbortSignal.timeout(10_000) });
+    if (!upstream.ok || !upstream.body) {
+      res.redirect(302, FALLBACK_PATH);
+      return;
+    }
+
+    const contentType = upstream.headers.get('content-type') ?? 'image/png';
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=86400');
+    const buffer = Buffer.from(await upstream.arrayBuffer());
+    res.status(200).send(buffer);
+  } catch {
+    res.redirect(302, FALLBACK_PATH);
+  }
+}

--- a/apps/website/src/pages/join-us/[slug].tsx
+++ b/apps/website/src/pages/join-us/[slug].tsx
@@ -126,9 +126,13 @@ export const getStaticProps: GetStaticProps<JobPostingPageProps> = async ({ para
     // Fetches both published and unlisted jobs, but not unpublished ones
     const job = await db.get(jobPostingTable, { slug, publicationStatus: { '!=': 'Unpublished' } });
 
+    // Route the og:image through our /api/og-image proxy when an Airtable
+    // image is set. miniextensions returns 403 to LinkedIn/Facebook/Twitter
+    // user-agents, so scrapers can't fetch the URL directly — bouncing it
+    // through bluedot.org sidesteps that.
     let jobOgImage: string;
     if (job.linkPreviewImage) {
-      jobOgImage = job.linkPreviewImage;
+      jobOgImage = `${process.env.NEXT_PUBLIC_SITE_URL}/api/og-image/${encodeURIComponent(slug)}`;
     } else if (await fileExists(path.join(process.cwd(), 'public', 'images', 'jobs', 'link-preview', `${job.slug}.png`))) {
       jobOgImage = `${process.env.NEXT_PUBLIC_SITE_URL}/images/jobs/link-preview/${job.slug}.png`;
     } else {


### PR DESCRIPTION
## Summary

LinkedIn Post Inspector reported "No image found" on `bluedot.org/join-us/course-ops-lead` despite the og:image meta tag being correct. Root cause: miniextensions returns **HTTP 403 to LinkedInBot, facebookexternalhit, and Twitterbot** User-Agents (Cloudflare anti-bot). Slack and WhatsApp are allowed; LinkedIn/Facebook/Twitter are not.

| UA | miniextensions returns |
|---|---|
| Browsers / curl / Slack / WhatsApp | 200 ✅ |
| LinkedInBot / facebookexternalhit / Twitterbot | **403 ❌** |

## Fix

Add `/api/og-image/[slug]` proxy. og:image meta points at our domain; we fetch from miniextensions server-side (allowed for our origin's UA) and stream the bytes back.

- New: `apps/website/src/pages/api/og-image/[slug].ts` — looks up `job.linkPreviewImage` from Postgres, proxies the upstream image with `image/png` + cache headers, falls back to `/images/logo/link-preview-fallback.png` on miss/error.
- Edit: `apps/website/src/pages/join-us/[slug].tsx` — when `job.linkPreviewImage` exists, og:image points at `${SITE_URL}/api/og-image/${slug}` instead of the raw miniextensions URL.
- The static-PNG and generic-logo fallback paths are unchanged (both already on bluedot.org domain — scrapers reach them fine).

## Verified locally

- LinkedInBot / facebookexternalhit / Twitterbot: all get HTTP 200 + `image/png` + 578565 bytes from the proxy ✅
- `course-ops-lead` (has Airtable image) → og:image points at proxy → proxy returns the right bytes
- `head-of-operations` (no Airtable image) → og:image points directly at fallback PNG (no proxy round-trip)
- Unknown slug → proxy 302s to fallback PNG
- `npm test` (104 files / 631 tests) + `npx tsc --noEmit` + `npm run lint` all clean

## Test plan

- [ ] Reviewer: confirm the proxy URL pattern (`/api/og-image/<slug>`) is acceptable for our routing conventions
- [ ] After merge + deploy: re-run [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/inspect/https%3A%2F%2Fbluedot.org%2Fjoin-us%2Fcourse-ops-lead) — should now show the Course Ops Lead preview image
- [ ] Confirm Slack/WhatsApp previews still work (scrapers can also reach the proxy URL)

## Caching

Proxy sets `Cache-Control: public, max-age=300, s-maxage=86400`. Cloudflare/our CDN caches at the edge for a day; clients revalidate every 5 min. If ops uploads a new image to Airtable, edge caches will pick it up within 24h (matches the existing ISR cadence on the role page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)