### PR TITLE
Block enrolment CTA on congratulations when course does not have upcoming rounds

### DIFF
--- a/apps/website/src/__tests__/pages/courses/congratulations.test.tsx
+++ b/apps/website/src/__tests__/pages/courses/congratulations.test.tsx
@@ -111,7 +111,10 @@ describe('CongratulationsPage', () => {
   });
 
   test('redirects FOAI learner who is not authenticated', async () => {
-    server.use(trpcMsw.certificates.getStatus.query(() => ({ status: 'not-authenticated' as const })));
+    server.use(trpcMsw.certificates.getStatus.query(() => ({
+      status: 'not-authenticated' as const,
+      hasUpcomingRounds: false,
+    })));
 
     render(<CongratulationsPage {...DEFAULT_PROPS} courseSlug="future-of-ai" />, { wrapper: TrpcProvider });
 
@@ -121,7 +124,10 @@ describe('CongratulationsPage', () => {
   });
 
   test('redirects FOAI learner who is not enrolled', async () => {
-    server.use(trpcMsw.certificates.getStatus.query(() => ({ status: 'not-enrolled' as const })));
+    server.use(trpcMsw.certificates.getStatus.query(() => ({
+      status: 'not-enrolled' as const,
+      hasUpcomingRounds: false,
+    })));
 
     render(<CongratulationsPage {...DEFAULT_PROPS} courseSlug="future-of-ai" />, { wrapper: TrpcProvider });
 
@@ -130,13 +136,33 @@ describe('CongratulationsPage', () => {
     });
   });
 
-  test('does not redirect non-FOAI learner who is not authenticated', async () => {
-    server.use(trpcMsw.certificates.getStatus.query(() => ({ status: 'not-authenticated' as const })));
+  test('does not redirect non-FOAI learner who is not authenticated when upcoming rounds exist', async () => {
+    server.use(trpcMsw.certificates.getStatus.query(() => ({
+      status: 'not-authenticated' as const,
+      hasUpcomingRounds: true,
+    })));
 
     render(<CongratulationsPage {...DEFAULT_PROPS} />, { wrapper: TrpcProvider });
 
     await waitFor(() => {
       expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  test.each([
+    'not-authenticated',
+    'not-enrolled',
+    'not-eligible',
+  ] as const)('redirects non-FOAI learner with status %s when no upcoming rounds exist', async (status) => {
+    server.use(trpcMsw.certificates.getStatus.query(() => ({
+      status,
+      hasUpcomingRounds: false,
+    })));
+
+    render(<CongratulationsPage {...DEFAULT_PROPS} />, { wrapper: TrpcProvider });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/courses/test-course/1/1');
     });
   });
 

--- a/apps/website/src/__tests__/pages/courses/congratulations.test.tsx
+++ b/apps/website/src/__tests__/pages/courses/congratulations.test.tsx
@@ -110,23 +110,18 @@ describe('CongratulationsPage', () => {
     });
   });
 
-  test('redirects FOAI learner who is not authenticated', async () => {
+  // FoAI uses its own gate (`status === 'has-certificate'`), independent of `hasUpcomingRounds`.
+  // Parameterising over `hasUpcomingRounds` proves FoAI behaviour doesn't accidentally couple
+  // to that field if someone refactors `shouldShowCongratulations`.
+  test.each([
+    ['not-authenticated', true],
+    ['not-authenticated', false],
+    ['not-enrolled', true],
+    ['not-enrolled', false],
+  ] as const)('redirects FOAI learner with status %s regardless of hasUpcomingRounds (=%s)', async (status, hasUpcomingRounds) => {
     server.use(trpcMsw.certificates.getStatus.query(() => ({
-      status: 'not-authenticated' as const,
-      hasUpcomingRounds: false,
-    })));
-
-    render(<CongratulationsPage {...DEFAULT_PROPS} courseSlug="future-of-ai" />, { wrapper: TrpcProvider });
-
-    await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith('/courses/future-of-ai/1/1');
-    });
-  });
-
-  test('redirects FOAI learner who is not enrolled', async () => {
-    server.use(trpcMsw.certificates.getStatus.query(() => ({
-      status: 'not-enrolled' as const,
-      hasUpcomingRounds: false,
+      status,
+      hasUpcomingRounds,
     })));
 
     render(<CongratulationsPage {...DEFAULT_PROPS} courseSlug="future-of-ai" />, { wrapper: TrpcProvider });

--- a/apps/website/src/__tests__/pages/courses/congratulations.test.tsx
+++ b/apps/website/src/__tests__/pages/courses/congratulations.test.tsx
@@ -136,9 +136,13 @@ describe('CongratulationsPage', () => {
     });
   });
 
-  test('does not redirect non-FOAI learner who is not authenticated when upcoming rounds exist', async () => {
+  test.each([
+    'not-authenticated',
+    'not-enrolled',
+    'not-eligible',
+  ] as const)('does not redirect non-FOAI learner with status %s when upcoming rounds exist', async (status) => {
     server.use(trpcMsw.certificates.getStatus.query(() => ({
-      status: 'not-authenticated' as const,
+      status,
       hasUpcomingRounds: true,
     })));
 

--- a/apps/website/src/components/courses/CourseCompletionSection.test.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.test.tsx
@@ -34,7 +34,7 @@ const defaultProps = {
 
 describe('CourseCompletionSection', () => {
   beforeEach(() => {
-    server.use(trpcMsw.certificates.getStatus.query(() => ({ status: 'not-eligible' as const })));
+    server.use(trpcMsw.certificates.getStatus.query(() => ({ status: 'not-eligible' as const, hasUpcomingRounds: true })));
   });
 
   test('shows ProgressDots while getCourseApplication is loading', () => {

--- a/apps/website/src/components/courses/SidebarCertificatePanel.stories.tsx
+++ b/apps/website/src/components/courses/SidebarCertificatePanel.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 export const NotAuthenticated: Story = {
   args: {
-    certificateData: { status: 'not-authenticated' },
+    certificateData: { status: 'not-authenticated', hasUpcomingRounds: true },
   },
 };
 
@@ -27,13 +27,13 @@ export const NotAuthenticatedFoai: Story = {
   args: {
     courseTitle: 'Future of AI',
     courseSlug: 'future-of-ai',
-    certificateData: { status: 'not-authenticated' },
+    certificateData: { status: 'not-authenticated', hasUpcomingRounds: false },
   },
 };
 
 export const NotEnrolled: Story = {
   args: {
-    certificateData: { status: 'not-enrolled' },
+    certificateData: { status: 'not-enrolled', hasUpcomingRounds: true },
   },
 };
 
@@ -41,13 +41,33 @@ export const NotEnrolledFoai: Story = {
   args: {
     courseTitle: 'Future of AI',
     courseSlug: 'future-of-ai',
-    certificateData: { status: 'not-enrolled' },
+    certificateData: { status: 'not-enrolled', hasUpcomingRounds: false },
   },
 };
 
 export const NotEligible: Story = {
   args: {
-    certificateData: { status: 'not-eligible' },
+    certificateData: { status: 'not-eligible', hasUpcomingRounds: true },
+  },
+};
+
+// Renders nothing — kept here so designers/PMs can confirm the empty state.
+
+export const NotAuthenticatedNoUpcomingRounds: Story = {
+  args: {
+    certificateData: { status: 'not-authenticated', hasUpcomingRounds: false },
+  },
+};
+
+export const NotEnrolledNoUpcomingRounds: Story = {
+  args: {
+    certificateData: { status: 'not-enrolled', hasUpcomingRounds: false },
+  },
+};
+
+export const NotEligibleNoUpcomingRounds: Story = {
+  args: {
+    certificateData: { status: 'not-eligible', hasUpcomingRounds: false },
   },
 };
 

--- a/apps/website/src/components/courses/SidebarCertificatePanel.test.tsx
+++ b/apps/website/src/components/courses/SidebarCertificatePanel.test.tsx
@@ -35,6 +35,23 @@ describe('SidebarCertificatePanel', () => {
     'not-authenticated',
     'not-enrolled',
     'not-eligible',
+  ] as const)('renders the join-cohort CTA when status is %s and upcoming rounds exist', (status) => {
+    render(<SidebarCertificatePanel
+      courseTitle="AGI Strategy"
+      courseSlug="agi-strategy"
+      certificateData={{ status, hasUpcomingRounds: true }}
+    />);
+
+    const link = screen.getByRole('link', {
+      name: /AGI Strategy Certificate Join a facilitated cohort today/i,
+    });
+    expect(link).toHaveAttribute('href', '/courses/agi-strategy/congratulations');
+  });
+
+  test.each([
+    'not-authenticated',
+    'not-enrolled',
+    'not-eligible',
   ] as const)('renders nothing when status is %s and no upcoming rounds exist', (status) => {
     const { container } = render(<SidebarCertificatePanel
       courseTitle="AGI Strategy"

--- a/apps/website/src/components/courses/SidebarCertificatePanel.test.tsx
+++ b/apps/website/src/components/courses/SidebarCertificatePanel.test.tsx
@@ -8,7 +8,7 @@ describe('SidebarCertificatePanel', () => {
     render(<SidebarCertificatePanel
       courseTitle="Introduction to Digital Minds"
       courseSlug="digital-minds"
-      certificateData={{ status: 'not-enrolled' }}
+      certificateData={{ status: 'not-enrolled', hasUpcomingRounds: true }}
     />);
 
     const link = screen.getByRole('link', { name: 'Learn more about this course' });
@@ -21,7 +21,7 @@ describe('SidebarCertificatePanel', () => {
     render(<SidebarCertificatePanel
       courseTitle="AGI Strategy"
       courseSlug="agi-strategy"
-      certificateData={{ status: 'not-enrolled' }}
+      certificateData={{ status: 'not-enrolled', hasUpcomingRounds: true }}
     />);
 
     const link = screen.getByRole('link', {
@@ -29,5 +29,19 @@ describe('SidebarCertificatePanel', () => {
     });
 
     expect(link).toHaveAttribute('href', '/courses/agi-strategy/congratulations');
+  });
+
+  test.each([
+    'not-authenticated',
+    'not-enrolled',
+    'not-eligible',
+  ] as const)('renders nothing when status is %s and no upcoming rounds exist', (status) => {
+    const { container } = render(<SidebarCertificatePanel
+      courseTitle="AGI Strategy"
+      courseSlug="agi-strategy"
+      certificateData={{ status, hasUpcomingRounds: false }}
+    />);
+
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/apps/website/src/components/courses/SidebarCertificatePanel.tsx
+++ b/apps/website/src/components/courses/SidebarCertificatePanel.tsx
@@ -145,6 +145,17 @@ export const SidebarCertificatePanel = ({
     );
   }
 
+  // Reached here only when `shouldShowCongratulations` returned false. For the three "join a
+  // cohort" statuses that implies `!hasUpcomingRounds`, and we render nothing rather than fall
+  // through to the LockedPanel below.
+  if (
+    certificateData.status === 'not-authenticated'
+    || certificateData.status === 'not-enrolled'
+    || certificateData.status === 'not-eligible'
+  ) {
+    return null;
+  }
+
   // action-plan-pending + not yet submitted + open: two-panel layout
   if (
     status === 'action-plan-pending'

--- a/apps/website/src/components/courses/SidebarCertificatePanel.tsx
+++ b/apps/website/src/components/courses/SidebarCertificatePanel.tsx
@@ -99,9 +99,13 @@ export const SidebarCertificatePanel = ({
   }
 
   // Unenrolled/unauthenticated users with no upcoming rounds: render nothing rather than
-  // surface a "join a cohort" CTA that leads nowhere.
+  // surface a "join a cohort" CTA that leads nowhere. Discriminate on `certificateData.status`
+  // directly so TypeScript narrows the object to the variants that carry `hasUpcomingRounds`;
+  // the aliased `status` from `certificateData?.status` breaks that narrowing.
   if (
-    (status === 'not-authenticated' || status === 'not-enrolled' || status === 'not-eligible')
+    (certificateData.status === 'not-authenticated'
+      || certificateData.status === 'not-enrolled'
+      || certificateData.status === 'not-eligible')
     && !certificateData.hasUpcomingRounds
   ) {
     return null;

--- a/apps/website/src/components/courses/SidebarCertificatePanel.tsx
+++ b/apps/website/src/components/courses/SidebarCertificatePanel.tsx
@@ -22,6 +22,21 @@ export const isCongratulationsAccessible = (data: CertificateData | undefined): 
   );
 };
 
+// Hides the panel and redirects the page when the only CTA we could offer is "join a cohort"
+// but no upcoming rounds exist for that course.
+export const shouldShowCongratulations = (data: CertificateData | undefined): boolean => {
+  if (!data) return true;
+  if (!isCongratulationsAccessible(data)) return false;
+  if (
+    (data.status === 'not-authenticated' || data.status === 'not-enrolled' || data.status === 'not-eligible')
+    && !data.hasUpcomingRounds
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
 const CertificateRequirementsModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => (
   <Modal isOpen={isOpen} setIsOpen={(open) => !open && onClose()} title="Certificate requirement">
     <P>You must meet both requirements to receive a certificate at the end of the course:</P>

--- a/apps/website/src/components/courses/SidebarCertificatePanel.tsx
+++ b/apps/website/src/components/courses/SidebarCertificatePanel.tsx
@@ -98,6 +98,15 @@ export const SidebarCertificatePanel = ({
     );
   }
 
+  // Unenrolled/unauthenticated users with no upcoming rounds: render nothing rather than
+  // surface a "join a cohort" CTA that leads nowhere.
+  if (
+    (status === 'not-authenticated' || status === 'not-enrolled' || status === 'not-eligible')
+    && !certificateData.hasUpcomingRounds
+  ) {
+    return null;
+  }
+
   if (isCongratulationsAccessible(certificateData)) {
     const defaultCtaOverride = (
       status === 'not-authenticated'

--- a/apps/website/src/components/courses/SidebarCertificatePanel.tsx
+++ b/apps/website/src/components/courses/SidebarCertificatePanel.tsx
@@ -98,20 +98,7 @@ export const SidebarCertificatePanel = ({
     );
   }
 
-  // Unenrolled/unauthenticated users with no upcoming rounds: render nothing rather than
-  // surface a "join a cohort" CTA that leads nowhere. Discriminate on `certificateData.status`
-  // directly so TypeScript narrows the object to the variants that carry `hasUpcomingRounds`;
-  // the aliased `status` from `certificateData?.status` breaks that narrowing.
-  if (
-    (certificateData.status === 'not-authenticated'
-      || certificateData.status === 'not-enrolled'
-      || certificateData.status === 'not-eligible')
-    && !certificateData.hasUpcomingRounds
-  ) {
-    return null;
-  }
-
-  if (isCongratulationsAccessible(certificateData)) {
+  if (shouldShowCongratulations(certificateData)) {
     const defaultCtaOverride = (
       status === 'not-authenticated'
       || status === 'not-enrolled'

--- a/apps/website/src/pages/courses/[courseSlug]/congratulations.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/congratulations.tsx
@@ -5,7 +5,7 @@ import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import CourseCompletionSection from '../../../components/courses/CourseCompletionSection';
 import CourseShell from '../../../components/courses/CourseShell';
-import { isCongratulationsAccessible } from '../../../components/courses/SidebarCertificatePanel';
+import { shouldShowCongratulations } from '../../../components/courses/SidebarCertificatePanel';
 import { FOAI_COURSE_SLUG } from '../../../lib/constants';
 import { type BasicChunk, getActiveChunksByUnit, getCourseData } from '../../../server/routers/courses';
 import { trpc } from '../../../utils/trpc';
@@ -43,10 +43,10 @@ export default function CongratulationsPage({
   }
 
   // FoAI is self-paced: the only valid entry to Congratulations is having earned the certificate.
-  // Cohort courses use the shared `isCongratulationsAccessible` rules.
+  // Cohort courses use the shared `shouldShowCongratulations` rules.
   const isAccessible = courseSlug === FOAI_COURSE_SLUG
     ? certificateData?.status === 'has-certificate'
-    : isCongratulationsAccessible(certificateData);
+    : shouldShowCongratulations(certificateData);
 
   if (!isAccessible) {
     router.replace(`/courses/${courseSlug}/1/1`);

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -1,5 +1,5 @@
 import {
-  courseRegistrationTable, courseTable, meetPersonTable, roundTable,
+  applicationsRoundTable, courseRegistrationTable, courseTable, meetPersonTable, roundTable,
 } from '@bluedot/db';
 import {
   describe, expect, test, vi,
@@ -133,14 +133,32 @@ describe('certificates.verifyOwnership', () => {
 });
 
 describe('certificates.getStatus', () => {
-  test('returns not-authenticated for unauthenticated callers', async () => {
+  test('returns not-authenticated with hasUpcomingRounds: false when none exist', async () => {
     const result = await createCaller(testAuthContextLoggedOut).certificates.getStatus({ courseId: FOAI_COURSE_ID });
-    expect(result).toEqual({ status: 'not-authenticated' });
+    expect(result).toEqual({ status: 'not-authenticated', hasUpcomingRounds: false });
   });
 
-  test('returns not-enrolled when the auth user has no accepted registration', async () => {
+  test('returns not-authenticated with hasUpcomingRounds: true when an upcoming round exists', async () => {
+    await testDb.insert(applicationsRoundTable, {
+      id: 'round-upcoming', courseId: FOAI_COURSE_ID, applicationDeadline: '2999-01-01',
+    });
+
+    const result = await createCaller(testAuthContextLoggedOut).certificates.getStatus({ courseId: FOAI_COURSE_ID });
+    expect(result).toEqual({ status: 'not-authenticated', hasUpcomingRounds: true });
+  });
+
+  test('treats a round with null applicationDeadline as upcoming', async () => {
+    await testDb.insert(applicationsRoundTable, {
+      id: 'round-tbd', courseId: FOAI_COURSE_ID, applicationDeadline: null,
+    });
+
+    const result = await createCaller(testAuthContextLoggedOut).certificates.getStatus({ courseId: FOAI_COURSE_ID });
+    expect(result).toEqual({ status: 'not-authenticated', hasUpcomingRounds: true });
+  });
+
+  test('returns not-enrolled with hasUpcomingRounds when the auth user has no accepted registration', async () => {
     const result = await createCaller(testAuthContextLoggedIn).certificates.getStatus({ courseId: FOAI_COURSE_ID });
-    expect(result).toEqual({ status: 'not-enrolled' });
+    expect(result).toEqual({ status: 'not-enrolled', hasUpcomingRounds: false });
   });
 
   test('returns has-certificate when the registration has a certificateId', async () => {
@@ -212,7 +230,7 @@ describe('certificates.getStatus', () => {
     });
 
     const result = await createCaller(testAuthContextLoggedIn).certificates.getStatus({ courseId: 'rec-other' });
-    expect(result).toEqual({ status: 'not-eligible' });
+    expect(result).toEqual({ status: 'not-eligible', hasUpcomingRounds: false });
   });
 
   test('returns action-plan-pending for non-FOAI Participants, with submission flag', async () => {
@@ -272,7 +290,7 @@ describe('certificates.getStatus', () => {
     });
 
     const result = await createCaller(testAuthContextLoggedIn).certificates.getStatus({ courseId: 'rec-other' });
-    expect(result).toEqual({ status: 'not-eligible' });
+    expect(result).toEqual({ status: 'not-eligible', hasUpcomingRounds: false });
   });
 
   test('returns attendance-ineligible when a participant misses more than one discussion', async () => {

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -15,6 +15,7 @@ import env from '../../lib/api/env';
 import { FOAI_COURSE_ID, ONE_DAY_MS } from '../../lib/constants';
 import { protectedProcedure, publicProcedure, router } from '../trpc';
 import type { AppRouter } from './_app';
+import { hasUpcomingRoundsForCourseId } from './course-rounds';
 
 async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
   const allExercises = await db.scan(exerciseTable, { courseId: FOAI_COURSE_ID, status: 'Active' });
@@ -134,7 +135,8 @@ export const certificatesRouter = router({
 
   getStatus: publicProcedure.input(z.object({ courseId: z.string() })).query(async ({ ctx, input: { courseId } }) => {
     if (!ctx.auth) {
-      return { status: 'not-authenticated' } as const;
+      const hasUpcomingRounds = await hasUpcomingRoundsForCourseId(courseId);
+      return { status: 'not-authenticated', hasUpcomingRounds } as const;
     }
 
     const courseRegistration = await db.getFirst(courseRegistrationTable, {
@@ -142,7 +144,8 @@ export const certificatesRouter = router({
     });
 
     if (!courseRegistration) {
-      return { status: 'not-enrolled' } as const;
+      const hasUpcomingRounds = await hasUpcomingRoundsForCourseId(courseId);
+      return { status: 'not-enrolled', hasUpcomingRounds } as const;
     }
 
     if (courseRegistration.certificateId) {
@@ -164,7 +167,8 @@ export const certificatesRouter = router({
     });
 
     if (!meetPerson) {
-      return { status: 'not-eligible' } as const;
+      const hasUpcomingRounds = await hasUpcomingRoundsForCourseId(courseId);
+      return { status: 'not-eligible', hasUpcomingRounds } as const;
     }
 
     if (meetPerson.role === 'Participant') {
@@ -204,6 +208,7 @@ export const certificatesRouter = router({
       return { status: 'is-facilitator' } as const;
     }
 
-    return { status: 'not-eligible' } as const;
+    const hasUpcomingRounds = await hasUpcomingRoundsForCourseId(courseId);
+    return { status: 'not-eligible', hasUpcomingRounds } as const;
   }),
 });

--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -75,6 +75,24 @@ function groupByIntensity<T extends { intensity: string | null }>(rounds: T[]): 
   };
 }
 
+export async function hasUpcomingRoundsForCourseId(courseId: string) {
+  const deadlineThreshold = getDeadlineThresholdUtc();
+
+  const rows = await db.pg
+    .select({ id: applicationsRoundTable.pg.id })
+    .from(applicationsRoundTable.pg)
+    .where(and(
+      eq(applicationsRoundTable.pg.courseId, courseId),
+      or(
+        sql`${applicationsRoundTable.pg.applicationDeadline} IS NULL`,
+        sql`${applicationsRoundTable.pg.applicationDeadline}::timestamp >= ${deadlineThreshold.toISOString()}::timestamp`,
+      ),
+    ))
+    .limit(1);
+
+  return rows.length > 0;
+}
+
 /**
  * Fetches course rounds data by course slug.
  * This function is shared between the tRPC procedure and getStaticProps.


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

When a course has no upcoming rounds, learners on `/courses/<slug>/congratulations` saw a mismatch: sidebar said "Join a facilitated cohort today", body said "Congratulations on finishing the course".

This PR hides the sidebar certificate panel and redirects the congratulations page to `/courses/<slug>/1/1` whenever the only CTA we could offer is "join a cohort" but none exist. Affects `not-authenticated`, `not-enrolled`, `not-eligible`. `has-certificate`,`attendance-ineligible`, and FoAI behaviour unchanged.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2506 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="360" height="694" alt="image" src="https://github.com/user-attachments/assets/a219098a-d8e5-4771-a271-0579ec27f1dd" /> | <img width="361" height="719" alt="image" src="https://github.com/user-attachments/assets/c3f17894-86b6-401c-a751-fe7fa900f7eb" /> |
