### PR TITLE
Rename `applyCTAProps` -> `courseApplication`

### DIFF
--- a/apps/website/src/components/courses/CourseCompletionSection.stories.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.stories.tsx
@@ -4,7 +4,7 @@ import { createMockRound } from '../../__tests__/testUtils';
 import { trpcStorybookMsw } from '../../__tests__/trpcMswSetup.browser';
 import CourseCompletionSection from './CourseCompletionSection';
 
-const mockApplyCTAProps = {
+const mockApplication = {
   applicationDeadline: '15 Jan',
   applicationUrl: 'https://bluedot.org/apply',
   hasApplied: false,
@@ -52,7 +52,7 @@ export const EnrollmentCTA: Story = {
   parameters: {
     msw: {
       handlers: [
-        trpcStorybookMsw.courseRounds.getApplyCTAProps.query(() => mockApplyCTAProps),
+        trpcStorybookMsw.courseRounds.getCourseApplication.query(() => mockApplication),
         trpcStorybookMsw.courseRounds.getRoundsForCourse.query(() => mockRounds),
       ],
     },
@@ -87,7 +87,7 @@ export const EnrollmentCTAWithManyUpcomingRounds: Story = {
   parameters: {
     msw: {
       handlers: [
-        trpcStorybookMsw.courseRounds.getApplyCTAProps.query(() => mockApplyCTAProps),
+        trpcStorybookMsw.courseRounds.getCourseApplication.query(() => mockApplication),
         trpcStorybookMsw.courseRounds.getRoundsForCourse.query(() => manyMockRounds),
       ],
     },

--- a/apps/website/src/components/courses/CourseCompletionSection.test.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.test.tsx
@@ -15,7 +15,7 @@ vi.mock('next/router', () => ({
   }),
 }));
 
-const mockApplyCTAProps = {
+const mockApplication = {
   applicationDeadline: '15 Jan',
   applicationUrl: 'https://bluedot.org/apply',
   hasApplied: false,
@@ -37,7 +37,7 @@ describe('CourseCompletionSection', () => {
     server.use(trpcMsw.certificates.getStatus.query(() => ({ status: 'not-eligible' as const })));
   });
 
-  test('shows ProgressDots while getApplyCTAProps is loading', () => {
+  test('shows ProgressDots while getCourseApplication is loading', () => {
     // No handler - query stays pending
     const { container } = render(<CourseCompletionSection {...defaultProps} />, { wrapper: TrpcProvider });
 
@@ -47,7 +47,7 @@ describe('CourseCompletionSection', () => {
 
   test('shows enrollment CTA when rounds are available and user has not applied', async () => {
     server.use(
-      trpcMsw.courseRounds.getApplyCTAProps.query(() => mockApplyCTAProps),
+      trpcMsw.courseRounds.getCourseApplication.query(() => mockApplication),
       trpcMsw.courseRounds.getRoundsForCourse.query(() => mockRounds),
     );
 
@@ -60,8 +60,8 @@ describe('CourseCompletionSection', () => {
     expect(container.querySelector('.congratulations')).toBeFalsy();
   });
 
-  test('shows Congratulations when getApplyCTAProps returns null', async () => {
-    server.use(trpcMsw.courseRounds.getApplyCTAProps.query(() => null));
+  test('shows Congratulations when getCourseApplication returns null', async () => {
+    server.use(trpcMsw.courseRounds.getCourseApplication.query(() => null));
 
     const { container } = render(<CourseCompletionSection {...defaultProps} />, { wrapper: TrpcProvider });
 
@@ -72,7 +72,7 @@ describe('CourseCompletionSection', () => {
   });
 
   test('shows Congratulations when user has already applied', async () => {
-    server.use(trpcMsw.courseRounds.getApplyCTAProps.query(() => ({ ...mockApplyCTAProps, hasApplied: true })));
+    server.use(trpcMsw.courseRounds.getCourseApplication.query(() => ({ ...mockApplication, hasApplied: true })));
 
     const { container } = render(<CourseCompletionSection {...defaultProps} />, { wrapper: TrpcProvider });
 
@@ -84,7 +84,7 @@ describe('CourseCompletionSection', () => {
 
   test('shows Congratulations when no rounds are available', async () => {
     server.use(
-      trpcMsw.courseRounds.getApplyCTAProps.query(() => mockApplyCTAProps),
+      trpcMsw.courseRounds.getCourseApplication.query(() => mockApplication),
       trpcMsw.courseRounds.getRoundsForCourse.query(() => ({ intense: [], partTime: [] })),
     );
 
@@ -98,7 +98,7 @@ describe('CourseCompletionSection', () => {
 
   test('caps each round group to the next 3 upcoming rounds', async () => {
     server.use(
-      trpcMsw.courseRounds.getApplyCTAProps.query(() => mockApplyCTAProps),
+      trpcMsw.courseRounds.getCourseApplication.query(() => mockApplication),
       trpcMsw.courseRounds.getRoundsForCourse.query(() => ({
         intense: [
           createMockRound({ dateRange: '1 – 5 Jun' }),

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -95,20 +95,20 @@ export default function CourseCompletionSection({
 }: CourseCompletionSectionProps) {
   const { latestUtmParams } = useLatestUtmParams();
 
-  const { data: applyCTAProps, isLoading: isApplyCTALoading } = trpc.courseRounds.getApplyCTAProps.useQuery({
+  const { data: application, isLoading: isApplicationLoading } = trpc.courseRounds.getCourseApplication.useQuery({
     courseSlug,
   });
 
-  const shouldFetchRounds = Boolean(applyCTAProps) && !applyCTAProps?.hasApplied;
+  const shouldFetchRounds = Boolean(application) && !application?.hasApplied;
 
   const { data: roundsData, isLoading: isRoundsLoading } = trpc.courseRounds.getRoundsForCourse.useQuery(
     { courseSlug },
     { enabled: shouldFetchRounds },
   );
 
-  const isLoading = isApplyCTALoading || (shouldFetchRounds && (isRoundsLoading || !roundsData));
+  const isLoading = isApplicationLoading || (shouldFetchRounds && (isRoundsLoading || !roundsData));
   const hasRounds = Boolean(roundsData && (roundsData.intense.length > 0 || roundsData.partTime.length > 0));
-  const showEnrollmentCTA = shouldFetchRounds && !isRoundsLoading && hasRounds && applyCTAProps && roundsData;
+  const showEnrollmentCTA = shouldFetchRounds && !isRoundsLoading && hasRounds && application && roundsData;
 
   if (isLoading) {
     return (
@@ -120,8 +120,8 @@ export default function CourseCompletionSection({
 
   if (showEnrollmentCTA) {
     const applicationUrlWithUtm = appendPosthogSessionIdPrefill(latestUtmParams.utm_source
-      ? addQueryParam(applyCTAProps.applicationUrl, 'prefill_Source', latestUtmParams.utm_source)
-      : applyCTAProps.applicationUrl);
+      ? addQueryParam(application.applicationUrl, 'prefill_Source', latestUtmParams.utm_source)
+      : application.applicationUrl);
 
     const info = COURSE_INFORMATION_DETAILS[courseSlug];
     const accentColor = COURSE_CONFIG[courseSlug]?.accentColor;

--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -242,7 +242,7 @@ export const courseRoundsRouter = router({
       return groupByIntensity(enrichedRounds);
     }),
 
-  getApplyCTAProps: publicProcedure
+  getCourseApplication: publicProcedure
     .input(z.object({ courseSlug: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const { courseSlug } = input;


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

We don't pass course application as props anymore, this is a rename to clarify intent.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

NA

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA
