### PR TITLE
[fix] Point CTG schema at the new synced tables

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -953,11 +953,11 @@ export const careerTransitionGrantTable = pgAirtable('career_transition_grant', 
   columns: {
     firstName: {
       pgColumn: text(),
-      airtableId: 'flduZeVfCBVWhq0YM',
+      airtableId: 'fldWQsNeLnniYRtBC',
     },
     lastName: {
       pgColumn: text(),
-      airtableId: 'fldKQXPr9ZiQq9DVT',
+      airtableId: 'fld3NWPmPAUoh9ck2',
     },
     // Formula field that outputs a permanent (miniextension-hosted) URL for the Photo attachment.
     // Concatenates up to 5 URLs space-separated; consumers should take the first.
@@ -975,22 +975,22 @@ export const careerTransitionGrantTable = pgAirtable('career_transition_grant', 
     },
     profileUrl: {
       pgColumn: text(),
-      airtableId: 'fld2h9ghKvg79nayH',
+      airtableId: 'fldES5kHoR5kvuWKP',
     },
   },
 });
-/** Operational table. Only amount + status synced; grantee identifying info stays in Airtable. */
+/** Operational table. Synced view restricted to Approved + Agreement signed in Airtable; sum all records here for the granted-amount total. */
 export const careerTransitionGrantApplicationTable = pgAirtable('career_transition_grant_application', {
   baseId: CONTRACTOR_PAYMENTS_BASE_ID,
-  tableId: 'tblTBVFKyJNlvhfA6',
+  tableId: 'tblYkZrxApKMUe7uf',
   columns: {
     grantAmountUsd: {
       pgColumn: numeric({ mode: 'number' }),
-      airtableId: 'fldkLVS7boXaC3sJT',
+      airtableId: 'fldFbvMJpX3r9eipG',
     },
     evaluationStatus: {
       pgColumn: text(),
-      airtableId: 'fldL3RXC6Yuwyng78',
+      airtableId: 'fld56iuBZpW1hZI6N',
     },
   },
 });


### PR DESCRIPTION
## Summary
- Re-target `careerTransitionGrantTable` to the live `firstName` / `lastName` / `profileUrl` field IDs in the Career transition grantees table after the CTG data migration. The previous IDs no longer exist in Airtable, so the GranteesSection on `/programs/career-transition-grant` has been rendering empty cards.
- Re-target `careerTransitionGrantApplicationTable` from the now-emptied `tblTBVFKyJNlvhfA6` (old CTG table) to the new synced `tblYkZrxApKMUe7uf` (pre-filtered to Approved + Agreement signed).

## Test plan
- [x] `npm run typecheck` clean (website)
- [x] `npm run lint` clean
- [x] `npx vitest run` — 677 tests pass, twice in a row (111 test files)
- [x] `libraries/db` tests pass (22 tests)

## Follow-up
This is a schema-only PR per `@bluedot/db` schema-first workflow. Once pg-sync materialises the new data, a follow-up will:
- Remove the now-redundant `evaluationStatus === 'Agreement signed'` filter from `getCareerTransitionGrantStats` (sync handles it)
- Move `evaluationStatus` to `deprecatedColumns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)