### PR TITLE
[feat] website: add Next steps: Programs chunk to last unit

### DIFF
--- a/apps/website/src/components/courses/NextStepsChunk.tsx
+++ b/apps/website/src/components/courses/NextStepsChunk.tsx
@@ -1,0 +1,51 @@
+import { ErrorSection, P, ProgressDots } from '@bluedot/ui';
+import { PageListGroup, PageListRow } from '../PageListRow';
+import { formatAmountUsd } from '../../lib/utils';
+import { trpc } from '../../utils/trpc';
+
+const pluralizeGrants = (count: number) => `${count} ${count === 1 ? 'grant' : 'grants'}`;
+
+const NextStepsChunk: React.FC = () => {
+  const { data: programs, isLoading, error } = trpc.programs.getAll.useQuery();
+  const { data: rapidStats } = trpc.grants.getRapidGrantStats.useQuery();
+  const { data: ctStats } = trpc.grants.getCareerTransitionGrantStats.useQuery();
+
+  const getMeta = (slug: string | null): string | null => {
+    if (slug === 'rapid-grants' && rapidStats) {
+      return `${formatAmountUsd(rapidStats.totalAmountUsd)} deployed so far across ${pluralizeGrants(rapidStats.count)}.`;
+    }
+
+    if (slug === 'career-transition-grant' && ctStats) {
+      return `${formatAmountUsd(ctStats.totalAmountUsd)} awarded so far across ${pluralizeGrants(ctStats.count)}.`;
+    }
+
+    return null;
+  };
+
+  return (
+    <div className="next-steps-chunk flex flex-col gap-6 mt-8 md:mt-6">
+      <P className="text-size-sm leading-[1.6] text-bluedot-navy">
+        You&apos;ve got context now. Here&apos;s how you can continue contributing to AI safety.
+      </P>
+
+      {error && <ErrorSection error={error} />}
+      {isLoading && <ProgressDots />}
+      {!isLoading && !error && programs && (
+        <PageListGroup>
+          {programs.map((program) => (
+            <PageListRow
+              key={program.id}
+              href={program.slug ? `/programs/${program.slug}` : (program.applicationForm ?? '#')}
+              title={program.name}
+              summary={program.description}
+              meta={getMeta(program.slug)}
+              ctaLabel="Explore program"
+            />
+          ))}
+        </PageListGroup>
+      )}
+    </div>
+  );
+};
+
+export default NextStepsChunk;

--- a/apps/website/src/components/courses/NextStepsChunk.tsx
+++ b/apps/website/src/components/courses/NextStepsChunk.tsx
@@ -1,4 +1,5 @@
 import { ErrorSection, P, ProgressDots } from '@bluedot/ui';
+import type React from 'react';
 import { PageListGroup, PageListRow } from '../PageListRow';
 import { formatAmountUsd } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -18,6 +18,7 @@ import {
   type UnitResource,
 } from '@bluedot/db';
 import { useBugReport } from '../../hooks/useBugReport';
+import { NEXT_STEPS_CHUNK_ID } from '../../lib/constants';
 import { buildCourseUnitUrl } from '../../lib/utils';
 import type { BasicChunk } from '../../server/routers/courses';
 import { trpc } from '../../utils/trpc';
@@ -25,6 +26,7 @@ import GroupDiscussionBanner from './GroupDiscussionBanner';
 import InactiveCourseBanners from './InactiveCourseBanners';
 import KeyboardNavMenu from './KeyboardNavMenu';
 import MarkdownExtendedRenderer from './MarkdownExtendedRenderer';
+import NextStepsChunk from './NextStepsChunk';
 import { ResourceDisplay } from './ResourceDisplay';
 import CourseShell from './CourseShell';
 
@@ -203,27 +205,33 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
               <H1 className="unit__title font-bold text-[32px] leading-[130%] tracking-[-0.015em] text-bluedot-navy">{chunk.chunkTitle}</H1>
             )}
           </div>
-          {/* chunk content → unit content if no chunks - Only render if there's actual content */}
-          {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-          {(chunk?.chunkContent || unit.content) && (
-            <MarkdownExtendedRenderer className="mt-8 md:mt-6">
+          {chunk?.id === NEXT_STEPS_CHUNK_ID ? (
+            <NextStepsChunk />
+          ) : (
+            <>
+              {/* chunk content → unit content if no chunks - Only render if there's actual content */}
               {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-              {chunk?.chunkContent || unit.content || ''}
-            </MarkdownExtendedRenderer>
-          )}
+              {(chunk?.chunkContent || unit.content) && (
+                <MarkdownExtendedRenderer className="mt-8 md:mt-6">
+                  {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
+                  {chunk?.chunkContent || unit.content || ''}
+                </MarkdownExtendedRenderer>
+              )}
 
-          {/* Chunk resources and exercises - Show if there are any resources or exercises */}
-          {chunk && (chunk.resources?.length || chunk.exercises?.length) ? (
-            <ResourceDisplay
-              resources={chunk.resources || []}
-              exercises={chunk.exercises || []}
-              unitTitle={unit.title}
-              unitNumber={unitNumber}
-              className={clsx((chunk?.chunkContent || unit.content) ? 'mt-8 md:mt-6' : 'mt-4')}
-              courseSlug={courseSlug}
-              chunkIndex={chunkIndex}
-            />
-          ) : null}
+              {/* Chunk resources and exercises - Show if there are any resources or exercises */}
+              {chunk && (chunk.resources?.length || chunk.exercises?.length) ? (
+                <ResourceDisplay
+                  resources={chunk.resources || []}
+                  exercises={chunk.exercises || []}
+                  unitTitle={unit.title}
+                  unitNumber={unitNumber}
+                  className={clsx((chunk?.chunkContent || unit.content) ? 'mt-8 md:mt-6' : 'mt-4')}
+                  courseSlug={courseSlug}
+                  chunkIndex={chunkIndex}
+                />
+              ) : null}
+            </>
+          )}
 
           {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
           {(nextUnit || !isLastChunk) && (

--- a/apps/website/src/lib/constants.ts
+++ b/apps/website/src/lib/constants.ts
@@ -18,6 +18,7 @@ export const FOAI_COURSE_SLUG = 'future-of-ai';
 // Synthetic chunk appended to the last unit of every non-FoAI course so the
 // final view points learners at next-step programs (advising, grants, etc.).
 export const NEXT_STEPS_CHUNK_ID = 'next-steps-synthetic';
+export const NEXT_STEPS_CHUNK_TITLE = 'Next steps: Programs';
 
 export const BLUEDOT_LINKEDIN_ORG_ID = '86200389';
 

--- a/apps/website/src/lib/constants.ts
+++ b/apps/website/src/lib/constants.ts
@@ -15,6 +15,10 @@ export const ONE_YEAR_SECONDS = 365 * ONE_DAY_SECONDS;
 export const FOAI_COURSE_ID = 'rec0Zgize0c4liMl5';
 export const FOAI_COURSE_SLUG = 'future-of-ai';
 
+// Synthetic chunk appended to the last unit of every non-FoAI course so the
+// final view points learners at next-step programs (advising, grants, etc.).
+export const NEXT_STEPS_CHUNK_ID = 'next-steps-synthetic';
+
 export const BLUEDOT_LINKEDIN_ORG_ID = '86200389';
 
 type CourseConfigItem = {

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -176,7 +176,7 @@ export const getServerSideProps: GetServerSideProps<CourseUnitChunkPageProps> = 
   }
 };
 
-const NEXT_STEPS_CHUNK_TITLE = 'Next steps';
+const NEXT_STEPS_CHUNK_TITLE = 'Next steps: Programs';
 
 const buildNextStepsBasicChunk = (chunkOrder: string): BasicChunk => ({
   id: NEXT_STEPS_CHUNK_ID,

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -7,9 +7,9 @@ import { type GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import UnitLayout from '../../../../components/courses/UnitLayout';
+import UnitLayout, { type ChunkWithContent } from '../../../../components/courses/UnitLayout';
 import db from '../../../../lib/api/db';
-import { FOAI_COURSE_ID } from '../../../../lib/constants';
+import { FOAI_COURSE_ID, FOAI_COURSE_SLUG, NEXT_STEPS_CHUNK_ID } from '../../../../lib/constants';
 import { getCourseOgImage } from '../../../../lib/courseOgImage';
 import { buildCourseUnitUrl } from '../../../../lib/utils';
 import { type BasicChunk, getActiveChunksByUnit, getCourseData } from '../../../../server/routers/courses';
@@ -176,6 +176,32 @@ export const getServerSideProps: GetServerSideProps<CourseUnitChunkPageProps> = 
   }
 };
 
+const NEXT_STEPS_CHUNK_TITLE = 'Next steps';
+
+const buildNextStepsBasicChunk = (chunkOrder: string): BasicChunk => ({
+  id: NEXT_STEPS_CHUNK_ID,
+  chunkTitle: NEXT_STEPS_CHUNK_TITLE,
+  chunkOrder,
+  estimatedTime: null,
+});
+
+const buildNextStepsChunkWithContent = (unitId: string, chunkOrder: string): ChunkWithContent => ({
+  id: NEXT_STEPS_CHUNK_ID,
+  chunkId: NEXT_STEPS_CHUNK_ID,
+  unitId,
+  chunkTitle: NEXT_STEPS_CHUNK_TITLE,
+  chunkOrder,
+  chunkType: 'next-steps',
+  chunkContent: '',
+  estimatedTime: null,
+  chunkResources: null,
+  chunkExercises: null,
+  status: 'Active',
+  metaDescription: null,
+  resources: [],
+  exercises: [],
+});
+
 type UnitWithChunks = Awaited<ReturnType<typeof getUnitWithChunks>>;
 async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
   const { units } = await getCourseData(courseSlug);
@@ -186,6 +212,17 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
   }
 
   const allUnitChunks = await getActiveChunksByUnit(units);
+
+  // Append a synthetic "Next steps" chunk to the last unit of every non-FoAI
+  // course so learners see programs to continue with after finishing.
+  const finalUnit = units[units.length - 1];
+  const shouldShowNextSteps = courseSlug !== FOAI_COURSE_SLUG && finalUnit !== undefined;
+  if (shouldShowNextSteps) {
+    const finalUnitChunks = allUnitChunks[finalUnit.id] ?? [];
+    const lastChunkOrder = finalUnitChunks[finalUnitChunks.length - 1]?.chunkOrder;
+    const nextStepsOrder = String(Number(lastChunkOrder ?? '0') + 1);
+    allUnitChunks[finalUnit.id] = [...finalUnitChunks, buildNextStepsBasicChunk(nextStepsOrder)];
+  }
 
   // Get chunks for current unit (with full resources/exercises)
   const currentUnitChunks = await db.pg
@@ -239,10 +276,21 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
     };
   });
 
+  const isFinalUnit = shouldShowNextSteps && unit.id === finalUnit.id;
+  const chunksForUnit: ChunkWithContent[] = isFinalUnit
+    ? [
+      ...chunksWithContent,
+      buildNextStepsChunkWithContent(
+        unit.id,
+        String(Number(chunksWithContent[chunksWithContent.length - 1]?.chunkOrder ?? '0') + 1),
+      ),
+    ]
+    : chunksWithContent;
+
   return {
     units,
     unit,
-    chunks: chunksWithContent,
+    chunks: chunksForUnit,
     allUnitChunks,
   };
 }

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -9,7 +9,9 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import UnitLayout, { type ChunkWithContent } from '../../../../components/courses/UnitLayout';
 import db from '../../../../lib/api/db';
-import { FOAI_COURSE_ID, FOAI_COURSE_SLUG, NEXT_STEPS_CHUNK_ID } from '../../../../lib/constants';
+import {
+  FOAI_COURSE_ID, FOAI_COURSE_SLUG, NEXT_STEPS_CHUNK_ID, NEXT_STEPS_CHUNK_TITLE,
+} from '../../../../lib/constants';
 import { getCourseOgImage } from '../../../../lib/courseOgImage';
 import { buildCourseUnitUrl } from '../../../../lib/utils';
 import { type BasicChunk, getActiveChunksByUnit, getCourseData } from '../../../../server/routers/courses';
@@ -175,8 +177,6 @@ export const getServerSideProps: GetServerSideProps<CourseUnitChunkPageProps> = 
     throw error;
   }
 };
-
-const NEXT_STEPS_CHUNK_TITLE = 'Next steps: Programs';
 
 const buildNextStepsBasicChunk = (chunkOrder: string): BasicChunk => ({
   id: NEXT_STEPS_CHUNK_ID,


### PR DESCRIPTION
# Description

After learners reach the end of a course, the final unit's last chunk used
to vary by course content with no consistent prompt to keep contributing.
This adds a synthetic "Next steps: Programs" chunk to the final unit of
every non-FoAI course. The chunk renders the same programs list (1-1
advising, Rapid Grants, Career Transition Grants, Incubator Week) used on
`/programs`, with the headline "You've got context now. Here's how you can
continue contributing to AI safety."

The chunk is fully synthetic — no Airtable change required, and FoAI is
intentionally excluded since its completion flow already nudges learners
into AGI Strategy.

## What changed

1. **`apps/website/src/lib/constants.ts`** — adds `NEXT_STEPS_CHUNK_ID`,
   the marker used by both data-fetching and rendering to detect the
   synthetic chunk.
2. **`apps/website/src/components/courses/NextStepsChunk.tsx`** — new
   component that mirrors `/programs` (heading + `PageListGroup`/
   `PageListRow`) and reuses the live `programs.getAll`,
   `grants.getRapidGrantStats`, and `grants.getCareerTransitionGrantStats`
   tRPC queries.
3. **`apps/website/src/components/courses/UnitLayout.tsx`** — branches on
   the synthetic chunk id to render `<NextStepsChunk />` instead of the
   markdown/resources pipeline.
4. **`apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx`**
   — appends the synthetic chunk to the final unit of every non-FoAI course
   in `getServerSideProps` (both the sidebar listing and, when viewing the
   final unit, the rendered chunks array).

## Notes on approach

A synthetic chunk approach was preferred over hard-coding the next-steps
content per-course in Airtable, because:

- It keeps the "Next steps: Programs" wording consistent across all
  courses by default.
- The grant stats stay live (rapid grant total, CT grant total) rather
  than baking stale numbers into Airtable.
- Course authors can still add a real "Next steps" chunk later if a
  course needs bespoke content; the synthetic chunk is course-agnostic.

## Issue

Closes #2431.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — uses existing PageListRow (semantic links + headings), reuses H1 from chunk title rendering.
- [x] Considered having snapshot tests / functional tests — declined: the existing unit-page tests cover the rendering path; the synthetic-chunk branching is exercised manually in the worktree dev server.
- [x] Considered adding Storybook stories — declined: NextStepsChunk is a thin wrapper over the existing /programs layout and has no standalone variants worth documenting separately.

No DB schema changes.

## Verification

Local dev (\`npx next dev -p 8042\` in the \`anglilian/next-steps-chunk\` worktree):

- ✅ \`/courses/agi-strategy/5/7\` — renders "Next steps: Programs" with the
  programs list and live grant stats; sidebar shows "Next steps: Programs"
  as the final chunk under Unit 5.
- ✅ \`/courses/future-of-ai/4\` — FoAI's final unit still shows only its 3
  real chunks (no synthetic chunk), as intended.
- ✅ \`/courses/agi-strategy/5/1\` and earlier units — sidebar shows the
  synthetic chunk under Unit 5 even when viewing other units.

Type check + lint + full test suite all pass:

\`\`\`
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 630 passed | 1 skipped (104 files), reproduced clean on second run
\`\`\`

## Screenshots

New URL — `/courses/agi-strategy/5/7` didn't render before this PR, so no Before shots.

|            | After   |
| ---------- | ------- |
| 📱 Mobile  |  <img width="1170" height="1992" alt="after-mobile" src="https://github.com/user-attachments/assets/bb9a341a-a1ba-409d-a879-14f837b983c7" />|
| 🖥️ Desktop | <img width="2560" height="1600" alt="after-desktop" src="https://github.com/user-attachments/assets/0eaa41c1-a1b4-43c9-b805-91bb76e8f6aa" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)