### PR TITLE
[feat] Builder Week: render Apply CTA for Draft rows + field builders restyle

### DIFF
--- a/apps/website/src/components/builder-week/FieldBuildersSection.tsx
+++ b/apps/website/src/components/builder-week/FieldBuildersSection.tsx
@@ -95,12 +95,12 @@ const styledLinkClass = 'font-semibold text-bluedot-navy underline underline-off
 
 const BuilderRow = ({ builder }: { builder: Builder }) => {
   return (
-    <div className="grid grid-cols-1 bd-md:grid-cols-[220px_1fr] gap-5 bd-md:gap-14 py-7 bd-md:py-9 items-center border-t border-bluedot-navy/10 first:border-t-0">
+    <div className="grid grid-cols-1 bd-md:grid-cols-[140px_1fr] gap-5 bd-md:gap-12 py-7 bd-md:py-9 items-center border-t border-bluedot-navy/10 first:border-t-0">
       <a
         href={builder.program.url}
         target="_blank"
         rel="noreferrer"
-        className="flex items-center justify-center w-[220px] h-[130px]"
+        className="flex items-center justify-center w-[140px] h-[80px]"
         aria-label={`${builder.program.name} website`}
       >
         <img
@@ -109,7 +109,7 @@ const BuilderRow = ({ builder }: { builder: Builder }) => {
           className="max-w-full max-h-full object-contain"
         />
       </a>
-      <P className="text-size-sm leading-[1.65] text-bluedot-navy/85 max-w-[640px]">
+      <P className="text-size-md leading-[1.6] text-bluedot-navy/85 max-w-[680px]">
         {builder.founder.profileUrl ? (
           <a
             href={builder.founder.profileUrl}

--- a/apps/website/src/components/builder-week/FieldBuildersSection.tsx
+++ b/apps/website/src/components/builder-week/FieldBuildersSection.tsx
@@ -145,14 +145,9 @@ const FieldBuildersSection = () => {
   return (
     <section className="section section-body builder-week-field-builders-section">
       <div className="w-full flex flex-col gap-7">
-        <div className="flex flex-col gap-3">
-          <H3 className={pageSectionHeadingClass}>
-            Most AI safety programs started with someone seeing a talent gap, and building a pathway.
-          </H3>
-          <P className="max-w-[62ch]">
-            They figured, &ldquo;I can just do the thing&rdquo; and <em>did it</em>.
-          </P>
-        </div>
+        <H3 className={`${pageSectionHeadingClass} max-w-[720px] text-balance`}>
+          Most AI safety programs started because someone saw a talent gap, and decided to do something about it.
+        </H3>
 
         <div className="flex flex-col border-t border-b border-bluedot-navy/10">
           {visibleBuilders.map((builder) => (

--- a/apps/website/src/components/builder-week/FieldBuildersSection.tsx
+++ b/apps/website/src/components/builder-week/FieldBuildersSection.tsx
@@ -16,10 +16,8 @@ type Builder = {
     src: string;
     alt: string;
   };
-  tint: string;
-  credentialBefore: string;
-  credentialAfter: string;
-  story: string;
+  before: string;
+  after: string;
 };
 
 const BUILDERS: Builder[] = [
@@ -31,10 +29,8 @@ const BUILDERS: Builder[] = [
     },
     program: { name: 'MATS', url: 'https://www.matsprogram.org/' },
     logo: { src: '/images/programs/builder-week-founders/mats.svg', alt: 'MATS logo' },
-    tint: 'rgba(34, 83, 230, 0.08)',
-    credentialBefore: 'Physics PhD doing independent alignment research at SERI, who co-founded ',
-    credentialAfter: '.',
-    story: 'He saw the shortage of excellent technical talent, and decided to build the pipeline.',
+    before: ' was a physics PhD doing independent alignment research at SERI who saw the shortage of excellent technical talent and co-founded ',
+    after: ' to build the pipeline.',
   },
   {
     slug: 'horizon',
@@ -44,10 +40,8 @@ const BUILDERS: Builder[] = [
     },
     program: { name: 'Horizon', url: 'https://horizonpublicservice.org/about-us/' },
     logo: { src: '/images/programs/builder-week-founders/horizon.png', alt: 'Horizon Institute logo' },
-    tint: 'rgba(58, 92, 196, 0.08)',
-    credentialBefore: 'Technical-policy researcher at CSET, who started ',
-    credentialAfter: '.',
-    story: 'He watched policy teams struggle to hire technical talent, and built the program to bring them in.',
+    before: ' was a technical-policy researcher at CSET watching policy teams struggle to hire technical talent, so he started ',
+    after: ' to bring them in.',
   },
   {
     slug: 'pibbss',
@@ -57,10 +51,8 @@ const BUILDERS: Builder[] = [
     },
     program: { name: 'PIBBSS', url: 'https://princint.ai/' },
     logo: { src: '/images/programs/builder-week-founders/pibbss.svg', alt: 'PIBBSS logo' },
-    tint: 'rgba(179, 71, 239, 0.08)',
-    credentialBefore: 'Complex-systems researcher at the Simon Institute, who co-founded ',
-    credentialAfter: '.',
-    story: 'She saw AI safety lacked diversity of expertise, and built a way to bring researchers from other fields in. Now, program director at ARIA.',
+    before: ' was a complex systems researcher at the Simon Institute, who saw that AI safety lacked diversity of expertise, so she co-founded ',
+    after: ' to bring researchers from other fields in. She’s now a program director at ARIA.',
   },
   {
     slug: 'arena',
@@ -70,10 +62,8 @@ const BUILDERS: Builder[] = [
     },
     program: { name: 'ARENA', url: 'https://www.arena.education/' },
     logo: { src: '/images/programs/builder-week-founders/arena.png', alt: 'ARENA logo' },
-    tint: 'rgba(124, 27, 179, 0.08)',
-    credentialBefore: 'Jane Street quant trying to break into AI safety research, who built ',
-    credentialAfter: '.',
-    story: 'He built the program he wished existed, to help others technically upskill into the field. Now, interp researcher at Google DeepMind.',
+    before: ' was a Jane Street quant trying to break into AI safety research who built ',
+    after: ' to help others technically upskill into the field. He’s now doing mech interp research at GDM.',
   },
   {
     slug: 'aisb',
@@ -83,10 +73,8 @@ const BUILDERS: Builder[] = [
     },
     program: { name: 'AI Security Bootcamp', url: 'https://aisb.dev/' },
     logo: { src: '/images/programs/builder-week-founders/aisb.svg', alt: 'AI Security Bootcamp logo' },
-    tint: 'rgba(46, 160, 28, 0.10)',
-    credentialBefore: 'Research engineer at Conjecture, who launched the ',
-    credentialAfter: '.',
-    story: 'He saw security professionals had no clear path into AI safety, and created one.',
+    before: ' was a research engineer at Conjecture, who saw security professionals had no clear path into AI safety, so he launched the ',
+    after: ' to create one.',
   },
   {
     slug: 'ml4good',
@@ -96,21 +84,16 @@ const BUILDERS: Builder[] = [
     },
     program: { name: 'ML4Good', url: 'https://ml4good.org/' },
     logo: { src: '/images/programs/builder-week-founders/ml4good.svg', alt: 'ML4Good logo' },
-    tint: 'rgba(212, 115, 15, 0.10)',
-    credentialBefore: 'ML engineer who built ',
-    credentialAfter: '.',
-    story: 'He saw coding bootcamps work for the tech industry, and brought the same model to AI safety.',
+    before: ' was an ML engineer who saw coding bootcamps work for the tech industry, and built ',
+    after: ' to bring talent into AI safety in the same way.',
   },
 ];
 
 const VISIBLE_COUNT = 3;
 
-const BuilderRow = ({ builder }: { builder: Builder }) => {
-  const NameTag = builder.founder.profileUrl ? 'a' : 'span';
-  const nameProps = builder.founder.profileUrl
-    ? { href: builder.founder.profileUrl, target: '_blank' as const, rel: 'noreferrer' }
-    : {};
+const styledLinkClass = 'font-semibold text-bluedot-navy underline underline-offset-2 hover:text-bluedot-normal';
 
+const BuilderRow = ({ builder }: { builder: Builder }) => {
   return (
     <div className="grid grid-cols-1 bd-md:grid-cols-[220px_1fr] gap-5 bd-md:gap-14 py-7 bd-md:py-9 items-center border-t border-bluedot-navy/10 first:border-t-0">
       <a
@@ -126,31 +109,30 @@ const BuilderRow = ({ builder }: { builder: Builder }) => {
           className="max-w-full max-h-full object-contain"
         />
       </a>
-      <div className="flex flex-col gap-2 max-w-[560px]">
-        <NameTag
-          {...nameProps}
-          className={`text-size-lg font-bold text-bluedot-navy leading-tight ${
-            builder.founder.profileUrl ? 'no-underline hover:text-bluedot-normal' : ''
-          }`}
-        >
-          {builder.founder.name}
-        </NameTag>
-        <P className="text-size-sm leading-[1.55] text-bluedot-navy/80">
-          {builder.credentialBefore}
+      <P className="text-size-sm leading-[1.65] text-bluedot-navy/85 max-w-[640px]">
+        {builder.founder.profileUrl ? (
           <a
-            href={builder.program.url}
+            href={builder.founder.profileUrl}
             target="_blank"
             rel="noreferrer"
-            className="font-semibold text-bluedot-navy underline underline-offset-2 hover:text-bluedot-normal"
+            className={styledLinkClass}
           >
-            {builder.program.name}
+            {builder.founder.name}
           </a>
-          {builder.credentialAfter}
-        </P>
-        <P className="text-size-xs leading-[1.65] text-bluedot-navy/65 mt-1">
-          {builder.story}
-        </P>
-      </div>
+        ) : (
+          <span className="font-semibold text-bluedot-navy">{builder.founder.name}</span>
+        )}
+        {builder.before}
+        <a
+          href={builder.program.url}
+          target="_blank"
+          rel="noreferrer"
+          className={styledLinkClass}
+        >
+          {builder.program.name}
+        </a>
+        {builder.after}
+      </P>
     </div>
   );
 };

--- a/apps/website/src/components/grants/useGrantApplicationUrl.ts
+++ b/apps/website/src/components/grants/useGrantApplicationUrl.ts
@@ -4,10 +4,10 @@ import { trpc } from '../../utils/trpc';
 import { type ConfigurableGrantProgramSlug } from './grantPrograms';
 
 export const useGrantApplicationUrl = (program: ConfigurableGrantProgramSlug): string | undefined => {
-  const { data: programs } = trpc.programs.getAll.useQuery();
+  const { data } = trpc.programs.getBySlug.useQuery({ slug: program });
   const { latestUtmParams } = useLatestUtmParams();
 
-  const applicationUrl = programs?.find((p) => p.slug === program)?.applicationForm;
+  const applicationUrl = data?.applicationForm;
   if (!applicationUrl) return undefined;
 
   return buildApplicationUrl(applicationUrl, latestUtmParams.utm_source);

--- a/apps/website/src/lib/programDetailPage.ts
+++ b/apps/website/src/lib/programDetailPage.ts
@@ -1,6 +1,6 @@
 import type { GetStaticPropsResult } from 'next';
 import { ONE_MINUTE_SECONDS } from './constants';
-import { getAllActivePrograms } from '../server/routers/programs';
+import { getProgramBySlug } from '../server/routers/programs';
 
 export type ProgramDetailPageProps = {
   programName: string;
@@ -8,10 +8,13 @@ export type ProgramDetailPageProps = {
 };
 
 /**
- * Fetches the active program with the given slug at build time so that
+ * Fetches the program with the given slug at build time so that
  * `<title>` and `<meta name="description">` (used by link previews and SEO)
  * stay in sync with the Programs Airtable table without a redeploy. ISR
  * revalidates every 5 minutes.
+ *
+ * Looks up by slug regardless of status — a Draft row still renders its
+ * own detail page; status only gates listing surfaces (/programs, Nav).
  *
  * Falls back to the supplied defaults when the program is missing from the
  * sync (e.g. while staging Postgres is still seeding) so the page still
@@ -22,8 +25,7 @@ export const getProgramDetailPageStaticProps = async (
   fallback: ProgramDetailPageProps,
 ): Promise<GetStaticPropsResult<ProgramDetailPageProps>> => {
   try {
-    const programs = await getAllActivePrograms();
-    const program = programs.find((p) => p.slug === slug);
+    const program = await getProgramBySlug(slug);
 
     return {
       props: {

--- a/apps/website/src/pages/programs/builder-week.tsx
+++ b/apps/website/src/pages/programs/builder-week.tsx
@@ -18,7 +18,7 @@ import {
 const PROGRAM_SLUG = 'builder-week';
 const FALLBACK_NAME = 'Builder Week';
 const FALLBACK_DESCRIPTION = 'There are ~2k people working full-time on AI safety. The field needs thousands more. Fly to London for 5 days to design and launch a new pathway. $5k on the spot if your pitch lands. Up to $200k for the strongest programs.';
-const APPLICATION_DEADLINE = '1 June 2026';
+const APPLICATION_DEADLINE = '1 June';
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bluedot.org';
 const LINK_PREVIEW_IMAGE = `${SITE_URL}/images/programs/link-preview/builder-week.png`;
 
@@ -62,7 +62,7 @@ const BuilderWeekProgramPage = ({ programName, programDescription }: ProgramDeta
         }}
         stats={[
           { label: 'Cohort', value: 'v1' },
-          { label: 'Runs', value: '8–12 June 2026' },
+          { label: 'Runs', value: '8–12 June' },
           { label: 'Funding', value: 'Up to $200k' },
           { label: 'Covered', value: 'Flights, accom, meals' },
         ]}

--- a/apps/website/src/server/routers/programs.test.ts
+++ b/apps/website/src/server/routers/programs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import { programTable } from '@bluedot/db';
+import { createCaller, setupTestDb, testDb } from '../../__tests__/dbTestUtils';
+
+setupTestDb();
+
+describe('programs.getBySlug', () => {
+  test('returns a Draft program — status filter is intentionally bypassed for detail-page lookups', async () => {
+    await testDb.insert(programTable, {
+      name: 'Builder Week',
+      slug: 'builder-week',
+      status: 'Draft',
+      applicationForm: 'https://example.com/builder-week',
+    });
+
+    const caller = createCaller();
+    const result = await caller.programs.getBySlug({ slug: 'builder-week' });
+
+    expect(result?.slug).toBe('builder-week');
+    expect(result?.applicationForm).toBe('https://example.com/builder-week');
+  });
+
+  test('returns null when no program matches the slug', async () => {
+    const caller = createCaller();
+    const result = await caller.programs.getBySlug({ slug: 'does-not-exist' });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('programs.getAll', () => {
+  test('excludes non-Active programs — locks down the listing-vs-detail contract divergence', async () => {
+    await testDb.insert(programTable, {
+      name: 'Active One', slug: 'active-one', status: 'Active',
+    });
+    await testDb.insert(programTable, {
+      name: 'Draft One', slug: 'draft-one', status: 'Draft',
+    });
+
+    const caller = createCaller();
+    const result = await caller.programs.getAll();
+
+    expect(result.map((p) => p.slug)).toEqual(['active-one']);
+  });
+});

--- a/apps/website/src/server/routers/programs.ts
+++ b/apps/website/src/server/routers/programs.ts
@@ -1,4 +1,5 @@
 import { programTable } from '@bluedot/db';
+import { z } from 'zod';
 import db from '../../lib/api/db';
 import { publicProcedure, router } from '../trpc';
 
@@ -13,8 +14,24 @@ export const getAllActivePrograms = async () => {
   return programs.sort((a, b) => getSortOrder(a.order) - getSortOrder(b.order));
 };
 
+/**
+ * Lookup a single program by slug, ignoring status. Used by program
+ * detail pages so a Draft row can still render its own page (meta tags,
+ * Apply CTA) while staying out of /programs index and Nav.
+ */
+export const getProgramBySlug = async (slug: string) => {
+  const [program] = await db.scan(programTable, { slug });
+  return program ?? null;
+};
+
 export const programsRouter = router({
   getAll: publicProcedure.query(async () => {
     return getAllActivePrograms();
   }),
+
+  getBySlug: publicProcedure
+    .input(z.object({ slug: z.string() }))
+    .query(async ({ input }) => {
+      return getProgramBySlug(input.slug);
+    }),
 });


### PR DESCRIPTION
# Description

Two bundled changes to the Builder Week page (and adjacent grant program infrastructure). Bundled because they were iterated together against the same live preview — the backend fix is what makes the frontend changes visible while the Airtable row is still in Draft.

**Backend:** Decouple program detail pages from the `status: 'Active'` filter. A Draft program row can now render its own `/programs/<slug>` page (with correct meta tags + Apply CTAs), while still staying off the `/programs` index, the Nav dropdown, and the homepage hero — all of which keep filtering by Active. This unblocks Li-Lian sharing the Builder Week URL with applicants before publicly launching the program on `/programs`.

**Frontend (Builder Week page):**
- Field Builders section restyled — each founder now renders as a single flowing sentence (matching the Notion source), with only the person's name and the program name styled (bold + linked).
- Logos shrunk to 140×80; sentence text bumped to `text-size-md` so the sentence is the row's centre of gravity.
- Section heading rewritten and constrained to `max-w-[720px]` with `text-balance` so it wraps symmetrically into two lines.
- Removed the "They figured…" subtitle line — the heading carries the framing on its own.
- Apply CTA / deadline reverts to "1 June" (no year); Runs stat reverts to "8–12 June" — matches how Li-Lian writes these dates internally.

## What changed

1. **`apps/website/src/server/routers/programs.ts`** — adds `programs.getBySlug` tRPC endpoint + a parallel server helper `getProgramBySlug` that looks up a single program by slug regardless of `status`. `programs.getAll` and `getAllActivePrograms` are unchanged.
2. **`apps/website/src/lib/programDetailPage.ts`** — switches `getProgramDetailPageStaticProps` from `getAllActivePrograms` to `getProgramBySlug`.
3. **`apps/website/src/components/grants/useGrantApplicationUrl.ts`** — switches from `trpc.programs.getAll` to `trpc.programs.getBySlug` so the Apply URL resolves even when the program is in Draft.
4. **`apps/website/src/components/builder-week/FieldBuildersSection.tsx`** — replaces the three-block layout (name heading + credential + story) with a single sentence per builder; shrinks the logo column to 140×80; rewrites the section heading.
5. **`apps/website/src/pages/programs/builder-week.tsx`** — reverts `APPLICATION_DEADLINE` to "1 June" and the Runs stat to "8–12 June".

## Issue

N/A — direct follow-up to PR #2476 (grant URL refactor) and PR #2474 (Builder Week page).

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — links have descriptive text, external program links use `rel="noreferrer"`.
- [x] Considered having snapshot tests / functional tests — declined. The `getBySlug` endpoint mirrors the `getAll` shape (covered by the existing `programs.test.tsx` pattern); no per-program detail-page tests exist for any program.
- [x] Considered adding Storybook stories — N/A; section component is page-specific.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8003` in the `anglilian/field-builders-sentence` worktree, with Builder Week Airtable row currently in Draft):
- ✅ `/programs/builder-week` — page renders, Apply CTAs in stats strip and AboutBlueDot section both show despite the Draft status (sourced via `getBySlug` lookup).
- ✅ `/programs` index — Builder Week is correctly **hidden** (status filter still applies at the listing layer).
- ✅ Nav dropdown — Builder Week is correctly **hidden**.
- ✅ `/programs/incubator-week` (Active row) — unchanged, Apply CTA renders.
- ✅ Field Builders section — top 3 visible as single-sentence rows with small logos, "Show 3 more" button reveals the rest, no console errors.

Type check + lint pass cleanly:
```
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
```

## Notes

- This branch includes the commits from `anglilian/program-status-detail-page-bypass`. Once this PR merges, that sibling branch can be deleted (its work is fully captured here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)