### PR TITLE
[refactor] pull grant application URLs from Airtable only

### DIFF
--- a/apps/website/src/components/grants/grantPrograms.tsx
+++ b/apps/website/src/components/grants/grantPrograms.tsx
@@ -18,12 +18,6 @@ export type GrantProgramDefinition = {
   scopeLabel?: string;
 };
 
-export const RAPID_GRANT_APPLICATION_URL = 'https://airtable.com/appMVNtdBtvtJvu5E/pag9G3oF4DYAyassX/form';
-export const CAREER_TRANSITION_GRANT_APPLICATION_URL = 'https://airtable.com/appMVNtdBtvtJvu5E/pagyKD4M0wd0ci2gH/form';
-export const ONE_ON_ONE_ADVISING_APPLICATION_URL = 'https://web.miniextensions.com/elMoT4tTN0jx49tNB0cS';
-export const INCUBATOR_WEEK_APPLICATION_URL = 'https://airtable.com/appnJbsG1eWbAdEvf/pagA7JU8pPkkbDCOJ/form';
-export const BUILDER_WEEK_APPLICATION_URL = 'https://airtable.com/';
-
 export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
   {
     slug: 'rapid-grants',
@@ -110,13 +104,11 @@ export const getGrantProgramViewTransitionStyle = (
 export type ConfigurableGrantProgramSlug = 'rapid-grants' | 'career-transition-grant' | 'advising' | 'incubator-week' | 'builder-week';
 
 export type GrantProgramSectionConfig = {
-  applicationUrl: string;
   faqItems: FAQItem[];
 };
 
 export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantProgramSectionConfig> = {
   'rapid-grants': {
-    applicationUrl: RAPID_GRANT_APPLICATION_URL,
     faqItems: [
       {
         id: 'unsure',
@@ -159,7 +151,6 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
     ],
   },
   'career-transition-grant': {
-    applicationUrl: CAREER_TRANSITION_GRANT_APPLICATION_URL,
     faqItems: [
       {
         id: 'eligibility',
@@ -192,7 +183,6 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
     ],
   },
   'incubator-week': {
-    applicationUrl: INCUBATOR_WEEK_APPLICATION_URL,
     faqItems: [
       {
         id: 'solo-or-team',
@@ -229,11 +219,9 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
     ],
   },
   'builder-week': {
-    applicationUrl: BUILDER_WEEK_APPLICATION_URL,
     faqItems: [],
   },
   advising: {
-    applicationUrl: ONE_ON_ONE_ADVISING_APPLICATION_URL,
     faqItems: [
       {
         id: 'no-bluedot-course',

--- a/apps/website/src/components/grants/sections/GrantCta.tsx
+++ b/apps/website/src/components/grants/sections/GrantCta.tsx
@@ -9,6 +9,8 @@ type Props = {
 const GrantCta = ({ program }: Props) => {
   const applicationUrl = useGrantApplicationUrl(program);
 
+  if (!applicationUrl) return null;
+
   return (
     <div className={`${program}-cta w-full max-w-max-width mx-auto px-spacing-x mt-spacing-y mb-16 flex justify-center`}>
       <CTALinkOrButton

--- a/apps/website/src/components/grants/sections/GrantStatsStrip.tsx
+++ b/apps/website/src/components/grants/sections/GrantStatsStrip.tsx
@@ -10,7 +10,7 @@ export type GrantStat = {
 
 export type GrantStatsAction = {
   label: string;
-  url: string;
+  url: string | undefined;
   onClick?: (e: React.BaseSyntheticEvent) => void;
 };
 
@@ -51,16 +51,18 @@ const GrantStatsStrip = ({
           ))}
         </div>
         <div className="flex flex-wrap gap-3">
-          <CTALinkOrButton
-            variant="primary"
-            withChevron
-            url={primary.url}
-            target="_blank"
-            onClick={primary.onClick}
-          >
-            {primary.label}
-          </CTALinkOrButton>
-          {secondaryAction && (
+          {primary.url && (
+            <CTALinkOrButton
+              variant="primary"
+              withChevron
+              url={primary.url}
+              target="_blank"
+              onClick={primary.onClick}
+            >
+              {primary.label}
+            </CTALinkOrButton>
+          )}
+          {secondaryAction?.url && (
             <CTALinkOrButton
               variant="secondary"
               withChevron

--- a/apps/website/src/components/grants/useGrantApplicationUrl.ts
+++ b/apps/website/src/components/grants/useGrantApplicationUrl.ts
@@ -1,17 +1,14 @@
 import { useLatestUtmParams } from '@bluedot/ui';
 import { buildApplicationUrl } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
-import {
-  GRANT_PROGRAM_SECTIONS,
-  type ConfigurableGrantProgramSlug,
-} from './grantPrograms';
+import { type ConfigurableGrantProgramSlug } from './grantPrograms';
 
-export const useGrantApplicationUrl = (program: ConfigurableGrantProgramSlug): string => {
+export const useGrantApplicationUrl = (program: ConfigurableGrantProgramSlug): string | undefined => {
   const { data: programs } = trpc.programs.getAll.useQuery();
   const { latestUtmParams } = useLatestUtmParams();
 
-  const fromAirtable = programs?.find((p) => p.slug === program)?.applicationForm;
-  const applicationUrl = fromAirtable ?? GRANT_PROGRAM_SECTIONS[program].applicationUrl;
+  const applicationUrl = programs?.find((p) => p.slug === program)?.applicationForm;
+  if (!applicationUrl) return undefined;
 
   return buildApplicationUrl(applicationUrl, latestUtmParams.utm_source);
 };

--- a/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
+++ b/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
@@ -2,7 +2,7 @@ import { CTALinkOrButton, P } from '@bluedot/ui';
 import { pageSectionHeadingClass } from '../PageListRow';
 
 type Props = {
-  applicationUrl: string;
+  applicationUrl: string | undefined;
   applicationDeadline: string;
 };
 
@@ -14,14 +14,16 @@ const AboutBlueDotSection = ({ applicationUrl, applicationDeadline }: Props) => 
         <P>
           BlueDot Impact is a nonprofit based in London and SF, building the workforce and organizations needed to safely navigate AGI. We&apos;ve raised over $35M and trained over 8,000 people since 2022.
         </P>
-        <CTALinkOrButton
-          variant="primary"
-          withChevron
-          url={applicationUrl}
-          target="_blank"
-        >
-          Apply by {applicationDeadline}
-        </CTALinkOrButton>
+        {applicationUrl && (
+          <CTALinkOrButton
+            variant="primary"
+            withChevron
+            url={applicationUrl}
+            target="_blank"
+          >
+            Apply by {applicationDeadline}
+          </CTALinkOrButton>
+        )}
       </div>
     </section>
   );

--- a/apps/website/src/components/rapid-grants/HowItWorksSection.tsx
+++ b/apps/website/src/components/rapid-grants/HowItWorksSection.tsx
@@ -2,7 +2,7 @@ import { P } from '@bluedot/ui';
 import { pageSectionHeadingClass } from '../PageListRow';
 import { useGrantApplicationUrl } from '../grants/useGrantApplicationUrl';
 
-const buildProcessSteps = (applicationUrl: string) => [
+const buildProcessSteps = (applicationUrl: string | undefined) => [
   {
     number: '01',
     title: 'Apply',

--- a/apps/website/src/components/rapid-grants/WhatThisIsForSection.tsx
+++ b/apps/website/src/components/rapid-grants/WhatThisIsForSection.tsx
@@ -23,18 +23,20 @@ const WhatThisIsForSection = () => {
 
         <div className="flex flex-col gap-5">
           <P>For anyone working on concrete AI safety projects. Research, events, community building, tooling, compute.</P>
-          <P>
-            If in doubt,{' '}
-            <a
-              href={applicationUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-bluedot-navy underline underline-offset-4"
-            >
-              apply
-            </a>
-            .
-          </P>
+          {applicationUrl && (
+            <P>
+              If in doubt,{' '}
+              <a
+                href={applicationUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-bluedot-navy underline underline-offset-4"
+              >
+                apply
+              </a>
+              .
+            </P>
+          )}
         </div>
 
         <div className="pt-2 grid gap-4 bd-md:grid-cols-2">


### PR DESCRIPTION
# Description

Removes the 5 hardcoded `*_APPLICATION_URL` constants from `grantPrograms.tsx` and the `applicationUrl` field on `GRANT_PROGRAM_SECTIONS`. The Airtable `programs` table's `applicationForm` column is now the single source of truth for grant program apply links.

`useGrantApplicationUrl` previously fell back to a hardcoded constant whenever the Airtable record was missing or loading. That fallback always returned a string, so consumers never had to handle the "no URL yet" case — but it meant the Builder Week page (which has no Airtable row yet) shipped with the Apply CTA pointing at the airtable.com homepage (flagged by Greptile on PR #2474). Now the hook returns `string | undefined`, and the few consumers that render Apply CTAs (`AboutBlueDotSection`, `GrantStatsStrip`, `GrantCta`) conditionally render only when the URL is defined.

## What changed

1. **`apps/website/src/components/grants/grantPrograms.tsx`** — deletes the 5 `*_APPLICATION_URL` constants and removes `applicationUrl` from `GrantProgramSectionConfig` and every entry in `GRANT_PROGRAM_SECTIONS`. `faqItems` is now the only field on that map.
2. **`apps/website/src/components/grants/useGrantApplicationUrl.ts`** — drops the fallback; returns `programs?.find(...)?.applicationForm` (via `buildApplicationUrl`) or `undefined`. New return type: `string | undefined`.
3. **`apps/website/src/components/grants/sections/GrantStatsStrip.tsx`** — `GrantStatsAction.url` becomes `string | undefined`; primary and secondary CTAs only render when their URL is defined.
4. **`apps/website/src/components/grants/sections/GrantCta.tsx`** — early-returns `null` when no URL.
5. **`apps/website/src/components/incubator-week/AboutBlueDotSection.tsx`** — `applicationUrl` prop becomes `string | undefined`; Apply button only renders when defined.
6. **`apps/website/src/components/rapid-grants/HowItWorksSection.tsx`** — relaxes `buildProcessSteps` signature to accept `string | undefined`. The existing `step.url ?` branching already handles the missing case correctly.

## Notes

- **Side-effect for Builder Week:** the Apply CTA stays hidden until the `builder-week` row is created in the programs Airtable table with `applicationForm` populated. Better than the current placeholder linking to `airtable.com`.
- **No change for the 4 active programs** (rapid-grants, career-transition-grant, advising, incubator-week) — they all have records in Airtable with `applicationForm` set, so behaviour is identical to before.

## Issue

N/A — follow-up cleanup discussed in PR #2474.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — no a11y changes, just conditional rendering.
- [x] Considered having snapshot tests / functional tests — declined. Existing tests for these components (where they exist) don't cover the URL fallback path; the type system enforces the contract.
- [x] Considered adding Storybook stories — N/A, no new components.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8002` in the `anglilian/grant-url-refactor` worktree):
- ✅ `/programs/builder-week` (no Airtable record): page renders, both Apply CTAs (stats strip + AboutBlueDot) gracefully hidden.
- ✅ `/programs/incubator-week` (Airtable record exists): Apply CTAs still render with the real URL.

Type check + lint + full test suite all pass:
```
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 646 passed | 1 skipped (107 files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)