### PR TITLE
[feat] speed-review: new summary format, rubric scores, sortable pile

### DIFF
--- a/apps/speed-review/src/components/ApplicationCard.tsx
+++ b/apps/speed-review/src/components/ApplicationCard.tsx
@@ -61,7 +61,13 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, p
 
       <PreviousApplicationsCard applicationId={application.id} course={course} />
 
-      {(!!aiSummary || commitmentScore !== undefined || impressivenessScore !== undefined || technicalSkillScore !== undefined) && (
+      {(!!aiSummary
+        || commitmentScore !== undefined
+        || impressivenessScore !== undefined
+        || technicalSkillScore !== undefined
+        || !!commitmentRationale
+        || !!impressivenessRationale
+        || !!technicalSkillRationale) && (
         <SummaryCard
           aiSummary={aiSummary ?? ''}
           course={course}

--- a/apps/speed-review/src/components/ApplicationCard.tsx
+++ b/apps/speed-review/src/components/ApplicationCard.tsx
@@ -26,7 +26,6 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, p
     reasoning,
     applicationSource,
     utmSource,
-    previousCourses,
     commitmentScore,
     commitmentRationale,
     impressivenessScore,
@@ -45,9 +44,6 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, p
           {subtitle && (
             <p className="text-size-sm text-stone-400 mt-0.5">{subtitle}</p>
           )}
-          {previousCourses && previousCourses.length > 0 && (
-            <p className="text-size-xs text-amber-400 mt-1">⟳ Previous participant: {previousCourses.join(', ')}</p>
-          )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {profileUrl && (
@@ -63,6 +59,8 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, p
         </div>
       </div>
 
+      <PreviousApplicationsCard applicationId={application.id} course={course} />
+
       {(!!aiSummary || commitmentScore !== undefined || impressivenessScore !== undefined || technicalSkillScore !== undefined) && (
         <SummaryCard
           aiSummary={aiSummary ?? ''}
@@ -75,8 +73,6 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, p
           technicalSkillRationale={technicalSkillRationale}
         />
       )}
-
-      <PreviousApplicationsCard applicationId={application.id} />
 
       <div className="border border-stone-700 rounded-lg divide-y divide-stone-700 overflow-hidden">
         {([

--- a/apps/speed-review/src/components/ApplicationCard.tsx
+++ b/apps/speed-review/src/components/ApplicationCard.tsx
@@ -27,6 +27,12 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, p
     applicationSource,
     utmSource,
     previousCourses,
+    commitmentScore,
+    commitmentRationale,
+    impressivenessScore,
+    impressivenessRationale,
+    technicalSkillScore,
+    technicalSkillRationale,
   } = application;
 
   const subtitle = [jobTitle, organisation, careerLevel].filter(Boolean).join(' · ');
@@ -57,7 +63,18 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({ application, p
         </div>
       </div>
 
-      {aiSummary && <SummaryCard aiSummary={aiSummary} course={course} />}
+      {(!!aiSummary || commitmentScore !== undefined || impressivenessScore !== undefined || technicalSkillScore !== undefined) && (
+        <SummaryCard
+          aiSummary={aiSummary ?? ''}
+          course={course}
+          commitmentScore={commitmentScore}
+          commitmentRationale={commitmentRationale}
+          impressivenessScore={impressivenessScore}
+          impressivenessRationale={impressivenessRationale}
+          technicalSkillScore={technicalSkillScore}
+          technicalSkillRationale={technicalSkillRationale}
+        />
+      )}
 
       <PreviousApplicationsCard applicationId={application.id} />
 

--- a/apps/speed-review/src/components/PreviousApplicationsCard.tsx
+++ b/apps/speed-review/src/components/PreviousApplicationsCard.tsx
@@ -10,6 +10,35 @@ type PreviousApplication = {
 
 type PreviousApplicationsCardProps = {
   applicationId: string;
+  course: string;
+};
+
+const TAIS_FAMILY = ['Technical AI Safety', 'Technical AI Safety Project'];
+const AGISC_FAMILY = ['AGI Strategy'];
+
+const familyFor = (course: string): string[] => {
+  if (TAIS_FAMILY.includes(course)) return TAIS_FAMILY;
+  if (AGISC_FAMILY.includes(course)) return AGISC_FAMILY;
+  return [course];
+};
+
+const courseFromRoundName = (roundName: string): string => roundName.split('(')[0]?.trim() ?? '';
+
+type Verdict =
+  | { kind: 'accepted'; entry: PreviousApplication }
+  | { kind: 'rejected'; entry: PreviousApplication }
+  | { kind: 'unrelated'; count: number }
+  | { kind: 'none' };
+
+const summarise = (history: PreviousApplication[], course: string): Verdict => {
+  if (history.length === 0) return { kind: 'none' };
+  const family = familyFor(course);
+  const inFamily = history.filter((h) => family.includes(courseFromRoundName(h.roundName)));
+  const accepted = inFamily.find((h) => h.decision === 'Accept');
+  if (accepted) return { kind: 'accepted', entry: accepted };
+  const rejected = inFamily.find((h) => h.decision === 'Reject');
+  if (rejected) return { kind: 'rejected', entry: rejected };
+  return { kind: 'unrelated', count: history.length };
 };
 
 const opinionBadgeClass = (opinion: string): string => {
@@ -37,45 +66,55 @@ const Badge: React.FC<{ label: string; className: string }> = ({ label, classNam
   </span>
 );
 
-export const PreviousApplicationsCard: React.FC<PreviousApplicationsCardProps> = ({ applicationId }) => {
+const BannerLabel: React.FC<{ verdict: Verdict }> = ({ verdict }) => {
+  if (verdict.kind === 'accepted') {
+    return <>↻ Previously accepted — {verdict.entry.roundName}</>;
+  }
+
+  if (verdict.kind === 'rejected') {
+    return <>↻ Previously rejected — {verdict.entry.roundName}</>;
+  }
+
+  if (verdict.kind === 'unrelated') {
+    return <>↻ Previous applications ({verdict.count})</>;
+  }
+
+  return null;
+};
+
+const bannerClass = (verdict: Verdict): string => {
+  if (verdict.kind === 'accepted') return 'bg-amber-900/40 border-amber-700 text-amber-200';
+  if (verdict.kind === 'rejected') return 'bg-stone-800 border-stone-700 text-stone-300';
+  return 'bg-stone-800 border-stone-700 text-stone-400';
+};
+
+export const PreviousApplicationsCard: React.FC<PreviousApplicationsCardProps> = ({ applicationId, course }) => {
   const [{ data, loading, error }] = useAxios<{ history: PreviousApplication[] }>({
     method: 'get',
     url: `/api/application-history?id=${encodeURIComponent(applicationId)}`,
   });
 
-  if (loading) {
-    return (
-      <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5">
-        <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">Previous applications</p>
-        <p className="text-size-sm text-stone-500">Loading…</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5">
-        <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">Previous applications</p>
-        <p className="text-size-sm text-red-400">{error.message}</p>
-      </div>
-    );
-  }
+  if (loading || error) return null;
 
   const history = data?.history ?? [];
-
-  if (history.length === 0) {
+  const verdict = summarise(history, course);
+  if (verdict.kind === 'none') {
     return (
-      <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5">
-        <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">Previous applications</p>
-        <p className="text-size-sm text-stone-500">No previous applications.</p>
-      </div>
+      <p className="text-size-xs text-stone-500 px-1">No previous applications.</p>
     );
   }
 
   return (
-    <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5 space-y-2">
-      <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-1">Previous applications</p>
-      <ul className="space-y-2">
+    <details className={`group rounded-lg border ${bannerClass(verdict)}`}>
+      <summary className="flex items-center justify-between gap-3 px-3 py-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+        <span className="text-size-sm font-medium">
+          <BannerLabel verdict={verdict} />
+        </span>
+        <svg className="size-4 transition-transform group-open:rotate-180 shrink-0 opacity-70" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </summary>
+      <ul className="px-3 pb-3 space-y-2">
         {history.map((h) => (
           <li key={h.id} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1.5 sm:gap-3">
             <span className="text-size-sm text-stone-200">{h.roundName}</span>
@@ -86,6 +125,6 @@ export const PreviousApplicationsCard: React.FC<PreviousApplicationsCardProps> =
           </li>
         ))}
       </ul>
-    </div>
+    </details>
   );
 };

--- a/apps/speed-review/src/components/PreviousApplicationsCard.tsx
+++ b/apps/speed-review/src/components/PreviousApplicationsCard.tsx
@@ -27,7 +27,7 @@ const courseFromRoundName = (roundName: string): string => roundName.split('(')[
 type Verdict =
   | { kind: 'accepted'; entry: PreviousApplication }
   | { kind: 'rejected'; entry: PreviousApplication }
-  | { kind: 'unrelated'; count: number }
+  | { kind: 'other'; count: number }
   | { kind: 'none' };
 
 const summarise = (history: PreviousApplication[], course: string): Verdict => {
@@ -38,7 +38,7 @@ const summarise = (history: PreviousApplication[], course: string): Verdict => {
   if (accepted) return { kind: 'accepted', entry: accepted };
   const rejected = inFamily.find((h) => h.decision === 'Reject');
   if (rejected) return { kind: 'rejected', entry: rejected };
-  return { kind: 'unrelated', count: history.length };
+  return { kind: 'other', count: history.length };
 };
 
 const opinionBadgeClass = (opinion: string): string => {
@@ -75,7 +75,7 @@ const BannerLabel: React.FC<{ verdict: Verdict }> = ({ verdict }) => {
     return <>↻ Previously rejected — {verdict.entry.roundName}</>;
   }
 
-  if (verdict.kind === 'unrelated') {
+  if (verdict.kind === 'other') {
     return <>↻ Previous applications ({verdict.count})</>;
   }
 
@@ -94,7 +94,15 @@ export const PreviousApplicationsCard: React.FC<PreviousApplicationsCardProps> =
     url: `/api/application-history?id=${encodeURIComponent(applicationId)}`,
   });
 
-  if (loading || error) return null;
+  if (loading) return null;
+
+  if (error) {
+    return (
+      <p className="text-size-xs text-red-400 px-1">
+        Couldn&apos;t load previous applications: {error.message}
+      </p>
+    );
+  }
 
   const history = data?.history ?? [];
   const verdict = summarise(history, course);

--- a/apps/speed-review/src/components/RoundPicker.tsx
+++ b/apps/speed-review/src/components/RoundPicker.tsx
@@ -2,34 +2,38 @@ import { useEffect, useState } from 'react';
 import useAxios from 'axios-hooks';
 import { CTALinkOrButton, ProgressDots } from '@bluedot/ui';
 import { type Round } from '../lib/api/airtable';
-import { type SortDirection } from '../lib/client/types';
+import { type Direction } from '../lib/client/types';
 
-const SORT_STORAGE_KEY = 'speed-review:sortDirection';
+const DIRECTION_STORAGE_KEY = 'speed-review:direction';
+const ROUNDS_PER_COURSE = 3;
+const ALLOWED_COURSES = ['AGI Strategy', 'Technical AI Safety', 'Technical AI Safety Project'];
 
-const loadSortDirection = (): SortDirection => {
-  if (typeof window === 'undefined') return 'desc';
-  return window.localStorage.getItem(SORT_STORAGE_KEY) === 'asc' ? 'asc' : 'desc';
+const loadDirection = (): Direction => {
+  if (typeof window === 'undefined') return 'top';
+  return window.localStorage.getItem(DIRECTION_STORAGE_KEY) === 'bottom' ? 'bottom' : 'top';
 };
 
 type RoundPickerProps = {
-  onSelect: (round: Round, sortDirection: SortDirection) => void;
+  onSelect: (round: Round, direction: Direction) => void;
 };
+
+const courseFromRoundName = (name: string): string => name.split('(')[0]?.trim() ?? '';
 
 export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
   const [{ data, loading, error }] = useAxios<{ rounds: Round[] }>({
     method: 'get',
     url: '/api/rounds',
   });
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [direction, setDirection] = useState<Direction>('top');
 
   useEffect(() => {
-    setSortDirection(loadSortDirection());
+    setDirection(loadDirection());
   }, []);
 
-  const updateSortDirection = (next: SortDirection) => {
-    setSortDirection(next);
+  const updateDirection = (next: Direction) => {
+    setDirection(next);
     if (typeof window !== 'undefined') {
-      window.localStorage.setItem(SORT_STORAGE_KEY, next);
+      window.localStorage.setItem(DIRECTION_STORAGE_KEY, next);
     }
   };
 
@@ -51,25 +55,21 @@ export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
 
   const rounds = data?.rounds ?? [];
 
-  const ALLOWED_COURSES = ['AGI Strategy', 'Technical AI Safety'];
-
-  const grouped = rounds.reduce<Record<string, { displayName: string; rounds: typeof rounds }>>((acc, round) => {
-    const matchedCourse = ALLOWED_COURSES.find((c) => round.name.includes(c));
-    if (!matchedCourse) return acc;
-    const key = round.course || matchedCourse;
-    acc[key] ??= { displayName: matchedCourse, rounds: [] };
-    acc[key].rounds.push(round);
+  const grouped = rounds.reduce<Record<string, Round[]>>((acc, round) => {
+    const courseName = courseFromRoundName(round.name);
+    if (!ALLOWED_COURSES.includes(courseName)) return acc;
+    acc[courseName] ??= [];
+    acc[courseName].push(round);
     return acc;
   }, {});
-  const courseKeys = Object.keys(grouped);
 
-  const sortOption = (value: SortDirection, label: string) => {
-    const active = sortDirection === value;
+  const directionButton = (value: Direction, label: string) => {
+    const active = direction === value;
     return (
       <button
         key={value}
         type="button"
-        onClick={() => updateSortDirection(value)}
+        onClick={() => updateDirection(value)}
         aria-pressed={active}
         className={`flex-1 px-3 py-2 rounded-md text-size-sm font-medium transition-colors ${
           active
@@ -93,8 +93,8 @@ export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
         <div>
           <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">Review from</p>
           <div className="flex gap-1 bg-stone-950 border border-stone-700 rounded-lg p-1">
-            {sortOption('desc', 'Top of pile')}
-            {sortOption('asc', 'Bottom of pile')}
+            {directionButton('top', 'Top of pile')}
+            {directionButton('bottom', 'Bottom of pile')}
           </div>
         </div>
 
@@ -102,20 +102,20 @@ export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
           <p className="text-size-sm text-stone-500">No active or future rounds found.</p>
         ) : (
           <div className="space-y-2">
-            {courseKeys.map((key) => (
-              <details key={key} open className="group">
+            {ALLOWED_COURSES.filter((c) => grouped[c]?.length).map((courseName) => (
+              <details key={courseName} open className="group">
                 <summary className="flex items-center justify-between cursor-pointer list-none [&::-webkit-details-marker]:hidden py-1">
-                  <span className="text-size-xs font-semibold uppercase tracking-wide text-stone-500">{grouped[key]!.displayName}</span>
+                  <span className="text-size-xs font-semibold uppercase tracking-wide text-stone-500">{courseName}</span>
                   <svg className="size-3.5 text-stone-600 transition-transform group-open:rotate-180 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
                 </summary>
                 <div className="space-y-2 mt-2">
-                  {grouped[key]!.rounds.slice(0, 7).map((round) => (
+                  {grouped[courseName]!.slice(0, ROUNDS_PER_COURSE).map((round) => (
                     <button
                       key={round.id}
                       type="button"
-                      onClick={() => onSelect(round, sortDirection)}
+                      onClick={() => onSelect(round, direction)}
                       className="w-full text-left px-4 py-3 rounded-lg border border-stone-700 hover:border-bluedot-normal hover:bg-stone-800 transition-colors font-medium text-stone-200"
                     >
                       {round.name}

--- a/apps/speed-review/src/components/RoundPicker.tsx
+++ b/apps/speed-review/src/components/RoundPicker.tsx
@@ -1,9 +1,18 @@
+import { useEffect, useState } from 'react';
 import useAxios from 'axios-hooks';
 import { CTALinkOrButton, ProgressDots } from '@bluedot/ui';
 import { type Round } from '../lib/api/airtable';
+import { type SortDirection } from '../lib/client/types';
+
+const SORT_STORAGE_KEY = 'speed-review:sortDirection';
+
+const loadSortDirection = (): SortDirection => {
+  if (typeof window === 'undefined') return 'desc';
+  return window.localStorage.getItem(SORT_STORAGE_KEY) === 'asc' ? 'asc' : 'desc';
+};
 
 type RoundPickerProps = {
-  onSelect: (round: Round) => void;
+  onSelect: (round: Round, sortDirection: SortDirection) => void;
 };
 
 export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
@@ -11,6 +20,18 @@ export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
     method: 'get',
     url: '/api/rounds',
   });
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
+  useEffect(() => {
+    setSortDirection(loadSortDirection());
+  }, []);
+
+  const updateSortDirection = (next: SortDirection) => {
+    setSortDirection(next);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(SORT_STORAGE_KEY, next);
+    }
+  };
 
   if (loading) {
     return (
@@ -42,12 +63,39 @@ export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
   }, {});
   const courseKeys = Object.keys(grouped);
 
+  const sortOption = (value: SortDirection, label: string) => {
+    const active = sortDirection === value;
+    return (
+      <button
+        key={value}
+        type="button"
+        onClick={() => updateSortDirection(value)}
+        aria-pressed={active}
+        className={`flex-1 px-3 py-2 rounded-md text-size-sm font-medium transition-colors ${
+          active
+            ? 'bg-stone-700 text-stone-100'
+            : 'text-stone-400 hover:text-stone-200'
+        }`}
+      >
+        {label}
+      </button>
+    );
+  };
+
   return (
     <div className="min-h-screen bg-stone-950 flex items-center justify-center p-4 sm:p-8">
       <div className="bg-stone-900 rounded-xl border border-stone-700 p-4 sm:p-8 max-w-md w-full space-y-6">
         <div>
           <h1 className="text-2xl font-bold text-stone-100">Speed Review</h1>
           <p className="text-size-sm text-stone-400 mt-1">Select a round to review</p>
+        </div>
+
+        <div>
+          <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-2">Review from</p>
+          <div className="flex gap-1 bg-stone-950 border border-stone-700 rounded-lg p-1">
+            {sortOption('desc', 'Top of pile')}
+            {sortOption('asc', 'Bottom of pile')}
+          </div>
         </div>
 
         {rounds.length === 0 ? (
@@ -67,7 +115,7 @@ export const RoundPicker: React.FC<RoundPickerProps> = ({ onSelect }) => {
                     <button
                       key={round.id}
                       type="button"
-                      onClick={() => onSelect(round)}
+                      onClick={() => onSelect(round, sortDirection)}
                       className="w-full text-left px-4 py-3 rounded-lg border border-stone-700 hover:border-bluedot-normal hover:bg-stone-800 transition-colors font-medium text-stone-200"
                     >
                       {round.name}

--- a/apps/speed-review/src/components/SessionComplete.tsx
+++ b/apps/speed-review/src/components/SessionComplete.tsx
@@ -181,10 +181,18 @@ export const SessionComplete: React.FC<SessionCompleteProps> = ({
         />
       )}
       <div>
-        <h1 className="text-2xl font-bold text-stone-100">
-          {roundComplete ? 'You\'ve evaluated all the applications for the round!' : 'Session complete'}
+        <h1 className="text-2xl font-bold text-stone-100">{(() => {
+          if (roundComplete) return 'You\'ve evaluated all the applications for the round!';
+          if (rated.length === 0) return 'No scored applications available';
+          return 'Session complete';
+        })()}
         </h1>
         <p className="text-size-sm text-stone-400 mt-1">{round}</p>
+        {!roundComplete && rated.length === 0 && (
+          <p className="text-size-sm text-stone-400 mt-2">
+            The scoring pipeline may still be running for this round. Try again later, or pick a different round.
+          </p>
+        )}
       </div>
 
       {/* Progress bar */}

--- a/apps/speed-review/src/components/SummaryCard.tsx
+++ b/apps/speed-review/src/components/SummaryCard.tsx
@@ -1,40 +1,84 @@
 import { parseSummary } from '../lib/client/parseSummary';
 
+type ScoreRow = {
+  label: string;
+  score?: number;
+  rationale?: string;
+};
+
 type SummaryCardProps = {
   aiSummary: string;
   course: string;
+  commitmentScore?: number;
+  commitmentRationale?: string;
+  impressivenessScore?: number;
+  impressivenessRationale?: string;
+  technicalSkillScore?: number;
+  technicalSkillRationale?: string;
 };
 
-export const SummaryCard: React.FC<SummaryCardProps> = ({ aiSummary, course }) => {
-  const { role, domain, technicalAbility, topAchievement, commitment } = parseSummary(aiSummary);
+const RATING_MAX = 5;
 
-  const showTechnicalAbility = (course === 'Technical AI Safety' || course === 'Technical AI Safety Project') && !!technicalAbility;
+const ScorePill: React.FC<ScoreRow> = ({ label, score, rationale }) => {
+  const hasRationale = !!rationale?.trim();
+  return (
+    <details className="group border border-stone-700 rounded-lg bg-stone-900">
+      <summary className="flex items-center justify-between gap-3 px-3 py-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+        <span className="text-size-xs font-semibold uppercase tracking-wide text-stone-500">{label}</span>
+        <span className="flex items-center gap-2 shrink-0">
+          <span className="text-size-sm font-mono text-stone-100">
+            {score !== undefined ? `${score}/${RATING_MAX}` : '—'}
+          </span>
+          {hasRationale && (
+            <svg className="size-4 text-stone-500 transition-transform group-open:rotate-180 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          )}
+        </span>
+      </summary>
+      {hasRationale && (
+        <p className="px-3 pb-3 text-size-sm text-stone-300 leading-relaxed whitespace-pre-wrap">{rationale}</p>
+      )}
+    </details>
+  );
+};
+
+export const SummaryCard: React.FC<SummaryCardProps> = ({
+  aiSummary,
+  course,
+  commitmentScore,
+  commitmentRationale,
+  impressivenessScore,
+  impressivenessRationale,
+  technicalSkillScore,
+  technicalSkillRationale,
+}) => {
+  const { summary, notable } = parseSummary(aiSummary);
+  const showTechnical = course === 'Technical AI Safety' || course === 'Technical AI Safety Project';
 
   return (
-    <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5 space-y-3">
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+    <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 sm:p-5 space-y-4">
+      {summary && (
+        <p className="text-size-sm text-stone-100 leading-relaxed">{summary}</p>
+      )}
+
+      {notable.length > 0 && (
         <div>
-          <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-0.5">Role</p>
-          <p className="text-size-sm text-stone-100">{role || '—'}</p>
-        </div>
-        <div>
-          <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-0.5">Domain</p>
-          <p className="text-size-sm text-stone-100">{domain || '—'}</p>
-        </div>
-      </div>
-      {showTechnicalAbility && (
-        <div>
-          <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-0.5">Technical Ability</p>
-          <p className="text-size-sm text-stone-100">{technicalAbility}</p>
+          <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-1.5">Notable</p>
+          <ul className="space-y-1 list-disc list-outside pl-5 text-size-sm text-stone-300 leading-relaxed">
+            {notable.map((bullet, i) => (
+              <li key={`${i}-${bullet.slice(0, 16)}`}>{bullet}</li>
+            ))}
+          </ul>
         </div>
       )}
-      <div>
-        <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-0.5">Top Achievement</p>
-        <p className="text-size-sm text-stone-100">{topAchievement || '—'}</p>
-      </div>
-      <div>
-        <p className="text-size-xs font-semibold uppercase tracking-wide text-stone-500 mb-0.5">Commitment</p>
-        <p className="text-size-sm text-stone-100">{commitment || '—'}</p>
+
+      <div className="space-y-2">
+        <ScorePill label="Commitment" score={commitmentScore} rationale={commitmentRationale} />
+        <ScorePill label="Impressiveness" score={impressivenessScore} rationale={impressivenessRationale} />
+        {showTechnical && (
+          <ScorePill label="Technical skill" score={technicalSkillScore} rationale={technicalSkillRationale} />
+        )}
       </div>
     </div>
   );

--- a/apps/speed-review/src/components/SummaryCard.tsx
+++ b/apps/speed-review/src/components/SummaryCard.tsx
@@ -19,26 +19,39 @@ type SummaryCardProps = {
 
 const RATING_MAX = 5;
 
+const PillContents: React.FC<ScoreRow & { hasRationale: boolean }> = ({ label, score, hasRationale }) => (
+  <>
+    <span className="text-size-xs font-semibold uppercase tracking-wide text-stone-500">{label}</span>
+    <span className="flex items-center gap-2 shrink-0">
+      <span className="text-size-sm font-mono text-stone-100">
+        {score !== undefined ? `${score}/${RATING_MAX}` : '—'}
+      </span>
+      {hasRationale && (
+        <svg className="size-4 text-stone-500 transition-transform group-open:rotate-180 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      )}
+    </span>
+  </>
+);
+
 const ScorePill: React.FC<ScoreRow> = ({ label, score, rationale }) => {
   const hasRationale = !!rationale?.trim();
+
+  if (!hasRationale) {
+    return (
+      <div className="flex items-center justify-between gap-3 px-3 py-2 border border-stone-700 rounded-lg bg-stone-900">
+        <PillContents label={label} score={score} hasRationale={false} />
+      </div>
+    );
+  }
+
   return (
     <details className="group border border-stone-700 rounded-lg bg-stone-900">
       <summary className="flex items-center justify-between gap-3 px-3 py-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
-        <span className="text-size-xs font-semibold uppercase tracking-wide text-stone-500">{label}</span>
-        <span className="flex items-center gap-2 shrink-0">
-          <span className="text-size-sm font-mono text-stone-100">
-            {score !== undefined ? `${score}/${RATING_MAX}` : '—'}
-          </span>
-          {hasRationale && (
-            <svg className="size-4 text-stone-500 transition-transform group-open:rotate-180 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          )}
-        </span>
+        <PillContents label={label} score={score} hasRationale />
       </summary>
-      {hasRationale && (
-        <p className="px-3 pb-3 text-size-sm text-stone-300 leading-relaxed whitespace-pre-wrap">{rationale}</p>
-      )}
+      <p className="px-3 pb-3 text-size-sm text-stone-300 leading-relaxed whitespace-pre-wrap">{rationale}</p>
     </details>
   );
 };

--- a/apps/speed-review/src/lib/api/airtable.ts
+++ b/apps/speed-review/src/lib/api/airtable.ts
@@ -1,5 +1,5 @@
 import env from './env';
-import { type Application } from '../client/types';
+import { type Application, type SortDirection } from '../client/types';
 
 const AIRTABLE_BASE = 'https://api.airtable.com/v0/appnJbsG1eWbAdEvf';
 const APPLICATIONS_URL = `${AIRTABLE_BASE}/tblXKnWoXK3R63F6D`;
@@ -32,7 +32,16 @@ const APPLICATION_FIELDS = [
   'fld1rOZGAHBRcdJcM', // [*] Full name
   'fldooZSRRtcLSKKvo', // [TAIS] Allow to move to AGISC
   'fldpYmO0PaZxRFL5v', // Previous courses (lookup)
+  'fldL5K79cFu6Bju2N', // Commitment score
+  'fldXdgD6to4gCs4Lj', // Commitment rationale
+  'fldcZWFBKtjOqX8A2', // Impressiveness score
+  'fldYcDjhWaLDL2RyT', // Impressiveness rationale
+  'fldtkropu9GZ7QLjr', // Technical skill score
+  'fld7qoZTSBPjY3gzl', // Technical skill rationale
+  'fldEPZ0UfYoypB1mp', // Total score
 ];
+
+const TOTAL_SCORE_FIELD_ID = 'fldEPZ0UfYoypB1mp';
 
 export type Round = { id: string; name: string; course: string };
 
@@ -54,6 +63,8 @@ type AirtableListResponse = {
 const str = (v: unknown): string | undefined => (
   typeof v === 'string' && v.length > 0 ? v : undefined
 );
+
+const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
 
 const url = (v: unknown): string | undefined => {
   const s = str(v);
@@ -100,16 +111,6 @@ const fetchAll = async (
   return all;
 };
 
-const shuffle = <T>(arr: T[]): T[] => {
-  const out = [...arr];
-  for (let i = out.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [out[i], out[j]] = [out[j]!, out[i]!];
-  }
-
-  return out;
-};
-
 const toApplication = (record: AirtableRecord): Application => {
   const f = record.fields;
   return {
@@ -132,6 +133,13 @@ const toApplication = (record: AirtableRecord): Application => {
     aiSummary: str(f.fldRXdZQ0rnuVOcl7),
     allowMoveToAgisc: !!f.fldooZSRRtcLSKKvo,
     previousCourses: Array.isArray(f.fldpYmO0PaZxRFL5v) ? [...new Set((f.fldpYmO0PaZxRFL5v as unknown[]).map(String).map((s) => s.trim()).filter(Boolean))] : undefined,
+    commitmentScore: num(f.fldL5K79cFu6Bju2N),
+    commitmentRationale: str(f.fldXdgD6to4gCs4Lj),
+    impressivenessScore: num(f.fldcZWFBKtjOqX8A2),
+    impressivenessRationale: str(f.fldYcDjhWaLDL2RyT),
+    technicalSkillScore: num(f.fldtkropu9GZ7QLjr),
+    technicalSkillRationale: str(f.fld7qoZTSBPjY3gzl),
+    totalScore: num(f.fldEPZ0UfYoypB1mp),
   };
 };
 
@@ -180,6 +188,7 @@ export const fetchRounds = async (): Promise<Round[]> => {
 export const fetchApplications = async (
   roundId: string,
   offset?: string,
+  sortDirection: SortDirection = 'desc',
 ): Promise<{ applications: Application[]; nextOffset?: string }> => {
   const collected: Application[] = [];
   // Airtable pagination can return the same record across internal pages when
@@ -196,6 +205,8 @@ export const fetchApplications = async (
         filterByFormula: 'AND({fldWVKY5EFAGSRcDT} = "", SEARCH("Participant", {fld7fzQNFhb7Oyy90}), NOT({fld1KQjHFGoDZKf94}), {fldRXdZQ0rnuVOcl7} != "")', // fld1KQjHFGoDZKf94 = Duplicate flag
         pageSize: String(AIRTABLE_PAGE_SIZE),
         returnFieldsByFieldId: 'true',
+        'sort[0][field]': TOTAL_SCORE_FIELD_ID,
+        'sort[0][direction]': sortDirection,
       },
       APPLICATION_FIELDS,
       currentOffset,
@@ -216,7 +227,7 @@ export const fetchApplications = async (
   }
 
   return {
-    applications: shuffle(collected),
+    applications: collected,
     nextOffset: currentOffset,
   };
 };

--- a/apps/speed-review/src/lib/api/airtable.ts
+++ b/apps/speed-review/src/lib/api/airtable.ts
@@ -1,5 +1,5 @@
 import env from './env';
-import { type Application, type SortDirection } from '../client/types';
+import { type Application, type Direction } from '../client/types';
 
 const AIRTABLE_BASE = 'https://api.airtable.com/v0/appnJbsG1eWbAdEvf';
 const APPLICATIONS_URL = `${AIRTABLE_BASE}/tblXKnWoXK3R63F6D`;
@@ -185,10 +185,12 @@ export const fetchRounds = async (): Promise<Round[]> => {
 // Fetches applications for a round, filtered by round record ID server-side.
 // Airtable paginates in pages of AIRTABLE_PAGE_SIZE; we collect until we have
 // RESPONSE_PAGE_SIZE matches and return the Airtable offset for the next call.
+const BASE_FILTER = 'AND({fldWVKY5EFAGSRcDT} = "", SEARCH("Participant", {fld7fzQNFhb7Oyy90}), NOT({fld1KQjHFGoDZKf94}), {fldRXdZQ0rnuVOcl7} != "", {fldEPZ0UfYoypB1mp} != BLANK())';
+
 export const fetchApplications = async (
   roundId: string,
   offset?: string,
-  sortDirection: SortDirection = 'desc',
+  direction: Direction = 'top',
 ): Promise<{ applications: Application[]; nextOffset?: string }> => {
   const collected: Application[] = [];
   // Airtable pagination can return the same record across internal pages when
@@ -202,11 +204,11 @@ export const fetchApplications = async (
     const { records, nextOffset } = await fetchPage(
       APPLICATIONS_URL,
       {
-        filterByFormula: 'AND({fldWVKY5EFAGSRcDT} = "", SEARCH("Participant", {fld7fzQNFhb7Oyy90}), NOT({fld1KQjHFGoDZKf94}), {fldRXdZQ0rnuVOcl7} != "")', // fld1KQjHFGoDZKf94 = Duplicate flag
+        filterByFormula: BASE_FILTER,
         pageSize: String(AIRTABLE_PAGE_SIZE),
         returnFieldsByFieldId: 'true',
         'sort[0][field]': TOTAL_SCORE_FIELD_ID,
-        'sort[0][direction]': sortDirection,
+        'sort[0][direction]': direction === 'top' ? 'desc' : 'asc',
       },
       APPLICATION_FIELDS,
       currentOffset,

--- a/apps/speed-review/src/lib/client/parseSummary.ts
+++ b/apps/speed-review/src/lib/client/parseSummary.ts
@@ -1,23 +1,19 @@
 export type ParsedSummary = {
-  role: string;
-  domain: string;
-  technicalAbility: string;
-  topAchievement: string;
-  commitment: string;
+  summary: string;
+  notable: string[];
 };
 
 export const parseSummary = (text: string): ParsedSummary => {
-  const extract = (label: string, nextLabel: string) => {
-    const regex = new RegExp(`${label}:\\s*(.+?)(?=${nextLabel}:|$)`, 's');
-    const match = text.match(regex);
-    return match?.[1]?.trim() ?? '';
-  };
-
+  const summaryMatch = /SUMMARY:\s*([\s\S]*?)(?=\n\s*NOTABLE:|$)/.exec(text);
+  const notableMatch = /NOTABLE:\s*([\s\S]*)$/.exec(text);
+  const notable = notableMatch
+    ? notableMatch[1]!
+      .split(/\n/)
+      .map((l) => l.replace(/^\s*[-•]\s*/, '').trim())
+      .filter(Boolean)
+    : [];
   return {
-    role: extract('ROLE', 'DOMAIN'),
-    domain: extract('DOMAIN', 'TECHNICAL ABILITY|TOP ACHIEVEMENT'),
-    technicalAbility: extract('TECHNICAL ABILITY', 'TOP ACHIEVEMENT'),
-    topAchievement: extract('TOP ACHIEVEMENT', 'COMMITMENT'),
-    commitment: extract('COMMITMENT', 'ZZZNOMATCH$'),
+    summary: summaryMatch?.[1]?.trim() ?? '',
+    notable,
   };
 };

--- a/apps/speed-review/src/lib/client/types.ts
+++ b/apps/speed-review/src/lib/client/types.ts
@@ -18,7 +18,16 @@ export type Application = {
   aiSummary?: string;
   allowMoveToAgisc?: boolean;
   previousCourses?: string[];
+  commitmentScore?: number;
+  commitmentRationale?: string;
+  impressivenessScore?: number;
+  impressivenessRationale?: string;
+  technicalSkillScore?: number;
+  technicalSkillRationale?: string;
+  totalScore?: number;
 };
+
+export type SortDirection = 'desc' | 'asc';
 
 export type RatingValue = 'no' | 'neutral-accept' | 'neutral-reject' | 'yes' | 'strong-yes' | 'moved-to-agisc';
 

--- a/apps/speed-review/src/lib/client/types.ts
+++ b/apps/speed-review/src/lib/client/types.ts
@@ -27,7 +27,7 @@ export type Application = {
   totalScore?: number;
 };
 
-export type SortDirection = 'desc' | 'asc';
+export type Direction = 'top' | 'bottom';
 
 export type RatingValue = 'no' | 'neutral-accept' | 'neutral-reject' | 'yes' | 'strong-yes' | 'moved-to-agisc';
 

--- a/apps/speed-review/src/pages/api/applications.ts
+++ b/apps/speed-review/src/pages/api/applications.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { makeApiRoute } from '../../lib/api/makeApiRoute';
 import { fetchApplications } from '../../lib/api/airtable';
 import { requireAdmin } from '../../lib/api/requireAdmin';
+import { type SortDirection } from '../../lib/client/types';
 
 const ApplicationSchema = z.object({
   id: z.string(),
@@ -23,7 +24,17 @@ const ApplicationSchema = z.object({
   utmSource: z.string().optional(),
   aiSummary: z.string().optional(),
   allowMoveToAgisc: z.boolean().optional(),
+  previousCourses: z.array(z.string()).optional(),
+  commitmentScore: z.number().optional(),
+  commitmentRationale: z.string().optional(),
+  impressivenessScore: z.number().optional(),
+  impressivenessRationale: z.string().optional(),
+  technicalSkillScore: z.number().optional(),
+  technicalSkillRationale: z.string().optional(),
+  totalScore: z.number().optional(),
 });
+
+const parseSortDirection = (raw: unknown): SortDirection => (raw === 'asc' ? 'asc' : 'desc');
 
 export default makeApiRoute({
   requireAuth: true,
@@ -37,14 +48,15 @@ export default makeApiRoute({
   const round = typeof req.query.round === 'string' ? req.query.round : '';
   if (!round) throw new createHttpError.BadRequest('Missing required query param: round');
   const offset = typeof req.query.offset === 'string' ? req.query.offset : undefined;
+  const sortDirection = parseSortDirection(req.query.sortDirection);
   try {
-    return await fetchApplications(round, offset);
+    return await fetchApplications(round, offset, sortDirection);
   } catch (err) {
     if (err instanceof Error && err.message.includes('LIST_RECORDS_ITERATOR_NOT_AVAILABLE')) {
       // Offset expired — restart pagination from the beginning.
       // The filter excludes already-decided applications, so this
       // will return the next batch of unreviewed ones.
-      return fetchApplications(round);
+      return fetchApplications(round, undefined, sortDirection);
     }
 
     throw err;

--- a/apps/speed-review/src/pages/api/applications.ts
+++ b/apps/speed-review/src/pages/api/applications.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { makeApiRoute } from '../../lib/api/makeApiRoute';
 import { fetchApplications } from '../../lib/api/airtable';
 import { requireAdmin } from '../../lib/api/requireAdmin';
-import { type SortDirection } from '../../lib/client/types';
+import { type Direction } from '../../lib/client/types';
 
 const ApplicationSchema = z.object({
   id: z.string(),
@@ -34,7 +34,7 @@ const ApplicationSchema = z.object({
   totalScore: z.number().optional(),
 });
 
-const parseSortDirection = (raw: unknown): SortDirection => (raw === 'asc' ? 'asc' : 'desc');
+const parseDirection = (raw: unknown): Direction => (raw === 'bottom' ? 'bottom' : 'top');
 
 export default makeApiRoute({
   requireAuth: true,
@@ -48,15 +48,15 @@ export default makeApiRoute({
   const round = typeof req.query.round === 'string' ? req.query.round : '';
   if (!round) throw new createHttpError.BadRequest('Missing required query param: round');
   const offset = typeof req.query.offset === 'string' ? req.query.offset : undefined;
-  const sortDirection = parseSortDirection(req.query.sortDirection);
+  const direction = parseDirection(req.query.direction);
   try {
-    return await fetchApplications(round, offset, sortDirection);
+    return await fetchApplications(round, offset, direction);
   } catch (err) {
     if (err instanceof Error && err.message.includes('LIST_RECORDS_ITERATOR_NOT_AVAILABLE')) {
       // Offset expired — restart pagination from the beginning.
       // The filter excludes already-decided applications, so this
       // will return the next batch of unreviewed ones.
-      return fetchApplications(round, undefined, sortDirection);
+      return fetchApplications(round, undefined, direction);
     }
 
     throw err;

--- a/apps/speed-review/src/pages/index.tsx
+++ b/apps/speed-review/src/pages/index.tsx
@@ -4,7 +4,7 @@ import {
 import useAxios from 'axios-hooks';
 import { ProgressDots, withAuth } from '@bluedot/ui';
 import {
-  type Application, type RatedApplication, type RatingValue, type SortDirection, toHumanOpinion, toDecision,
+  type Application, type RatedApplication, type RatingValue, type Direction, toHumanOpinion, toDecision,
 } from '../lib/client/types';
 import { type Round } from '../lib/api/airtable';
 import { ApplicationCard } from '../components/ApplicationCard';
@@ -14,6 +14,12 @@ import { SessionComplete } from '../components/SessionComplete';
 import { RoundPicker } from '../components/RoundPicker';
 import { MoveToAgiscControl } from '../components/MoveToAgiscControl';
 import { authFetch } from '../lib/client/api';
+
+const buildApplicationsUrl = (roundId: string, direction: Direction, offset?: string): string => {
+  const params = new URLSearchParams({ round: roundId, direction });
+  if (offset) params.set('offset', offset);
+  return `/api/applications?${params.toString()}`;
+};
 
 const COUNTDOWN_MS = 30_000;
 // Fetch next batch when queue drops to this many remaining
@@ -33,14 +39,16 @@ const MILESTONE_MESSAGES: Record<number, string> = {
 
 // ── State machine ──────────────────────────────────────────────────────────
 
+type RoundContext = { roundId: string; roundName: string; course: string; direction: Direction };
+
 type SessionState =
   | { status: 'picking-round' }
-  | { status: 'loading'; roundId: string; roundName: string; course: string; sortDirection: SortDirection }
-  | { status: 'reviewing'; roundId: string; roundName: string; course: string; sortDirection: SortDirection; queue: Application[]; seen: RatedApplication[]; timerPaused: boolean; startMs: number; nextOffset?: string }
-  | { status: 'complete'; roundId: string; roundName: string; course: string; sortDirection: SortDirection; rated: RatedApplication[]; totalMs: number; totalLoaded: number };
+  | ({ status: 'loading' } & RoundContext)
+  | ({ status: 'reviewing'; queue: Application[]; seen: RatedApplication[]; timerPaused: boolean; startMs: number; nextOffset?: string } & RoundContext)
+  | ({ status: 'complete'; rated: RatedApplication[]; totalMs: number; totalLoaded: number } & RoundContext);
 
 type Action =
-  | { type: 'ROUND_SELECTED'; round: Round; sortDirection: SortDirection }
+  | { type: 'ROUND_SELECTED'; round: Round; direction: Direction }
   | { type: 'LOADED'; applications: Application[]; nextOffset?: string }
   | { type: 'MORE_LOADED'; applications: Application[]; nextOffset?: string }
   | { type: 'RATE'; rating: RatingValue }
@@ -62,14 +70,14 @@ const reduce = (state: SessionState, action: Action): SessionState => {
       roundId: action.round.id,
       roundName: action.round.name,
       course: action.round.name.split('(')[0]?.trim() ?? '',
-      sortDirection: action.sortDirection,
+      direction: action.direction,
     };
   }
 
   if (action.type === 'LOADED' && state.status === 'loading') {
     if (action.applications.length === 0) {
       return {
-        status: 'complete', roundId: state.roundId, roundName: state.roundName, course: state.course, sortDirection: state.sortDirection, rated: [], totalMs: 0, totalLoaded: 0,
+        status: 'complete', roundId: state.roundId, roundName: state.roundName, course: state.course, direction: state.direction, rated: [], totalMs: 0, totalLoaded: 0,
       };
     }
 
@@ -78,7 +86,7 @@ const reduce = (state: SessionState, action: Action): SessionState => {
       roundId: state.roundId,
       roundName: state.roundName,
       course: state.course,
-      sortDirection: state.sortDirection,
+      direction: state.direction,
       queue: action.applications,
       seen: [],
       timerPaused: false,
@@ -118,7 +126,7 @@ const reduce = (state: SessionState, action: Action): SessionState => {
       roundId: state.roundId,
       roundName: state.roundName,
       course: state.course,
-      sortDirection: state.sortDirection,
+      direction: state.direction,
       rated: state.seen,
       totalMs: Date.now() - state.startMs,
       totalLoaded: state.seen.length + state.queue.length,
@@ -155,7 +163,7 @@ const reduce = (state: SessionState, action: Action): SessionState => {
         roundId: state.roundId,
         roundName: state.roundName,
         course: state.course,
-        sortDirection: state.sortDirection,
+        direction: state.direction,
         rated: newSeen,
         totalMs: Date.now() - state.startMs,
         totalLoaded: newSeen.length,
@@ -174,7 +182,7 @@ const reduce = (state: SessionState, action: Action): SessionState => {
         roundId: state.roundId,
         roundName: state.roundName,
         course: state.course,
-        sortDirection: state.sortDirection,
+        direction: state.direction,
         rated: newSeen,
         totalMs: Date.now() - state.startMs,
         totalLoaded: newSeen.length,
@@ -191,17 +199,17 @@ const reduce = (state: SessionState, action: Action): SessionState => {
 
 type ApplicationLoaderProps = {
   round: string;
-  sortDirection: SortDirection;
+  direction: Direction;
   onLoaded: (applications: Application[], nextOffset?: string) => void;
   onError: (err: Error) => void;
 };
 
 const ApplicationLoader: React.FC<ApplicationLoaderProps> = ({
-  round, sortDirection, onLoaded, onError,
+  round, direction, onLoaded, onError,
 }) => {
   const [{ data, loading, error }] = useAxios<{ applications: Application[]; nextOffset?: string }>({
     method: 'get',
-    url: `/api/applications?round=${encodeURIComponent(round)}&sortDirection=${encodeURIComponent(sortDirection)}`,
+    url: buildApplicationsUrl(round, direction),
   }, { useCache: false });
 
   useEffect(() => {
@@ -318,17 +326,17 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
   const queueLength = state.status === 'reviewing' ? state.queue.length : 0;
   const nextOffset = state.status === 'reviewing' ? state.nextOffset : undefined;
   const roundId = state.status === 'reviewing' ? state.roundId : undefined;
-  const sortDirection = state.status === 'reviewing' ? state.sortDirection : undefined;
+  const direction = state.status === 'reviewing' ? state.direction : undefined;
 
   useEffect(() => {
     if (state.status !== 'reviewing') return;
-    if (!nextOffset || !roundId || !sortDirection) return;
+    if (!nextOffset || !roundId || !direction) return;
     if (queueLength > PREFETCH_THRESHOLD) return;
     if (fetchingMoreRef.current) return;
 
     fetchingMoreRef.current = true;
 
-    authFetch(`/api/applications?round=${encodeURIComponent(roundId)}&offset=${encodeURIComponent(nextOffset)}&sortDirection=${encodeURIComponent(sortDirection)}`)
+    authFetch(buildApplicationsUrl(roundId, direction, nextOffset))
       .then((r) => r.json())
       .then((data: { applications: Application[]; nextOffset?: string; error?: unknown }) => {
         if (data.error) {
@@ -344,7 +352,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
       .finally(() => {
         fetchingMoreRef.current = false;
       });
-  }, [state.status, queueLength, nextOffset, roundId, sortDirection]);
+  }, [state.status, queueLength, nextOffset, roundId, direction]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -413,7 +421,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
   // ── Round picker ──────────────────────────────────────────────────────────
 
   if (state.status === 'picking-round') {
-    return <RoundPicker onSelect={(round, direction) => dispatch({ type: 'ROUND_SELECTED', round, sortDirection: direction })} />;
+    return <RoundPicker onSelect={(round, direction) => dispatch({ type: 'ROUND_SELECTED', round, direction })} />;
   }
 
   // ── Loading applications ──────────────────────────────────────────────────
@@ -422,7 +430,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
     return (
       <ApplicationLoader
         round={state.roundId}
-        sortDirection={state.sortDirection}
+        direction={state.direction}
         onLoaded={handleLoaded}
         onError={handleLoadError}
       />
@@ -441,7 +449,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
             rated={state.rated}
             totalMs={state.totalMs}
             onReset={() => dispatch({ type: 'RESET' })}
-            onReviewRound={(roundId, roundName) => dispatch({ type: 'ROUND_SELECTED', round: { id: roundId, name: roundName, course: state.course }, sortDirection: state.sortDirection })}
+            onReviewRound={(roundId, roundName) => dispatch({ type: 'ROUND_SELECTED', round: { id: roundId, name: roundName, course: state.course }, direction: state.direction })}
           />
         </div>
       </div>

--- a/apps/speed-review/src/pages/index.tsx
+++ b/apps/speed-review/src/pages/index.tsx
@@ -4,7 +4,7 @@ import {
 import useAxios from 'axios-hooks';
 import { ProgressDots, withAuth } from '@bluedot/ui';
 import {
-  type Application, type RatedApplication, type RatingValue, toHumanOpinion, toDecision,
+  type Application, type RatedApplication, type RatingValue, type SortDirection, toHumanOpinion, toDecision,
 } from '../lib/client/types';
 import { type Round } from '../lib/api/airtable';
 import { ApplicationCard } from '../components/ApplicationCard';
@@ -35,12 +35,12 @@ const MILESTONE_MESSAGES: Record<number, string> = {
 
 type SessionState =
   | { status: 'picking-round' }
-  | { status: 'loading'; roundId: string; roundName: string; course: string }
-  | { status: 'reviewing'; roundId: string; roundName: string; course: string; queue: Application[]; seen: RatedApplication[]; timerPaused: boolean; startMs: number; nextOffset?: string }
-  | { status: 'complete'; roundId: string; roundName: string; course: string; rated: RatedApplication[]; totalMs: number; totalLoaded: number };
+  | { status: 'loading'; roundId: string; roundName: string; course: string; sortDirection: SortDirection }
+  | { status: 'reviewing'; roundId: string; roundName: string; course: string; sortDirection: SortDirection; queue: Application[]; seen: RatedApplication[]; timerPaused: boolean; startMs: number; nextOffset?: string }
+  | { status: 'complete'; roundId: string; roundName: string; course: string; sortDirection: SortDirection; rated: RatedApplication[]; totalMs: number; totalLoaded: number };
 
 type Action =
-  | { type: 'ROUND_SELECTED'; round: Round }
+  | { type: 'ROUND_SELECTED'; round: Round; sortDirection: SortDirection }
   | { type: 'LOADED'; applications: Application[]; nextOffset?: string }
   | { type: 'MORE_LOADED'; applications: Application[]; nextOffset?: string }
   | { type: 'RATE'; rating: RatingValue }
@@ -62,13 +62,14 @@ const reduce = (state: SessionState, action: Action): SessionState => {
       roundId: action.round.id,
       roundName: action.round.name,
       course: action.round.name.split('(')[0]?.trim() ?? '',
+      sortDirection: action.sortDirection,
     };
   }
 
   if (action.type === 'LOADED' && state.status === 'loading') {
     if (action.applications.length === 0) {
       return {
-        status: 'complete', roundId: state.roundId, roundName: state.roundName, course: state.course, rated: [], totalMs: 0, totalLoaded: 0,
+        status: 'complete', roundId: state.roundId, roundName: state.roundName, course: state.course, sortDirection: state.sortDirection, rated: [], totalMs: 0, totalLoaded: 0,
       };
     }
 
@@ -77,6 +78,7 @@ const reduce = (state: SessionState, action: Action): SessionState => {
       roundId: state.roundId,
       roundName: state.roundName,
       course: state.course,
+      sortDirection: state.sortDirection,
       queue: action.applications,
       seen: [],
       timerPaused: false,
@@ -116,6 +118,7 @@ const reduce = (state: SessionState, action: Action): SessionState => {
       roundId: state.roundId,
       roundName: state.roundName,
       course: state.course,
+      sortDirection: state.sortDirection,
       rated: state.seen,
       totalMs: Date.now() - state.startMs,
       totalLoaded: state.seen.length + state.queue.length,
@@ -152,6 +155,7 @@ const reduce = (state: SessionState, action: Action): SessionState => {
         roundId: state.roundId,
         roundName: state.roundName,
         course: state.course,
+        sortDirection: state.sortDirection,
         rated: newSeen,
         totalMs: Date.now() - state.startMs,
         totalLoaded: newSeen.length,
@@ -170,6 +174,7 @@ const reduce = (state: SessionState, action: Action): SessionState => {
         roundId: state.roundId,
         roundName: state.roundName,
         course: state.course,
+        sortDirection: state.sortDirection,
         rated: newSeen,
         totalMs: Date.now() - state.startMs,
         totalLoaded: newSeen.length,
@@ -186,14 +191,17 @@ const reduce = (state: SessionState, action: Action): SessionState => {
 
 type ApplicationLoaderProps = {
   round: string;
+  sortDirection: SortDirection;
   onLoaded: (applications: Application[], nextOffset?: string) => void;
   onError: (err: Error) => void;
 };
 
-const ApplicationLoader: React.FC<ApplicationLoaderProps> = ({ round, onLoaded, onError }) => {
+const ApplicationLoader: React.FC<ApplicationLoaderProps> = ({
+  round, sortDirection, onLoaded, onError,
+}) => {
   const [{ data, loading, error }] = useAxios<{ applications: Application[]; nextOffset?: string }>({
     method: 'get',
-    url: `/api/applications?round=${encodeURIComponent(round)}`,
+    url: `/api/applications?round=${encodeURIComponent(round)}&sortDirection=${encodeURIComponent(sortDirection)}`,
   }, { useCache: false });
 
   useEffect(() => {
@@ -310,16 +318,17 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
   const queueLength = state.status === 'reviewing' ? state.queue.length : 0;
   const nextOffset = state.status === 'reviewing' ? state.nextOffset : undefined;
   const roundId = state.status === 'reviewing' ? state.roundId : undefined;
+  const sortDirection = state.status === 'reviewing' ? state.sortDirection : undefined;
 
   useEffect(() => {
     if (state.status !== 'reviewing') return;
-    if (!nextOffset || !roundId) return;
+    if (!nextOffset || !roundId || !sortDirection) return;
     if (queueLength > PREFETCH_THRESHOLD) return;
     if (fetchingMoreRef.current) return;
 
     fetchingMoreRef.current = true;
 
-    authFetch(`/api/applications?round=${encodeURIComponent(roundId)}&offset=${encodeURIComponent(nextOffset)}`)
+    authFetch(`/api/applications?round=${encodeURIComponent(roundId)}&offset=${encodeURIComponent(nextOffset)}&sortDirection=${encodeURIComponent(sortDirection)}`)
       .then((r) => r.json())
       .then((data: { applications: Application[]; nextOffset?: string; error?: unknown }) => {
         if (data.error) {
@@ -335,7 +344,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
       .finally(() => {
         fetchingMoreRef.current = false;
       });
-  }, [state.status, queueLength, nextOffset, roundId]);
+  }, [state.status, queueLength, nextOffset, roundId, sortDirection]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -404,7 +413,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
   // ── Round picker ──────────────────────────────────────────────────────────
 
   if (state.status === 'picking-round') {
-    return <RoundPicker onSelect={(round) => dispatch({ type: 'ROUND_SELECTED', round })} />;
+    return <RoundPicker onSelect={(round, direction) => dispatch({ type: 'ROUND_SELECTED', round, sortDirection: direction })} />;
   }
 
   // ── Loading applications ──────────────────────────────────────────────────
@@ -413,6 +422,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
     return (
       <ApplicationLoader
         round={state.roundId}
+        sortDirection={state.sortDirection}
         onLoaded={handleLoaded}
         onError={handleLoadError}
       />
@@ -431,7 +441,7 @@ const SpeedReviewPage = (_props: { auth: unknown; setAuth: unknown }) => {
             rated={state.rated}
             totalMs={state.totalMs}
             onReset={() => dispatch({ type: 'RESET' })}
-            onReviewRound={(roundId, roundName) => dispatch({ type: 'ROUND_SELECTED', round: { id: roundId, name: roundName, course: state.course } })}
+            onReviewRound={(roundId, roundName) => dispatch({ type: 'ROUND_SELECTED', round: { id: roundId, name: roundName, course: state.course }, sortDirection: state.sortDirection })}
           />
         </div>
       </div>


### PR DESCRIPTION
# Description

Speed-review's reviewer surface is reshaped around the new application-summary pipeline and the separate rubric fields now living on Course registration. The card used to render five regex-parsed sections (ROLE/DOMAIN/TECHNICAL ABILITY/TOP ACHIEVEMENT/COMMITMENT) — the AI summary prompt has been rewritten and that parser no longer matches anything, so the card was effectively blank. This PR replaces it with a one-line SUMMARY headline, NOTABLE bullets, and score pills for Commitment / Impressiveness (+ Technical skill on TAIS rounds) with click-to-expand rationales.

The pile is now sorted by the Total score formula field. RoundPicker carries a "Top of pile / Bottom of pile" toggle (default top, persisted to localStorage), and the filter excludes records with a blank Total score so the bottom-of-pile order doesn't surface unscored applications first.

Previous-application history moves from a full bordered card below the summary to a banner above it: amber when previously accepted in the same course family, subtle stone when previously rejected, plain pill for unrelated history, and an explicit "No previous applications." line so absence isn't ambiguous. Clicking the banner expands the round-by-round list. TAIS pairs Technical AI Safety with Technical AI Safety Project for that course-family check.

RoundPicker also splits TAIS and TAIS Project into separate sections (they were bucketed together because `name.includes` matched both) and caps each course at the next 3 rounds.

## What changed

1. **`apps/speed-review/src/lib/client/parseSummary.ts`** — replaced the 5-label regex parser with one that extracts `SUMMARY` + `NOTABLE` bullets from the new prompt's output format.
2. **`apps/speed-review/src/components/SummaryCard.tsx`** — full re-render: SUMMARY line, NOTABLE bullets, score pills with `<details>`-collapsed rationales. Technical pill gated on `Technical AI Safety` / `Technical AI Safety Project` course.
3. **`apps/speed-review/src/components/PreviousApplicationsCard.tsx`** — became the new banner-style component described above; renders nothing extra when no history exists beyond the small "No previous applications." note.
4. **`apps/speed-review/src/components/ApplicationCard.tsx`** — wires the new score / rationale props into SummaryCard, moves the previous-applications banner above SummaryCard, drops the redundant "Previous participant: …" line under the name.
5. **`apps/speed-review/src/components/RoundPicker.tsx`** — added the direction toggle, split the TAIS courses, capped each section at 3 rounds.
6. **`apps/speed-review/src/lib/api/airtable.ts`** — added the seven new Airtable field IDs (Commitment / Impressiveness / Technical skill score + rationale, Total score), mapped them in `toApplication`, replaced the client-side shuffle with Airtable-side sort by Total score, added the blank-score filter clause.
7. **`apps/speed-review/src/pages/api/applications.ts`** — schema additions + reads `?direction=top|bottom` from query.
8. **`apps/speed-review/src/pages/index.tsx`** — threaded direction through the reducer state, ApplicationLoader, and the prefetch effect. Added the `URLSearchParams`-based URL builder.
9. **`apps/speed-review/src/lib/client/types.ts`** — added the rubric fields to `Application` and a `Direction` type.

## Issue

N/A — driven by the new AI summary prompt + rubric pipeline going live on Course registration.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — score-pill toggles use `<details>`, direction toggle uses `aria-pressed`, no new colour-only signals.
- [x] Considered having snapshot tests / functional tests — declined; the only existing test in speed-review is a status smoke test, and the regex parser was sanity-checked manually against three representative summary shapes (full, empty, "nothing notable").
- [x] Considered adding Storybook stories — declined; speed-review isn't in the storybook workspace.

No DB schema changes (speed-review talks to Airtable directly, not via `@bluedot/db`).

## Verification

Local dev (`npx next dev -p 8000` in the `anglilian/speed-review-rubrics` worktree, eyeballed in the browser):

- ✅ Round picker shows the three course sections (AGI Strategy / Technical AI Safety / Technical AI Safety Project) with the next 3 rounds each.
- ✅ "Top of pile / Bottom of pile" toggle persists across page reload via localStorage.
- ✅ SummaryCard renders the new SUMMARY line + NOTABLE bullets; Commitment + Impressiveness pills always present; Technical skill pill appears on TAIS / TAIS Project rounds. Rationales start collapsed and reveal on click.
- ✅ Previous-applications banner: amber when previously accepted in the same course family, subtle stone when rejected, "No previous applications." line when there's no history.
- ✅ Bottom-of-pile no longer surfaces unscored applications first (blank-Total-score filter).

Type check + lint + full test suite all pass:

\`\`\`
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 1 passed (only test file in this app)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)