### PR TITLE
Support for vanity URLs

### DIFF
--- a/apps/website/src/__tests__/pages/[vanity].test.tsx
+++ b/apps/website/src/__tests__/pages/[vanity].test.tsx
@@ -62,7 +62,7 @@ describe('vanity URL catch-all page', () => {
     expect(result).toEqual({ notFound: true });
   });
 
-  test('returns notFound for slugs with invalid characters', async () => {
+  test('returns notFound for unmatched slugs containing unusual characters', async () => {
     const result = await callGetServerSideProps('has spaces');
     expect(result).toEqual({ notFound: true });
   });

--- a/apps/website/src/__tests__/pages/[vanity].test.tsx
+++ b/apps/website/src/__tests__/pages/[vanity].test.tsx
@@ -1,7 +1,7 @@
 import { vanityUrlsTable } from '@bluedot/db';
 import type { GetServerSidePropsContext } from 'next';
 import {
-  describe, expect, test, vi,
+  afterEach, describe, expect, test, vi,
 } from 'vitest';
 import { getServerSideProps } from '../../pages/[vanity]';
 import db from '../../lib/api/db';
@@ -15,6 +15,11 @@ const callGetServerSideProps = (vanity: string) =>
   } as unknown as GetServerSidePropsContext);
 
 describe('vanity URL catch-all page', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+
   test('redirects with 307 to resolvedUrl on hit', async () => {
     await testDb.insert(vanityUrlsTable, {
       vanityName: 'minutephysics',
@@ -82,13 +87,11 @@ describe('vanity URL catch-all page', () => {
   });
 
   test('falls back to notFound when the DB lookup throws', async () => {
-    const spy = vi.spyOn(db, 'getFirst').mockRejectedValueOnce(new Error('connection refused'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(db, 'getFirst').mockRejectedValueOnce(new Error('connection refused'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const result = await callGetServerSideProps('anything');
 
     expect(result).toEqual({ notFound: true });
-    spy.mockRestore();
-    consoleSpy.mockRestore();
   });
 });

--- a/apps/website/src/__tests__/pages/[vanity].test.tsx
+++ b/apps/website/src/__tests__/pages/[vanity].test.tsx
@@ -1,7 +1,10 @@
 import { vanityUrlsTable } from '@bluedot/db';
 import type { GetServerSidePropsContext } from 'next';
-import { describe, expect, test } from 'vitest';
+import {
+  describe, expect, test, vi,
+} from 'vitest';
 import { getServerSideProps } from '../../pages/[vanity]';
+import db from '../../lib/api/db';
 import { setupTestDb, testDb } from '../dbTestUtils';
 
 setupTestDb();
@@ -76,5 +79,16 @@ describe('vanity URL catch-all page', () => {
 
     const result = await callGetServerSideProps('evil');
     expect(result).toEqual({ notFound: true });
+  });
+
+  test('falls back to notFound when the DB lookup throws', async () => {
+    const spy = vi.spyOn(db, 'getFirst').mockRejectedValueOnce(new Error('connection refused'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await callGetServerSideProps('anything');
+
+    expect(result).toEqual({ notFound: true });
+    spy.mockRestore();
+    consoleSpy.mockRestore();
   });
 });

--- a/apps/website/src/__tests__/pages/[vanity].test.tsx
+++ b/apps/website/src/__tests__/pages/[vanity].test.tsx
@@ -1,0 +1,80 @@
+import { vanityUrlsTable } from '@bluedot/db';
+import type { GetServerSidePropsContext } from 'next';
+import { describe, expect, test } from 'vitest';
+import { getServerSideProps } from '../../pages/[vanity]';
+import { setupTestDb, testDb } from '../dbTestUtils';
+
+setupTestDb();
+
+const callGetServerSideProps = (vanity: string) =>
+  getServerSideProps({
+    params: { vanity },
+  } as unknown as GetServerSidePropsContext);
+
+describe('vanity URL catch-all page', () => {
+  test('redirects with 307 to resolvedUrl on hit', async () => {
+    await testDb.insert(vanityUrlsTable, {
+      vanityName: 'minutephysics',
+      resolvedUrl: 'https://bluedot.org/courses/future-of-ai?utm_campaign=minutephysics',
+      isActive: true,
+    });
+
+    const result = await callGetServerSideProps('minutephysics');
+
+    expect(result).toEqual({
+      redirect: {
+        destination: 'https://bluedot.org/courses/future-of-ai?utm_campaign=minutephysics',
+        statusCode: 307,
+      },
+    });
+  });
+
+  test('lowercases incoming slug before lookup', async () => {
+    await testDb.insert(vanityUrlsTable, {
+      vanityName: 'mrbeast',
+      resolvedUrl: 'https://bluedot.org/courses/future-of-ai',
+      isActive: true,
+    });
+
+    const result = await callGetServerSideProps('MrBeast');
+
+    expect(result).toEqual({
+      redirect: {
+        destination: 'https://bluedot.org/courses/future-of-ai',
+        statusCode: 307,
+      },
+    });
+  });
+
+  test('returns notFound when slug has no matching row', async () => {
+    const result = await callGetServerSideProps('does-not-exist');
+    expect(result).toEqual({ notFound: true });
+  });
+
+  test('returns notFound when row is inactive', async () => {
+    await testDb.insert(vanityUrlsTable, {
+      vanityName: 'retired',
+      resolvedUrl: 'https://bluedot.org/courses/future-of-ai',
+      isActive: false,
+    });
+
+    const result = await callGetServerSideProps('retired');
+    expect(result).toEqual({ notFound: true });
+  });
+
+  test('returns notFound for slugs with invalid characters', async () => {
+    const result = await callGetServerSideProps('has spaces');
+    expect(result).toEqual({ notFound: true });
+  });
+
+  test('rejects non-http(s) resolvedUrl to avoid open-redirect abuse', async () => {
+    await testDb.insert(vanityUrlsTable, {
+      vanityName: 'evil',
+      resolvedUrl: ['java', 'script:alert(1)'].join(''),
+      isActive: true,
+    });
+
+    const result = await callGetServerSideProps('evil');
+    expect(result).toEqual({ notFound: true });
+  });
+});

--- a/apps/website/src/__tests__/pages/[vanity].test.tsx
+++ b/apps/website/src/__tests__/pages/[vanity].test.tsx
@@ -19,7 +19,6 @@ describe('vanity URL catch-all page', () => {
     vi.restoreAllMocks();
   });
 
-
   test('redirects with 307 to resolvedUrl on hit', async () => {
     await testDb.insert(vanityUrlsTable, {
       vanityName: 'minutephysics',

--- a/apps/website/src/lib/sanitizeUrl.ts
+++ b/apps/website/src/lib/sanitizeUrl.ts
@@ -1,0 +1,18 @@
+export const sanitizeUrl = (value: string | null | undefined): string | undefined => {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue) {
+    return undefined;
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedValue);
+
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return parsedUrl.toString();
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+};

--- a/apps/website/src/pages/[vanity].tsx
+++ b/apps/website/src/pages/[vanity].tsx
@@ -21,10 +21,20 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
     return { notFound: true };
   }
 
-  const row = await db.getFirst(vanityUrlsTable, {
-    filter: { vanityName: slug },
-    sortBy: 'vanityName',
-  });
+  // Treat any DB failure as a miss so a transient outage degrades to 404 rather than 500,
+  // keeping the redirect path resilient for sponsorship traffic.
+  let row;
+  try {
+    row = await db.getFirst(vanityUrlsTable, {
+      filter: { vanityName: slug },
+      sortBy: 'vanityName',
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('vanity_redirect_db_error', err);
+    vanityRedirectCounter.add(1, { status: 'miss' });
+    return { notFound: true };
+  }
 
   const destination = row?.isActive ? sanitizeUrl(row.resolvedUrl) : undefined;
   if (!destination) {

--- a/apps/website/src/pages/[vanity].tsx
+++ b/apps/website/src/pages/[vanity].tsx
@@ -5,8 +5,6 @@ import { metrics } from '@opentelemetry/api';
 import db from '../lib/api/db';
 import { sanitizeUrl } from '../lib/sanitizeUrl';
 
-const SLUG_REGEX = /^[a-z0-9-]+$/;
-
 const meter = metrics.getMeter('vanity-urls');
 const vanityRedirectCounter = meter.createCounter('vanity_redirect_total', {
   description:
@@ -19,7 +17,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   const raw = typeof params?.vanity === 'string' ? params.vanity : '';
   const slug = raw.toLowerCase();
 
-  if (!SLUG_REGEX.test(slug)) {
+  if (!slug) {
     return { notFound: true };
   }
 

--- a/apps/website/src/pages/[vanity].tsx
+++ b/apps/website/src/pages/[vanity].tsx
@@ -1,0 +1,46 @@
+import { type GetServerSideProps } from 'next';
+import { vanityUrlsTable } from '@bluedot/db';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { metrics } from '@opentelemetry/api';
+import db from '../lib/api/db';
+import { sanitizeUrl } from '../lib/sanitizeUrl';
+
+const SLUG_REGEX = /^[a-z0-9-]+$/;
+
+const meter = metrics.getMeter('vanity-urls');
+const vanityRedirectCounter = meter.createCounter('vanity_redirect_total', {
+  description:
+    'Vanity URL redirect attempts, labelled by outcome (hit | miss). Per-slug conversion tracked downstream via UTMs on the destination page.',
+});
+
+const VanityRedirectPage = () => null;
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const raw = typeof params?.vanity === 'string' ? params.vanity : '';
+  const slug = raw.toLowerCase();
+
+  if (!SLUG_REGEX.test(slug)) {
+    return { notFound: true };
+  }
+
+  const row = await db.getFirst(vanityUrlsTable, {
+    filter: { vanityName: slug },
+    sortBy: 'vanityName',
+  });
+
+  const destination = row?.isActive ? sanitizeUrl(row.resolvedUrl) : undefined;
+  if (!destination) {
+    vanityRedirectCounter.add(1, { status: 'miss' });
+    return { notFound: true };
+  }
+
+  vanityRedirectCounter.add(1, { status: 'hit' });
+  return {
+    redirect: {
+      destination,
+      statusCode: 307,
+    },
+  };
+};
+
+export default VanityRedirectPage;

--- a/apps/website/src/server/routers/grants.ts
+++ b/apps/website/src/server/routers/grants.ts
@@ -6,6 +6,7 @@ import {
   rapidGrantTable,
 } from '@bluedot/db';
 import db from '../../lib/api/db';
+import { sanitizeUrl } from '../../lib/sanitizeUrl';
 import { publicProcedure, router } from '../trpc';
 
 export type GrantStats = {
@@ -60,25 +61,6 @@ const trimmedMean = (values: number[], trimPct: number): number => {
   const cut = Math.floor(sorted.length * trimPct);
   const inner = sorted.slice(cut, sorted.length - cut);
   return inner.reduce((sum, v) => sum + v, 0) / inner.length;
-};
-
-const sanitizeUrl = (value: string | null): string | undefined => {
-  const trimmedValue = value?.trim();
-  if (!trimmedValue) {
-    return undefined;
-  }
-
-  try {
-    const parsedUrl = new URL(trimmedValue);
-
-    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
-      return parsedUrl.toString();
-    }
-  } catch {
-    return undefined;
-  }
-
-  return undefined;
 };
 
 // pgAirtable stores Airtable date columns as text; parse here and bucket


### PR DESCRIPTION
# Description

Marketing-managed sponsorship redirects. Listener hits `bluedot.org/<vanity>`, gets 307'd to a UTM-tagged URL from Airtable. No code change per campaign.

**Notes**
- Catch-all `pages/[vanity].tsx`, runs only for unmatched paths.
- Reads `vanity_urls` (Airtable → pg via `pg-sync-service`); no app cache.
- `sanitizeUrl` (extracted from `grants.ts`) blocks non-`http(s)` destinations.
- `isActive=false` → 404; Airtable defaults the column to checked.
- OTel counter `vanity_redirect_total{status=hit|miss}`. Per-slug conversion = PostHog UTMs on destination.

**Depends on:** schema PR #2534 (merged, synced).

## Issue
Fixes #2523

## Test plan

- [x] Unit tests: hit, case-insensitive, miss, inactive, invalid slug, unsafe protocol.
- [x] Local against synced pg:
  - `/minutephysics` → 307 → `…/courses/future-of-ai?utm_campaign=minutephysics&…`
  - `/notreal` → 404
  - `/Has%20Spaces` → 404

## Screenshot

<img width="1497" height="879" alt="vanity" src="https://github.com/user-attachments/assets/4ed9f94f-6d4b-4d8a-96b3-8ee04d8ccd39" />
