### PR TITLE
[feat] db: add priority column to job_posting table

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -761,6 +761,10 @@ export const jobPostingTable = pgAirtable('job_posting', {
       pgColumn: text(),
       airtableId: 'fldXua1PI4iXLKCKm',
     },
+    priority: {
+      pgColumn: text(),
+      airtableId: 'fld819hEjDV1DI0je',
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

Adds the Airtable "Prio" singleSelect field (`fld819hEjDV1DI0je`) to `jobPostingTable` so the website careers page can sort open roles by priority.

The Airtable field has three options: `1 Top`, `2 Med`, `3 Low`. The numeric prefix means a plain string sort produces the right order.

This PR is schema-only, following the [`linkPreviewImage` precedent (#2432)](https://github.com/bluedotimpact/bluedot/pull/2432) so `pg-sync-service` materialises the column in staging Postgres before the consuming website code lands.

**Follow-up PR:** website router + JobsListSection changes that consume `priority` for sorting will open as a draft against master, ready to rebase once this merges and pg-sync auto-runs a full sync.

## Test plan

- [x] `npx tsc --noEmit` in `libraries/db`, `apps/website`, `apps/editor` — all pass
- [x] `npm test` in `apps/website` — 633 tests pass
- [ ] After merge: watch `pg-sync-service` redeploy, confirm `priority` column populated in staging