### PR TITLE
[chore] db: drop deprecated unused fields (PR 2/2)

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -144,16 +144,6 @@ export const courseTable = pgAirtable('course', {
       airtableId: 'fldCX0bk6SQuXZaI7',
       deprecated: true,
     },
-    level: {
-      pgColumn: text(),
-      airtableId: 'fldkL7aWITGCPqzxc',
-      deprecated: true,
-    },
-    durationDescription: {
-      pgColumn: text(),
-      airtableId: 'fldHxekJ6BioQMF3e',
-      deprecated: true,
-    },
   },
 });
 
@@ -1120,21 +1110,6 @@ export const unitTable = pgAirtable('unit', {
     coursePath: {
       pgColumn: text(),
       airtableId: 'fldlCrg7Nv1TPTorZ',
-      deprecated: true,
-    },
-    learningOutcomes: {
-      pgColumn: text(),
-      airtableId: 'fld9vAMgn0Fm7x6Xf',
-      deprecated: true,
-    },
-    unitPodcastUrl: {
-      pgColumn: text(),
-      airtableId: 'fldwByN7lbmcjc3Fj',
-      deprecated: true,
-    },
-    autoNumberId: {
-      pgColumn: numeric({ mode: 'number' }),
-      airtableId: 'fld1rl39p5fSOiFya',
       deprecated: true,
     },
   },


### PR DESCRIPTION
# Description

Drop `courseTable.level`, `courseTable.durationDescription`, `unitTable.learningOutcomes`, `unitTable.unitPodcastUrl`, `unitTable.autoNumberId` from Postgres now that #2440 is deployed to production.

PR 2 of 2 per DEVELOPMENT_HANDBOOK.md. Do not merge until #2440 is released to production.

## Issue

Fixes #2439

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories