### PR TITLE
[codex] Show dropout defer action on course rows

### DIFF
--- a/apps/website/src/components/courses/DropoutModal.test.tsx
+++ b/apps/website/src/components/courses/DropoutModal.test.tsx
@@ -1,0 +1,104 @@
+import '@testing-library/jest-dom';
+import {
+  render, screen, waitFor, within,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
+import { TrpcProvider } from '../../__tests__/trpcProvider';
+import { trpc } from '../../utils/trpc';
+import DropoutModal from './DropoutModal';
+
+const mockCourseRounds = {
+  intense: [],
+  partTime: [],
+};
+
+const QueryWatchers = () => {
+  trpc.meetPerson.getInactiveCourseRegistrations.useQuery({});
+  trpc.dropout.getStatusForUser.useQuery();
+  trpc.courseRegistrations.getAll.useQuery();
+
+  return null;
+};
+
+describe('DropoutModal', () => {
+  let inactiveRegistrationsRequests: number;
+  let dropoutStatusRequests: number;
+  let courseRegistrationsRequests: number;
+
+  beforeEach(() => {
+    inactiveRegistrationsRequests = 0;
+    dropoutStatusRequests = 0;
+    courseRegistrationsRequests = 0;
+
+    server.use(
+      trpcMsw.courseRounds.getRoundsForCourse.query(() => mockCourseRounds),
+      trpcMsw.meetPerson.getInactiveCourseRegistrations.query(() => {
+        inactiveRegistrationsRequests += 1;
+        return [];
+      }),
+      trpcMsw.dropout.getStatusForUser.query(() => {
+        dropoutStatusRequests += 1;
+        return {};
+      }),
+      trpcMsw.courseRegistrations.getAll.query(() => {
+        courseRegistrationsRequests += 1;
+        return [];
+      }),
+      trpcMsw.dropout.dropoutOrDeferral.mutation(({ input }) => ({
+        id: 'new-dropout-id',
+        applicantId: [input.applicantId],
+        reason: input.reason ?? null,
+        type: input.type,
+        newRoundId: null,
+        oldRoundId: null,
+      })),
+    );
+  });
+
+  it('invalidates course dropout state after a successful request closes', async () => {
+    const user = userEvent.setup();
+    const handleClose = vi.fn();
+
+    render(
+      <>
+        <QueryWatchers />
+        <DropoutModal
+          applicantId="reg-active"
+          courseSlug="ai-safety"
+          currentRoundId="round-active"
+          handleClose={handleClose}
+        />
+      </>,
+      { wrapper: TrpcProvider },
+    );
+
+    await waitFor(() => {
+      expect(inactiveRegistrationsRequests).toBe(1);
+      expect(dropoutStatusRequests).toBe(1);
+      expect(courseRegistrationsRequests).toBe(1);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Action type' }));
+    const actionTypeListbox = await screen.findByRole('listbox');
+    await user.click(within(actionTypeListbox).getByText('Drop out of the course'));
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Your dropout request has been submitted/)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Close'));
+
+    expect(handleClose).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(inactiveRegistrationsRequests).toBeGreaterThan(1);
+      expect(dropoutStatusRequests).toBeGreaterThan(1);
+      expect(courseRegistrationsRequests).toBeGreaterThan(1);
+    });
+  });
+});

--- a/apps/website/src/components/courses/DropoutModal.tsx
+++ b/apps/website/src/components/courses/DropoutModal.tsx
@@ -61,7 +61,9 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
 
   const handleCloseWithInvalidation = () => {
     if (dropoutMutation.isSuccess) {
-      utils.meetPerson.getInactiveCourseRegistrations.invalidate();
+      void utils.meetPerson.getInactiveCourseRegistrations.invalidate();
+      void utils.dropout.getStatusForUser.invalidate();
+      void utils.courseRegistrations.getAll.invalidate();
     }
 
     handleClose();

--- a/apps/website/src/components/settings/CourseList.test.tsx
+++ b/apps/website/src/components/settings/CourseList.test.tsx
@@ -21,6 +21,7 @@ type MockCourseDetailsProps = {
 type MockDropoutModalProps = {
   applicantId: string;
   currentRoundId: string | null;
+  handleClose: () => void;
 };
 
 // Mock the CourseDetails component to avoid testing it here
@@ -31,9 +32,10 @@ vi.mock('./CourseDetails', () => ({
 }));
 
 vi.mock('../courses/DropoutModal', () => ({
-  default: ({ applicantId, currentRoundId }: MockDropoutModalProps) => (
+  default: ({ applicantId, currentRoundId, handleClose }: MockDropoutModalProps) => (
     <div role="dialog" aria-label="Dropout or deferral modal">
       {`Dropout modal for ${applicantId} in ${currentRoundId ?? 'no-round'}`}
+      <button type="button" onClick={handleClose}>Close modal</button>
     </div>
   ),
 }));

--- a/apps/website/src/components/settings/CourseList.test.tsx
+++ b/apps/website/src/components/settings/CourseList.test.tsx
@@ -18,10 +18,23 @@ type MockCourseDetailsProps = {
   course: { title: string };
 };
 
+type MockDropoutModalProps = {
+  applicantId: string;
+  currentRoundId: string | null;
+};
+
 // Mock the CourseDetails component to avoid testing it here
 vi.mock('./CourseDetails', () => ({
   default: ({ course }: MockCourseDetailsProps) => (
     <div aria-label={`Expanded details for ${course.title}`}>Course Details Content</div>
+  ),
+}));
+
+vi.mock('../courses/DropoutModal', () => ({
+  default: ({ applicantId, currentRoundId }: MockDropoutModalProps) => (
+    <div role="dialog" aria-label="Dropout or deferral modal">
+      {`Dropout modal for ${applicantId} in ${currentRoundId ?? 'no-round'}`}
+    </div>
   ),
 }));
 
@@ -131,6 +144,76 @@ describe('CourseList', () => {
     expect(certificateLinks[0]).toBeInTheDocument();
     const completedTexts = screen.getAllByText(/Completed on/);
     expect(completedTexts.length).toBeGreaterThan(0);
+  });
+
+  it('shows dropout or deferral action for active courses even without upcoming discussions', async () => {
+    const user = userEvent.setup();
+    const activeRegistration = {
+      ...mockCourseRegistration,
+      id: 'active-reg',
+      roundId: 'active-round',
+      roundStatus: 'Active',
+      certificateCreatedAt: null,
+    };
+
+    render(
+      <CourseList courses={[{ course: mockCourse, courseRegistration: activeRegistration }]} />,
+      { wrapper: TrpcProvider },
+    );
+
+    const dropoutButtons = await screen.findAllByRole('button', { name: 'Drop out or defer' });
+    expect(dropoutButtons.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      await user.click(dropoutButtons[0]!);
+    });
+
+    expect(screen.getByRole('dialog', { name: 'Dropout or deferral modal' })).toHaveTextContent('Dropout modal for active-reg in active-round');
+  });
+
+  it('shows dropout or deferral action for upcoming non-rejected applications', () => {
+    const futureRegistration = {
+      ...mockCourseRegistration,
+      id: 'future-reg',
+      roundId: 'future-round',
+      roundStatus: 'Future',
+      decision: null,
+      certificateCreatedAt: null,
+    };
+
+    render(
+      <CourseList courses={[{ course: mockCourse, courseRegistration: futureRegistration }]} />,
+      { wrapper: TrpcProvider },
+    );
+
+    expect(screen.getAllByRole('button', { name: 'Drop out or defer' }).length).toBeGreaterThan(0);
+  });
+
+  it('does not show dropout or deferral action for rejected upcoming or past courses', () => {
+    const rejectedFutureRegistration = {
+      ...mockCourseRegistration,
+      id: 'rejected-future-reg',
+      roundStatus: 'Future',
+      decision: 'Reject',
+      certificateCreatedAt: null,
+    };
+    const pastRegistration = {
+      ...mockCourseRegistration,
+      id: 'past-reg',
+      roundStatus: 'Past',
+      certificateCreatedAt: null,
+    };
+
+    render(
+      <CourseList courses={[
+        { course: mockCourse, courseRegistration: rejectedFutureRegistration },
+        { course: createMockCourse({ id: 'course-2', title: 'Past Course', slug: 'past-course' }), courseRegistration: pastRegistration },
+      ]}
+      />,
+      { wrapper: TrpcProvider },
+    );
+
+    expect(screen.queryByRole('button', { name: 'Drop out or defer' })).not.toBeInTheDocument();
   });
 
   it('collapses and expands course details', async () => {

--- a/apps/website/src/components/settings/CourseList.tsx
+++ b/apps/website/src/components/settings/CourseList.tsx
@@ -241,6 +241,7 @@ const CourseListRow = ({
             </div>
           </div>
           {/* Mobile CTA buttons */}
+          {/* Keep Active-row CTAs visible while expanded because discussion details do not contain every row-level action. */}
           {ctaButtons.length > 0 && (!isExpanded || courseRegistration.roundStatus === 'Active') && (
             <div className="flex gap-2 mt-4 sm:hidden" {...stopPropagation} role="presentation">
               {ctaButtons}

--- a/apps/website/src/components/settings/CourseList.tsx
+++ b/apps/website/src/components/settings/CourseList.tsx
@@ -16,6 +16,7 @@ import type { GroupDiscussionWithGroupAndUnit } from '../../server/routers/group
 import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
 import { getActionPlanUrl, formatMonthAndDay } from '../../lib/utils';
 import { FOAI_COURSE_SLUG } from '../../lib/constants';
+import DropoutModal from '../courses/DropoutModal';
 
 const CourseList = ({ courses, startExpanded = false, roundStartDates }: {
   courses: { course: Course; courseRegistration: CourseRegistration }[];
@@ -71,6 +72,7 @@ const CourseListRow = ({
   const [isExpanded, setIsExpanded] = useState(startExpanded);
   const currentTimeMs = useCurrentTimeMs();
   const [groupSwitchModalOpen, setGroupSwitchModalOpen] = useState(false);
+  const [dropoutModalOpen, setDropoutModalOpen] = useState(false);
 
   const isFuture = courseRegistration.roundStatus === 'Future';
 
@@ -130,6 +132,7 @@ const CourseListRow = ({
     isExpanded,
     isLoading,
     isFacilitatorRole,
+    onOpenDropoutModal: () => setDropoutModalOpen(true),
   });
 
   const subtitle = getSubtitle({
@@ -238,7 +241,7 @@ const CourseListRow = ({
             </div>
           </div>
           {/* Mobile CTA buttons */}
-          {!isExpanded && ctaButtons.length > 0 && (
+          {ctaButtons.length > 0 && (!isExpanded || courseRegistration.roundStatus === 'Active') && (
             <div className="flex gap-2 mt-4 sm:hidden" {...stopPropagation} role="presentation">
               {ctaButtons}
             </div>
@@ -266,6 +269,15 @@ const CourseListRow = ({
           roundId={meetPerson.round}
         />
       )}
+
+      {dropoutModalOpen && course.slug && (
+        <DropoutModal
+          applicantId={courseRegistration.id}
+          courseSlug={course.slug}
+          currentRoundId={courseRegistration.roundId ?? null}
+          handleClose={() => setDropoutModalOpen(false)}
+        />
+      )}
     </div>
   );
 };
@@ -287,6 +299,7 @@ const getCtaButtons = ({
   isExpanded,
   isLoading,
   isFacilitatorRole,
+  onOpenDropoutModal,
 }: {
   course: Course;
   courseRegistration: CourseRegistration;
@@ -296,7 +309,10 @@ const getCtaButtons = ({
   isExpanded: boolean;
   isLoading: boolean;
   isFacilitatorRole: boolean;
+  onOpenDropoutModal: () => void;
 }): ReactNode[] => {
+  const dropoutButton = getDropoutOrDeferralButton({ course, courseRegistration, onOpenDropoutModal });
+
   // Future courses: show availability + curriculum buttons
   if (courseRegistration.roundStatus === 'Future') {
     const buttons: ReactNode[] = [];
@@ -333,7 +349,7 @@ const getCtaButtons = ({
       </CTALinkOrButton>);
     }
 
-    return buttons;
+    return [...buttons, ...dropoutButton];
   }
 
   const feedbackFormUrl = meetPerson?.courseFeedbackForm;
@@ -411,7 +427,11 @@ const getCtaButtons = ({
       >
         {buttonText}
       </CTALinkOrButton>
-    )];
+    ), ...dropoutButton];
+  }
+
+  if (courseRegistration.roundStatus === 'Active') {
+    return dropoutButton;
   }
 
   if (courseRegistration.roundStatus === 'Past') {
@@ -469,6 +489,36 @@ const getCtaButtons = ({
   }
 
   return [];
+};
+
+const getDropoutOrDeferralButton = ({
+  course,
+  courseRegistration,
+  onOpenDropoutModal,
+}: {
+  course: Course;
+  courseRegistration: CourseRegistration;
+  onOpenDropoutModal: () => void;
+}): ReactNode[] => {
+  const canRequestDropoutOrDeferral = Boolean(course.slug)
+    && (courseRegistration.roundStatus === 'Active' || courseRegistration.roundStatus === 'Future')
+    && courseRegistration.decision !== 'Reject';
+
+  if (!canRequestDropoutOrDeferral) {
+    return [];
+  }
+
+  return [(
+    <CTALinkOrButton
+      key="dropout-or-deferral"
+      variant="outline-black"
+      size="small"
+      onClick={onOpenDropoutModal}
+      className="w-full sm:w-auto border-bluedot-darker"
+    >
+      Drop out or defer
+    </CTALinkOrButton>
+  )];
 };
 
 const getSubtitle = ({

--- a/apps/website/src/pages/settings/courses.tsx
+++ b/apps/website/src/pages/settings/courses.tsx
@@ -85,7 +85,7 @@ const CoursesContent = () => {
       return bTime - aTime;
     });
 
-  // Facilitated: past courses for facilitators (facilitators cannot defer)
+  // Facilitated: past courses for facilitators
   const facilitatedCourses = enrolledCourses
     .filter(({ courseRegistration }) => isCompleted(courseRegistration) && courseRegistration.role === 'Facilitator');
 


### PR DESCRIPTION
## Summary
- Add a row-level `Drop out or defer` action in Settings → Courses for active and upcoming non-rejected course registrations.
- Reuse the existing dropout/deferral modal with the current course registration and round.
- Add focused coverage for active, upcoming, rejected, and past course cases.

## Why
The previous entry point lived in an upcoming discussion overflow menu, so enrolled users could miss it if they had an upcoming application, no upcoming discussion row, or were looking at the course row itself.

## Validation
- `npm --workspace @bluedot/website test -- CourseList.test.tsx`
- `npm --workspace @bluedot/website test -- CoursesPage.test.tsx`
- `npm --workspace @bluedot/website run typecheck`
- `npm --workspace @bluedot/website run lint -- src/components/settings/CourseList.tsx src/components/settings/CourseList.test.tsx src/pages/settings/courses.tsx`