### PR TITLE
[refactor] Unify reschedule eligibility in groupSwitchingRouter

### DIFF
--- a/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
@@ -112,6 +112,7 @@ const mockAvailableGroupsAndDiscussions: DiscussionsAvailable = {
       },
     ],
   },
+  rescheduleEligibleUnits: ['1', '2'],
 };
 
 const manyGroupNames = [
@@ -163,6 +164,7 @@ const mockManyGroupsData: DiscussionsAvailable = {
       })),
     ],
   },
+  rescheduleEligibleUnits: ['1'],
 };
 
 const meta = {

--- a/apps/website/src/components/courses/GroupSwitchModal.test.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.test.tsx
@@ -121,6 +121,7 @@ const mockAvailableGroupsAndDiscussions: DiscussionsAvailable = {
       },
     ],
   },
+  rescheduleEligibleUnits: ['1'],
 };
 
 describe('GroupSwitchModal', () => {
@@ -443,6 +444,7 @@ describe('GroupSwitchModal', () => {
           ],
           2: [], // Unit 2 has no upcoming discussions
         },
+        rescheduleEligibleUnits: ['1'],
       };
 
       // Override mock for this test
@@ -894,6 +896,7 @@ describe('GroupSwitchModal', () => {
           })),
         ],
       },
+      rescheduleEligibleUnits: ['1'],
     };
 
     test('shows first 3 options collapsed, then expands on click', async () => {

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -84,9 +84,9 @@ export default function GroupSwitchModal({
   const groups = availableGroupsAndDiscussions?.groupsAvailable ?? [];
   const discussions = availableGroupsAndDiscussions?.discussionsAvailable?.[selectedUnitNumber] ?? [];
 
+  const rescheduleEligibleUnits = new Set(availableGroupsAndDiscussions?.rescheduleEligibleUnits ?? []);
   const unitOptions = courseData?.units.map((u) => {
-    const unitDiscussions = availableGroupsAndDiscussions?.discussionsAvailable?.[u.unitNumber];
-    const hasAvailableDiscussions = unitDiscussions?.length;
+    const hasAvailableDiscussions = rescheduleEligibleUnits.has(u.unitNumber.toString());
 
     return {
       value: u.unitNumber.toString(),

--- a/apps/website/src/components/courses/InactiveCourseBanners.stories.tsx
+++ b/apps/website/src/components/courses/InactiveCourseBanners.stories.tsx
@@ -27,6 +27,7 @@ const mockAvailableGroups: DiscussionsAvailable = {
     },
   ],
   discussionsAvailable: {},
+  rescheduleEligibleUnits: [],
 };
 
 const meta = {

--- a/apps/website/src/components/courses/RejoinGroupModal.stories.tsx
+++ b/apps/website/src/components/courses/RejoinGroupModal.stories.tsx
@@ -38,6 +38,7 @@ const mockAvailableGroups: DiscussionsAvailable = {
     },
   ],
   discussionsAvailable: {},
+  rescheduleEligibleUnits: [],
 };
 
 const mockNoSpotsGroups: DiscussionsAvailable = {
@@ -62,6 +63,7 @@ const mockNoSpotsGroups: DiscussionsAvailable = {
     },
   ],
   discussionsAvailable: {},
+  rescheduleEligibleUnits: [],
 };
 
 const mockManyGroups: DiscussionsAvailable = {
@@ -82,6 +84,7 @@ const mockManyGroups: DiscussionsAvailable = {
     spotsLeftIfKnown: i === 2 ? 0 : i + 1,
   })),
   discussionsAvailable: {},
+  rescheduleEligibleUnits: [],
 };
 
 const meta = {
@@ -120,6 +123,7 @@ export const NoAvailableGroups: Story = {
         trpcStorybookMsw.groupSwitching.discussionsAvailable.query(() => ({
           groupsAvailable: [],
           discussionsAvailable: {},
+          rescheduleEligibleUnits: [],
         })),
         trpcStorybookMsw.groupSwitching.switchGroup.mutation(() => null),
       ],

--- a/apps/website/src/server/routers/group-switching.test.ts
+++ b/apps/website/src/server/routers/group-switching.test.ts
@@ -15,7 +15,7 @@ import { createMockGroup, createMockGroupDiscussion } from '../../__tests__/test
 import {
   setupTestDb, createCaller, testAuthContextLoggedIn, testDb,
 } from '../../__tests__/dbTestUtils';
-import { calculateGroupAvailability } from './group-switching';
+import { calculateGroupAvailability, getAvailableGroupsAndDiscussions } from './group-switching';
 import { ONE_DAY_SECONDS } from '../../lib/constants';
 
 setupTestDb();
@@ -310,6 +310,80 @@ describe('calculateGroupAvailability', () => {
     // Should calculate based on 2 other participants: 5 - 2 = 3
     expect(result.groupsAvailable[0]?.spotsLeftIfKnown).toBe(3);
     expect(result.discussionsAvailable[String(discussions[0]!.unitNumber)]?.[0]?.spotsLeftIfKnown).toBe(3);
+  });
+});
+
+describe('getAvailableGroupsAndDiscussions', () => {
+  const futureSec = Math.floor(Date.now() / 1000) + ONE_DAY_SECONDS;
+  const participantId = 'participant-1';
+
+  test('filters groups, discussions, and reschedule-eligible units to humanOpinion-allowed groups', () => {
+    const ownGroup = createMockGroup({ id: 'g-own', participants: [participantId], whoCanSwitchIntoThisGroup: [] });
+    const allowedGroup = createMockGroup({ id: 'g-allowed', participants: [], whoCanSwitchIntoThisGroup: ['Strong yes'] });
+    const blockedGroup = createMockGroup({ id: 'g-blocked', participants: [], whoCanSwitchIntoThisGroup: ['Weak yes'] });
+
+    const discussions = [
+      createMockGroupDiscussion({
+        id: 'd-own', group: 'g-own', unitNumber: 1, participantsExpected: [participantId], startDateTime: futureSec, endDateTime: futureSec + 60,
+      }),
+      createMockGroupDiscussion({
+        id: 'd-allowed', group: 'g-allowed', unitNumber: 1, participantsExpected: [], startDateTime: futureSec, endDateTime: futureSec + 60,
+      }),
+      // Blocked group's discussion — should not appear anywhere in the output.
+      createMockGroupDiscussion({
+        id: 'd-blocked', group: 'g-blocked', unitNumber: 2, participantsExpected: [], startDateTime: futureSec, endDateTime: futureSec + 60,
+      }),
+    ];
+
+    const result = getAvailableGroupsAndDiscussions({
+      allGroupsInRound: [ownGroup, allowedGroup, blockedGroup],
+      allGroupDiscussionsInRound: discussions,
+      participantId,
+      participantHumanOpinion: 'Strong yes',
+      maxParticipants: 5,
+    });
+
+    expect(result.groupsAvailable.map((g) => g.group.id).sort()).toEqual(['g-allowed', 'g-own']);
+    expect(result.discussionsAvailable['1']?.map((d) => d.discussion.id).sort()).toEqual(['d-allowed', 'd-own']);
+    expect(result.discussionsAvailable['2']).toBeUndefined();
+    expect(result.rescheduleEligibleUnits).toEqual(['1']);
+  });
+
+  test('always includes the user\'s own group even when humanOpinion does not match', () => {
+    // User is a participant in g-own, but the group's whoCanSwitchIntoThisGroup excludes Strong yes.
+    // The own-group participation should win — the user must still be able to see their own group.
+    const ownGroup = createMockGroup({ id: 'g-own', participants: [participantId], whoCanSwitchIntoThisGroup: ['Weak yes'] });
+
+    const result = getAvailableGroupsAndDiscussions({
+      allGroupsInRound: [ownGroup],
+      allGroupDiscussionsInRound: [
+        createMockGroupDiscussion({
+          id: 'd-own', group: 'g-own', unitNumber: 1, participantsExpected: [participantId], startDateTime: futureSec, endDateTime: futureSec + 60,
+        }),
+      ],
+      participantId,
+      participantHumanOpinion: 'Strong yes',
+      maxParticipants: 5,
+    });
+
+    expect(result.allowedGroups.map((g) => g.id)).toEqual(['g-own']);
+    expect(result.groupsAvailable.map((g) => g.group.id)).toEqual(['g-own']);
+  });
+
+  test.each([null, 'TODO', 'Strong no'])('falls back to \'Neutral\' when humanOpinion is %j', (humanOpinion) => {
+    // Group requires Neutral; participant has null/invalid opinion. Should still match.
+    const neutralGroup = createMockGroup({ id: 'g-neutral', participants: [], whoCanSwitchIntoThisGroup: ['Neutral'] });
+    const strongYesGroup = createMockGroup({ id: 'g-strong', participants: [], whoCanSwitchIntoThisGroup: ['Strong yes'] });
+
+    const result = getAvailableGroupsAndDiscussions({
+      allGroupsInRound: [neutralGroup, strongYesGroup],
+      allGroupDiscussionsInRound: [],
+      participantId,
+      participantHumanOpinion: humanOpinion,
+      maxParticipants: 5,
+    });
+
+    expect(result.allowedGroups.map((g) => g.id)).toEqual(['g-neutral']);
   });
 });
 

--- a/apps/website/src/server/routers/group-switching.test.ts
+++ b/apps/website/src/server/routers/group-switching.test.ts
@@ -727,6 +727,105 @@ describe('groupSwitching.discussionsAvailable', () => {
 
     expect(result.groupsAvailable[0]!.spotsLeftIfKnown).toBeNull();
   });
+
+  test('returns rescheduleEligibleUnits for units with a non-self future discussion', async () => {
+    await seedCourseWithGroups();
+
+    // Unit 2: only the user's own group has a discussion (no alternative to switch into).
+    await testDb.insert(groupDiscussionTable, {
+      id: 'disc-a2',
+      group: 'group-a',
+      round: 'round-1',
+      unitNumber: 2,
+      unit: 'unit-2',
+      startDateTime: futureTimeSecs,
+      endDateTime: farFutureTimeSecs,
+      facilitators: ['facilitator-1'],
+      participantsExpected: ['participant-1', 'other-participant'],
+    });
+
+    const result = await caller.groupSwitching.discussionsAvailable({ roundId: 'round-1' });
+
+    // Unit 1 has Group B as an alternative → eligible.
+    // Unit 2 only has the user's own discussion → not eligible.
+    expect(result.rescheduleEligibleUnits).toEqual(['1']);
+  });
+
+  test('excludes units whose only alternative is in a humanOpinion-blocked group', async () => {
+    await testDb.insert(courseTable, {
+      id: 'course-1',
+      slug: 'test-course',
+      title: 'Test',
+      shortDescription: 'Test',
+      units: [],
+    });
+
+    await testDb.insert(roundTable, {
+      id: 'round-1',
+      title: 'Round 1',
+      course: 'course-1',
+      maxParticipantsPerGroup: 5,
+    });
+
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-1',
+      email: 'test@example.com',
+      courseId: 'course-1',
+      decision: 'Accept',
+    });
+
+    await testDb.insert(meetPersonTable, {
+      id: 'participant-1',
+      email: 'test@example.com',
+      applicationsBaseRecordId: 'reg-1',
+      round: 'round-1',
+      role: 'Participant',
+      humanOpinion: 'Strong yes',
+    });
+
+    // User's own group + an alternative gated to a different opinion.
+    await testDb.insert(groupTable, {
+      id: 'my-group',
+      groupName: 'My Group',
+      round: 'round-1',
+      participants: ['participant-1'],
+      whoCanSwitchIntoThisGroup: ['Strong yes'],
+    });
+
+    await testDb.insert(groupTable, {
+      id: 'blocked-group',
+      groupName: 'Blocked Group',
+      round: 'round-1',
+      participants: ['someone-else'],
+      whoCanSwitchIntoThisGroup: ['Weak yes'],
+    });
+
+    await testDb.insert(groupDiscussionTable, {
+      group: 'my-group',
+      round: 'round-1',
+      unitNumber: 1,
+      unit: 'unit-1',
+      startDateTime: futureTimeSecs,
+      endDateTime: farFutureTimeSecs,
+      facilitators: ['fac-1'],
+      participantsExpected: ['participant-1'],
+    });
+
+    await testDb.insert(groupDiscussionTable, {
+      group: 'blocked-group',
+      round: 'round-1',
+      unitNumber: 1,
+      unit: 'unit-1',
+      startDateTime: futureTimeSecs,
+      endDateTime: farFutureTimeSecs,
+      facilitators: ['fac-2'],
+      participantsExpected: ['someone-else'],
+    });
+
+    const result = await caller.groupSwitching.discussionsAvailable({ roundId: 'round-1' });
+
+    expect(result.rescheduleEligibleUnits).toEqual([]);
+  });
 });
 
 describe('groupSwitching.switchGroup', () => {

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -118,7 +118,7 @@ export function calculateGroupAvailability({
   };
 }
 
-export function getAllowedGroupsForParticipant({
+function getAllowedGroupsForParticipant({
   allGroups,
   participantId,
   participantHumanOpinion,
@@ -136,7 +136,7 @@ export function getAllowedGroupsForParticipant({
   ));
 }
 
-export function calculateRescheduleEligibleUnits(discussionsAvailable: DiscussionsByUnit): Set<string> {
+function calculateRescheduleEligibleUnits(discussionsAvailable: DiscussionsByUnit): Set<string> {
   const eligible = new Set<string>();
   for (const [unitKey, list] of Object.entries(discussionsAvailable)) {
     if (list.some((d) => !d.userIsParticipant)) {

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -118,6 +118,70 @@ export function calculateGroupAvailability({
   };
 }
 
+export function getAllowedGroupsForParticipant({
+  allGroups,
+  participantId,
+  participantHumanOpinion,
+}: {
+  allGroups: Group[];
+  participantId: string;
+  participantHumanOpinion: string | null;
+}): Group[] {
+  const opinion = participantHumanOpinion && (VALID_HUMAN_OPINIONS as readonly string[]).includes(participantHumanOpinion)
+    ? participantHumanOpinion
+    : 'Neutral';
+  return allGroups.filter((group) => (
+    (group.participants ?? []).includes(participantId)
+    || (group.whoCanSwitchIntoThisGroup ?? []).includes(opinion)
+  ));
+}
+
+export function calculateRescheduleEligibleUnits(discussionsAvailable: DiscussionsByUnit): Set<string> {
+  const eligible = new Set<string>();
+  for (const [unitKey, list] of Object.entries(discussionsAvailable)) {
+    if (list.some((d) => !d.userIsParticipant)) {
+      eligible.add(unitKey);
+    }
+  }
+
+  return eligible;
+}
+
+/**
+ * Source of truth for the participant-facing "what can I switch into?" answer.
+ */
+export function getAvailableGroupsAndDiscussions({
+  allGroupsInRound,
+  allGroupDiscussionsInRound,
+  participantId,
+  participantHumanOpinion,
+  maxParticipants,
+}: {
+  allGroupsInRound: Group[];
+  allGroupDiscussionsInRound: GroupDiscussion[];
+  participantId: string;
+  participantHumanOpinion: string | null;
+  maxParticipants: number | null | undefined;
+}) {
+  const allowedGroups = getAllowedGroupsForParticipant({ allGroups: allGroupsInRound, participantId, participantHumanOpinion });
+  const allowedGroupIds = new Set(allowedGroups.map((g) => g.id));
+  const allowedDiscussions = allGroupDiscussionsInRound.filter((d) => allowedGroupIds.has(d.group));
+
+  const { groupsAvailable, discussionsAvailable } = calculateGroupAvailability({
+    groupDiscussions: allowedDiscussions,
+    groups: allowedGroups,
+    maxParticipants,
+    participantId,
+  });
+
+  return {
+    allowedGroups,
+    groupsAvailable,
+    discussionsAvailable,
+    rescheduleEligibleUnits: [...calculateRescheduleEligibleUnits(discussionsAvailable)],
+  };
+}
+
 export const groupSwitchingRouter = router({
   discussionsAvailable: protectedProcedure
     .input(z.object({ roundId: z.string() }))
@@ -132,58 +196,28 @@ export const groupSwitchingRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'No course round found' });
       }
 
-      /**
-       * Get groups the user is allowed to switch to:
-       * 1. Get all the groups in this round of the course.
-       * 2. Match the participant's humanOpinion against each group's whoCanSwitchIntoThisGroup.
-       * 3. Always include groups the participant is already in.
-       */
-      const getGroupsAllowedToSwitchInto = async () => {
-        const allGroups = await db.scan(groupTable, { round: roundId });
-        const participantGroupIds = allGroups.filter((g) => (g.participants ?? []).includes(participant.id)).map((g) => g.id);
+      const [allGroupsInRound, allGroupDiscussionsInRound] = await Promise.all([
+        db.scan(groupTable, { round: roundId }),
+        db.scan(groupDiscussionTable, { round: roundId }),
+      ]);
 
-        // Explicitly allow groups the user is already in
-        const allowedGroupIds = new Set<string>(participantGroupIds);
+      const result = getAvailableGroupsAndDiscussions({
+        allGroupsInRound,
+        allGroupDiscussionsInRound,
+        participantId: participant.id,
+        participantHumanOpinion: participant.humanOpinion ?? null,
+        maxParticipants: courseRound.maxParticipantsPerGroup,
+      });
 
-        const opinion = participant.humanOpinion && (VALID_HUMAN_OPINIONS as readonly string[]).includes(participant.humanOpinion)
-          ? participant.humanOpinion
-          : 'Neutral';
-
-        for (const group of allGroups) {
-          if ((group.whoCanSwitchIntoThisGroup ?? []).includes(opinion)) {
-            allowedGroupIds.add(group.id);
-          }
-        }
-
-        return allGroups.filter((group) => allowedGroupIds.has(group.id));
-      };
-
-      const allowedGroups = await getGroupsAllowedToSwitchInto();
-
-      if (allowedGroups.filter((g) => !(g.participants ?? []).includes(participant.id)).length === 0) {
+      if (result.allowedGroups.filter((g) => !(g.participants ?? []).includes(participant.id)).length === 0) {
         // eslint-disable-next-line no-console
         console.warn(`[Group switching] Warning for course registration ${participant.id}: No groups allowed to switch into. This is likely due to the "Who can switch into this group" field not including the participant's Human opinion value.`);
       }
 
-      const allowedGroupDiscussions = allowedGroups.length ? await db.scan(groupDiscussionTable, {
-        OR: allowedGroups.map((g) => ({ group: g.id })),
-      }) : [];
-
-      const maxParticipants = courseRound.maxParticipantsPerGroup;
-
-      const {
-        discussionsAvailable,
-        groupsAvailable,
-      } = calculateGroupAvailability({
-        groupDiscussions: allowedGroupDiscussions,
-        groups: allowedGroups,
-        maxParticipants,
-        participantId: participant.id,
-      });
-
       return {
-        groupsAvailable,
-        discussionsAvailable,
+        groupsAvailable: result.groupsAvailable,
+        discussionsAvailable: result.discussionsAvailable,
+        rescheduleEligibleUnits: result.rescheduleEligibleUnits,
       };
     }),
 


### PR DESCRIPTION
# Description

This is a like-for-like refactor of `routers/group-switching.ts` which exposes a pure function `getAvailableGroupsAndDiscussions` for calculating group switching availability.

The motivation for this is that #2413 starts using group switching availability in a different backend router (to decide where to show "Reschedule" buttons in the new My Courses page). With this addition there would be ~3 places where a calculation of this sort would be needed (`routers/group-switching.ts`, the new router, and the `GroupSwitchModal` itself). The change in this PR is intended to push all of this into the backend, and into this shared `getAvailableGroupsAndDiscussions` so we don't get subtle divergences between these sites.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2400

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->