### PR TITLE
[fix] Revert _v2 rename so pg-sync can unblock

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -980,7 +980,7 @@ export const careerTransitionGrantTable = pgAirtable('career_transition_grant', 
   },
 });
 /** Master CTG applications table. All statuses present — code filters by status for the granted-amount total, and uses timeToDecisionDays for the avg-days-to-decision stat. */
-export const careerTransitionGrantApplicationTable = pgAirtable('career_transition_grant_application_v2', {
+export const careerTransitionGrantApplicationTable = pgAirtable('career_transition_grant_application', {
   baseId: APPLICATIONS_BASE_ID,
   tableId: 'tblh5zr4jRdrndKnC',
   columns: {


### PR DESCRIPTION
## Summary
PR #2516 renamed the pg-airtable identifier to `_v2` to force pg-sync to create a fresh table — meant to avoid the orphan-row pattern from #2513. But the orphans had already been cleared via TRUNCATE, so the rename was unnecessary belt-and-suspenders that turned into a foot-gun.

**What broke:** pg-sync's drizzle-kit `pushSchema` (in headless mode) can't auto-resolve "table-not-in-schema-anymore vs new-table-in-schema" — same pattern as #2296. After #2516 merged, pg-sync's schema-sync presumably hung on the 120s timeout, the `_v2` table never landed, production stats remained served by the hardcoded stopgap from #2513.

**Fix:** revert the single-line identifier rename. Keep everything else from #2516 (master CTG `baseId`/`tableId`, new `status` and `timeToDecisionDays` columns). On deploy, drizzle-kit sees "existing table, just add columns" — no rename ambiguity — and pg-sync's data-sync repopulates the existing (currently empty after our TRUNCATE) table from the master CTG.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Skipping the full vitest suite — schema-only one-character diff, low risk

## Follow-up
Once this lands and pg-sync populates the table (~5-10 min), PR B will un-hardcode `getCareerTransitionGrantStats`, add the avg-days calc, render 3 stats on the CTG page, ship `v2.26.39`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)