### PR TITLE
[codex] Tighten AI governance lander headings

### DIFF
--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -71,6 +71,8 @@ export type CourseLanderContent = {
   /** Override URL for the courseInformation CTA. Defaults to `applicationUrlWithUtm`.
    *  Used by self-paced courses (e.g. Future of AI) that point at a start URL instead of an apply form. */
   courseInformationApplicationUrl?: string;
+  /** Optional smaller heading treatment for the default course-information block. */
+  courseInformationHeadingVariant?: 'default' | 'compact';
   /** Editorial prose "How the course works" — replaces the courseInformation registry block when set. Renders paragraphs with course-round unit counts interpolated from the database. */
   howTheCourseWorks?: HowTheCourseWorksSectionProps;
   /** Standalone schedule section using PageListRow rows — renders alongside howTheCourseWorks instead of inside courseInformation's box. */
@@ -322,6 +324,7 @@ const CourseLander = ({
             applicationUrl={content.courseInformationApplicationUrl ?? applicationUrlWithUtm}
             courseSlug={courseSlug}
             accentColor={COURSE_COLORS[courseSlug as CourseColorSlug]?.full ?? content.hero.accentColor}
+            headingVariant={content.courseInformationHeadingVariant}
           />
         </>
       )}

--- a/apps/website/src/components/lander/components/CourseInformationSection.tsx
+++ b/apps/website/src/components/lander/components/CourseInformationSection.tsx
@@ -5,6 +5,7 @@ import {
 } from '@bluedot/ui';
 import type { IconType } from 'react-icons';
 import { ScheduleRounds } from './ScheduleRounds';
+import { pageSectionHeadingClass } from '../../PageListRow';
 
 export type CourseDetail = {
   /** Icon component from react-icons (e.g., PiGraduationCap, PiClockClockwise) */
@@ -34,6 +35,8 @@ export type CourseInformationSectionProps = {
   courseSlug: string;
   /** Accent color for bars and "Apply now" links in the schedule section */
   accentColor?: string;
+  /** Smaller heading treatment used by editorial-style landers. */
+  headingVariant?: 'default' | 'compact';
 };
 
 const CourseInformationSection = ({
@@ -44,14 +47,21 @@ const CourseInformationSection = ({
   scheduleCtaText,
   courseSlug,
   accentColor,
+  headingVariant = 'default',
 }: CourseInformationSectionProps) => {
   return (
     <section id={id} className="w-full bg-white">
       <div className="max-w-max-width mx-auto px-5 py-12 bd-md:px-8 bd-md:py-16 lg:px-spacing-x xl:py-24 flex flex-col items-center gap-8 md:gap-10">
         {/* Section Title */}
-        <H2 className="w-full bd-md:max-w-text text-size-xl text-center font-semibold leading-[125%] text-bluedot-navy tracking-[-0.01em]">
-          {title}
-        </H2>
+        {headingVariant === 'compact' ? (
+          <h3 className={`w-full bd-md:max-w-text ${pageSectionHeadingClass}`}>
+            {title}
+          </h3>
+        ) : (
+          <H2 className="w-full bd-md:max-w-text text-size-xl text-center font-semibold leading-[125%] text-bluedot-navy tracking-[-0.01em]">
+            {title}
+          </H2>
+        )}
 
         {/* White Card Container — capped to the same 840px column as ScheduleListSection. */}
         <div className="w-full bd-md:max-w-text bg-white border border-bluedot-navy/10 rounded-xl py-8 flex flex-col items-center gap-6">

--- a/apps/website/src/components/lander/components/CourseOutcomesSection.tsx
+++ b/apps/website/src/components/lander/components/CourseOutcomesSection.tsx
@@ -4,6 +4,7 @@ import {
 import { type ReactNode } from 'react';
 import { type IconType } from 'react-icons';
 import Link from 'next/link';
+import { pageSectionHeadingClass } from '../../PageListRow';
 
 export type CourseOutcome = {
   icon: IconType;
@@ -18,6 +19,7 @@ export type CourseOutcomesSectionProps = {
   title?: string;
   outcomes: CourseOutcome[];
   accentColor?: string;
+  headingVariant?: 'default' | 'compact';
   cta?: {
     text: string;
     url: string;
@@ -29,14 +31,21 @@ const CourseOutcomesSection = ({
   title = 'What you\'ll get',
   outcomes,
   accentColor = '#1F588A',
+  headingVariant = 'default',
   cta,
 }: CourseOutcomesSectionProps) => {
   return (
     <section id={id} className="w-full bg-white">
       <div className="max-w-max-width mx-auto px-5 py-12 bd-md:px-8 bd-md:py-16 lg:px-spacing-x xl:py-24">
-        <H2 className="text-size-xl font-semibold leading-[125%] text-bluedot-navy text-center mb-12 md:mb-16 tracking-[-0.01em]">
-          {title}
-        </H2>
+        {headingVariant === 'compact' ? (
+          <h3 className={`${pageSectionHeadingClass} w-full bd-md:max-w-text bd-md:mx-auto mb-8 md:mb-10`}>
+            {title}
+          </h3>
+        ) : (
+          <H2 className="text-size-xl font-semibold leading-[125%] text-bluedot-navy text-center mb-12 md:mb-16 tracking-[-0.01em]">
+            {title}
+          </H2>
+        )}
         <div className="max-w-section-wide mx-auto">
           <div className="flex flex-wrap justify-center gap-6 lg:gap-8">
             {outcomes.map((outcome) => {

--- a/apps/website/src/components/lander/components/FieldBuildingSection.tsx
+++ b/apps/website/src/components/lander/components/FieldBuildingSection.tsx
@@ -1,5 +1,6 @@
 import { H2, P } from '@bluedot/ui';
 import Link from 'next/link';
+import { pageSectionHeadingClass } from '../../PageListRow';
 
 export type FieldBuildingRole = {
   title: string;
@@ -13,6 +14,7 @@ export type FieldBuildingSectionProps = {
   title: string;
   intro: React.ReactNode;
   roles: FieldBuildingRole[];
+  headingVariant?: 'default' | 'compact';
 };
 
 const FieldBuildingSection = ({
@@ -20,14 +22,21 @@ const FieldBuildingSection = ({
   title,
   intro,
   roles,
+  headingVariant = 'default',
 }: FieldBuildingSectionProps) => {
   return (
     <section id={id} className="w-full bg-white">
       <div className="max-w-max-width mx-auto px-5 bd-md:px-8 lg:px-12 xl:px-40 py-12 bd-md:py-16 xl:py-24 flex flex-col items-center gap-8 md:gap-10">
-        <div className="max-w-text text-center">
-          <H2 className="text-size-xl font-semibold leading-[125%] text-bluedot-navy tracking-[-0.01em]">
-            {title}
-          </H2>
+        <div className={headingVariant === 'compact' ? 'w-full max-w-text' : 'max-w-text text-center'}>
+          {headingVariant === 'compact' ? (
+            <h3 className={pageSectionHeadingClass}>
+              {title}
+            </h3>
+          ) : (
+            <H2 className="text-size-xl font-semibold leading-[125%] text-bluedot-navy tracking-[-0.01em]">
+              {title}
+            </H2>
+          )}
           <P className="mt-4 text-size-sm bd-md:text-size-md leading-[1.6] text-bluedot-navy/70">
             {intro}
           </P>

--- a/apps/website/src/components/lander/course-content/AiGovernanceContent.tsx
+++ b/apps/website/src/components/lander/course-content/AiGovernanceContent.tsx
@@ -42,6 +42,7 @@ export const createAiGovernanceContent = (
   },
 
   hideTestimonials: true,
+  courseInformationHeadingVariant: 'compact',
 
   whoIsThisForText: {
     id: 'personas',
@@ -131,6 +132,7 @@ export const createAiGovernanceContent = (
   courseOutcomes: {
     title: 'What you\'ll actually do',
     accentColor: AI_GOVERNANCE_COLORS.iconBackground,
+    headingVariant: 'compact',
     outcomes: [
       {
         icon: PiBookOpen,
@@ -194,6 +196,7 @@ export const createAiGovernanceContent = (
   fieldBuilding: {
     title: 'Help build the field',
     intro: 'We also hire Adjunct Experts and Facilitators (~5h/week) and Fellow-Researchers (20-30h/week) to teach.',
+    headingVariant: 'compact',
     roles: [
       {
         title: 'Adjunct Experts and Facilitators',


### PR DESCRIPTION
## Summary
- Add a compact heading option for shared course-lander sections that currently use the larger centered H2 treatment.
- Apply the compact style to the Frontier AI Governance lander for `What you'll actually do`, `How it works`, and `Help build the field`.
- Keep the governance alumni testimonials hidden for now while better quote/story content is gathered.

## Validation
- `npm exec --workspace @bluedot/website -- eslint src/components/lander/CourseLander.tsx src/components/lander/components/CourseInformationSection.tsx src/components/lander/components/CourseOutcomesSection.tsx src/components/lander/components/FieldBuildingSection.tsx src/components/lander/course-content/AiGovernanceContent.tsx --max-warnings=0`
- `npm run typecheck --workspace @bluedot/website`
- `npm run test --workspace @bluedot/website -- CourseInformationSection.test.tsx AgiStrategyLander.test.tsx` — 12 passed
- `npm run build --workspace @bluedot/website`

## Note
Local test/build startup was initially blocked because ignored `node_modules` had malformed esbuild optional binary installs: the expected `bin/esbuild` files were missing and duplicate files existed as `esbuild 2`, `esbuild 3`, etc. Restoring the expected local binary filenames fixed the environment issue; no tracked files changed.