### PR TITLE
[copy] Correct Ryan Kidd's MATS origin story on fieldbuilder-week page

### DIFF
--- a/apps/website/src/components/fieldbuilder-week/FieldBuildersSection.tsx
+++ b/apps/website/src/components/fieldbuilder-week/FieldBuildersSection.tsx
@@ -29,8 +29,8 @@ const BUILDERS: Builder[] = [
     },
     program: { name: 'MATS', url: 'https://www.matsprogram.org/' },
     logo: { src: '/images/programs/fieldbuilder-week-founders/mats.svg', alt: 'MATS logo' },
-    before: ' was a physics PhD doing independent alignment research at SERI who saw the shortage of excellent technical talent and co-founded ',
-    after: ' to build the pipeline.',
+    before: ' was a physics PhD and SERI MATS pilot participant who saw how the program could grow to meet the shortage of technical alignment researchers. He sent the organisers a plan to scale it and now co-leads ',
+    after: '.',
   },
   {
     slug: 'horizon',


### PR DESCRIPTION
## Summary

- The previous copy described Ryan Kidd as doing independent alignment research at SERI and co-founding MATS. Both are inaccurate per Ryan's own account.
- He was a participant in the SERI MATS pilot, sent the organisers a plan to scale it, and was invited in to co-lead MATS. The new copy reflects that.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (--max-warnings=0)
- [x] `npx vitest run` — 655 passed, 1 skipped
- [x] Eyeballed locally on `/programs/fieldbuilder-week` (port 8011)

## Screenshots

_paste WebP_

🤖 Generated with [Claude Code](https://claude.com/claude-code)