### PR TITLE
/congratulations enrolment CTA shows '8,000+ professionals'

### DIFF
--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -17,8 +17,8 @@ type CourseCompletionSectionProps = {
   className?: string;
 };
 
-// TODO: replace with a real fetched count once the metric is available.
-const COMMUNITY_SIZE_LABEL = '2,847 professionals';
+const FALLBACK_COMMUNITY_LABEL = '8,000+ alumni';
+const FALLBACK_COMMUNITY_TAIL = 'across BlueDot Impact';
 
 const AVATAR_IMAGES = [
   '/images/graduates/adam.webp',
@@ -62,29 +62,35 @@ const FeatureCardItem = ({ card, accentColor }: { card: FeatureCard; accentColor
   </div>
 );
 
-const SocialProof = ({ accentColor }: { accentColor?: string }) => (
-  <div
-    className="inline-flex flex-col items-center gap-3 rounded-[24px] px-4 py-3 max-w-full sm:flex-row sm:rounded-full sm:py-2"
-    // 8-digit hex (#RRGGBBAA) — `1F` ≈ 12% opacity tint of the course accent.
-    style={{ backgroundColor: accentColor ? `${accentColor}1F` : undefined }}
-  >
-    <div className="flex -space-x-2 shrink-0">
-      {AVATAR_IMAGES.map((src) => (
-        <img
-          key={src}
-          src={src}
-          alt=""
-          className="size-6 rounded-full object-cover ring-2 ring-white"
-        />
-      ))}
+const SocialProof = ({ accentColor, completerCount }: { accentColor?: string; completerCount: number }) => {
+  const hasDynamicCount = completerCount > 0;
+  const label = hasDynamicCount ? `${completerCount.toLocaleString('en-US')} graduates` : FALLBACK_COMMUNITY_LABEL;
+  const tail = hasDynamicCount ? 'of this course' : FALLBACK_COMMUNITY_TAIL;
+
+  return (
+    <div
+      className="inline-flex flex-col items-center gap-3 rounded-[24px] px-4 py-3 max-w-full sm:flex-row sm:rounded-full sm:py-2"
+      // 8-digit hex (#RRGGBBAA) — `1F` ≈ 12% opacity tint of the course accent.
+      style={{ backgroundColor: accentColor ? `${accentColor}1F` : undefined }}
+    >
+      <div className="flex -space-x-2 shrink-0">
+        {AVATAR_IMAGES.map((src) => (
+          <img
+            key={src}
+            src={src}
+            alt=""
+            className="size-6 rounded-full object-cover ring-2 ring-white"
+          />
+        ))}
+      </div>
+      <p className="text-size-xs leading-[1.4] text-bluedot-navy text-center sm:text-left">
+        Join{' '}
+        <span className="font-semibold" style={{ color: accentColor }}>{label}</span>
+        {' '}{tail}
+      </p>
     </div>
-    <p className="text-size-xs leading-[1.4] text-bluedot-navy text-center sm:text-left">
-      Join{' '}
-      <span className="font-semibold" style={{ color: accentColor }}>{COMMUNITY_SIZE_LABEL}</span>
-      {' '}already enrolled
-    </p>
-  </div>
-);
+  );
+};
 
 // eslint-disable-next-line react/function-component-definition
 export default function CourseCompletionSection({
@@ -135,7 +141,7 @@ export default function CourseCompletionSection({
     return (
       <div className={cn('flex flex-col gap-8', className)}>
         <div className="flex flex-col items-center gap-8 py-4 text-center max-w-[640px] mx-auto">
-          <SocialProof accentColor={accentColor} />
+          <SocialProof accentColor={accentColor} completerCount={completerCountData?.count ?? 0} />
           <div className="flex flex-col gap-3">
             {/* eslint-disable-next-line @bluedot/custom/no-arbitrary-text-size */}
             <H2 className="font-bold text-[28px] md:text-[32px] leading-[1.3] tracking-[-0.015em] text-bluedot-navy">

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -106,7 +106,12 @@ export default function CourseCompletionSection({
     { enabled: shouldFetchRounds },
   );
 
-  const isLoading = isApplicationLoading || (shouldFetchRounds && (isRoundsLoading || !roundsData));
+  const { data: completerCountData, isLoading: isCompleterCountLoading } = trpc.courses.getCompleterCount.useQuery(
+    { courseId },
+    { enabled: shouldFetchRounds },
+  );
+
+  const isLoading = isApplicationLoading || (shouldFetchRounds && (isRoundsLoading || !roundsData || isCompleterCountLoading));
   const hasRounds = Boolean(roundsData && (roundsData.intense.length > 0 || roundsData.partTime.length > 0));
   const showEnrollmentCTA = shouldFetchRounds && !isRoundsLoading && hasRounds && application && roundsData;
 

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -17,8 +17,7 @@ type CourseCompletionSectionProps = {
   className?: string;
 };
 
-const FALLBACK_COMMUNITY_LABEL = '8,000+ alumni';
-const FALLBACK_COMMUNITY_TAIL = 'across BlueDot Impact';
+const COMMUNITY_SIZE_LABEL = '8,000+ professionals';
 
 const AVATAR_IMAGES = [
   '/images/graduates/adam.webp',
@@ -62,35 +61,29 @@ const FeatureCardItem = ({ card, accentColor }: { card: FeatureCard; accentColor
   </div>
 );
 
-const SocialProof = ({ accentColor, completerCount }: { accentColor?: string; completerCount: number }) => {
-  const hasDynamicCount = completerCount > 0;
-  const label = hasDynamicCount ? `${completerCount.toLocaleString('en-US')} graduates` : FALLBACK_COMMUNITY_LABEL;
-  const tail = hasDynamicCount ? 'of this course' : FALLBACK_COMMUNITY_TAIL;
-
-  return (
-    <div
-      className="inline-flex flex-col items-center gap-3 rounded-[24px] px-4 py-3 max-w-full sm:flex-row sm:rounded-full sm:py-2"
-      // 8-digit hex (#RRGGBBAA) — `1F` ≈ 12% opacity tint of the course accent.
-      style={{ backgroundColor: accentColor ? `${accentColor}1F` : undefined }}
-    >
-      <div className="flex -space-x-2 shrink-0">
-        {AVATAR_IMAGES.map((src) => (
-          <img
-            key={src}
-            src={src}
-            alt=""
-            className="size-6 rounded-full object-cover ring-2 ring-white"
-          />
-        ))}
-      </div>
-      <p className="text-size-xs leading-[1.4] text-bluedot-navy text-center sm:text-left">
-        Join{' '}
-        <span className="font-semibold" style={{ color: accentColor }}>{label}</span>
-        {' '}{tail}
-      </p>
+const SocialProof = ({ accentColor }: { accentColor?: string }) => (
+  <div
+    className="inline-flex flex-col items-center gap-3 rounded-[24px] px-4 py-3 max-w-full sm:flex-row sm:rounded-full sm:py-2"
+    // 8-digit hex (#RRGGBBAA) — `1F` ≈ 12% opacity tint of the course accent.
+    style={{ backgroundColor: accentColor ? `${accentColor}1F` : undefined }}
+  >
+    <div className="flex -space-x-2 shrink-0">
+      {AVATAR_IMAGES.map((src) => (
+        <img
+          key={src}
+          src={src}
+          alt=""
+          className="size-6 rounded-full object-cover ring-2 ring-white"
+        />
+      ))}
     </div>
-  );
-};
+    <p className="text-size-xs leading-[1.4] text-bluedot-navy text-center sm:text-left">
+      Join{' '}
+      <span className="font-semibold" style={{ color: accentColor }}>{COMMUNITY_SIZE_LABEL}</span>
+      {' '}already enrolled
+    </p>
+  </div>
+);
 
 // eslint-disable-next-line react/function-component-definition
 export default function CourseCompletionSection({
@@ -112,12 +105,7 @@ export default function CourseCompletionSection({
     { enabled: shouldFetchRounds },
   );
 
-  const { data: completerCountData, isLoading: isCompleterCountLoading } = trpc.courses.getCompleterCount.useQuery(
-    { courseId },
-    { enabled: shouldFetchRounds },
-  );
-
-  const isLoading = isApplicationLoading || (shouldFetchRounds && (isRoundsLoading || !roundsData || isCompleterCountLoading));
+  const isLoading = isApplicationLoading || (shouldFetchRounds && (isRoundsLoading || !roundsData));
   const hasRounds = Boolean(roundsData && (roundsData.intense.length > 0 || roundsData.partTime.length > 0));
   const showEnrollmentCTA = shouldFetchRounds && !isRoundsLoading && hasRounds && application && roundsData;
 
@@ -141,7 +129,7 @@ export default function CourseCompletionSection({
     return (
       <div className={cn('flex flex-col gap-8', className)}>
         <div className="flex flex-col items-center gap-8 py-4 text-center max-w-[640px] mx-auto">
-          <SocialProof accentColor={accentColor} completerCount={completerCountData?.count ?? 0} />
+          <SocialProof accentColor={accentColor} />
           <div className="flex flex-col gap-3">
             {/* eslint-disable-next-line @bluedot/custom/no-arbitrary-text-size */}
             <H2 className="font-bold text-[28px] md:text-[32px] leading-[1.3] tracking-[-0.015em] text-bluedot-navy">

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -1,6 +1,8 @@
 import {
   and,
   chunkTable,
+  count,
+  courseRegistrationTable,
   courseTable,
   desc,
   eq,
@@ -8,6 +10,8 @@ import {
   exerciseTable,
   inArray,
   isNotNull,
+  isNull,
+  or,
   resourceCompletionTable,
   unitResourceTable,
   unitTable,
@@ -212,6 +216,24 @@ export const coursesRouter = router({
   getAll: publicProcedure
     .query(async () => {
       return getAllActiveCourses();
+    }),
+
+  getCompleterCount: publicProcedure
+    .input(z.object({ courseId: z.string().min(1) }))
+    .query(async ({ input: { courseId } }) => {
+      const result = await db.pg
+        .select({ count: count() })
+        .from(courseRegistrationTable.pg)
+        .where(and(
+          eq(courseRegistrationTable.pg.courseId, courseId),
+          isNotNull(courseRegistrationTable.pg.certificateId),
+          or(
+            eq(courseRegistrationTable.pg.isDuplicate, false),
+            isNull(courseRegistrationTable.pg.isDuplicate),
+          ),
+        ));
+
+      return { count: result[0]?.count ?? 0 };
     }),
 
   getCurriculumMetadata: publicProcedure

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -1,8 +1,6 @@
 import {
   and,
   chunkTable,
-  count,
-  courseRegistrationTable,
   courseTable,
   desc,
   eq,
@@ -10,8 +8,6 @@ import {
   exerciseTable,
   inArray,
   isNotNull,
-  isNull,
-  or,
   resourceCompletionTable,
   unitResourceTable,
   unitTable,
@@ -216,24 +212,6 @@ export const coursesRouter = router({
   getAll: publicProcedure
     .query(async () => {
       return getAllActiveCourses();
-    }),
-
-  getCompleterCount: publicProcedure
-    .input(z.object({ courseId: z.string().min(1) }))
-    .query(async ({ input: { courseId } }) => {
-      const result = await db.pg
-        .select({ count: count() })
-        .from(courseRegistrationTable.pg)
-        .where(and(
-          eq(courseRegistrationTable.pg.courseId, courseId),
-          isNotNull(courseRegistrationTable.pg.certificateId),
-          or(
-            eq(courseRegistrationTable.pg.isDuplicate, false),
-            isNull(courseRegistrationTable.pg.isDuplicate),
-          ),
-        ));
-
-      return { count: result[0]?.count ?? 0 };
     }),
 
   getCurriculumMetadata: publicProcedure


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

The original request was to dynamically show the number of course alumni. However, we agreed that this is not particularly motivating. Showing the total number of alumni is a better fit.  

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2450 

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="412" height="60" alt="image" src="https://github.com/user-attachments/assets/782708af-bfff-49e6-ad82-afb507787cb4" /> | <img width="433" height="56" alt="image" src="https://github.com/user-attachments/assets/58f060f7-ab1e-4e56-b6cf-3ab595145cf5" /> |
