### PR TITLE
[copy] Fieldbuilder Week: Friday body update + drop hero fallback

### DIFF
--- a/apps/website/src/components/fieldbuilder-week/TheWeekSection.tsx
+++ b/apps/website/src/components/fieldbuilder-week/TheWeekSection.tsx
@@ -1,7 +1,14 @@
+import type { ReactNode } from 'react';
 import { H3, H4, P } from '@bluedot/ui';
 import { pageSectionHeadingClass } from '../PageListRow';
 
-const SCHEDULE = [
+type ScheduleItem = {
+  cadence: string;
+  title: string;
+  body: ReactNode;
+};
+
+const SCHEDULE: ScheduleItem[] = [
   {
     cadence: 'Monday',
     title: 'Outcome and opportunities',
@@ -15,7 +22,11 @@ const SCHEDULE = [
   {
     cadence: 'Friday',
     title: 'Pitch',
-    body: 'Pitch to us. The conversations, the prototype, the signal. Where it goes from here. Strong pitches get $5k on the spot, up to $45k more after two weeks of progress, and a path to $200k total for the strongest programs.',
+    body: (
+      <>
+        Strong pitches get $5k on the spot, up to $45k more after two weeks of progress, and a path to $200k total for the strongest programs. <a href="https://bluedot.org/programs/career-transition-grant" className="underline">Career transition grants</a> available.
+      </>
+    ),
   },
 ];
 

--- a/apps/website/src/components/fieldbuilder-week/TheWeekSection.tsx
+++ b/apps/website/src/components/fieldbuilder-week/TheWeekSection.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
-import { H3, H4, P } from '@bluedot/ui';
+import {
+  A, H3, H4, P,
+} from '@bluedot/ui';
 import { pageSectionHeadingClass } from '../PageListRow';
 
 type ScheduleItem = {
@@ -24,7 +26,7 @@ const SCHEDULE: ScheduleItem[] = [
     title: 'Pitch',
     body: (
       <>
-        Strong pitches get $5k on the spot, up to $45k more after two weeks of progress, and a path to $200k total for the strongest programs. <a href="https://bluedot.org/programs/career-transition-grant" className="underline">Career transition grants</a> available.
+        Strong pitches get $5k on the spot, up to $45k more after two weeks of progress, and a path to $200k total for the strongest programs. <A href="/programs/career-transition-grant">Career transition grants</A> available.
       </>
     ),
   },

--- a/apps/website/src/pages/programs/fieldbuilder-week.tsx
+++ b/apps/website/src/pages/programs/fieldbuilder-week.tsx
@@ -17,7 +17,6 @@ import {
 
 const PROGRAM_SLUG = 'fieldbuilder-week';
 const FALLBACK_NAME = 'Fieldbuilder Week';
-const FALLBACK_DESCRIPTION = 'There are ~2k people working full-time on AI safety. The field needs thousands more. Fly to London for 5 days to design and launch a new pathway. $5k on the spot if your pitch lands. Up to $200k for the strongest programs.';
 const APPLICATION_DEADLINE = '27 May';
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bluedot.org';
 const LINK_PREVIEW_IMAGE = `${SITE_URL}/images/programs/link-preview/fieldbuilder-week.png`;
@@ -81,7 +80,7 @@ const FieldbuilderWeekProgramPage = ({ programName, programDescription }: Progra
 
 export const getStaticProps: GetStaticProps<ProgramDetailPageProps> = () => getProgramDetailPageStaticProps(
   PROGRAM_SLUG,
-  { programName: FALLBACK_NAME, programDescription: FALLBACK_DESCRIPTION },
+  { programName: FALLBACK_NAME, programDescription: '' },
 );
 
 FieldbuilderWeekProgramPage.pageRendersOwnNav = true;


### PR DESCRIPTION
## Summary
- Update the Friday Pitch body to match the Notion landing-page copy: drop the "Pitch to us..." lead-in, keep the funding figures, add an inline link to Career Transition Grants.
- Remove the hardcoded `FALLBACK_DESCRIPTION` constant on `/programs/fieldbuilder-week`. The hero subtitle now comes from Airtable only, so there's no stale duplicate copy to maintain.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Hero subtitle renders from Airtable on staging
- [ ] Friday Pitch body shows the new copy with a working link to `/programs/career-transition-grant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)