### PR TITLE
[codex] Add advisor profile description schema field

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1478,6 +1478,7 @@ export const teamMemberTable = pgAirtable('team_member', {
     url: { pgColumn: text(), airtableId: 'fld3ChLLOQHQGDK18' },
     status: { pgColumn: text(), airtableId: 'fld5nsgLdaDUoMC2N' },
     isOneOnOneAdvisor: { pgColumn: boolean(), airtableId: 'fld2buAZqzoTYiYW3' },
+    advisorProfileDescription: { pgColumn: text(), airtableId: 'fld0IXiTxomwfcstc' },
   },
 });
 


### PR DESCRIPTION
## Summary

Adds `advisorProfileDescription` to the Airtable-backed `teamMemberTable` schema, mapped to the new Airtable field `fld0IXiTxomwfcstc` (`Advisor Profile Description`).

## Why

The 1-1 advising page uses team members flagged as advisors. This schema-only PR prepares the Airtable/Postgres sync layer before a follow-up PR starts returning and rendering the field in the advising UI.

## Notes

This intentionally does not add consumer code yet, following the repo guidance to merge schema additions separately and wait for sync before usage.

## Checks

- `npm test -- validate-schema.test.ts` from `libraries/db`
- `npm run lint -- src/schema.ts` from `libraries/db`