### PR TITLE
[feat] CTG page: 3 live stats (grants made, funding awarded, avg days to decision)

### DIFF
--- a/apps/website/src/__tests__/pages/programs.test.tsx
+++ b/apps/website/src/__tests__/pages/programs.test.tsx
@@ -72,7 +72,7 @@ beforeEach(() => {
   server.use(
     trpcMsw.programs.getAll.query(() => mockPrograms),
     trpcMsw.grants.getRapidGrantStats.query(() => ({ count: 104, totalAmountUsd: 105000 })),
-    trpcMsw.grants.getCareerTransitionGrantStats.query(() => ({ count: 1, totalAmountUsd: 67500 })),
+    trpcMsw.grants.getCareerTransitionGrantStats.query(() => ({ count: 1, totalAmountUsd: 67500, averageDaysToDecision: null })),
   );
 });
 

--- a/apps/website/src/components/homepage/MergedLadder.test.tsx
+++ b/apps/website/src/components/homepage/MergedLadder.test.tsx
@@ -71,7 +71,7 @@ describe('MergedLadder', () => {
       trpcMsw.courses.getAll.query(() => mockCourses),
       trpcMsw.programs.getAll.query(() => mockPrograms),
       trpcMsw.grants.getRapidGrantStats.query(() => ({ totalAmountUsd: 0, count: 0 })),
-      trpcMsw.grants.getCareerTransitionGrantStats.query(() => ({ totalAmountUsd: 0, count: 0 })),
+      trpcMsw.grants.getCareerTransitionGrantStats.query(() => ({ totalAmountUsd: 0, count: 0, averageDaysToDecision: null })),
     );
   });
 

--- a/apps/website/src/pages/programs/career-transition-grant.tsx
+++ b/apps/website/src/pages/programs/career-transition-grant.tsx
@@ -24,6 +24,7 @@ const CareerTransitionGrantPage = ({ programName, programDescription }: ProgramD
   const { data: stats } = trpc.grants.getCareerTransitionGrantStats.useQuery();
   const grantsMadeLabel = stats ? String(stats.count) : '—';
   const fundingAwardedLabel = stats ? formatAmountUsd(stats.totalAmountUsd) : '—';
+  const avgDaysToDecisionLabel = stats?.averageDaysToDecision != null ? `~${stats.averageDaysToDecision}` : '—';
 
   return (
     <div>
@@ -47,6 +48,7 @@ const CareerTransitionGrantPage = ({ programName, programDescription }: ProgramD
         stats={[
           { label: 'Grants made', value: grantsMadeLabel },
           { label: 'Funding awarded', value: fundingAwardedLabel },
+          { label: 'Avg days to decision', value: avgDaysToDecisionLabel },
         ]}
       />
       <WhatThisIsForSection />

--- a/apps/website/src/server/routers/grants.test.ts
+++ b/apps/website/src/server/routers/grants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { rapidGrantTable } from '@bluedot/db';
+import { careerTransitionGrantApplicationTable, rapidGrantTable } from '@bluedot/db';
 import { createCaller, setupTestDb, testDb } from '../../__tests__/dbTestUtils';
 
 setupTestDb();
@@ -127,13 +127,37 @@ describe('grants.getAllPublicRapidGrantees', () => {
 });
 
 describe('grants.getCareerTransitionGrantStats', () => {
-  // Hardcoded stopgap until the orphaned pg-sync rows are cleaned up. When the
-  // function reads from the table again, restore the data-driven tests from
-  // grants.test.ts in the PR #2512 history.
-  test('returns the hardcoded stopgap stats', async () => {
+  test('counts and sums only Approved + Agreement signed; averages all decided rows', async () => {
+    // Granted (Approved + Agreement signed) — counted in count + totalAmountUsd.
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 80000, status: 'Agreement signed', timeToDecisionDays: 10 });
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 60000, status: 'Approved', timeToDecisionDays: 20 });
+    // Rejected — excluded from count/total, but its decision time still feeds avg.
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 0, status: 'Rejected', timeToDecisionDays: 6 });
+    // Not yet decided (timeToDecisionDays = 0 or null) — excluded from avg.
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: null, status: 'TODO', timeToDecisionDays: 0 });
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: null, status: 'TODO', timeToDecisionDays: null });
+
     const caller = createCaller();
     const result = await caller.grants.getCareerTransitionGrantStats();
 
-    expect(result).toEqual({ count: 10, totalAmountUsd: 591000 });
+    // avg over [10, 20, 6] = 12
+    expect(result).toEqual({ count: 2, totalAmountUsd: 140000, averageDaysToDecision: 12 });
+  });
+
+  test('returns null avg when no rows have a positive decision time', async () => {
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 50000, status: 'Agreement signed', timeToDecisionDays: 0 });
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: null, status: 'TODO', timeToDecisionDays: null });
+
+    const caller = createCaller();
+    const result = await caller.grants.getCareerTransitionGrantStats();
+
+    expect(result).toEqual({ count: 1, totalAmountUsd: 50000, averageDaysToDecision: null });
+  });
+
+  test('returns zeros and null when the table is empty', async () => {
+    const caller = createCaller();
+    const result = await caller.grants.getCareerTransitionGrantStats();
+
+    expect(result).toEqual({ count: 0, totalAmountUsd: 0, averageDaysToDecision: null });
   });
 });

--- a/apps/website/src/server/routers/grants.ts
+++ b/apps/website/src/server/routers/grants.ts
@@ -1,5 +1,6 @@
 import type { CareerTransitionGrant, RapidGrant } from '@bluedot/db';
 import {
+  careerTransitionGrantApplicationTable,
   careerTransitionGrantTable,
   rapidGrantApplicationTable,
   rapidGrantTable,
@@ -10,6 +11,10 @@ import { publicProcedure, router } from '../trpc';
 export type GrantStats = {
   count: number;
   totalAmountUsd: number;
+};
+
+export type CareerTransitionGrantStats = GrantStats & {
+  averageDaysToDecision: number | null;
 };
 
 export type PublicRapidGrant = {
@@ -144,11 +149,19 @@ export const grantsRouter = router({
     };
   }),
 
-  // Stopgap: pg-sync left orphaned rows in `career_transition_grant_application` after
-  // the source-table swap, so reading from the table currently double-counts CTGs.
-  // Hardcoding the public-facing stat until the orphaned rows are cleaned up. Update
-  // when new CTGs are awarded; see https://github.com/bluedotimpact/bluedot/pull/2512.
-  getCareerTransitionGrantStats: publicProcedure.query((): GrantStats => {
-    return { count: 10, totalAmountUsd: 591000 };
+  // Master CTG table carries every status — count + funding-awarded filter to granted
+  // statuses, avg-days-to-decision averages all decided rows (rows where the
+  // [*] Time to decision (days) formula yielded a positive integer).
+  getCareerTransitionGrantStats: publicProcedure.query(async (): Promise<CareerTransitionGrantStats> => {
+    const all = await db.scan(careerTransitionGrantApplicationTable);
+    const granted = all.filter((g) => g.status === 'Approved' || g.status === 'Agreement signed');
+    const decided = all.filter((g) => (g.timeToDecisionDays ?? 0) > 0);
+    return {
+      count: granted.length,
+      totalAmountUsd: granted.reduce((sum, g) => sum + (g.grantAmountUsd ?? 0), 0),
+      averageDaysToDecision: decided.length
+        ? Math.round(decided.reduce((sum, g) => sum + (g.timeToDecisionDays ?? 0), 0) / decided.length)
+        : null,
+    };
   }),
 });


### PR DESCRIPTION
## Summary
Un-hardcodes `getCareerTransitionGrantStats` now that pg has the master CTG data correctly synced (PRs #2516–#2518). Reads from `careerTransitionGrantApplicationTable`, filters count + funding-awarded to Approved + Agreement signed records, and averages `timeToDecisionDays` over all decided rows.

Adds a third item — **"Avg days to decision"** — to the `GrantStatsStrip` on `/programs/career-transition-grant`, rendered as `~N` to signal an approximate average.

`GrantStats` is extended via a new `CareerTransitionGrantStats` subtype so the rapid-grants endpoint isn't forced to carry the avg-days field.

## Data flow
- pg-sync materialises `career_transition_grant_application` from the master CTG table (`tblh5zr4jRdrndKnC`) — ~162 rows of all statuses.
- `getCareerTransitionGrantStats` runs in JS:
  - `count` + `totalAmountUsd`: filter to `status IN ['Approved', 'Agreement signed']`
  - `averageDaysToDecision`: average `timeToDecisionDays` over rows where it's > 0 (excludes TODO/unscheduled rows and same-day decisions); `null` if no decided rows

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run` — 680 tests pass (+1 test file new coverage for filter and avg behaviour)

## Verification before release
Staging will auto-deploy on merge. Eyeball https://website-staging.k8s.bluedot.org/programs/career-transition-grant — expecting **3 stats**, with values pulled live from pg (likely Grants made ≈ 10-12, Funding awarded ≈ $591–691k, Avg days to decision ≈ small single-digit number `~N`).

Once staging looks right, cut `website/v2.26.39` to ship to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)