### PR TITLE
'Congratulations' UI tweaks

### DIFF
--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -131,7 +131,7 @@ export default function CourseCompletionSection({
 
     return (
       <div className={cn('flex flex-col gap-8', className)}>
-        <div className="flex flex-col items-center gap-8 pt-24 pb-4 text-center max-w-[640px] mx-auto">
+        <div className="flex flex-col items-center gap-8 py-4 text-center max-w-[640px] mx-auto">
           <SocialProof accentColor={accentColor} />
           <div className="flex flex-col gap-3">
             {/* eslint-disable-next-line @bluedot/custom/no-arbitrary-text-size */}

--- a/apps/website/src/components/courses/CourseShell.tsx
+++ b/apps/website/src/components/courses/CourseShell.tsx
@@ -28,20 +28,16 @@ type MobileHeaderProps = {
   courseSlug: string;
   courseProgressData?: CourseProgress;
   onCourseMenuClick: () => void;
-} & MobileNavigation;
+  mobileNavigation?: MobileNavigation;
+};
 
 const MobileHeader: React.FC<MobileHeaderProps> = ({
   className,
   courseTitle,
   courseSlug,
-  prevUnit,
-  nextUnit,
-  isFirstChunk,
-  isLastChunk,
-  onPrevClick,
-  onNextClick,
   onCourseMenuClick,
   courseProgressData,
+  mobileNavigation,
 }) => (
   <div
     className={cn(
@@ -68,32 +64,34 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({
         </div>
       </button>
       {/* Right side - navigation arrows */}
-      <div className="mobile-unit-header__navigation flex h-8 w-16 flex-row items-center p-0">
-        <button
-          type="button"
-          className="mobile-unit-header__prev-unit-cta focus:ring-color-primary flex size-8 flex-col items-center justify-center gap-2 rounded-full p-0 focus:ring-2 focus:ring-offset-2 focus:outline-none"
-          disabled={isFirstChunk && !prevUnit}
-          onClick={onPrevClick}
-          aria-label={isFirstChunk && prevUnit ? 'Previous unit' : 'Previous section'}
-        >
-          <ArrowRightIcon
-            aria-hidden="true"
-            className={cn('rotate-180', isFirstChunk && !prevUnit ? 'text-[#6A6F7A]' : 'text-bluedot-darker')}
-          />
-        </button>
-        <button
-          type="button"
-          className="mobile-unit-header__next-unit-cta focus:ring-color-primary flex size-8 flex-col items-center justify-center gap-2 rounded-full p-0 focus:ring-2 focus:ring-offset-2 focus:outline-none"
-          disabled={isLastChunk && !nextUnit}
-          onClick={onNextClick}
-          aria-label={isLastChunk && nextUnit ? 'Next unit' : 'Next section'}
-        >
-          <ArrowRightIcon
-            aria-hidden="true"
-            className={isLastChunk && !nextUnit ? 'text-[#6A6F7A]' : 'text-bluedot-darker'}
-          />
-        </button>
-      </div>
+      {mobileNavigation && (
+        <div className="mobile-unit-header__navigation flex h-8 w-16 flex-row items-center p-0">
+          <button
+            type="button"
+            className="mobile-unit-header__prev-unit-cta focus:ring-color-primary flex size-8 flex-col items-center justify-center gap-2 rounded-full p-0 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+            disabled={mobileNavigation.isFirstChunk && !mobileNavigation.prevUnit}
+            onClick={mobileNavigation.onPrevClick}
+            aria-label={mobileNavigation.isFirstChunk && mobileNavigation.prevUnit ? 'Previous unit' : 'Previous section'}
+          >
+            <ArrowRightIcon
+              aria-hidden="true"
+              className={cn('rotate-180', mobileNavigation.isFirstChunk && !mobileNavigation.prevUnit ? 'text-[#6A6F7A]' : 'text-bluedot-darker')}
+            />
+          </button>
+          <button
+            type="button"
+            className="mobile-unit-header__next-unit-cta focus:ring-color-primary flex size-8 flex-col items-center justify-center gap-2 rounded-full p-0 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+            disabled={mobileNavigation.isLastChunk && !mobileNavigation.nextUnit}
+            onClick={mobileNavigation.onNextClick}
+            aria-label={mobileNavigation.isLastChunk && mobileNavigation.nextUnit ? 'Next unit' : 'Next section'}
+          >
+            <ArrowRightIcon
+              aria-hidden="true"
+              className={mobileNavigation.isLastChunk && !mobileNavigation.nextUnit ? 'text-[#6A6F7A]' : 'text-bluedot-darker'}
+            />
+          </button>
+        </div>
+      )}
       {courseProgressData && courseProgressData.courseProgress.totalCount > 0 && (
         <div className="absolute inset-x-0 bottom-0 h-1">
           <div
@@ -217,16 +215,14 @@ const CourseShell: React.FC<CourseShellProps> = ({
 
   return (
     <div>
-      {mobileNavigation && (
-        <MobileHeader
-          className="unit__mobile-header sticky top-(--nav-height-mobile) z-10 md:hidden"
-          courseTitle={courseTitle}
-          courseSlug={courseSlug}
-          courseProgressData={courseProgressData}
-          onCourseMenuClick={() => setIsMobileCourseMenuOpen(true)}
-          {...mobileNavigation}
-        />
-      )}
+      <MobileHeader
+        className="unit__mobile-header sticky top-(--nav-height-mobile) z-10 md:hidden"
+        courseTitle={courseTitle}
+        courseSlug={courseSlug}
+        courseProgressData={courseProgressData}
+        onCourseMenuClick={() => setIsMobileCourseMenuOpen(true)}
+        mobileNavigation={mobileNavigation}
+      />
 
       <div className="md:flex">
         {!isSidebarHidden && (
@@ -295,23 +291,21 @@ const CourseShell: React.FC<CourseShellProps> = ({
         </div>
       </div>
 
-      {mobileNavigation && (
-        <MobileCourseModal
-          isOpen={isMobileCourseMenuOpen}
-          setIsOpen={setIsMobileCourseMenuOpen}
-          certificateData={certificateData}
-          courseTitle={courseTitle}
-          courseSlug={courseSlug}
-          units={units}
-          currentUnitNumber={currentUnitNumber}
-          currentChunkIndex={currentChunkIndex}
-          onChunkSelect={onChunkSelect}
-          onUnitSelect={onUnitSelect}
-          unitChunks={allUnitChunks}
-          applyCTAProps={applyCTAProps}
-          courseProgressData={courseProgressData}
-        />
-      )}
+      <MobileCourseModal
+        isOpen={isMobileCourseMenuOpen}
+        setIsOpen={setIsMobileCourseMenuOpen}
+        certificateData={certificateData}
+        courseTitle={courseTitle}
+        courseSlug={courseSlug}
+        units={units}
+        currentUnitNumber={currentUnitNumber}
+        currentChunkIndex={currentChunkIndex}
+        onChunkSelect={onChunkSelect}
+        onUnitSelect={onUnitSelect}
+        unitChunks={allUnitChunks}
+        applyCTAProps={applyCTAProps}
+        courseProgressData={courseProgressData}
+      />
     </div>
   );
 };

--- a/apps/website/src/components/courses/CourseShell.tsx
+++ b/apps/website/src/components/courses/CourseShell.tsx
@@ -114,7 +114,6 @@ export type CourseShellProps = {
   currentUnitNumber?: number;
   currentChunkIndex?: number;
   onChunkSelect?: (index: number) => void;
-  onUnitSelect?: (unitPath: string) => void;
   applyCTAProps?: ApplyCTAProps;
   courseProgressData?: CourseProgress;
   breadcrumb: ReactNode;
@@ -133,7 +132,6 @@ const CourseShell: React.FC<CourseShellProps> = ({
   currentUnitNumber = 0,
   currentChunkIndex = 0,
   onChunkSelect = () => {},
-  onUnitSelect,
   applyCTAProps,
   courseProgressData,
   breadcrumb,
@@ -301,7 +299,7 @@ const CourseShell: React.FC<CourseShellProps> = ({
         currentUnitNumber={currentUnitNumber}
         currentChunkIndex={currentChunkIndex}
         onChunkSelect={onChunkSelect}
-        onUnitSelect={onUnitSelect}
+        onUnitSelect={(unitPath) => router.push(unitPath)}
         unitChunks={allUnitChunks}
         applyCTAProps={applyCTAProps}
         courseProgressData={courseProgressData}

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -133,7 +133,6 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
       currentUnitNumber={parseInt(unitNumber, 10)}
       currentChunkIndex={chunkIndex}
       onChunkSelect={handleChunkSelect}
-      onUnitSelect={(unitPath) => router.push(unitPath)}
       applyCTAProps={applyCTAProps}
       courseProgressData={courseProgressData}
       onNavigate={setNavigationAnnouncement}


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

1. Reduce to padding for enrolment CTA
2. Fix missing mobile course modal navbar on congratulations page


## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="375" height="668" alt="image" src="https://github.com/user-attachments/assets/d04ded4f-5c09-4734-8656-dff96a3f9e7f" /> | <img width="373" height="668" alt="image" src="https://github.com/user-attachments/assets/24948587-6234-4132-95e2-70c713641294" /> |
| 🖥️ | <img width="1192" height="786" alt="image" src="https://github.com/user-attachments/assets/29f86797-e672-4070-bf8a-12f7ba27625a" /> | <img width="1190" height="813" alt="image" src="https://github.com/user-attachments/assets/4cd27911-6aa5-42f3-9a69-558a4b47a331" /> |
