### PR TITLE
[chore] db: deprecate unitResource.avgRating

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -266,7 +266,6 @@ export const createMockResource = (overrides: Partial<UnitResource> = {}): UnitR
   coreFurtherMaybe: 'Core',
   readingOrder: null,
   unitId: 'unit-1',
-  avgRating: null,
   syncedAudioUrl: null,
   year: 2024,
   autoNumberId: 1,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1172,10 +1172,6 @@ export const unitResourceTable = pgAirtable('unit_resource', {
       pgColumn: text(),
       airtableId: 'fldJX4h1sTNkacKru',
     },
-    avgRating: {
-      pgColumn: numeric({ mode: 'number' }),
-      airtableId: 'fldOWWeymJQTwlfaY',
-    },
     syncedAudioUrl: {
       pgColumn: text().default(''), // For future github issue #1148
       airtableId: 'fldIqUoLYILUmMgY0',
@@ -1187,6 +1183,13 @@ export const unitResourceTable = pgAirtable('unit_resource', {
     autoNumberId: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldUOh3MNUIf0vnYb',
+    },
+  },
+  deprecatedColumns: {
+    avgRating: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldOWWeymJQTwlfaY',
+      deprecated: true,
     },
   },
 });


### PR DESCRIPTION
# Description

The `Avg rating` field (`fldOWWeymJQTwlfaY`) on the Course Builder "Chunk resource" table (`unitResourceTable` in code) was deleted from Airtable by Dewi during cleanup for #2493, so it no longer receives sync updates.

This moves `avgRating` from `columns` to `deprecatedColumns` in `libraries/db/src/schema.ts`. Per the two-PR column-removal process in the handbook, this:

- keeps the existing Postgres column (via `pgWithDeprecatedColumns`) so no data is dropped,
- stops `pg-sync-service` trying to read a field that no longer exists in Airtable,
- removes it from the `UnitResource` type, so the now-dead `avgRating: null` value in the `createMockResource` test util is dropped too.

The field was never read in application code (only the schema entry + the test mock referenced it), so there's no consumer change.

Full removal from the schema is a **follow-up PR** once this has merged and deployed to production.

## Issue

Related to #2493

## Developer checklist

- [x] Considered having snapshot tests and/or happy path functional tests (db tests pass 22/22, incl. `validate-schema`; website typecheck clean)
- [ ] Front-end code follows Component Accessibility Checklist — n/a
- [ ] Considered adding Storybook stories — n/a

## Screenshot

n/a — schema-only change.