### PR TITLE
CLAUDE.md proposal: allow named palette utilities (e.g. text-bluedot-navy), preserve the ban on raw hex

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ We're fans of [boring technology](https://boringtechnology.club/) — don't intr
 ## Before you start a task
 
 - Look for existing components/utilities first. Most marketing primitives already live in `@bluedot/ui` or `apps/website/src/components/`. See `apps/website/README.md` → "Reusing existing components first".
-- Use design tokens (`text-size-md`, `bg-color-primary-accent`, `border-color-divider`, …), not raw Tailwind values like `text-[16px]` or `bg-bluedot-normal`. Tokens are documented in `apps/storybook/src/GettingStarted.mdx` and defined in `apps/website/src/globals.css`.
+- Use the project's named design tokens / utilities (`text-size-md`, `text-bluedot-navy`, `bg-color-primary-accent`, `border-color-divider`, …), not raw or arbitrary values like `text-[#0037ff]`. Exact pixel values like `gap-[3px]` are sometimes ok. Tokens are documented in `apps/storybook/src/GettingStarted.mdx` and defined in `apps/website/src/globals.css`.
 - Check existing components in Storybook (`apps/storybook/` or [storybook.k8s.bluedot.org](https://storybook.k8s.bluedot.org)) before building new ones. If a new component would benefit from visual documentation (e.g. for design review or reuse by non-technical team members), ask the user if they'd like a Storybook story.
 - For non-trivial work, sketch a plan before editing.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ We're fans of [boring technology](https://boringtechnology.club/) — don't intr
 ## Before you start a task
 
 - Look for existing components/utilities first. Most marketing primitives already live in `@bluedot/ui` or `apps/website/src/components/`. See `apps/website/README.md` → "Reusing existing components first".
-- Use the project's named design tokens / utilities (`text-size-md`, `text-bluedot-navy`, `bg-color-primary-accent`, `border-color-divider`, …), not raw or arbitrary values like `text-[#0037ff]`. Exact pixel values like `gap-[3px]` are sometimes ok. Tokens are documented in `apps/storybook/src/GettingStarted.mdx` and defined in `apps/website/src/globals.css`.
+- Use the named `bluedot-*` palette utilities for colour (`text-bluedot-navy`, `bg-bluedot-normal`, including opacity like `text-bluedot-navy/60`) and the size tokens for type (`text-size-md`). Avoid raw hex (`text-[#0037ff]`) **and** the semantic `color-*` tokens (`bg-color-primary-accent`, `border-color-divider`). Exact pixel values like `gap-[3px]` are sometimes ok. Tokens are documented in `apps/storybook/src/GettingStarted.mdx` and defined in `apps/website/src/globals.css`.
 - Check existing components in Storybook (`apps/storybook/` or [storybook.k8s.bluedot.org](https://storybook.k8s.bluedot.org)) before building new ones. If a new component would benefit from visual documentation (e.g. for design review or reuse by non-technical team members), ask the user if they'd like a Storybook story.
 - For non-trivial work, sketch a plan before editing.
 

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -99,18 +99,16 @@ npm run render-preview # render OG/preview images
 
 If you find yourself duplicating one of these, stop and reuse instead.
 
-### Use design tokens, not raw Tailwind values
+### Use named tokens/utilities, not raw colour or size literals
 
 The token system is documented in `apps/storybook/src/GettingStarted.mdx` (browse it via Storybook's "Getting Started" intro page).
 
 | Don't write | Write instead |
 | --- | --- |
+| `text-[#0037ff]`, `bg-[#f5f5f5]` (raw hex) | a named colour utility, e.g. `text-bluedot-navy`, `bg-color-primary-accent` |
 | `text-[16px]`, `text-[18px]`, `text-[24px]` | `text-size-sm`, `text-size-md`, `text-size-lg` |
-| `text-bluedot-navy/62` | `text-color-secondary-text` |
-| `bg-bluedot-normal` (primary accent) | `bg-color-primary-accent` |
-| `border-bluedot-lighter` | `border-color-divider` |
 
-If a token doesn't exist for what you need, add it to `globals.css` rather than inlining.
+Named palette utilities (`text-bluedot-navy`, including opacity like `text-bluedot-navy/60`) and semantic tokens (`bg-color-primary-accent`, `border-color-divider`) are both fine — use whichever reads more clearly. Exact pixel values for spacing (e.g. `gap-[3px]`) are sometimes OK.
 
 ### Creating a New Component
 

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -105,10 +105,11 @@ The token system is documented in `apps/storybook/src/GettingStarted.mdx` (brows
 
 | Don't write | Write instead |
 | --- | --- |
-| `text-[#0037ff]`, `bg-[#f5f5f5]` (raw hex) | a named colour utility, e.g. `text-bluedot-navy`, `bg-color-primary-accent` |
+| `text-[#0037ff]`, `bg-[#f5f5f5]` (raw hex) | a named palette utility, e.g. `text-bluedot-navy`, `bg-bluedot-normal` |
+| `bg-color-primary-accent`, `border-color-divider` (semantic tokens) | the palette utility it aliases: `bg-bluedot-normal`, `border-charcoal-light`, `text-bluedot-darker` |
 | `text-[16px]`, `text-[18px]`, `text-[24px]` | `text-size-sm`, `text-size-md`, `text-size-lg` |
 
-Named palette utilities (`text-bluedot-navy`, including opacity like `text-bluedot-navy/60`) and semantic tokens (`bg-color-primary-accent`, `border-color-divider`) are both fine — use whichever reads more clearly. Exact pixel values for spacing (e.g. `gap-[3px]`) are sometimes OK.
+Prefer the named `bluedot-*` palette utilities (`text-bluedot-navy`, including opacity like `text-bluedot-navy/60`) over the semantic `color-*` tokens. Size tokens (`text-size-*`) are still preferred over raw px, though exact pixel values for spacing (e.g. `gap-[3px]`) are sometimes OK.
 
 ### Creating a New Component
 


### PR DESCRIPTION
# Description

**Proposal, opening for discussion (also raising in Slack).**

Our docs currently steer assistants/humans toward semantic colour tokens (`text-color-secondary-text`, `bg-color-primary-accent`) and frame the named `bluedot-*` palette utilities, e.g. `bg-bluedot-normal`, `text-bluedot-navy/62`, as "raw values to avoid".

In practice the `bluedot-*` utilities are used pervasively (~109 files in `apps/website`). I also personally find them more dev-friendly, because I can keep in my mind the main colours (`bluedot-normal` and `bluedot-navy`) and picture gradations like text-bluedot-navy/60, whereas I find it hard to remember `bluedot-secondary`, `color-divider` etc.

This PR reframes the docs so:
- The real enemy is raw hex values, and excessive use of raw pixel values
- Named palette utilities (`text-bluedot-navy`, incl. opacity like `/60`) and semantic tokens (`bg-color-primary-accent`, `border-color-divider`) are **both acceptable**

The immediate motivation for this was getting a bunch of misfiring "use design token instead of raw colour class" comments on #2413. The main effect of this change will be to stop AI assistants from nudging in this semantic-token direction.

**The case against**

I think there are reasonable arguments against this:
- Under a strict design system (with rigidly followed rule _and_ stock components), semantic tokens help to uphold the strictness
- If we ever support dark mode, it may make it somewhat easier to define non-exact inverses of semantic colour tokens (though, this is a long way off, and I'm not sure if it would actually be easier because it just creates more tokens).

## Issue

N/A

## Developer checklist

N/A

## Screenshot

N/A
