### PR TITLE
[feat] facilitators: show 'Edit feedback' on /settings/courses after submission

### DIFF
--- a/apps/website/src/components/settings/CourseList.tsx
+++ b/apps/website/src/components/settings/CourseList.tsx
@@ -419,7 +419,9 @@ const getCtaButtons = ({
 
     const facilitatorFeedbackUrl = isFacilitatorRole && meetPerson ? `/facilitator-feedback/${meetPerson.id}` : null;
     const feedbackUrl = facilitatorFeedbackUrl ?? feedbackFormUrl;
-    if (!hasSubmittedFeedback && feedbackUrl) {
+    // Facilitators always see the button so they can return to amend their submission
+    const showFeedbackButton = feedbackUrl && (isFacilitatorRole || !hasSubmittedFeedback);
+    if (showFeedbackButton) {
       buttons.push(<CTALinkOrButton
         key="feedback"
         variant="outline-black"
@@ -428,7 +430,7 @@ const getCtaButtons = ({
         target={facilitatorFeedbackUrl ? undefined : '_blank'}
         className="w-full sm:w-auto border-bluedot-darker"
       >
-        Share feedback
+        {hasSubmittedFeedback ? 'Edit feedback' : 'Share feedback'}
       </CTALinkOrButton>);
     }
 


### PR DESCRIPTION
# Description

From the Issue:
> Related to https://github.com/bluedotimpact/bluedot/issues/2454, this is another way for facilitators to find their way back to a submitted feedback form to edit it.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2460

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="662" height="1066" alt="Screenshot 2026-05-12 at 15 00 52" src="https://github.com/user-attachments/assets/6759a7c7-15a7-4e28-84af-20ddc7897378" /> | <img width="662" height="1066" alt="Screenshot 2026-05-12 at 15 00 18" src="https://github.com/user-attachments/assets/b6d7ea21-44fd-4f29-b572-974ba9eb6531" /> |
| 🖥️ | <img width="2336" height="966" alt="Screenshot 2026-05-12 at 15 00 57" src="https://github.com/user-attachments/assets/ea4d5b6d-2e76-4469-adac-8e91e52b7fb8" /> | <img width="2334" height="960" alt="Screenshot 2026-05-12 at 15 00 06" src="https://github.com/user-attachments/assets/89339a6a-2bb1-4ab2-881c-e8271c19e881" /> |