### PR TITLE
[fix] Use correct master CTG field IDs (Applications base, not deleted Contractor Payments)

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -986,11 +986,11 @@ export const careerTransitionGrantApplicationTable = pgAirtable('career_transiti
   columns: {
     grantAmountUsd: {
       pgColumn: numeric({ mode: 'number' }),
-      airtableId: 'fldkLVS7boXaC3sJT',
+      airtableId: 'fldYhy8btQ5r8vRk0',
     },
     status: {
       pgColumn: text(),
-      airtableId: 'fldL3RXC6Yuwyng78',
+      airtableId: 'fldnfK6Wgb1CAuvFE',
     },
     timeToDecisionDays: {
       pgColumn: numeric({ mode: 'number' }),


### PR DESCRIPTION
## Summary
PR #2516 set the `grantAmountUsd` and `status` field IDs to the IDs of the OLD master CTG table in Contractor Payments (`tblTBVFKyJNlvhfA6`, since deleted by Li-Lian after the data migration) rather than the NEW master CTG table in Applications base (`tblh5zr4jRdrndKnC`).

After #2517 unblocked pg-sync's schema-sync, the table populated with 160 rows but `SUM(grantAmountUsd) = 0`. Airtable was returning null for both `grantAmountUsd` and `status` because the requested field IDs don't exist on `tblh5zr4jRdrndKnC`.

Corrections (verified via `get_table_schema` against the live table):
- `grantAmountUsd.airtableId`: `fldkLVS7boXaC3sJT` → `fldYhy8btQ5r8vRk0`
- `status.airtableId`: `fldL3RXC6Yuwyng78` → `fldnfK6Wgb1CAuvFE`
- `timeToDecisionDays.airtableId`: unchanged (was already correct)

## Test plan
- [x] `npm run typecheck` clean
- [x] Field IDs confirmed via Airtable schema API against `tblh5zr4jRdrndKnC`

## What happens after merge
pg-sync redeploys, picks up the corrected field IDs, and re-fetches grantAmountUsd + status from the right Airtable fields. The existing 160 rows in pg should get populated values within minutes (sync re-fetches all fields when schema-sync detects the changed mappings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)