### PR TITLE
[fix] Hotfix: hardcode CTG stats for orphaned pg-sync rows

### DIFF
--- a/apps/website/src/server/routers/grants.test.ts
+++ b/apps/website/src/server/routers/grants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { careerTransitionGrantApplicationTable, rapidGrantTable } from '@bluedot/db';
+import { rapidGrantTable } from '@bluedot/db';
 import { createCaller, setupTestDb, testDb } from '../../__tests__/dbTestUtils';
 
 setupTestDb();
@@ -127,24 +127,13 @@ describe('grants.getAllPublicRapidGrantees', () => {
 });
 
 describe('grants.getCareerTransitionGrantStats', () => {
-  test('counts and sums every row from the synced application table without filtering by status', async () => {
-    // Source Airtable view is pre-filtered to Approved + Agreement signed,
-    // so the website should trust the sync and not filter again here.
-    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 80000 });
-    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 60000 });
-    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 35000 });
-    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: null });
-
+  // Hardcoded stopgap until the orphaned pg-sync rows are cleaned up. When the
+  // function reads from the table again, restore the data-driven tests from
+  // grants.test.ts in the PR #2512 history.
+  test('returns the hardcoded stopgap stats', async () => {
     const caller = createCaller();
     const result = await caller.grants.getCareerTransitionGrantStats();
 
-    expect(result).toEqual({ count: 4, totalAmountUsd: 175000 });
-  });
-
-  test('returns zero when the table is empty', async () => {
-    const caller = createCaller();
-    const result = await caller.grants.getCareerTransitionGrantStats();
-
-    expect(result).toEqual({ count: 0, totalAmountUsd: 0 });
+    expect(result).toEqual({ count: 10, totalAmountUsd: 591000 });
   });
 });

--- a/apps/website/src/server/routers/grants.ts
+++ b/apps/website/src/server/routers/grants.ts
@@ -1,6 +1,5 @@
 import type { CareerTransitionGrant, RapidGrant } from '@bluedot/db';
 import {
-  careerTransitionGrantApplicationTable,
   careerTransitionGrantTable,
   rapidGrantApplicationTable,
   rapidGrantTable,
@@ -145,13 +144,11 @@ export const grantsRouter = router({
     };
   }),
 
-  // The Airtable source view is pre-filtered to Approved + Agreement signed,
-  // so every row here counts toward the public grant total.
-  getCareerTransitionGrantStats: publicProcedure.query(async (): Promise<GrantStats> => {
-    const all = await db.scan(careerTransitionGrantApplicationTable);
-    return {
-      count: all.length,
-      totalAmountUsd: all.reduce((sum, g) => sum + (g.grantAmountUsd ?? 0), 0),
-    };
+  // Stopgap: pg-sync left orphaned rows in `career_transition_grant_application` after
+  // the source-table swap, so reading from the table currently double-counts CTGs.
+  // Hardcoding the public-facing stat until the orphaned rows are cleaned up. Update
+  // when new CTGs are awarded; see https://github.com/bluedotimpact/bluedot/pull/2512.
+  getCareerTransitionGrantStats: publicProcedure.query((): GrantStats => {
+    return { count: 10, totalAmountUsd: 591000 };
   }),
 });


### PR DESCRIPTION
## Summary
**Production is broken** — `/programs/career-transition-grant` shows `Grants made: 164` / `Funding awarded: \$8,101,032` instead of the correct `10` / `\$591,000`.

**Root cause:** PR #2511 re-pointed `careerTransitionGrantApplicationTable` to the new synced view `tblYkZrxApKMUe7uf`, but pg-sync has no orphan-row cleanup when a `tableId` changes. The Postgres `career_transition_grant_application` table still holds ~153 stale rows from the old master CTG (`tblTBVFKyJNlvhfA6`, since deleted in Airtable) alongside the 10 fresh synced rows. PR #2512's filter-free aggregate then sums all 164 rows.

**Stopgap:** Hardcode the stats in `grants.ts`. Site immediately shows the correct number on the next release. Constant must be updated manually when new CTGs are awarded.

**Proper follow-up (separate PR):** Rename the pg-airtable identifier from `career_transition_grant_application` to `…_v2` so pg-sync creates a fresh table with no orphans; then revert this hardcoding.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run` — 678 tests pass (1 fewer than #2512: collapsed two data-driven tests into one hardcoded check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)