### PR TITLE
[codex] Show advisor profile descriptions

### DIFF
--- a/apps/website/src/components/advising/AdvisorsSection.test.tsx
+++ b/apps/website/src/components/advising/AdvisorsSection.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import {
+  describe,
+  expect,
+  test,
+} from 'vitest';
+import { TrpcProvider } from '../../__tests__/trpcProvider';
+import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
+import AdvisorsSection from './AdvisorsSection';
+
+describe('AdvisorsSection', () => {
+  test('renders advisor profile descriptions when present', async () => {
+    server.use(trpcMsw.teamMembers.getOneOnOneAdvisors.query(() => [
+      {
+        name: 'Ada Advisor',
+        jobTitle: 'AI governance lead',
+        imageUrl: 'https://example.com/ada.jpg',
+        url: 'https://example.com/ada',
+        advisorProfileDescription: 'Useful to talk to about choosing between AI governance career paths.',
+      },
+      {
+        name: 'Noor No Description',
+        jobTitle: 'Technical advisor',
+        imageUrl: 'https://example.com/noor.jpg',
+        url: undefined,
+        advisorProfileDescription: undefined,
+      },
+    ]));
+
+    render(<AdvisorsSection />, { wrapper: TrpcProvider });
+
+    expect(await screen.findByText('Ada Advisor')).toBeInTheDocument();
+    expect(screen.getByText('Noor No Description')).toBeInTheDocument();
+    expect(screen.getByText('Useful to talk to about choosing between AI governance career paths.')).toBeInTheDocument();
+  });
+});

--- a/apps/website/src/components/advising/AdvisorsSection.tsx
+++ b/apps/website/src/components/advising/AdvisorsSection.tsx
@@ -31,7 +31,7 @@ const AdvisorsSection = () => {
       <div className="w-full flex flex-col gap-6">
         <h3 className={pageSectionHeadingClass}>Advisors</h3>
 
-        <ul className="list-none grid gap-6 grid-cols-2 bd-md:grid-cols-3 lg:grid-cols-5">
+        <ul className="list-none grid gap-8 grid-cols-1 bd-md:grid-cols-2 min-[1120px]:grid-cols-3">
           {advisors.map((advisor) => {
             const card = (
               <div className="flex flex-col gap-3">
@@ -41,13 +41,20 @@ const AdvisorsSection = () => {
                   className="aspect-square w-full rounded-lg object-cover"
                   loading="lazy"
                 />
-                <div className="flex flex-col gap-1">
-                  <h4 className="text-size-sm font-semibold leading-tight text-bluedot-navy">
-                    {advisor.name}
-                  </h4>
-                  {advisor.jobTitle && (
-                    <p className="text-size-xs leading-[1.4] text-bluedot-navy/68">
-                      {advisor.jobTitle}
+                <div className="flex flex-col gap-2">
+                  <div className="flex flex-col gap-1">
+                    <h4 className="text-size-sm font-semibold leading-tight text-bluedot-navy">
+                      {advisor.name}
+                    </h4>
+                    {advisor.jobTitle && (
+                      <p className="text-size-xs leading-[1.4] text-bluedot-navy/68">
+                        {advisor.jobTitle}
+                      </p>
+                    )}
+                  </div>
+                  {advisor.advisorProfileDescription && (
+                    <p className="text-size-xs leading-[1.5] text-bluedot-navy/80">
+                      {advisor.advisorProfileDescription}
                     </p>
                   )}
                 </div>

--- a/apps/website/src/components/advising/WhoYouAreSection.tsx
+++ b/apps/website/src/components/advising/WhoYouAreSection.tsx
@@ -1,29 +1,20 @@
-import { P } from '@bluedot/ui';
-import { type IconType } from 'react-icons';
-import { PiArrowsClockwise, PiCompass, PiGraduationCap } from 'react-icons/pi';
 import { pageSectionHeadingClass } from '../PageListRow';
 
-const ACCENT_COLOR = '#1F588A';
-
 type Persona = {
-  icon: IconType;
   title: string;
   description: string;
 };
 
 const PERSONAS: Persona[] = [
   {
-    icon: PiGraduationCap,
     title: 'BlueDot graduate',
     description: 'You know the landscape, and you\'ve laid out your options through your action plan and 1-pager. The hard part now is committing to one direction and making real progress.',
   },
   {
-    icon: PiArrowsClockwise,
     title: 'Pivoting your career',
     description: 'You\'re making big moves to contribute your personal and professional experience to AI safety. You\'ve left your current job (or are planning to), gone on sabbatical or are applying to roles or programs. You need help figuring out what the transition looks like for someone with your background.',
   },
   {
-    icon: PiCompass,
     title: 'Finding your fit',
     description: 'You\'ve completed fellowships, run reading groups and published your thinking on AI safety. You\'re looking for where you can make an impactful contribution given your background, and how you can get there.',
   },
@@ -33,36 +24,21 @@ const WhoYouAreSection = () => {
   return (
     <section className="section section-body advising-who-you-are-section">
       <div className="w-full flex flex-col gap-6">
-        <h3 className={pageSectionHeadingClass}>Who you are</h3>
+        <h3 className={pageSectionHeadingClass}>Who we can help</h3>
 
-        <div className="flex flex-col gap-4">
-          {PERSONAS.map(({ icon: Icon, title, description }) => (
-            <div
+        <ul className="list-disc pl-6 flex flex-col gap-2">
+          {PERSONAS.map(({ title, description }) => (
+            <li
               key={title}
-              className="bg-white rounded-xl border border-bluedot-navy/10 overflow-hidden"
+              className="text-bluedot-navy/80 leading-[1.6]"
             >
-              <div
-                className="w-full px-6 py-5 bd-md:px-8 bd-md:py-6 flex items-center gap-4"
-                style={{ backgroundColor: ACCENT_COLOR }}
-              >
-                <div
-                  className="size-12 rounded-xl flex items-center justify-center flex-shrink-0"
-                  style={{ backgroundColor: 'rgba(255,255,255,0.2)' }}
-                >
-                  <Icon size={24} className="text-white" />
-                </div>
-                <span className="text-size-md font-semibold leading-[130%] flex-grow text-left text-white">
-                  {title}
-                </span>
-              </div>
-              <div className="p-6 bd-md:p-8">
-                <P className="text-size-sm leading-[1.7] text-bluedot-navy/70">
-                  {description}
-                </P>
-              </div>
-            </div>
+              <strong className="text-bluedot-navy">
+                {title}
+              </strong>
+              {`: ${description}`}
+            </li>
           ))}
-        </div>
+        </ul>
       </div>
     </section>
   );

--- a/apps/website/src/server/routers/teamMembers.test.ts
+++ b/apps/website/src/server/routers/teamMembers.test.ts
@@ -1,0 +1,53 @@
+import { teamMemberTable } from '@bluedot/db';
+import { describe, expect, test } from 'vitest';
+import { createCaller, setupTestDb, testDb } from '../../__tests__/dbTestUtils';
+
+setupTestDb();
+
+describe('teamMembers.getOneOnOneAdvisors', () => {
+  test('returns advisor profile descriptions for active 1-1 advisors', async () => {
+    await testDb.insert(teamMemberTable, {
+      name: 'Zoe Advisor',
+      jobTitle: 'Strategy advisor',
+      imagePublicUrls: 'https://example.com/zoe.jpg',
+      status: 'Active',
+      isOneOnOneAdvisor: true,
+      advisorProfileDescription: 'Useful to talk to about operations and strategy roles.',
+    });
+    await testDb.insert(teamMemberTable, {
+      name: 'Ada Advisor',
+      jobTitle: 'Governance advisor',
+      imagePublicUrls: 'https://example.com/ada.jpg',
+      status: 'Active',
+      isOneOnOneAdvisor: true,
+      advisorProfileDescription: '   ',
+    });
+    await testDb.insert(teamMemberTable, {
+      name: 'Hidden Person',
+      jobTitle: 'Not an advisor',
+      imagePublicUrls: 'https://example.com/hidden.jpg',
+      status: 'Active',
+      isOneOnOneAdvisor: false,
+      advisorProfileDescription: 'This should not be returned.',
+    });
+
+    const result = await createCaller().teamMembers.getOneOnOneAdvisors();
+
+    expect(result).toEqual([
+      {
+        name: 'Ada Advisor',
+        jobTitle: 'Governance advisor',
+        imageUrl: 'https://example.com/ada.jpg',
+        url: undefined,
+        advisorProfileDescription: undefined,
+      },
+      {
+        name: 'Zoe Advisor',
+        jobTitle: 'Strategy advisor',
+        imageUrl: 'https://example.com/zoe.jpg',
+        url: undefined,
+        advisorProfileDescription: 'Useful to talk to about operations and strategy roles.',
+      },
+    ]);
+  });
+});

--- a/apps/website/src/server/routers/teamMembers.ts
+++ b/apps/website/src/server/routers/teamMembers.ts
@@ -14,6 +14,15 @@ function getFirstImageUrl(imageAttachmentUrls: string | string[] | null): string
   return imageAttachmentUrls.split(' ')[0] ?? '';
 }
 
+function getAdvisorProfileDescription(advisorProfileDescription: string | null): string | undefined {
+  const trimmed = advisorProfileDescription?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed;
+}
+
 export const teamMembersRouter = router({
   getAll: publicProcedure
     .query(async () => {
@@ -45,6 +54,7 @@ export const teamMembersRouter = router({
           jobTitle: m.jobTitle,
           imageUrl: getFirstImageUrl(m.imagePublicUrls),
           url: m.url ?? undefined,
+          advisorProfileDescription: getAdvisorProfileDescription(m.advisorProfileDescription),
         }))
         .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
     }),


### PR DESCRIPTION
## Summary
- Surface the new Airtable-backed advisor profile description on the 1-1 advising advisor cards.
- Widen the advisor grid so the added copy has room to breathe.
- Replace the heavy “Who you are” cards with a quieter “Who we can help” list that matches the surrounding advising page rhythm.
- Add focused router and component tests for advisor profile descriptions.

## Validation
- `npm test -- AdvisorsSection.test.tsx teamMembers.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- Local browser check at `http://localhost:8000/programs/advising`