### PR TITLE
[chore] db: add decidedAt to rapidGrantApplicationTable

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1015,6 +1015,10 @@ export const rapidGrantApplicationTable = pgAirtable('rapid_grant_application', 
       pgColumn: text(),
       airtableId: 'fldSEVGlsG4wcKk4k',
     },
+    decidedAt: {
+      pgColumn: text(),
+      airtableId: 'fldYSUC9oNUMrRiKr',
+    },
   },
 });
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -998,7 +998,7 @@ export const careerTransitionGrantApplicationTable = pgAirtable('career_transiti
     },
   },
 });
-/** Operational table. Only amount + decision + createdAt synced; applicant identifying info stays in Airtable. */
+/** Operational table. Only amount + decision + createdAt + decidedAt synced; applicant identifying info stays in Airtable. */
 export const rapidGrantApplicationTable = pgAirtable('rapid_grant_application', {
   baseId: CONTRACTOR_PAYMENTS_BASE_ID,
   tableId: 'tblS9NHgtwl7YaHiZ',


### PR DESCRIPTION
## Summary

- Adds `decidedAt` (Airtable `lastModifiedTime` watching `Grant decision`, field id `fldYSUC9oNUMrRiKr`) to the `rapid_grant_application` Postgres sync.
- Unlocks a follow-up PR that will compute live decision-time stats for the `/programs/rapid-grants` marketing page (currently hardcoded as `~5 working days`; real median is ~14h).
- `pg-sync-service` auto-detects the schema diff at startup and backfills — no manual trigger needed.

## Test plan

- [x] `npm test` in `libraries/db` (22/22 pass)
- [x] `npx tsc --noEmit` in `libraries/db` (clean)
- [x] `npm run lint` in `libraries/db` (clean)
- [ ] Confirm `decided_at` column populated in staging after merge before opening the consumer PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)