### PR TITLE
[feat] website: sort careers page roles by Airtable Prio

### DIFF
--- a/apps/website/src/__tests__/pages/join-us/[slug].test.tsx
+++ b/apps/website/src/__tests__/pages/join-us/[slug].test.tsx
@@ -46,6 +46,7 @@ const mockJob: JobPosting = {
   publicationStatus: 'Published',
   category: null,
   linkPreviewImage: null,
+  priority: null,
 };
 
 describe('JobPostingPage SSR/SEO', () => {

--- a/apps/website/src/components/join-us/JobsListSection.test.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.test.tsx
@@ -15,6 +15,7 @@ const mockCmsJobs = [
     publishedAt: Date.now() / 1000,
     category: null,
     linkPreviewImage: null,
+    priority: null,
   },
   {
     id: '2',
@@ -26,6 +27,7 @@ const mockCmsJobs = [
     publishedAt: Date.now() / 1000,
     category: null,
     linkPreviewImage: null,
+    priority: null,
   },
 ];
 

--- a/apps/website/src/components/join-us/JobsListSection.tsx
+++ b/apps/website/src/components/join-us/JobsListSection.tsx
@@ -7,11 +7,9 @@ import { PageListGroup, PageListRow, pageSectionHeadingClass } from '../PageList
 type JobsListSectionProps = inferRouterOutputs<AppRouter>['jobs']['getAll'];
 
 const JobsListSection = ({ jobs }: { jobs: JobsListSectionProps }) => {
-  // Split jobs into regular and contractor positions
-  // job.category is a single string value from Airtable
-  const regularJobs = jobs
-    .filter((job) => job.category !== 'Contractor')
-    .sort((a, b) => (a.slug === 'talent' ? 1 : 0) - (b.slug === 'talent' ? 1 : 0));
+  // Split jobs into regular and contractor positions. Ordering is set by the
+  // router (Airtable Prio field), so the component just preserves it.
+  const regularJobs = jobs.filter((job) => job.category !== 'Contractor');
   const contractorJobs = jobs.filter((job) => job.category === 'Contractor');
 
   const renderRow = (job: JobsListSectionProps[number]) => (

--- a/apps/website/src/server/routers/jobs.test.ts
+++ b/apps/website/src/server/routers/jobs.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { jobPostingTable } from '@bluedot/db';
+import { createCaller, setupTestDb, testDb } from '../../__tests__/dbTestUtils';
+
+setupTestDb();
+
+describe('jobs.getAll', () => {
+  test('sorts by Airtable Prio (1 Top → 2 Med → 3 Low), falls back to title, and pushes null-priority jobs to the bottom', async () => {
+    // Order of inserts is deliberately scrambled to ensure the router does the sorting.
+    await testDb.insert(jobPostingTable, {
+      title: 'Beta', slug: 'beta', priority: '2 Med', publicationStatus: 'Published',
+    });
+    await testDb.insert(jobPostingTable, {
+      title: 'Zeta', slug: 'zeta', priority: null, publicationStatus: 'Published',
+    });
+    await testDb.insert(jobPostingTable, {
+      title: 'Alpha', slug: 'alpha', priority: '1 Top', publicationStatus: 'Published',
+    });
+    await testDb.insert(jobPostingTable, {
+      title: 'Charlie', slug: 'charlie', priority: '2 Med', publicationStatus: 'Published',
+    });
+    await testDb.insert(jobPostingTable, {
+      title: 'Delta', slug: 'delta', priority: '3 Low', publicationStatus: 'Published',
+    });
+    await testDb.insert(jobPostingTable, {
+      title: 'Aardvark', slug: 'aardvark', priority: null, publicationStatus: 'Published',
+    });
+
+    // Unpublished jobs should never appear.
+    await testDb.insert(jobPostingTable, {
+      title: 'Hidden', slug: 'hidden', priority: '1 Top', publicationStatus: 'Unpublished',
+    });
+
+    const caller = createCaller();
+    const result = await caller.jobs.getAll();
+
+    expect(result.map((j) => j.slug)).toEqual([
+      'alpha', // 1 Top
+      'beta', // 2 Med, title-alphabetical with charlie
+      'charlie', // 2 Med
+      'delta', // 3 Low
+      'aardvark', // null, title-alphabetical with zeta
+      'zeta', // null
+    ]);
+  });
+});

--- a/apps/website/src/server/routers/jobs.ts
+++ b/apps/website/src/server/routers/jobs.ts
@@ -9,10 +9,15 @@ export const jobsRouter = router({
         publicationStatus: 'Published',
       });
 
-      // Sort jobs alphabetically by title and remove the body field
-      // TODO: just fetch these fields from the DB in the first place
+      // Sort by Airtable Prio (e.g. "1 Top", "2 Med", "3 Low"), then title.
+      // Jobs without a priority sort to the bottom.
       return allJobs
-        .sort((a, b) => (a.title ?? '').localeCompare(b.title ?? ''))
+        .sort((a, b) => {
+          const pa = a.priority ?? '￿';
+          const pb = b.priority ?? '￿';
+          if (pa !== pb) return pa.localeCompare(pb);
+          return (a.title ?? '').localeCompare(b.title ?? '');
+        })
         .map(({ body, ...rest }) => rest);
     }),
 });

--- a/apps/website/src/server/routers/jobs.ts
+++ b/apps/website/src/server/routers/jobs.ts
@@ -10,7 +10,8 @@ export const jobsRouter = router({
       });
 
       // Sort by Airtable Prio (e.g. "1 Top", "2 Med", "3 Low"), then title.
-      // Jobs without a priority sort to the bottom.
+      // '￿' (U+FFFF, the max BMP code point) is a sentinel so jobs without
+      // a priority sort after every real value.
       return allJobs
         .sort((a, b) => {
           const pa = a.priority ?? '￿';


### PR DESCRIPTION
## Summary

Sorts the `/join-us` open roles list by the new Airtable "Prio" singleSelect (`1 Top` → `2 Med` → `3 Low`), with title as the tiebreaker. Roles without a Prio fall to the bottom. Applies to both the main "Open roles" list and the contractor "Support our mission" list.

Also drops the hardcoded `talent`-slug push-to-bottom in `JobsListSection.tsx` — Prio is now the single source of truth for ordering.

**Depends on #2461** (schema-only PR adding the `priority` column). This PR is draft and based on `dewi/joinus-priority-schema`; once #2461 merges and pg-sync materialises the column in staging, GitHub will auto-retarget this PR to master.

## Why split

Following the [`linkPreviewImage` precedent (#2432)](https://github.com/bluedotimpact/bluedot/pull/2432): website code that reads a not-yet-materialised column 500s on staging until pg-sync redeploys. Shipping the schema separately means staging never breaks.

## Test plan

- [x] `npx tsc --noEmit` in `libraries/db`, `apps/website`, `apps/editor` — all pass
- [x] `cd apps/website && npm test` — 633 tests pass
- [ ] After #2461 merges + pg-sync redeploys: locally hit `/join-us` and confirm order matches Airtable Prio; sweep viewports 320/480/720/1024/1440
- [ ] After merge: confirm prod ordering matches Airtable after the manual website deploy