### PR TITLE
[fix] CTG: sum all approved grants + correct check-in cadence

### DIFF
--- a/apps/website/src/components/career-transition-grant/ExpectationsSection.tsx
+++ b/apps/website/src/components/career-transition-grant/ExpectationsSection.tsx
@@ -13,9 +13,9 @@ const EXPECTATIONS = [
     body: 'Short async updates to your BlueDot point of contact on what you did, who you talked to, what you learned, and how your thinking is evolving.',
   },
   {
-    cadence: 'Quarterly',
+    cadence: 'Monthly',
     title: 'Check-in',
-    body: 'Every three months, a more structured conversation to review progress and discuss what support you need.',
+    body: 'Every month, a more structured conversation to review progress and discuss what support you need.',
   },
   {
     cadence: 'At the end',

--- a/apps/website/src/server/routers/grants.test.ts
+++ b/apps/website/src/server/routers/grants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { rapidGrantTable } from '@bluedot/db';
+import { careerTransitionGrantApplicationTable, rapidGrantTable } from '@bluedot/db';
 import { createCaller, setupTestDb, testDb } from '../../__tests__/dbTestUtils';
 
 setupTestDb();
@@ -123,5 +123,28 @@ describe('grants.getAllPublicRapidGrantees', () => {
         monthLabel: undefined,
       },
     ]);
+  });
+});
+
+describe('grants.getCareerTransitionGrantStats', () => {
+  test('counts and sums every row from the synced application table without filtering by status', async () => {
+    // Source Airtable view is pre-filtered to Approved + Agreement signed,
+    // so the website should trust the sync and not filter again here.
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 80000 });
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 60000 });
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 35000 });
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: null });
+
+    const caller = createCaller();
+    const result = await caller.grants.getCareerTransitionGrantStats();
+
+    expect(result).toEqual({ count: 4, totalAmountUsd: 175000 });
+  });
+
+  test('returns zero when the table is empty', async () => {
+    const caller = createCaller();
+    const result = await caller.grants.getCareerTransitionGrantStats();
+
+    expect(result).toEqual({ count: 0, totalAmountUsd: 0 });
   });
 });

--- a/apps/website/src/server/routers/grants.ts
+++ b/apps/website/src/server/routers/grants.ts
@@ -145,12 +145,13 @@ export const grantsRouter = router({
     };
   }),
 
+  // The Airtable source view is pre-filtered to Approved + Agreement signed,
+  // so every row here counts toward the public grant total.
   getCareerTransitionGrantStats: publicProcedure.query(async (): Promise<GrantStats> => {
     const all = await db.scan(careerTransitionGrantApplicationTable);
-    const signed = all.filter((g) => g.evaluationStatus === 'Agreement signed');
     return {
-      count: signed.length,
-      totalAmountUsd: signed.reduce((sum, g) => sum + (g.grantAmountUsd ?? 0), 0),
+      count: all.length,
+      totalAmountUsd: all.reduce((sum, g) => sum + (g.grantAmountUsd ?? 0), 0),
     };
   }),
 });

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -988,9 +988,12 @@ export const careerTransitionGrantApplicationTable = pgAirtable('career_transiti
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldFbvMJpX3r9eipG',
     },
+  },
+  deprecatedColumns: {
     evaluationStatus: {
       pgColumn: text(),
       airtableId: 'fld56iuBZpW1hZI6N',
+      deprecated: true,
     },
   },
 });


### PR DESCRIPTION
## Summary
- Removes the redundant `evaluationStatus === 'Agreement signed'` filter from `getCareerTransitionGrantStats`. The Airtable source view is already pre-filtered to Approved + Agreement signed, so the website should trust the sync — this makes the stats include the 3 currently-Approved grants too. **Stat changes: $481,000 → $591,000.**
- Moves `evaluationStatus` to `deprecatedColumns` since nothing reads it anymore. A PR 3 will delete it entirely once this ships to production.
- Corrects the CTG page check-in cadence copy: actual cadence is monthly, not quarterly. Updates the chip from `Quarterly` to `Monthly` and the body from "Every three months" to "Every month".

## Test plan
- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (clean)
- [x] `npx vitest run` — 679 tests pass, twice in a row (added 2 new tests for `getCareerTransitionGrantStats`)

## Follow-up
- PR 3 (after this ships to production): delete `evaluationStatus` from `deprecatedColumns` entirely, per `@bluedot/db` 2-PR removal workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)