### PR TITLE
[codex] Simplify defer/dropout actions

### DIFF
--- a/apps/website/src/components/settings/CourseDetails.test.tsx
+++ b/apps/website/src/components/settings/CourseDetails.test.tsx
@@ -30,15 +30,6 @@ vi.mock('../courses/GroupSwitchModal', () => ({
   ),
 }));
 
-vi.mock('../courses/DropoutModal', () => ({
-  default: ({ handleClose }: { handleClose: () => void }) => (
-    <div data-testid="dropout-modal">
-      <div>Dropout Modal</div>
-      <button type="button" onClick={handleClose}>Close Dropout Modal</button>
-    </div>
-  ),
-}));
-
 vi.mock('../../lib/downloadCalendarFile', () => ({
   downloadDiscussionCalendarFile: vi.fn(),
 }));
@@ -330,7 +321,7 @@ describe('CourseDetails: Participant view', () => {
     // This one should not have an href since it opens a modal
     expect(switchGroupPermanently).not.toHaveAttribute('href');
     expect(screen.queryByRole('menuitem', { name: 'Request dropout or deferral' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Defer or drop out' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Defer or drop out' })).not.toBeInTheDocument();
 
     // Click "Switch group permanently" to verify it opens modal WITHOUT initial unit number
     await act(async () => {
@@ -344,7 +335,7 @@ describe('CourseDetails: Participant view', () => {
     expect(screen.getByText('Switch type: Switch group permanently')).toBeInTheDocument();
   });
 
-  it('shows dropout or deferral as a footer action on the see all discussions line', async () => {
+  it('keeps the see all discussions footer without dropout or deferral action', async () => {
     const user = userEvent.setup();
     const currentTimeMs = Date.now();
 
@@ -376,14 +367,13 @@ describe('CourseDetails: Participant view', () => {
       expect(screen.getByRole('button', { name: 'See all (5) discussions' })).toBeInTheDocument();
     });
 
-    const dropoutButton = screen.getByRole('button', { name: 'Defer or drop out' });
-    expect(dropoutButton).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Defer or drop out' })).not.toBeInTheDocument();
 
     await act(async () => {
-      await user.click(dropoutButton);
+      await user.click(screen.getByRole('button', { name: 'See all (5) discussions' }));
     });
 
-    expect(screen.getByTestId('dropout-modal')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
   });
 
   it('shows NOW/LIVE indicators when discussion is live', async () => {

--- a/apps/website/src/components/settings/CourseDetails.tsx
+++ b/apps/website/src/components/settings/CourseDetails.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import type { GroupDiscussionWithGroupAndUnit } from '../../server/routers/group-discussions';
 import GroupSwitchModal, { type SwitchType } from '../courses/GroupSwitchModal';
 import FacilitatorSwitchModal, { type FacilitatorModalType } from '../courses/FacilitatorSwitchModal';
-import DropoutModal from '../courses/DropoutModal';
 import DiscussionList from './DiscussionList';
 
 type CourseDetailsProps = {
@@ -36,7 +35,6 @@ const CourseDetails = ({
 
   const [groupSwitchModalOpen, setGroupSwitchModalOpen] = useState(false);
   const [facilitatorSwitchModalOpen, setFacilitatorSwitchModalOpen] = useState(false);
-  const [dropoutModalOpen, setDropoutModalOpen] = useState(false);
   const [selectedSwitchType, setSelectedSwitchType] = useState<SwitchType>('Switch group for one unit');
   const [selectedFacilitatorModalType, setSelectedFacilitatorModalType] = useState<FacilitatorModalType>('Update discussion time');
   const [activeTab, setActiveTab] = useState<'upcoming' | 'attended' | 'facilitated'>(getInitialTab());
@@ -54,10 +52,6 @@ const CourseDetails = ({
     setSelectedDiscussion(discussion);
     setSelectedFacilitatorModalType(modalType);
     setFacilitatorSwitchModalOpen(true);
-  };
-
-  const handleOpenDropoutModal = () => {
-    setDropoutModalOpen(true);
   };
 
   return (
@@ -122,7 +116,6 @@ const CourseDetails = ({
                     isFacilitator={isFacilitatorRole}
                     onOpenGroupSwitchModal={handleOpenGroupSwitch}
                     onOpenFacilitatorModal={handleOpenFacilitatorModal}
-                    onOpenDropoutModal={handleOpenDropoutModal}
                     isPast={false}
                     emptyMessage="No upcoming discussions"
                   />
@@ -134,7 +127,6 @@ const CourseDetails = ({
                     isFacilitator={isFacilitatorRole}
                     onOpenGroupSwitchModal={handleOpenGroupSwitch}
                     onOpenFacilitatorModal={handleOpenFacilitatorModal}
-                    onOpenDropoutModal={handleOpenDropoutModal}
                     isPast
                     emptyMessage="No attended discussions yet"
                   />
@@ -146,7 +138,6 @@ const CourseDetails = ({
                     isFacilitator={isFacilitatorRole}
                     onOpenGroupSwitchModal={handleOpenGroupSwitch}
                     onOpenFacilitatorModal={handleOpenFacilitatorModal}
-                    onOpenDropoutModal={handleOpenDropoutModal}
                     isPast
                     emptyMessage="No facilitated discussions yet"
                   />
@@ -179,14 +170,6 @@ const CourseDetails = ({
           roundId={selectedDiscussion.groupDetails.round}
           initialDiscussion={selectedDiscussion}
           initialModalType={selectedFacilitatorModalType}
-        />
-      )}
-      {dropoutModalOpen && (
-        <DropoutModal
-          applicantId={courseRegistration.id}
-          courseSlug={course.slug}
-          currentRoundId={courseRegistration.roundId ?? null}
-          handleClose={() => setDropoutModalOpen(false)}
         />
       )}
     </>

--- a/apps/website/src/components/settings/CourseList.test.tsx
+++ b/apps/website/src/components/settings/CourseList.test.tsx
@@ -163,7 +163,7 @@ describe('CourseList', () => {
       { wrapper: TrpcProvider },
     );
 
-    const dropoutButtons = await screen.findAllByRole('button', { name: 'Drop out or defer' });
+    const dropoutButtons = await screen.findAllByRole('button', { name: 'Defer or drop out' });
     expect(dropoutButtons.length).toBeGreaterThan(0);
 
     await act(async () => {
@@ -188,7 +188,7 @@ describe('CourseList', () => {
       { wrapper: TrpcProvider },
     );
 
-    expect(screen.getAllByRole('button', { name: 'Drop out or defer' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Defer or drop out' }).length).toBeGreaterThan(0);
   });
 
   it('does not show dropout or deferral action for rejected upcoming or past courses', () => {
@@ -215,7 +215,7 @@ describe('CourseList', () => {
       { wrapper: TrpcProvider },
     );
 
-    expect(screen.queryByRole('button', { name: 'Drop out or defer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Defer or drop out' })).not.toBeInTheDocument();
   });
 
   it('collapses and expands course details', async () => {

--- a/apps/website/src/components/settings/CourseList.tsx
+++ b/apps/website/src/components/settings/CourseList.tsx
@@ -517,7 +517,7 @@ const getDropoutOrDeferralButton = ({
       onClick={onOpenDropoutModal}
       className="w-full sm:w-auto border-bluedot-darker"
     >
-      Drop out or defer
+      Defer or drop out
     </CTALinkOrButton>
   )];
 };

--- a/apps/website/src/components/settings/DiscussionList.tsx
+++ b/apps/website/src/components/settings/DiscussionList.tsx
@@ -30,7 +30,6 @@ export type DiscussionListProps = {
   isFacilitator: boolean;
   onOpenGroupSwitchModal: (discussion: GroupDiscussionWithGroupAndUnit, switchType: SwitchType) => void;
   onOpenFacilitatorModal: (discussion: GroupDiscussionWithGroupAndUnit, modalType: FacilitatorModalType) => void;
-  onOpenDropoutModal: () => void;
   isPast: boolean;
   emptyMessage: string;
 };
@@ -41,7 +40,6 @@ const DiscussionList = ({
   isFacilitator,
   onOpenGroupSwitchModal,
   onOpenFacilitatorModal,
-  onOpenDropoutModal,
   isPast,
   emptyMessage,
 }: DiscussionListProps) => {
@@ -52,7 +50,6 @@ const DiscussionList = ({
   }
 
   const showSeeAllButton = discussions.length > 3;
-  const showDropoutOrDeferralButton = !isFacilitator && !isPast;
 
   return (
     <div>
@@ -68,33 +65,16 @@ const DiscussionList = ({
           onOpenFacilitatorModal={onOpenFacilitatorModal}
         />
       ))}
-      {(showSeeAllButton || showDropoutOrDeferralButton) && (
-        <div className="grid grid-cols-1 gap-3 pt-4 sm:grid-cols-[1fr_auto_1fr] sm:items-center">
-          <div className="hidden sm:block" />
-          <div className="justify-self-center">
-            {showSeeAllButton && (
-              <button
-                type="button"
-                onClick={() => setShowAll(!showAll)}
-                className="text-size-sm font-medium text-bluedot-normal hover:text-blue-700 transition-colors cursor-pointer"
-                aria-expanded={showAll}
-              >
-                {showAll ? 'Show less' : `See all (${discussions.length}) discussions`}
-              </button>
-            )}
-          </div>
-          <div className="sm:justify-self-end">
-            {showDropoutOrDeferralButton && (
-              <CTALinkOrButton
-                variant={BUTTON_STYLES.secondary.variant}
-                size="small"
-                className={cn('w-full sm:w-auto', BUTTON_STYLES.secondary.className)}
-                onClick={onOpenDropoutModal}
-              >
-                Defer or drop out
-              </CTALinkOrButton>
-            )}
-          </div>
+      {showSeeAllButton && (
+        <div className="pt-4 text-center">
+          <button
+            type="button"
+            onClick={() => setShowAll(!showAll)}
+            className="text-size-sm font-medium text-bluedot-normal hover:text-blue-700 transition-colors cursor-pointer"
+            aria-expanded={showAll}
+          >
+            {showAll ? 'Show less' : `See all (${discussions.length}) discussions`}
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Remove the discussion-details/footer entry point for defer/dropout requests
- Keep the settings course-row CTA as the single entry point
- Rename the row CTA from "Drop out or defer" to "Defer or drop out"

## Impact
This reduces duplicate defer/dropout actions inside expanded course discussion details while preserving access from the course row for eligible active and future course registrations.

## Validation
- `npm --workspace @bluedot/website test -- CourseList.test.tsx CourseDetails.test.tsx`
- `npm --workspace @bluedot/website run lint -- src/components/settings/CourseDetails.tsx src/components/settings/DiscussionList.tsx src/components/settings/CourseList.tsx src/components/settings/CourseDetails.test.tsx src/components/settings/CourseList.test.tsx`
- `npm --workspace @bluedot/website run typecheck`
- `git diff --check`