### PR TITLE
Remove `dropoutId`, `deferredId` columns

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -141,8 +141,6 @@ export const createMockCourseRegistration = (overrides: Partial<CourseRegistrati
   courseApplicationsBaseId: 'base123',
   courseId: MOCK_COURSE_ID,
   decision: 'Accept',
-  dropoutId: null,
-  deferredId: null,
   isDuplicate: null,
   email: 'user@example.com',
   firstName: 'Test',

--- a/apps/website/src/components/pages/settings/CoursesPage.stories.tsx
+++ b/apps/website/src/components/pages/settings/CoursesPage.stories.tsx
@@ -15,6 +15,8 @@ import {
   createMockGroupDiscussion,
 } from '../../../__tests__/testUtils';
 
+type DropoutStatus = Record<string, { isDroppedOut: boolean; isDeferred: boolean }>;
+
 const meta: Meta<typeof CoursesSettingsPage> = {
   title: 'Settings/CoursesPage',
   component: CoursesSettingsPage,
@@ -72,7 +74,6 @@ const mockRegistrationDroppedOut = createMockCourseRegistration({
   courseId: 'course-1',
   roundStatus: 'Active',
   certificateCreatedAt: null,
-  dropoutId: ['dropout-1'], // Has dropoutId but no deferredId = dropped out
 });
 
 const mockRegistrationDeferred = createMockCourseRegistration({
@@ -80,8 +81,15 @@ const mockRegistrationDeferred = createMockCourseRegistration({
   courseId: 'course-2',
   roundStatus: 'Active',
   certificateCreatedAt: null,
-  deferredId: ['deferred-1'], // Has deferredId but no dropoutId = deferred
 });
+
+const mockDropoutStatusForDroppedReg: DropoutStatus = {
+  'reg-dropped': { isDroppedOut: true, isDeferred: false },
+};
+
+const mockDropoutStatusForDeferredReg: DropoutStatus = {
+  'reg-deferred': { isDroppedOut: false, isDeferred: true },
+};
 
 const mockRegistrationFuturePending = createMockCourseRegistration({
   id: 'reg-future-pending',
@@ -142,6 +150,7 @@ const mockDiscussion: GroupDiscussionWithGroupAndUnit = {
 const createHandlers = ({
   registrations = [],
   courses = [],
+  dropoutStatus = {},
   meetPerson = mockMeetPerson,
   discussions = [mockDiscussion],
   roundStartDates = {},
@@ -149,6 +158,7 @@ const createHandlers = ({
 }: {
   registrations?: CourseRegistration[];
   courses?: Course[];
+  dropoutStatus?: DropoutStatus;
   meetPerson?: MeetPerson | null;
   discussions?: GroupDiscussionWithGroupAndUnit[];
   roundStartDates?: Record<string, string | null>;
@@ -184,6 +194,7 @@ const createHandlers = ({
     userHandler,
     trpcStorybookMsw.courseRegistrations.getAll.query(() => registrations),
     trpcStorybookMsw.courses.getAll.query(() => courses),
+    trpcStorybookMsw.dropout.getStatusForUser.query(() => dropoutStatus),
     trpcStorybookMsw.meetPerson.getByCourseRegistrationId.query(() => meetPerson),
     trpcStorybookMsw.groupDiscussions.getByDiscussionIds.query(() => ({
       discussions,
@@ -272,6 +283,7 @@ export const WithDroppedOutCourse: Story = {
       handlers: createHandlers({
         registrations: [mockRegistrationDroppedOut],
         courses: [mockCourse1],
+        dropoutStatus: mockDropoutStatusForDroppedReg,
       }),
     },
   },
@@ -283,6 +295,7 @@ export const WithDeferredCourse: Story = {
       handlers: createHandlers({
         registrations: [mockRegistrationDeferred],
         courses: [mockCourse2],
+        dropoutStatus: mockDropoutStatusForDeferredReg,
       }),
     },
   },
@@ -299,6 +312,10 @@ export const MixedWithDropoutAndDeferred: Story = {
           mockRegistrationCompleted, // Normal completed course
         ],
         courses: [mockCourse1, mockCourse2],
+        dropoutStatus: {
+          ...mockDropoutStatusForDroppedReg,
+          ...mockDropoutStatusForDeferredReg,
+        },
       }),
     },
   },

--- a/apps/website/src/components/pages/settings/CoursesPage.stories.tsx
+++ b/apps/website/src/components/pages/settings/CoursesPage.stories.tsx
@@ -183,6 +183,9 @@ const createHandlers = ({
       trpcStorybookMsw.courses.getAll.query(() => {
         throw new Error('Failed to fetch');
       }),
+      trpcStorybookMsw.dropout.getStatusForUser.query(() => {
+        throw new Error('Failed to fetch');
+      }),
     ];
   }
 

--- a/apps/website/src/components/pages/settings/CoursesPage.stories.tsx
+++ b/apps/website/src/components/pages/settings/CoursesPage.stories.tsx
@@ -1,9 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import type {
-  Course,
-  CourseRegistration,
-  MeetPerson,
-} from '@bluedot/db';
+import type { Course, CourseRegistration, MeetPerson } from '@bluedot/db';
 import type { GroupDiscussionWithGroupAndUnit } from '../../../server/routers/group-discussions';
 import CoursesSettingsPage from '../../../pages/settings/courses';
 import { ONE_HOUR_SECONDS } from '../../../lib/constants';

--- a/apps/website/src/components/pages/settings/CoursesPage.test.tsx
+++ b/apps/website/src/components/pages/settings/CoursesPage.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 import CoursesSettingsPage from '../../../pages/settings/courses';
 import { server, trpcMsw } from '../../../__tests__/trpcMswSetup';
 import { TrpcProvider } from '../../../__tests__/trpcProvider';
-import { createMockCourseRegistration, createMockCourse } from '../../../__tests__/testUtils';
+import { createMockCourse, createMockCourseRegistration } from '../../../__tests__/testUtils';
 
 type MockCourseListProps = {
   courses: { course: { title: string } }[];
@@ -46,6 +46,7 @@ describe('CoursesPage', () => {
         allowedImpersonationTargets: [],
       })),
       trpcMsw.courseRegistrations.getRoundStartDates.query(() => ({})),
+      trpcMsw.dropout.getStatusForUser.query(() => ({})),
     );
   });
 
@@ -176,26 +177,28 @@ describe('CoursesPage', () => {
         roundStatus: 'Active',
         certificateCreatedAt: null,
       }),
-      // Dropped out course (has dropoutId but no deferredId) - should be filtered out
+      // Dropped out course - should be filtered out
       createMockCourseRegistration({
         id: 'reg-2',
         courseId: 'course-2',
         roundStatus: 'Active',
         certificateCreatedAt: null,
-        dropoutId: ['dropout-1'],
       }),
-      // Deferred course (has deferredId but no dropoutId) - should appear
+      // Deferred course - should appear
       createMockCourseRegistration({
         id: 'reg-3',
         courseId: 'course-3',
         roundStatus: 'Active',
         certificateCreatedAt: null,
-        deferredId: ['deferred-1'],
       }),
     ];
 
     server.use(trpcMsw.courses.getAll.query(() => courses));
     server.use(trpcMsw.courseRegistrations.getAll.query(() => registrations));
+    server.use(trpcMsw.dropout.getStatusForUser.query(() => ({
+      'reg-2': { isDroppedOut: true, isDeferred: false },
+      'reg-3': { isDroppedOut: false, isDeferred: true },
+    })));
 
     render(<CoursesSettingsPage />, { wrapper: TrpcProvider });
 
@@ -226,12 +229,14 @@ describe('CoursesPage', () => {
         courseId: 'course-1',
         roundStatus: 'Past',
         certificateCreatedAt: 1672531200,
-        deferredId: ['deferred-1'],
       }),
     ];
 
     server.use(trpcMsw.courses.getAll.query(() => courses));
     server.use(trpcMsw.courseRegistrations.getAll.query(() => registrations));
+    server.use(trpcMsw.dropout.getStatusForUser.query(() => ({
+      'reg-1': { isDroppedOut: false, isDeferred: true },
+    })));
 
     render(<CoursesSettingsPage />, { wrapper: TrpcProvider });
 

--- a/apps/website/src/pages/settings/courses.tsx
+++ b/apps/website/src/pages/settings/courses.tsx
@@ -41,7 +41,11 @@ const CoursesContent = () => {
 
   const { data: courses, isLoading: coursesLoading, error: coursesError } = trpc.courses.getAll.useQuery();
 
+  const { data: dropoutStatus, isLoading: dropoutsLoading, error: dropoutsError } = trpc.dropout.getStatusForUser.useQuery();
+
   const isCompleted = (reg: CourseRegistration) => reg.roundStatus !== 'Active' && reg.roundStatus !== 'Future';
+  const isDeferred = (reg: CourseRegistration) => dropoutStatus?.[reg.id]?.isDeferred ?? false;
+  const isDroppedOut = (reg: CourseRegistration) => dropoutStatus?.[reg.id]?.isDroppedOut ?? false;
 
   // Combine courses and enrollments
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -51,11 +55,7 @@ const CoursesContent = () => {
     // hide them once the round is active or past
     .filter((reg) => reg.decision !== 'Reject' || reg.roundStatus === 'Future')
     // Exclude dropped out courses (not deferrals)
-    .filter((reg) => {
-      // Dropped out means that we have a reference dropout record that is not a deferral
-      const isDroppedOut = reg.dropoutId?.length && !reg.deferredId?.length;
-      return !isDroppedOut;
-    })
+    .filter((reg) => !isDroppedOut(reg))
     .map((courseRegistration) => {
       const course = courses?.find((c) => c.id === courseRegistration.courseId);
       return course ? [{ course, courseRegistration }] : [];
@@ -76,7 +76,7 @@ const CoursesContent = () => {
 
   // Completed: past courses for participants (non-facilitators), excluding deferred courses
   const completedCourses = enrolledCourses
-    .filter(({ courseRegistration }) => isCompleted(courseRegistration) && courseRegistration.role !== 'Facilitator' && !courseRegistration.deferredId?.length)
+    .filter(({ courseRegistration }) => isCompleted(courseRegistration) && courseRegistration.role !== 'Facilitator' && !isDeferred(courseRegistration))
     // No-cert courses first (to nudge user to complete), then by completion date descending
     .sort((a, b) => {
       const aTime = a.courseRegistration.certificateCreatedAt ?? Infinity;
@@ -92,9 +92,9 @@ const CoursesContent = () => {
   // In-progress: Active courses (both participants and facilitators)
   const inProgressCourses = enrolledCourses.filter(({ courseRegistration }) => courseRegistration.roundStatus === 'Active');
 
-  const loading = courseRegistrationsLoading || coursesLoading;
+  const loading = courseRegistrationsLoading || coursesLoading || dropoutsLoading;
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const error = courseRegistrationsError || coursesError;
+  const error = courseRegistrationsError || coursesError || dropoutsError;
 
   if (loading) return <ProgressDots />;
   if (error) return <ErrorSection error={error} />;

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -1,10 +1,46 @@
-import { courseRegistrationTable, dropoutTable } from '@bluedot/db';
+import {
+  arrayOverlaps, courseRegistrationTable, dropoutTable, eq,
+} from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
 import { protectedProcedure, router } from '../trpc';
 
 export const dropoutRouter = router({
+  getStatusForUser: protectedProcedure.query(async ({ ctx }) => {
+    const regs = await db.pg
+      .select({ id: courseRegistrationTable.pg.id })
+      .from(courseRegistrationTable.pg)
+      .where(eq(courseRegistrationTable.pg.email, ctx.auth.email));
+    const regIds = regs.map((r) => r.id);
+    if (regIds.length === 0) {
+      return {};
+    }
+
+    const dropouts = await db.pg
+      .select({ applicantId: dropoutTable.pg.applicantId, type: dropoutTable.pg.type })
+      .from(dropoutTable.pg)
+      .where(arrayOverlaps(dropoutTable.pg.applicantId, regIds));
+
+    const result: Record<string, { isDroppedOut: boolean; isDeferred: boolean }> = {};
+    for (const dropout of dropouts) {
+      for (const regId of dropout.applicantId ?? []) {
+        if (!regIds.includes(regId)) continue;
+        const existing = result[regId] ?? { isDroppedOut: false, isDeferred: false };
+        if (dropout.type === 'Deferral') {
+          existing.isDeferred = true;
+          existing.isDroppedOut = false;
+        } else if (!existing.isDeferred) {
+          existing.isDroppedOut = true;
+        }
+
+        result[regId] = existing;
+      }
+    }
+
+    return result;
+  }),
+
   dropoutOrDeferral: protectedProcedure
     .input(z.object({
       applicantId: z.string().min(1),

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1348,15 +1348,6 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       pgColumn: boolean(),
       airtableId: 'fld1KQjHFGoDZKf94',
     },
-    // Join to 'dropout' table if the user has dropped out or deferred from a course
-    dropoutId: {
-      pgColumn: text().array(),
-      airtableId: 'fldaEk9K3m25Hs4Ga',
-    },
-    deferredId: {
-      pgColumn: text().array(),
-      airtableId: 'fldc7bNIkEyrMsQ4w',
-    },
   },
   deprecatedColumns: {
     lastVisitedUnitNumber: {
@@ -1367,6 +1358,16 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
     lastVisitedChunkIndex: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldqBkQC2fZLtPEZX',
+      deprecated: true,
+    },
+    dropoutId: {
+      pgColumn: text().array(),
+      airtableId: 'fldaEk9K3m25Hs4Ga',
+      deprecated: true,
+    },
+    deferredId: {
+      pgColumn: text().array(),
+      airtableId: 'fldc7bNIkEyrMsQ4w',
       deprecated: true,
     },
   },


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

- Stops the `pg-sync-service` Slack alert for `fldc7bNIkEyrMsQ4w` and fixes the silent UX bugs (ghost dropouts in all sections; past deferrals leaking into Completed as no-cert entries sorted to top).
- Replaces reads of `courseRegistration.dropoutId` / `deferredId` (broken Airtable reverse-links) with a new `dropout.getStatusForUser` tRPC procedure that derives `isDroppedOut` / `isDeferred` server-side from the `dropout` table via `applicantId`.
- Deprecates both columns

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2482

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

NA