### PR TITLE
Add discussion doc to group table

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -203,6 +203,7 @@ export const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
   startTimeUtc: Math.floor(Date.now() / 1000), // Unix timestamp in seconds
   whoCanSwitchIntoThisGroup: [],
   facilitator: null,
+  discussionDoc: null,
   groupNumber: null,
   slackChannelId: null,
   ...overrides,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -312,6 +312,10 @@ export const groupTable = pgAirtable('group', {
       pgColumn: text(),
       airtableId: 'fldDE9zdLglu33Z1V',
     },
+    discussionDoc: {
+      pgColumn: text(),
+      airtableId: 'fldtERcBHJfq8UeGX',
+    },
   },
 });
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Useful for #2400, because the `activityDoc` field on `groupDiscussionTable` is just a lookup of this field

## Issue

#2400

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->
