### PR TITLE
`RoundGroup` has default num rounds as 3

### DIFF
--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -157,7 +157,6 @@ export default function CourseCompletionSection({
               rounds={roundsData.intense}
               applicationUrl={applicationUrlWithUtm}
               accentColor={accentColor}
-              maxRounds={3}
             />
           )}
 
@@ -168,7 +167,6 @@ export default function CourseCompletionSection({
                 rounds={roundsData.partTime}
                 applicationUrl={applicationUrlWithUtm}
                 accentColor={accentColor}
-                maxRounds={3}
               />
             </div>
           )}

--- a/apps/website/src/components/courses/CourseSchedule.tsx
+++ b/apps/website/src/components/courses/CourseSchedule.tsx
@@ -253,7 +253,6 @@ const CourseScheduleCard = ({ course }: CourseScheduleCardProps) => {
                 rounds={rounds.intense}
                 applicationUrl={applicationUrlWithUtm}
                 accentColor={getCourseAccentColor(course.slug)}
-                maxRounds={3}
               />
             )}
             {hasPartTime && (
@@ -262,7 +261,6 @@ const CourseScheduleCard = ({ course }: CourseScheduleCardProps) => {
                 rounds={rounds.partTime}
                 applicationUrl={applicationUrlWithUtm}
                 accentColor={getCourseAccentColor(course.slug)}
-                maxRounds={3}
               />
             )}
           </div>

--- a/apps/website/src/components/shared/RoundGroup.stories.tsx
+++ b/apps/website/src/components/shared/RoundGroup.stories.tsx
@@ -70,10 +70,10 @@ export const PartTime: Story = {
   },
 };
 
-export const Capped: Story = {
+export const ShowAll: Story = {
   args: {
     type: 'intensive',
     rounds: intensiveRounds,
-    maxRounds: 3,
+    maxRounds: Infinity,
   },
 };

--- a/apps/website/src/components/shared/RoundGroup.tsx
+++ b/apps/website/src/components/shared/RoundGroup.tsx
@@ -1,18 +1,22 @@
 import type { CourseRound } from '../../server/routers/course-rounds';
 import { buildRoundApplyUrl, RoundItem } from './RoundItem';
 
+const DEFAULT_MAX_ROUNDS = 3;
+
 type RoundGroupProps = {
   type: 'intensive' | 'part-time';
   rounds: CourseRound[];
   applicationUrl: string;
   accentColor?: string;
-  /** Cap the number of rounds shown. Defaults to showing all. */
+  /** Cap the number of rounds shown. Defaults to 3. */
   maxRounds?: number;
 };
 
 // eslint-disable-next-line react/function-component-definition
-export default function RoundGroup({ type, rounds, applicationUrl, accentColor, maxRounds }: RoundGroupProps) {
-  const displayedRounds = maxRounds !== undefined ? rounds.slice(0, maxRounds) : rounds;
+export default function RoundGroup({
+  type, rounds, applicationUrl, accentColor, maxRounds = DEFAULT_MAX_ROUNDS,
+}: RoundGroupProps) {
+  const displayedRounds = rounds.slice(0, maxRounds);
   const firstRound = displayedRounds[0];
   const numberOfUnits = firstRound?.numberOfUnits;
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

All callers of `RoundGroup` default to showing next 3 rounds. These changes add a default. Future callers can pass `maxRounds: Infinity` if they wish to fetch all rounds.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2422.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
