### PR TITLE
Remove 'Apply by' CTA from sidebar

### DIFF
--- a/apps/website/src/__tests__/pages/courses/congratulations.test.tsx
+++ b/apps/website/src/__tests__/pages/courses/congratulations.test.tsx
@@ -52,10 +52,7 @@ const DEFAULT_PROPS = {
 describe('CongratulationsPage', () => {
   beforeEach(() => {
     mockReplace.mockClear();
-    server.use(
-      trpcMsw.courseRounds.getApplyCTAProps.query(() => null),
-      trpcMsw.groupDiscussions.getByCourseSlug.query(() => null),
-    );
+    server.use(trpcMsw.groupDiscussions.getByCourseSlug.query(() => null));
   });
 
   test('redirects to first unit when user is ineligible (action-plan-pending)', async () => {

--- a/apps/website/src/components/courses/CourseShell.tsx
+++ b/apps/website/src/components/courses/CourseShell.tsx
@@ -234,7 +234,6 @@ const CourseShell: React.FC<CourseShellProps> = ({
             currentChunkIndex={currentChunkIndex}
             onChunkSelect={onChunkSelect}
             unitChunks={allUnitChunks}
-            applyCTAProps={applyCTAProps}
             courseProgressData={courseProgressData}
           />
         )}

--- a/apps/website/src/components/courses/CourseShell.tsx
+++ b/apps/website/src/components/courses/CourseShell.tsx
@@ -5,13 +5,12 @@ import type React from 'react';
 import { type ReactNode, useEffect, useState } from 'react';
 import { FaBars, FaChevronDown, FaChevronRight } from 'react-icons/fa6';
 import { ROUTES } from '../../lib/routes';
-import type { BasicChunk } from '../../server/routers/courses';
 import type { CertificateData } from '../../server/routers/certificates';
-import type { CourseProgress } from '../../server/routers/courses';
+import type { BasicChunk, CourseProgress } from '../../server/routers/courses';
 import { ArrowRightIcon } from '../icons';
 import { CourseIcon } from './CourseIcon';
 import { MobileCourseModal } from './MobileCourseModal';
-import SideBar, { type ApplyCTAProps } from './SideBar';
+import SideBar from './SideBar';
 
 type MobileNavigation = {
   prevUnit?: Unit;
@@ -114,7 +113,6 @@ export type CourseShellProps = {
   currentUnitNumber?: number;
   currentChunkIndex?: number;
   onChunkSelect?: (index: number) => void;
-  applyCTAProps?: ApplyCTAProps;
   courseProgressData?: CourseProgress;
   breadcrumb: ReactNode;
   navigationControls?: ReactNode;
@@ -132,7 +130,6 @@ const CourseShell: React.FC<CourseShellProps> = ({
   currentUnitNumber = 0,
   currentChunkIndex = 0,
   onChunkSelect = () => {},
-  applyCTAProps,
   courseProgressData,
   breadcrumb,
   navigationControls,
@@ -300,7 +297,6 @@ const CourseShell: React.FC<CourseShellProps> = ({
         onChunkSelect={onChunkSelect}
         onUnitSelect={(unitPath) => router.push(unitPath)}
         unitChunks={allUnitChunks}
-        applyCTAProps={applyCTAProps}
         courseProgressData={courseProgressData}
       />
     </div>

--- a/apps/website/src/components/courses/MobileCourseModal.stories.tsx
+++ b/apps/website/src/components/courses/MobileCourseModal.stories.tsx
@@ -62,14 +62,3 @@ export const LoggedInAllCompleted: Story = {
     },
   },
 };
-
-export const WithApplyCTA: Story = {
-  ...loggedInStory(),
-  args: {
-    applyCTAProps: {
-      applicationDeadline: '15 Jan',
-      applicationUrl: 'https://example.com/apply',
-      hasApplied: false,
-    },
-  },
-};

--- a/apps/website/src/components/courses/MobileCourseModal.tsx
+++ b/apps/website/src/components/courses/MobileCourseModal.tsx
@@ -1,5 +1,5 @@
 import type { Unit } from '@bluedot/db';
-import { CTALinkOrButton, Modal } from '@bluedot/ui';
+import { Modal } from '@bluedot/ui';
 import clsx from 'clsx';
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -9,7 +9,6 @@ import type { CertificateData } from '../../server/routers/certificates';
 import type { ChunkProgress, CourseProgress } from '../../server/routers/courses';
 import { ChunkIcon } from '../icons';
 import { CourseIcon } from './CourseIcon';
-import type { ApplyCTAProps } from './SideBar';
 import { SidebarCertificatePanel } from './SidebarCertificatePanel';
 
 type MobileCourseModalProps = {
@@ -24,7 +23,6 @@ type MobileCourseModalProps = {
   onChunkSelect: (index: number) => void;
   onUnitSelect?: (unitPath: string) => void;
   unitChunks: Record<string, BasicChunk[]>;
-  applyCTAProps?: ApplyCTAProps;
   courseProgressData?: CourseProgress;
 };
 
@@ -40,7 +38,6 @@ export const MobileCourseModal: React.FC<MobileCourseModalProps> = ({
   onChunkSelect,
   onUnitSelect,
   unitChunks,
-  applyCTAProps,
   courseProgressData,
 }) => {
   // Track which units are expanded (current unit starts expanded)
@@ -79,8 +76,6 @@ export const MobileCourseModal: React.FC<MobileCourseModalProps> = ({
     setIsOpen(false);
   };
 
-  const showApplyCTA = applyCTAProps && !applyCTAProps.hasApplied;
-
   return (
     <Modal
       isOpen={isOpen}
@@ -93,16 +88,6 @@ export const MobileCourseModal: React.FC<MobileCourseModalProps> = ({
               {courseTitle}
             </h3>
           </div>
-          {showApplyCTA && (
-            <CTALinkOrButton
-              url={applyCTAProps.applicationUrl}
-              variant="outline-black"
-              target="_blank"
-              className="px-3 py-1.5 text-size-xs"
-            >
-              {`Apply by ${applyCTAProps.applicationDeadline}`}
-            </CTALinkOrButton>
-          )}
         </div>
       )}
       bottomDrawerOnMobile

--- a/apps/website/src/components/courses/SideBar.stories.tsx
+++ b/apps/website/src/components/courses/SideBar.stories.tsx
@@ -66,13 +66,6 @@ export const LoggedInAllCompleted: Story = {
 
 export const WithApplyCTA: Story = {
   ...loggedInStory(),
-  args: {
-    applyCTAProps: {
-      applicationDeadline: '15 Jan',
-      applicationUrl: 'https://example.com/apply',
-      hasApplied: false,
-    },
-  },
 };
 
 export const OnSecondUnit: Story = {

--- a/apps/website/src/components/courses/SideBar.stories.tsx
+++ b/apps/website/src/components/courses/SideBar.stories.tsx
@@ -64,10 +64,6 @@ export const LoggedInAllCompleted: Story = {
   },
 };
 
-export const WithApplyCTA: Story = {
-  ...loggedInStory(),
-};
-
 export const OnSecondUnit: Story = {
   ...loggedInStory(),
   args: {

--- a/apps/website/src/components/courses/SideBar.test.tsx
+++ b/apps/website/src/components/courses/SideBar.test.tsx
@@ -76,38 +76,4 @@ describe('SideBar', () => {
     );
     expect(container).toMatchSnapshot();
   });
-
-  test('shows Apply CTA with deadline when upcoming round exists', () => {
-    const { getByRole } = render(
-      <SideBar
-        {...defaultProps}
-        applyCTAProps={{
-          applicationDeadline: '31 Jan',
-          applicationUrl: 'https://example.com/apply',
-          hasApplied: false,
-        }}
-      />,
-      { wrapper: TrpcProvider },
-    );
-
-    const button = getByRole('link', { name: 'Apply by 31 Jan' });
-    expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute('href', 'https://example.com/apply');
-  });
-
-  test('does not show Apply CTA when user has already applied', () => {
-    const { queryByRole } = render(
-      <SideBar
-        {...defaultProps}
-        applyCTAProps={{
-          applicationDeadline: '31 Jan',
-          applicationUrl: 'https://example.com/apply',
-          hasApplied: true,
-        }}
-      />,
-      { wrapper: TrpcProvider },
-    );
-
-    expect(queryByRole('link', { name: /apply/i })).not.toBeInTheDocument();
-  });
 });

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -161,29 +161,6 @@ const SideBarCollapsible: React.FC<SideBarCollapsibleProps> = ({
   );
 };
 
-export type ApplyCTAProps = {
-  applicationDeadline: string;
-  applicationUrl: string;
-  hasApplied: boolean;
-};
-
-const ApplyCTA = ({ applicationDeadline, applicationUrl, hasApplied }: ApplyCTAProps) => {
-  if (hasApplied) {
-    return null;
-  }
-
-  return (
-    <CTALinkOrButton
-      url={applicationUrl}
-      variant="outline-black"
-      target="_blank"
-      className="px-3 py-1.5 text-size-xs"
-    >
-      {`Apply by ${applicationDeadline}`}
-    </CTALinkOrButton>
-  );
-};
-
 const SideBar: React.FC<SideBarProps> = ({
   courseTitle,
   courseSlug,
@@ -222,7 +199,6 @@ const SideBar: React.FC<SideBarProps> = ({
             </div>
           </div>
         </div>
-        {applyCTAProps && <ApplyCTA {...applyCTAProps} />}
       </div>
 
       {/* Units */}

--- a/apps/website/src/components/courses/SideBar.tsx
+++ b/apps/website/src/components/courses/SideBar.tsx
@@ -1,5 +1,5 @@
 import type { Unit } from '@bluedot/db';
-import { A, CTALinkOrButton, P } from '@bluedot/ui';
+import { A, P } from '@bluedot/ui';
 import clsx from 'clsx';
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -20,7 +20,6 @@ type SideBarProps = {
   currentChunkIndex: number;
   onChunkSelect: (index: number) => void;
   unitChunks: Record<string, BasicChunk[]>;
-  applyCTAProps?: ApplyCTAProps;
   className?: string;
   courseProgressData?: CourseProgress;
 };
@@ -171,7 +170,6 @@ const SideBar: React.FC<SideBarProps> = ({
   currentUnitNumber,
   currentChunkIndex,
   onChunkSelect,
-  applyCTAProps,
   unitChunks,
 }) => {
   const isCurrentUnit = (unit: Unit) => {

--- a/apps/website/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website/src/components/courses/UnitLayout.test.tsx
@@ -90,7 +90,6 @@ describe('UnitLayout', () => {
         chunkIndex={0}
         setChunkIndex={vi.fn()}
         courseSlug="test-course"
-        applyCTAProps={undefined}
         allUnitChunks={ALL_UNIT_CHUNKS}
       />,
       { wrapper: TrpcProvider },
@@ -114,7 +113,6 @@ describe('UnitLayout', () => {
         chunkIndex={0}
         setChunkIndex={vi.fn()}
         courseSlug="test-course"
-        applyCTAProps={undefined}
         allUnitChunks={ALL_UNIT_CHUNKS}
       />,
       { wrapper: TrpcProvider },
@@ -138,7 +136,6 @@ describe('UnitLayout', () => {
         chunkIndex={0}
         setChunkIndex={vi.fn()}
         courseSlug="test-course"
-        applyCTAProps={undefined}
         allUnitChunks={ALL_UNIT_CHUNKS}
       />,
       { wrapper: TrpcProvider },
@@ -164,7 +161,6 @@ describe('UnitLayout', () => {
         chunkIndex={CHUNKS.length - 1}
         setChunkIndex={vi.fn()}
         courseSlug="test-course"
-        applyCTAProps={undefined}
         allUnitChunks={ALL_UNIT_CHUNKS}
       />,
       { wrapper: TrpcProvider },
@@ -188,7 +184,6 @@ describe('UnitLayout', () => {
         chunkIndex={0}
         setChunkIndex={vi.fn()}
         courseSlug="test-course"
-        applyCTAProps={undefined}
         allUnitChunks={ALL_UNIT_CHUNKS}
       />,
       { wrapper: TrpcProvider },
@@ -215,7 +210,6 @@ describe('UnitLayout', () => {
         chunkIndex={0}
         setChunkIndex={vi.fn()}
         courseSlug="test-course"
-        applyCTAProps={undefined}
         allUnitChunks={ALL_UNIT_CHUNKS}
       />,
       { wrapper: TrpcProvider },
@@ -252,7 +246,6 @@ describe('UnitLayout', () => {
         chunkIndex={1}
         setChunkIndex={mockSetChunkIndex}
         courseSlug="test-course"
-        applyCTAProps={undefined}
         allUnitChunks={ALL_UNIT_CHUNKS}
       />,
       { wrapper: TrpcProvider },

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -26,7 +26,6 @@ import InactiveCourseBanners from './InactiveCourseBanners';
 import KeyboardNavMenu from './KeyboardNavMenu';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
 import { ResourceDisplay } from './ResourceDisplay';
-import type { ApplyCTAProps } from './SideBar';
 import CourseShell from './CourseShell';
 
 export type ChunkWithContent = Chunk & {
@@ -44,8 +43,6 @@ type UnitLayoutProps = {
   setChunkIndex: (index: number) => void;
   courseSlug: string;
   allUnitChunks: Record<string, BasicChunk[]>;
-  // Optional
-  applyCTAProps?: ApplyCTAProps;
 };
 
 const UnitLayout: React.FC<UnitLayoutProps> = ({
@@ -57,7 +54,6 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
   setChunkIndex,
   courseSlug,
   allUnitChunks,
-  applyCTAProps,
 }) => {
   const router = useRouter();
   const auth = useAuthStore((s) => s.auth);
@@ -133,7 +129,6 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
       currentUnitNumber={parseInt(unitNumber, 10)}
       currentChunkIndex={chunkIndex}
       onChunkSelect={handleChunkSelect}
-      applyCTAProps={applyCTAProps}
       courseProgressData={courseProgressData}
       onNavigate={setNavigationAnnouncement}
       breadcrumb={`${unitNumber}. ${unit.title}`}

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -77,8 +77,6 @@ const CourseUnitChunkPage = ({
   const { latestUtmParams, isLoading: isUtmLoading } = useLatestUtmParams();
   const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.courseRegistrations.ensureExists.useMutation();
 
-  const { data: applyCTAProps } = trpc.courseRounds.getApplyCTAProps.useQuery({ courseSlug });
-
   useEffect(() => {
     // FoAI course only: If we're logged in, ensures a course registration is recorded
     const shouldRecordCourseRegistration = auth && (unit.courseId === FOAI_COURSE_ID);
@@ -140,7 +138,6 @@ const CourseUnitChunkPage = ({
         setChunkIndex={handleSetChunkIndex}
         courseSlug={courseSlug}
         allUnitChunks={allUnitChunks}
-        applyCTAProps={applyCTAProps ?? undefined}
       />
     </>
   );

--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -7,7 +7,6 @@ import {
   or, sql,
 } from '@bluedot/db';
 import { z } from 'zod';
-import type { ApplyCTAProps } from '../../components/courses/SideBar';
 import db from '../../lib/api/db';
 import { ONE_DAY_MS } from '../../lib/constants';
 import { formatApplicationDeadlineUtcDetailed, formatMonthAndDay } from '../../lib/utils';
@@ -245,7 +244,7 @@ export const courseRoundsRouter = router({
 
   getApplyCTAProps: publicProcedure
     .input(z.object({ courseSlug: z.string().min(1) }))
-    .query(async ({ ctx, input }): Promise<ApplyCTAProps | null> => {
+    .query(async ({ ctx, input }) => {
       const { courseSlug } = input;
 
       // Get course with applyUrl from database


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Request from Li-lian. Now that we have the certificate side panel in the sidebar, we no longer need this button. Remove it from the sidebar and mobile course modal, as well as all prop drilling.

I've also let callers of `getApplyCTAProps` (now only one caller, `CourseCompletionSection.tsx`) infer the data shape from the router, rather than making it explicit. This is always better imo.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2445

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="378" height="514" alt="image" src="https://github.com/user-attachments/assets/d1e6bdb0-7f35-4b46-9b8a-a484d631dcee" /> | <img width="373" height="508" alt="image" src="https://github.com/user-attachments/assets/4819c6b0-a86a-49d4-8f27-ab1212005324" /> |
| 🖥️ | <img width="359" height="904" alt="image" src="https://github.com/user-attachments/assets/3aa8e7af-4309-4799-9425-ba7292125860" /> | <img width="356" height="856" alt="image" src="https://github.com/user-attachments/assets/0b0ab48e-44fa-473e-9a3e-3930499b74e8" /> |
