### PR TITLE
[codex] Fix TASP certificate badge assets

### DIFF
--- a/apps/website/src/components/certificate/CertificateCard.test.tsx
+++ b/apps/website/src/components/certificate/CertificateCard.test.tsx
@@ -56,5 +56,18 @@ describe('CertificateCard', () => {
       expect(screen.getByText('Issued')).toBeInTheDocument();
       expect(screen.getByText('Certificate ID')).toBeInTheDocument();
     });
+
+    test('reuses Technical AI Safety badge for the project certificate', () => {
+      render(<CertificateCard
+        {...defaultProps}
+        courseName="Technical AI Safety Project"
+        courseSlug="technical-ai-safety-project"
+      />);
+
+      expect(screen.getByAltText('Technical AI Safety Project Certificate Badge')).toHaveAttribute(
+        'src',
+        expect.stringContaining('technical-ai-safety.png'),
+      );
+    });
   });
 });

--- a/apps/website/src/components/certificate/CertificateCard.tsx
+++ b/apps/website/src/components/certificate/CertificateCard.tsx
@@ -1,6 +1,9 @@
 import type React from 'react';
 import Image from 'next/image';
-import { COURSE_CONFIG } from '../../lib/constants';
+import {
+  getCertificateBadgePath,
+  getCertificateIconPath,
+} from '../../lib/certificateAssets';
 
 type CertificateCardProps = {
   courseName: string;
@@ -11,7 +14,6 @@ type CertificateCardProps = {
   certificateId: string;
 };
 
-const DEFAULT_BADGE_PATH = '/images/certificates/certificate-fallback-image.png';
 const DISPLAY_FONT_STYLE = { fontFeatureSettings: '\'ss04\' 1' };
 
 const generatePatternPositions = () => {
@@ -45,13 +47,8 @@ export const CertificateCard: React.FC<CertificateCardProps> = ({
   issuedDate,
   certificateId,
 }) => {
-  const isKnownCourse = courseSlug in COURSE_CONFIG;
-  const badgePath = isKnownCourse
-    ? `/images/certificates/${courseSlug}.png`
-    : DEFAULT_BADGE_PATH;
-  const iconPath = isKnownCourse
-    ? `/images/certificates/icons/${courseSlug}-icon.svg`
-    : null;
+  const badgePath = getCertificateBadgePath(courseSlug);
+  const iconPath = getCertificateIconPath(courseSlug);
 
   return (
     <div className="w-full max-w-text-narrow bg-white rounded-lg border border-slate-200 overflow-hidden shadow-[0_8px_60px_rgba(0,0,0,0.06)]">

--- a/apps/website/src/components/courses/Congratulations.tsx
+++ b/apps/website/src/components/courses/Congratulations.tsx
@@ -12,6 +12,7 @@ import {
   FaXTwitter,
 } from 'react-icons/fa6';
 import { BLUEDOT_LINKEDIN_ORG_ID, COURSE_CONFIG, FOAI_COURSE_ID } from '../../lib/constants';
+import { getCertificateBadgePath } from '../../lib/certificateAssets';
 import { getCourseCtaColors } from '../../lib/courseCtaColors';
 import { ROUTES } from '../../lib/routes';
 import { getActionPlanUrl } from '../../lib/utils';
@@ -181,10 +182,7 @@ const AttendanceIneligibleCard = ({
 type CertificateHeroProps = { courseId: string; courseSlug: string; courseTitle: string };
 
 const CertificatePreviewCard = ({ courseSlug, courseTitle }: { courseSlug: string; courseTitle: string }) => {
-  const badgeSrc
-    = courseSlug in COURSE_CONFIG
-      ? `/images/certificates/${courseSlug}.png`
-      : '/images/certificates/certificate-fallback-image.png';
+  const badgeSrc = getCertificateBadgePath(courseSlug);
 
   return (
     <div className="flex w-full max-w-[640px] flex-col items-center gap-4 rounded-lg border border-slate-200 bg-white px-6 py-10 shadow-sm">

--- a/apps/website/src/lib/certificateAssets.test.ts
+++ b/apps/website/src/lib/certificateAssets.test.ts
@@ -1,0 +1,23 @@
+import {
+  describe, expect, test,
+} from 'vitest';
+import {
+  DEFAULT_CERTIFICATE_BADGE_PATH,
+  getCertificateAssetSlug,
+  getCertificateBadgePath,
+  getCertificateIconPath,
+} from './certificateAssets';
+
+describe('certificateAssets', () => {
+  test('uses Technical AI Safety artwork for the project certificate', () => {
+    expect(getCertificateAssetSlug('technical-ai-safety-project')).toBe('technical-ai-safety');
+    expect(getCertificateBadgePath('technical-ai-safety-project')).toBe('/images/certificates/technical-ai-safety.png');
+    expect(getCertificateIconPath('technical-ai-safety-project')).toBe('/images/certificates/icons/technical-ai-safety-icon.svg');
+  });
+
+  test('falls back when a course has no certificate artwork', () => {
+    expect(getCertificateAssetSlug('personal-theory-of-impact')).toBeNull();
+    expect(getCertificateBadgePath('personal-theory-of-impact')).toBe(DEFAULT_CERTIFICATE_BADGE_PATH);
+    expect(getCertificateIconPath('personal-theory-of-impact')).toBeNull();
+  });
+});

--- a/apps/website/src/lib/certificateAssets.ts
+++ b/apps/website/src/lib/certificateAssets.ts
@@ -1,0 +1,24 @@
+const CERTIFICATE_ASSET_SLUG_BY_COURSE_SLUG: Record<string, string> = {
+  'future-of-ai': 'future-of-ai',
+  'ai-governance': 'ai-governance',
+  'agi-strategy': 'agi-strategy',
+  'technical-ai-safety': 'technical-ai-safety',
+  biosecurity: 'biosecurity',
+  'technical-ai-safety-project': 'technical-ai-safety',
+};
+
+export const DEFAULT_CERTIFICATE_BADGE_PATH = '/images/certificates/certificate-fallback-image.png';
+
+export const getCertificateAssetSlug = (courseSlug: string): string | null => (
+  CERTIFICATE_ASSET_SLUG_BY_COURSE_SLUG[courseSlug] ?? null
+);
+
+export const getCertificateBadgePath = (courseSlug: string): string => {
+  const assetSlug = getCertificateAssetSlug(courseSlug);
+  return assetSlug ? `/images/certificates/${assetSlug}.png` : DEFAULT_CERTIFICATE_BADGE_PATH;
+};
+
+export const getCertificateIconPath = (courseSlug: string): string | null => {
+  const assetSlug = getCertificateAssetSlug(courseSlug);
+  return assetSlug ? `/images/certificates/icons/${assetSlug}-icon.svg` : null;
+};

--- a/apps/website/src/pages/certification.tsx
+++ b/apps/website/src/pages/certification.tsx
@@ -25,6 +25,7 @@ import { CertificateCard } from '../components/certificate/CertificateCard';
 import { CertificateCTA } from '../components/certificate/CertificateCTA';
 import { ONE_DAY_SECONDS, ONE_MINUTE_SECONDS } from '../lib/constants';
 import { getCourseCtaColors } from '../lib/courseCtaColors';
+import { getCertificateAssetSlug } from '../lib/certificateAssets';
 import { getCertificateData } from '../server/routers/certificates';
 
 type Certificate = Awaited<ReturnType<typeof getCertificateData>>;
@@ -272,16 +273,17 @@ export const getServerSideProps: GetServerSideProps<CertificatePageProps> = asyn
   try {
     const certificate = await getCertificateData(certificateId);
 
+    const linkPreviewAssetSlug = getCertificateAssetSlug(certificate.courseSlug) ?? certificate.courseSlug;
     const linkPreviewFsPath = path.join(
       process.cwd(),
       'public',
       'images',
       'certificates',
       'link-preview',
-      `${certificate.courseSlug}.png`,
+      `${linkPreviewAssetSlug}.png`,
     );
     const linkPreviewFilename = (await fileExists(linkPreviewFsPath))
-      ? `${certificate.courseSlug}.png`
+      ? `${linkPreviewAssetSlug}.png`
       : 'link-preview-fallback.png';
 
     // Fetch cohort data to display next cohort start date


### PR DESCRIPTION
## Summary

- Add a certificate asset helper that maps `technical-ai-safety-project` to the existing Technical AI Safety certificate artwork.
- Use the helper in the rendered certificate card, the congratulations certificate preview, and the public `/certification` link-preview lookup.
- Add coverage for the TASP asset mapping and rendered certificate badge path.

## Root Cause

The Technical AI Safety Project course slug was present in `COURSE_CONFIG`, so certificate UI treated it as a known course and requested `/images/certificates/technical-ai-safety-project.png` plus a matching icon. Those certificate assets do not exist, even though the certificate record itself can exist.

## Validation

- `npm --workspace apps/website run lint`
- `npm --workspace apps/website run test -- certificateAssets.test.ts CertificateCard.test.tsx`
- `npm --workspace apps/website run test -- certificateAssets.test.ts CertificateCard.test.tsx Congratulations.test.tsx certification.test.tsx`
- `npm --workspace apps/website run typecheck`