### PR TITLE
[codex] Move course deferral action to discussions footer

### DIFF
--- a/apps/website/src/components/settings/CourseDetails.stories.tsx
+++ b/apps/website/src/components/settings/CourseDetails.stories.tsx
@@ -103,6 +103,27 @@ export const Default: Story = {
   },
 };
 
+export const ManyUpcomingDiscussions: Story = {
+  args: {
+    courseRegistration: { ...mockCourseRegistration, role: 'Participant' },
+    upcomingDiscussions: Array.from({ length: 5 }, (_, index) => {
+      const unitNumber = index + 1;
+      return {
+        ...mockDiscussions['discussion-1']!,
+        id: `discussion-${unitNumber}`,
+        startDateTime: now + (unitNumber + 1) * 7 * 24 * ONE_HOUR_SECONDS,
+        endDateTime: now + (unitNumber + 1) * 7 * 24 * ONE_HOUR_SECONDS + ONE_HOUR_SECONDS,
+        unitNumber,
+        unitFallback: `${unitNumber}: Unit ${unitNumber}`,
+        unitRecord: {
+          unitNumber: unitNumber.toString(),
+          title: `Unit ${unitNumber}`,
+        } as GroupDiscussionWithGroupAndUnit['unitRecord'],
+      };
+    }),
+  },
+};
+
 export const Facilitator: Story = {
   args: {
     courseRegistration: { ...mockCourseRegistration, role: 'Facilitator' },

--- a/apps/website/src/components/settings/CourseDetails.test.tsx
+++ b/apps/website/src/components/settings/CourseDetails.test.tsx
@@ -30,6 +30,15 @@ vi.mock('../courses/GroupSwitchModal', () => ({
   ),
 }));
 
+vi.mock('../courses/DropoutModal', () => ({
+  default: ({ handleClose }: { handleClose: () => void }) => (
+    <div data-testid="dropout-modal">
+      <div>Dropout Modal</div>
+      <button type="button" onClick={handleClose}>Close Dropout Modal</button>
+    </div>
+  ),
+}));
+
 vi.mock('../../lib/downloadCalendarFile', () => ({
   downloadDiscussionCalendarFile: vi.fn(),
 }));
@@ -320,6 +329,8 @@ describe('CourseDetails: Participant view', () => {
     expect(switchGroupPermanently).toBeInTheDocument();
     // This one should not have an href since it opens a modal
     expect(switchGroupPermanently).not.toHaveAttribute('href');
+    expect(screen.queryByRole('menuitem', { name: 'Request dropout or deferral' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Defer or drop out' })).toBeInTheDocument();
 
     // Click "Switch group permanently" to verify it opens modal WITHOUT initial unit number
     await act(async () => {
@@ -331,6 +342,48 @@ describe('CourseDetails: Participant view', () => {
     // Should NOT have a unit number for "Switch group permanently"
     expect(modal).not.toHaveTextContent(/Unit \d/);
     expect(screen.getByText('Switch type: Switch group permanently')).toBeInTheDocument();
+  });
+
+  it('shows dropout or deferral as a footer action on the see all discussions line', async () => {
+    const user = userEvent.setup();
+    const currentTimeMs = Date.now();
+
+    const upcomingDiscussions = Array.from({ length: 5 }, (_, index) => {
+      const unitNumber = index + 1;
+
+      return {
+        ...createMockGroupDiscussion({
+          id: `discussion-footer-${unitNumber}`,
+          unitNumber,
+          startDateTime: Math.floor(currentTimeMs / 1000) + (index + 2) * 60 * 60,
+          endDateTime: Math.floor(currentTimeMs / 1000) + (index + 3) * 60 * 60,
+        }),
+        unitRecord: createMockUnit({ unitNumber: unitNumber.toString(), title: `Unit ${unitNumber}` }),
+        groupDetails: createMockGroup(),
+      };
+    });
+
+    render(<CourseDetails
+      course={mockCourse}
+      courseRegistration={mockCourseRegistration}
+      upcomingDiscussions={upcomingDiscussions}
+      attendedDiscussions={[]}
+      facilitatedDiscussions={[]}
+      isLoading={false}
+    />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'See all (5) discussions' })).toBeInTheDocument();
+    });
+
+    const dropoutButton = screen.getByRole('button', { name: 'Defer or drop out' });
+    expect(dropoutButton).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(dropoutButton);
+    });
+
+    expect(screen.getByTestId('dropout-modal')).toBeInTheDocument();
   });
 
   it('shows NOW/LIVE indicators when discussion is live', async () => {

--- a/apps/website/src/components/settings/DiscussionList.tsx
+++ b/apps/website/src/components/settings/DiscussionList.tsx
@@ -4,7 +4,7 @@ import {
   useCurrentTimeMs, cn,
 } from '@bluedot/ui';
 import { useState } from 'react';
-import { FaArrowRightArrowLeft, FaRightToBracket } from 'react-icons/fa6';
+import { FaArrowRightArrowLeft } from 'react-icons/fa6';
 import { PiCalendarDots } from 'react-icons/pi';
 import {
   buildGroupSlackChannelUrl, formatDateMonthAndDay, formatDateTimeRelative, formatTime12HourClock,
@@ -51,6 +51,9 @@ const DiscussionList = ({
     return <p className="text-size-sm text-gray-500 py-4">{emptyMessage}</p>;
   }
 
+  const showSeeAllButton = discussions.length > 3;
+  const showDropoutOrDeferralButton = !isFacilitator && !isPast;
+
   return (
     <div>
       {(showAll ? discussions : discussions.slice(0, 3)).map((discussion, index) => (
@@ -63,19 +66,35 @@ const DiscussionList = ({
           isFacilitator={isFacilitator}
           onOpenGroupSwitchModal={onOpenGroupSwitchModal}
           onOpenFacilitatorModal={onOpenFacilitatorModal}
-          onOpenDropoutModal={onOpenDropoutModal}
         />
       ))}
-      {discussions.length > 3 && (
-        <div className="pt-4 text-center">
-          <button
-            type="button"
-            onClick={() => setShowAll(!showAll)}
-            className="text-size-sm font-medium text-bluedot-normal hover:text-blue-700 transition-colors cursor-pointer"
-            aria-expanded={showAll}
-          >
-            {showAll ? 'Show less' : `See all (${discussions.length}) discussions`}
-          </button>
+      {(showSeeAllButton || showDropoutOrDeferralButton) && (
+        <div className="grid grid-cols-1 gap-3 pt-4 sm:grid-cols-[1fr_auto_1fr] sm:items-center">
+          <div className="hidden sm:block" />
+          <div className="justify-self-center">
+            {showSeeAllButton && (
+              <button
+                type="button"
+                onClick={() => setShowAll(!showAll)}
+                className="text-size-sm font-medium text-bluedot-normal hover:text-blue-700 transition-colors cursor-pointer"
+                aria-expanded={showAll}
+              >
+                {showAll ? 'Show less' : `See all (${discussions.length}) discussions`}
+              </button>
+            )}
+          </div>
+          <div className="sm:justify-self-end">
+            {showDropoutOrDeferralButton && (
+              <CTALinkOrButton
+                variant={BUTTON_STYLES.secondary.variant}
+                size="small"
+                className={cn('w-full sm:w-auto', BUTTON_STYLES.secondary.className)}
+                onClick={onOpenDropoutModal}
+              >
+                Defer or drop out
+              </CTALinkOrButton>
+            )}
+          </div>
         </div>
       )}
     </div>
@@ -92,7 +111,6 @@ type DiscussionListRowProps = {
   isFacilitator: boolean;
   onOpenGroupSwitchModal: (discussion: GroupDiscussionWithGroupAndUnit, switchType: SwitchType) => void;
   onOpenFacilitatorModal: (discussion: GroupDiscussionWithGroupAndUnit, modalType: FacilitatorModalType) => void;
-  onOpenDropoutModal: () => void;
 };
 
 const DiscussionListRow = ({
@@ -103,7 +121,6 @@ const DiscussionListRow = ({
   isFacilitator,
   onOpenGroupSwitchModal,
   onOpenFacilitatorModal,
-  onOpenDropoutModal,
 }: DiscussionListRowProps) => {
   const currentTimeMs = useCurrentTimeMs();
   const [isDownloadingCalendar, setIsDownloadingCalendar] = useState(false);
@@ -208,14 +225,6 @@ const DiscussionListRow = ({
       onClick: () => onOpenGroupSwitchModal(discussion, 'Switch group permanently'),
       isVisible: !isFacilitator && !isPast,
       overflowIcon: <FaArrowRightArrowLeft className="mx-auto size-[14px]" />,
-    },
-    {
-      id: 'dropout-or-deferral',
-      label: 'Request dropout or deferral',
-      variant: 'secondary',
-      isVisible: !isFacilitator && !isPast,
-      onClick: onOpenDropoutModal,
-      overflowIcon: <FaRightToBracket className="mx-auto size-[14px]" />,
     },
     {
       id: 'download-calendar',


### PR DESCRIPTION
## Summary

- Moves the participant dropout/deferral action out of each upcoming discussion row overflow menu.
- Adds a single `Defer or drop out` button to the discussion list footer, aligned with the row action column beside `See all (...) discussions`.
- Adds a five-discussion Storybook scenario and test coverage for the new footer placement.

## Why

The dropout/deferral request applies to the course registration, not an individual discussion, so it belongs as a standalone course-level action rather than inside every row's overflow menu.

## Validation

- `npm test -- src/components/settings/CourseDetails.test.tsx`
- `npx eslint apps/website/src/components/settings/DiscussionList.tsx apps/website/src/components/settings/CourseDetails.test.tsx apps/website/src/components/settings/CourseDetails.stories.tsx --max-warnings=0`
- `npm run typecheck`