### PR TITLE
[copy] Reframe fieldbuilder-week as register-interest

### DIFF
--- a/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
+++ b/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
@@ -3,10 +3,12 @@ import { pageSectionHeadingClass } from '../PageListRow';
 
 type Props = {
   applicationUrl: string | undefined;
-  applicationDeadline: string;
+  applicationDeadline?: string;
+  ctaLabel?: string;
 };
 
-const AboutBlueDotSection = ({ applicationUrl, applicationDeadline }: Props) => {
+const AboutBlueDotSection = ({ applicationUrl, applicationDeadline, ctaLabel }: Props) => {
+  const label = ctaLabel ?? (applicationDeadline ? `Apply by ${applicationDeadline}` : 'Apply now');
   return (
     <section className="section section-body incubator-week-about-bluedot-section">
       <div className="w-full flex flex-col gap-6">
@@ -21,7 +23,7 @@ const AboutBlueDotSection = ({ applicationUrl, applicationDeadline }: Props) => 
             url={applicationUrl}
             target="_blank"
           >
-            Apply by {applicationDeadline}
+            {label}
           </CTALinkOrButton>
         )}
       </div>

--- a/apps/website/src/pages/programs/fieldbuilder-week.tsx
+++ b/apps/website/src/pages/programs/fieldbuilder-week.tsx
@@ -17,7 +17,6 @@ import {
 
 const PROGRAM_SLUG = 'fieldbuilder-week';
 const FALLBACK_NAME = 'Fieldbuilder Week';
-const APPLICATION_DEADLINE = '27 May';
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bluedot.org';
 const LINK_PREVIEW_IMAGE = `${SITE_URL}/images/programs/link-preview/fieldbuilder-week.png`;
 
@@ -56,12 +55,11 @@ const FieldbuilderWeekProgramPage = ({ programName, programDescription }: Progra
         program="fieldbuilder-week"
         compact
         primaryAction={{
-          label: `Apply by ${APPLICATION_DEADLINE}`,
+          label: 'Register interest',
           url: applicationUrl,
         }}
         stats={[
           { label: 'Cohort', value: 'v1' },
-          { label: 'Runs', value: '8–12 June' },
           { label: 'Funding', value: 'Up to $200k' },
           { label: 'Covered', value: 'Flights, accom, meals' },
         ]}
@@ -72,7 +70,7 @@ const FieldbuilderWeekProgramPage = ({ programName, programDescription }: Progra
       <WhatCouldYouBuildSection />
       <AboutBlueDotSection
         applicationUrl={applicationUrl}
-        applicationDeadline={APPLICATION_DEADLINE}
+        ctaLabel="Register interest"
       />
     </div>
   );


### PR DESCRIPTION
# Description

The fieldbuilder-week landing page previously committed to specific dates ("Apply by 27 May", "Runs 8–12 June") and an apply-now CTA. We're no longer certain we'll run it on that date, so the page now reads as a register-interest signal-gathering exercise instead.

The week structure (Mon → Fri pitch flow), funding amounts ($5k on the spot, up to $200k total), and London/5-day format all stay — only the commitment-language and dates change. The form URL is unchanged; folks still hit the existing fieldbuilder-week application form.

The shared `AboutBlueDotSection` (also used by incubator-week) picks up an optional `ctaLabel` prop with backwards-compatible defaults, so incubator-week continues to render "Apply by 26 May" untouched.

## What changed

1. **`apps/website/src/pages/programs/fieldbuilder-week.tsx`** — drops the `APPLICATION_DEADLINE` constant and the `Runs: 8–12 June` stat; stats strip now shows three stats (Cohort / Funding / Covered) with a "Register interest" CTA. Passes `ctaLabel="Register interest"` to the bottom AboutBlueDotSection.
2. **`apps/website/src/components/incubator-week/AboutBlueDotSection.tsx`** — adds optional `ctaLabel` and makes `applicationDeadline` optional. Label resolution: `ctaLabel` → "Apply by {deadline}" → "Apply now".

## Issue

N/A — copy-only / soft-launch reframing, no linked issue.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — CTA labels remain descriptive; no semantic changes.
- [x] Considered having snapshot tests / functional tests — declined; copy-only change with no logic.
- [x] Considered adding Storybook stories — declined; AboutBlueDotSection change is a backwards-compatible prop addition.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8012` in the `anglilian/fieldbuilder-register-interest` worktree):
- ✅ `/programs/fieldbuilder-week` — stats strip shows 3 stats + "Register interest" CTA on both mobile and desktop; bottom "About BlueDot" CTA reads "Register interest"; dates are gone from the page surface.
- ✅ `/programs/incubator-week` — unchanged (still renders "Apply by 26 May" via the default code path).

Type check + lint + full test suite all pass:
\`\`\`
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 655 passed, 1 skipped (111 files)
\`\`\`

## Screenshots

### Stats strip

|            | Before  | After  |
| ---------- | ------- | ------ |
| 📱 Mobile  | _paste_ | _paste_ |
| 🖥️ Desktop | _paste_ | _paste_ |

### About BlueDot CTA

|            | Before  | After  |
| ---------- | ------- | ------ |
| 📱 Mobile  | _paste_ | _paste_ |
| 🖥️ Desktop | _paste_ | _paste_ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)