### PR TITLE
[feat] speed-review: more rounds + tech ability + application history

### DIFF
--- a/apps/speed-review/src/components/ApplicationCard.tsx
+++ b/apps/speed-review/src/components/ApplicationCard.tsx
@@ -1,5 +1,6 @@
 import { type Application } from '../lib/client/types';
 import { SummaryCard } from './SummaryCard';
+import { PreviousApplicationsCard } from './PreviousApplicationsCard';
 
 type ApplicationCardProps = {
   application: Application;
@@ -57,6 +58,8 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, p
       </div>
 
       {aiSummary && <SummaryCard aiSummary={aiSummary} course={course} />}
+
+      <PreviousApplicationsCard applicationId={application.id} />
 
       <div className="border border-stone-700 rounded-lg divide-y divide-stone-700 overflow-hidden">
         {([

--- a/apps/speed-review/src/components/PreviousApplicationsCard.tsx
+++ b/apps/speed-review/src/components/PreviousApplicationsCard.tsx
@@ -1,0 +1,91 @@
+import useAxios from 'axios-hooks';
+
+type PreviousApplication = {
+  id: string;
+  roundName: string;
+  humanOpinion: string;
+  decision: string;
+  createdAt: string;
+};
+
+type PreviousApplicationsCardProps = {
+  applicationId: string;
+};
+
+const opinionBadgeClass = (opinion: string): string => {
+  switch (opinion) {
+    case 'Strong yes': return 'bg-blue-800 text-white';
+    case 'Weak yes': return 'bg-sky-400 text-stone-900';
+    case 'Neutral': return 'bg-stone-500 text-white';
+    case 'Weak no': return 'bg-red-500 text-white';
+    case 'Strong no': return 'bg-red-800 text-white';
+    default: return 'bg-stone-700 text-stone-300';
+  }
+};
+
+const decisionBadgeClass = (decision: string): string => {
+  switch (decision) {
+    case 'Accept': return 'bg-blue-600 text-white';
+    case 'Reject': return 'bg-red-600 text-white';
+    default: return 'bg-stone-700 text-stone-300';
+  }
+};
+
+const Badge: React.FC<{ label: string; className: string }> = ({ label, className }) => (
+  <span className={`inline-block px-2 py-0.5 rounded text-size-xs font-semibold whitespace-nowrap ${className}`}>
+    {label}
+  </span>
+);
+
+export const PreviousApplicationsCard: React.FC<PreviousApplicationsCardProps> = ({ applicationId }) => {
+  const [{ data, loading, error }] = useAxios<{ history: PreviousApplication[] }>({
+    method: 'get',
+    url: `/api/application-history?id=${encodeURIComponent(applicationId)}`,
+  });
+
+  if (loading) {
+    return (
+      <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5">
+        <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">Previous applications</p>
+        <p className="text-size-sm text-stone-500">Loading…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5">
+        <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">Previous applications</p>
+        <p className="text-size-sm text-red-400">{error.message}</p>
+      </div>
+    );
+  }
+
+  const history = data?.history ?? [];
+
+  if (history.length === 0) {
+    return (
+      <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5">
+        <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">Previous applications</p>
+        <p className="text-size-sm text-stone-500">No previous applications.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5 space-y-2">
+      <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-1">Previous applications</p>
+      <ul className="space-y-2">
+        {history.map((h) => (
+          <li key={h.id} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1.5 sm:gap-3">
+            <span className="text-size-sm text-stone-200">{h.roundName}</span>
+            <span className="flex items-center gap-1.5 shrink-0">
+              <Badge label={h.humanOpinion || 'TODO'} className={opinionBadgeClass(h.humanOpinion || 'TODO')} />
+              <Badge label={h.decision || 'TODO'} className={decisionBadgeClass(h.decision || 'TODO')} />
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/apps/speed-review/src/components/RoundPicker.tsx
+++ b/apps/speed-review/src/components/RoundPicker.tsx
@@ -63,7 +63,7 @@ export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
                   </svg>
                 </summary>
                 <div className="space-y-2 mt-2">
-                  {grouped[key]!.rounds.slice(0, 3).map((round) => (
+                  {grouped[key]!.rounds.slice(0, 7).map((round) => (
                     <button
                       key={round.id}
                       type="button"

--- a/apps/speed-review/src/components/SummaryCard.tsx
+++ b/apps/speed-review/src/components/SummaryCard.tsx
@@ -8,7 +8,7 @@ type SummaryCardProps = {
 export const SummaryCard: React.FC<SummaryCardProps> = ({ aiSummary, course }) => {
   const { role, domain, technicalAbility, topAchievement, commitment } = parseSummary(aiSummary);
 
-  const showTechnicalAbility = course === 'Technical AI Safety' && !!technicalAbility;
+  const showTechnicalAbility = (course === 'Technical AI Safety' || course === 'Technical AI Safety Project') && !!technicalAbility;
 
   return (
     <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5 space-y-3">

--- a/apps/speed-review/src/lib/api/airtable.ts
+++ b/apps/speed-review/src/lib/api/airtable.ts
@@ -221,6 +221,73 @@ export const fetchApplications = async (
   };
 };
 
+export type PreviousApplication = {
+  id: string;
+  roundName: string;
+  humanOpinion: string;
+  decision: string;
+  createdAt: string;
+};
+
+const APPLICATION_EMAIL_FIELD = 'fld0g392xytratknm';
+const APPLICATION_ROUND_NAME_FIELD = 'fldQymBa7milTYP9q'; // [*] Round name formula
+const APPLICATION_HUMAN_OPINION_FIELD = 'fldOm6fJcqhq78M71';
+const APPLICATION_DECISION_FIELD = 'fldWVKY5EFAGSRcDT';
+const APPLICATION_CREATED_AT_FIELD = 'fldyZHM0qpgIkzo8c';
+const APPLICATION_DUPLICATE_FIELD = 'fld1KQjHFGoDZKf94';
+
+const fetchApplicationEmailAndRound = async (applicationId: string): Promise<{ email?: string; roundId?: string }> => {
+  const { records } = await fetchPage(
+    APPLICATIONS_URL,
+    {
+      filterByFormula: `RECORD_ID() = "${applicationId}"`,
+      returnFieldsByFieldId: 'true',
+    },
+    [APPLICATION_EMAIL_FIELD, 'fldYaHSLqnvBXyjur'],
+  );
+  const fields = records[0]?.fields ?? {};
+  const roundField = fields.fldYaHSLqnvBXyjur;
+  const roundId = Array.isArray(roundField) ? (roundField as string[])[0] : undefined;
+  return { email: str(fields[APPLICATION_EMAIL_FIELD]), roundId };
+};
+
+export const fetchApplicationHistory = async (applicationId: string): Promise<PreviousApplication[]> => {
+  const { email, roundId } = await fetchApplicationEmailAndRound(applicationId);
+  if (!email) return [];
+
+  const escaped = email.replace(/"/g, '\\"');
+  const records = await fetchAll(
+    APPLICATIONS_URL,
+    {
+      filterByFormula: `AND(LOWER({${APPLICATION_EMAIL_FIELD}}) = "${escaped.toLowerCase()}", NOT({${APPLICATION_DUPLICATE_FIELD}}))`,
+      returnFieldsByFieldId: 'true',
+    },
+    [
+      APPLICATION_ROUND_NAME_FIELD,
+      APPLICATION_HUMAN_OPINION_FIELD,
+      APPLICATION_DECISION_FIELD,
+      APPLICATION_CREATED_AT_FIELD,
+      'fldYaHSLqnvBXyjur',
+    ],
+  );
+
+  return records
+    .filter((r) => {
+      if (!roundId) return r.id !== applicationId;
+      const rounds = r.fields.fldYaHSLqnvBXyjur;
+      return !Array.isArray(rounds) || !(rounds as string[]).includes(roundId);
+    })
+    .map((r) => ({
+      id: r.id,
+      roundName: str(r.fields[APPLICATION_ROUND_NAME_FIELD]) ?? '',
+      humanOpinion: str(r.fields[APPLICATION_HUMAN_OPINION_FIELD]) ?? '',
+      decision: str(r.fields[APPLICATION_DECISION_FIELD]) ?? '',
+      createdAt: str(r.fields[APPLICATION_CREATED_AT_FIELD]) ?? '',
+    }))
+    .filter((a) => a.roundName !== '')
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+};
+
 export type RoundStats = {
   total: number;
   evaluated: number;

--- a/apps/speed-review/src/lib/api/airtable.ts
+++ b/apps/speed-review/src/lib/api/airtable.ts
@@ -285,7 +285,11 @@ export const fetchApplicationHistory = async (applicationId: string): Promise<Pr
       createdAt: str(r.fields[APPLICATION_CREATED_AT_FIELD]) ?? '',
     }))
     .filter((a) => a.roundName !== '')
-    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+    .sort((a, b) => {
+      if (a.createdAt < b.createdAt) return 1;
+      if (a.createdAt > b.createdAt) return -1;
+      return 0;
+    });
 };
 
 export type RoundStats = {

--- a/apps/speed-review/src/pages/api/application-history.ts
+++ b/apps/speed-review/src/pages/api/application-history.ts
@@ -1,0 +1,24 @@
+import createHttpError from 'http-errors';
+import { z } from 'zod';
+import { makeApiRoute } from '../../lib/api/makeApiRoute';
+import { fetchApplicationHistory } from '../../lib/api/airtable';
+import { requireAdmin } from '../../lib/api/requireAdmin';
+
+export default makeApiRoute({
+  requireAuth: true,
+  responseBody: z.object({
+    history: z.array(z.object({
+      id: z.string(),
+      roundName: z.string(),
+      humanOpinion: z.string(),
+      decision: z.string(),
+      createdAt: z.string(),
+    })),
+  }),
+}, async (_, { auth, raw: { req } }) => {
+  await requireAdmin(auth.email);
+  const id = typeof req.query.id === 'string' ? req.query.id : '';
+  if (!id) throw new createHttpError.BadRequest('Missing required query param: id');
+  const history = await fetchApplicationHistory(id);
+  return { history };
+});

--- a/apps/speed-review/src/pages/api/application-history.ts
+++ b/apps/speed-review/src/pages/api/application-history.ts
@@ -18,7 +18,7 @@ export default makeApiRoute({
 }, async (_, { auth, raw: { req } }) => {
   await requireAdmin(auth.email);
   const id = typeof req.query.id === 'string' ? req.query.id : '';
-  if (!id) throw new createHttpError.BadRequest('Missing required query param: id');
+  if (!/^rec[A-Za-z0-9]{14}$/.test(id)) throw new createHttpError.BadRequest('Missing or invalid query param: id');
   const history = await fetchApplicationHistory(id);
   return { history };
 });


### PR DESCRIPTION
## Summary

- **Round picker shows up to 7 upcoming rounds per course** (was 3) — gives reviewers visibility into more of the pipeline.
- **TAIS Project course now displays the Technical Ability section** in the AI summary card. Previously this section was only shown for the Technical AI Safety course; AGI Strategy still hides it.
- **New "Previous applications" card** below the AI summary, listing the applicant's prior applications across all rounds with coloured badges for human opinion (strong yes → dark blue, weak yes → light blue, neutral → grey, weak/strong no → red) and decision (accept → blue, reject → red). Applications to the round currently being reviewed are excluded.

Backed by a new `GET /api/application-history?id=<applicationId>` endpoint that looks up the applicant's email and round, then fetches all non-duplicate applications by that email and filters out anything linked to the current round.

## Test plan

- [ ] Pick an AGI Strategy round → Previous applications card shows, Technical Ability section hidden in AI summary
- [ ] Pick a Technical AI Safety round → Previous applications card shows, Technical Ability section visible
- [ ] Pick a Technical AI Safety Project round → Previous applications card shows, Technical Ability section visible
- [ ] Round picker shows up to 7 rounds per course
- [ ] For an applicant with prior applications, the card lists them with correct badge colours and the round currently being reviewed is excluded
- [ ] For an applicant with no prior applications, the card shows "No previous applications."

🤖 Generated with [Claude Code](https://claude.com/claude-code)