### PR TITLE
[refactor] Move CTG pgAirtable to master table; add status + timeToDecisionDays

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -979,21 +979,22 @@ export const careerTransitionGrantTable = pgAirtable('career_transition_grant', 
     },
   },
 });
-/** Operational table. Synced view restricted to Approved + Agreement signed in Airtable; sum all records here for the granted-amount total. */
-export const careerTransitionGrantApplicationTable = pgAirtable('career_transition_grant_application', {
-  baseId: CONTRACTOR_PAYMENTS_BASE_ID,
-  tableId: 'tblYkZrxApKMUe7uf',
+/** Master CTG applications table. All statuses present — code filters by status for the granted-amount total, and uses timeToDecisionDays for the avg-days-to-decision stat. */
+export const careerTransitionGrantApplicationTable = pgAirtable('career_transition_grant_application_v2', {
+  baseId: APPLICATIONS_BASE_ID,
+  tableId: 'tblh5zr4jRdrndKnC',
   columns: {
     grantAmountUsd: {
       pgColumn: numeric({ mode: 'number' }),
-      airtableId: 'fldFbvMJpX3r9eipG',
+      airtableId: 'fldkLVS7boXaC3sJT',
     },
-  },
-  deprecatedColumns: {
-    evaluationStatus: {
+    status: {
       pgColumn: text(),
-      airtableId: 'fld56iuBZpW1hZI6N',
-      deprecated: true,
+      airtableId: 'fldL3RXC6Yuwyng78',
+    },
+    timeToDecisionDays: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fld7SiD8ShzS8sgis',
     },
   },
 });


### PR DESCRIPTION
## Summary
Re-points `careerTransitionGrantApplicationTable` from the Contractor Payments synced view (`tblYkZrxApKMUe7uf`, 10-12 records, pre-filtered to Approved + Agreement signed) to the master CTG table in the Applications base (`tblh5zr4jRdrndKnC`, ~158 records, all statuses).

**Key trick:** the pg-airtable identifier renames from `career_transition_grant_application` → `…_v2` so pg-sync creates a fresh table. This avoids the orphan-row pattern that caused #2513 (after the previous source switch in #2511, pg-sync left ~153 stale rows behind because it only deletes via webhooks, not via full-source reconciliation).

The master-table source carries every status (TODO/Rejected/Approved/Agreement signed), so the schema adds:
- `status` — code will filter to granted statuses for the count + funding-awarded totals in the consumer PR.
- `timeToDecisionDays` — feeds an "Average days to decision" stat that the consumer PR will add to the CTG page.

Drops the deprecated `evaluationStatus` entry — fully replaced by the new `status` column.

## What happens at deploy time
- pg-sync sees the new identifier in schema → creates `career_transition_grant_application_v2` fresh from the master CTG.
- Old `career_transition_grant_application` table sits as harmless cruft with its frozen rows. Will/I can drop it manually after the follow-up ships.
- Production website still serves `v2.26.38` (hardcoded $591k/10), so unaffected.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run` — 676 tests pass (3 unrelated timing flakes on first run; all green on retry; not touching the snapshot churn from the flaky `ImpersonationBadge` test)

## Follow-up
**PR B** (next): un-hardcode `getCareerTransitionGrantStats` to read from pg, add status filter, compute `averageDaysToDecision`, render 3 stats on `/programs/career-transition-grant`, ship `v2.26.39`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)