### PR TITLE
[docs] CLAUDE.md: add worktree workflow, viewport sweep, AI review loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,19 @@ TypeScript • Next.js pages router (usually no SSR) • React • Tailwind • 
 
 We're fans of [boring technology](https://boringtechnology.club/) — don't introduce new dependencies without good reason. If you reach for one, justify it in the PR.
 
+## Set up a worktree before you start
+
+- Always work from a fresh branch in a git worktree — never on `master`, never on a stale branch. `master` drifts hourly, so rebase first:
+  ```bash
+  cd ~/code/bluedot
+  git fetch origin
+  git worktree add -b <handle>/<slug> ../bluedot-worktrees/<slug> origin/master
+  cd ../bluedot-worktrees/<slug>
+  ```
+- Copy env files for every app you'll touch: `cp ~/code/bluedot/apps/<app>/.env.local apps/<app>/.env.local`. Don't invent placeholders — ask a teammate if a file is missing.
+- If the branch is more than a few hours old when you come back to it, rebase on `origin/master` again before pushing.
+- After the PR merges, clean up: `git worktree remove ../bluedot-worktrees/<slug>` and delete the local branch.
+
 ## Before you start a task
 
 - Look for existing components/utilities first. Most marketing primitives already live in `@bluedot/ui` or `apps/website/src/components/`. See `apps/website/README.md` → "Reusing existing components first".
@@ -50,8 +63,9 @@ Mixing schema additions and consumer code in one PR breaks staging because the t
 ## Before opening a PR
 
 - **Run the app's full test suite** (e.g. `cd apps/website && npm test`). Typecheck and lint do *not* catch test-context regressions — for example, adding a component that calls `useRouter()` to a page covered by an SSR/SEO test will pass typecheck and fail in CI.
-- Run lint and typecheck.
-- If the change touches UI, manually verify it in a browser at the real viewport. Don't trust bbox numbers; for full-bleed/desktop checks, screenshot at `vh ≥ 1800`. Re-check all four sides after a CSS fix, not just the one you changed.
+- Run lint and typecheck. After changes that touch shared types — especially `@bluedot/db` schema — also run `npx tsc --noEmit` from the workspace root. `npm test` won't catch fixture drift when a schema adds a required property.
+- **UI changes — run a viewport sweep.** Use a real browser (headless Playwright is fine) at 390 × 844, 768 × 1024, 1024 × 768, 1280 × 800, 1440 × 900, and 1920 × 1080. At each, check for horizontal scroll, overflowing content, broken sticky/fixed elements, and touch targets <44 px on mobile. Don't trust bbox numbers; re-check all four sides after a CSS fix, not just the one you changed. For full-bleed/desktop checks, screenshot at `vh ≥ 1800`.
+- **Prose surfaces — cap body text at ~65 ch.** For blog posts, course descriptions, about pages, long-form marketing copy, wrap body text in `max-w-prose` (≈65 ch) or `max-w-[70ch]`. Lines longer than ~80 characters are genuinely hard to read (Baymard / WCAG 1.4.8). Doesn't apply to headings, nav, table cells, code blocks, dashboard data, form labels, or hero taglines.
 - If you genuinely cannot run tests (e.g. missing credentials), say so loudly in the PR body — don't paper over it.
 
 ## PR conventions
@@ -59,6 +73,26 @@ Mixing schema additions and consumer code in one PR breaks staging because the t
 - Commit prefix: `[feat]`, `[fix]`, `[style]`, `[chore]`, `[docs]`, `[refactor]`.
 - Open a real PR with `gh pr create` — title + body. Don't leave a "create PR" link for the human to fill in.
 - **UI screenshots**: embed real `<img>` tags, not text descriptions. Commit screenshots to `.github/pr-screenshots/<n>/` (where `<n>` is the PR number or branch slug), push, then embed via SHA-pinned `raw.githubusercontent.com` URLs (`<img width="390">` for mobile, `<img width="1280">` for desktop). Dismiss any cookie banner before capturing. After embedding, push a follow-up commit deleting the screenshots from `.github/pr-screenshots/` so the folder doesn't grow. The SHA-pinned URLs will still work. If you can't take screenshots, note in the PR body that a human should take them.
+
+## After opening a PR — run the AI review loop
+
+Don't wait for the human to ask. As soon as the PR is open (with screenshots embedded if it's a UI change), run this loop autonomously.
+
+1. Trigger Claude bot: `gh pr comment <N> --body "@claude review"`. Bake it into the same turn as `gh pr create` / `gh pr ready`.
+2. Greptile auto-reviews within ~5 min of PR open. Claude bot responds ~1–2 min after the trigger comment. CodeRabbit is rate-limited and often skips — that's fine.
+3. Poll for both bots' responses:
+   ```bash
+   gh pr view <N> --json comments \
+     --jq '.comments[] | select(.author.login != "<your-gh-handle>" and .author.login != "render") | "\(.author.login): \(.body)"'
+   ```
+4. Categorise every finding:
+   - **P1 / critical / scale-inversion-class bugs** → fix in a follow-up commit on the same branch, push.
+   - **P2 / dead code / redundant ternary / cleanup** → fix unless the cost is meaningful; bias toward fixing.
+   - **Stylistic / nice-to-have** → judge case by case; don't blindly apply.
+5. Reply on the PR explaining what you addressed and what you intentionally didn't: `gh pr comment <N> --body "..."`.
+6. If you pushed substantive fixes, re-trigger: comment `@claude review` again to get a fresh pass.
+
+If a bot is wrong — they sometimes are — push back politely in a PR reply explaining why. Don't silently ignore, and don't change correct code to appease a bot.
 
 ## apps/website specifics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ We're fans of [boring technology](https://boringtechnology.club/) — don't intr
   ```
 - Copy env files for every app you'll touch: `cp ~/code/bluedot/apps/<app>/.env.local apps/<app>/.env.local`. Don't invent placeholders — ask a teammate if a file is missing.
 - If the branch is more than a few hours old when you come back to it, rebase on `origin/master` again before pushing.
-- After the PR merges, clean up: `git worktree remove ../bluedot-worktrees/<slug>` and delete the local branch.
+- After the PR merges, clean up: from outside the worktree (e.g. `cd ~/code/bluedot`), run `git worktree remove ../bluedot-worktrees/<slug>` and delete the local branch. Add `--force` if you've decided to discard uncommitted local changes; the command refuses to remove a dirty worktree otherwise.
 
 ## Before you start a task
 
@@ -64,7 +64,7 @@ Mixing schema additions and consumer code in one PR breaks staging because the t
 
 - **Run the app's full test suite** (e.g. `cd apps/website && npm test`). Typecheck and lint do *not* catch test-context regressions — for example, adding a component that calls `useRouter()` to a page covered by an SSR/SEO test will pass typecheck and fail in CI.
 - Run lint and typecheck. After changes that touch shared types — especially `@bluedot/db` schema — also run `npx tsc --noEmit` from the workspace root. `npm test` won't catch fixture drift when a schema adds a required property.
-- **UI changes — run a viewport sweep.** Use a real browser (headless Playwright is fine) at 390 × 844, 768 × 1024, 1024 × 768, 1280 × 800, 1440 × 900, and 1920 × 1080. At each, check for horizontal scroll, overflowing content, broken sticky/fixed elements, and touch targets <44 px on mobile. Don't trust bbox numbers; re-check all four sides after a CSS fix, not just the one you changed. For full-bleed/desktop checks, screenshot at `vh ≥ 1800`.
+- **UI changes — run a viewport sweep.** Use a real browser (headless Playwright is fine) at 390 × 844, 768 × 1024, 1024 × 768, 1280 × 800, 1440 × 900, and 1920 × 1080. At each, check for horizontal scroll, overflowing content, broken sticky/fixed elements, and touch targets <44 px on mobile. Don't trust bounding-box measurements from dev tools — they round and lie about subpixel overflow; eyeball the rendered page. Re-check all four sides after a CSS fix, not just the one you changed. For full-bleed / desktop checks, screenshot at a viewport height of at least 1800 px so above-the-fold + below-the-fold land in one image.
 - **Prose surfaces — cap body text at ~65 ch.** For blog posts, course descriptions, about pages, long-form marketing copy, wrap body text in `max-w-prose` (≈65 ch) or `max-w-[70ch]`. Lines longer than ~80 characters are genuinely hard to read (Baymard / WCAG 1.4.8). Doesn't apply to headings, nav, table cells, code blocks, dashboard data, form labels, or hero taglines.
 - If you genuinely cannot run tests (e.g. missing credentials), say so loudly in the PR body — don't paper over it.
 
@@ -80,10 +80,10 @@ Don't wait for the human to ask. As soon as the PR is open (with screenshots emb
 
 1. Trigger Claude bot: `gh pr comment <N> --body "@claude review"`. Bake it into the same turn as `gh pr create` / `gh pr ready`.
 2. Greptile auto-reviews within ~5 min of PR open. Claude bot responds ~1–2 min after the trigger comment. CodeRabbit is rate-limited and often skips — that's fine.
-3. Poll for both bots' responses:
+3. Poll for both bots' responses. Pull `comments` **and** `reviews` — GitHub stores them as separate object types and Greptile posts as a review:
    ```bash
-   gh pr view <N> --json comments \
-     --jq '.comments[] | select(.author.login != "<your-gh-handle>" and .author.login != "render") | "\(.author.login): \(.body)"'
+   gh pr view <N> --json comments,reviews \
+     --jq '[.comments[], .reviews[]] | .[] | select(.author.login != "<your-gh-handle>" and .author.login != "render") | "\(.author.login): \(.body)"'
    ```
 4. Categorise every finding:
    - **P1 / critical / scale-inversion-class bugs** → fix in a follow-up commit on the same branch, push.


### PR DESCRIPTION
## Summary

Adds the team-shared conventions that weren't yet documented in `CLAUDE.md` but are already in active use (or should be) across the team:

- **Set up a worktree before you start** — `master` drifts hourly, so rebase + worktree per task; copy `.env.local` files explicitly.
- **Before opening a PR** — expanded:
  - `npx tsc --noEmit` after changes to shared types (especially `@bluedot/db` schema). `npm test` misses fixture drift when a schema adds a required property.
  - Replaced the vague "manually verify in a browser" line with a concrete viewport sweep: 390 / 768 / 1024 / 1280 / 1440 / 1920 widths, plus what to check at each.
  - Prose surfaces wrap body text at ~65 ch (Baymard / WCAG 1.4.8).
- **After opening a PR — run the AI review loop** (new section) — trigger `@claude review`, poll for Greptile + Claude bot, categorise findings (P1 fix / P2 bias to fix / stylistic judge case by case), reply on the PR with what you addressed and what you didn't. Re-trigger if substantive fixes were pushed. Push back politely on wrong bot feedback rather than silently ignoring.

No code change; all edits are in `CLAUDE.md`.

## Why

A new teammate joining the repo today wouldn't know any of this from reading the existing `CLAUDE.md`. The rules already exist as personal-config / memory / verbal convention for some of us. Putting them in the repo means everyone's Claude Code (and human teammates) follow the same recipe without each person rebuilding it.

## Test plan

- [x] Markdown renders correctly (read-through)
- [x] Existing sections (read these first, schema-change protocols, screenshot recipe, font/release-tag caveats) preserved verbatim
- [x] No code changes — no test suite to run
- [ ] Greptile + `@claude review` pass on the doc changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)