### PR TITLE
[feat] Add grant-structure FAQ to career transition grant page

### DIFF
--- a/apps/website/src/components/grants/grantPrograms.tsx
+++ b/apps/website/src/components/grants/grantPrograms.tsx
@@ -180,6 +180,19 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
         question: 'Will you fund a Master\'s or PhD?',
         answer: 'Generally, no. For most people, a Master\'s or PhD isn\'t the most direct route to impactful AI safety work. There are exceptions. Mention it in your application if you think yours is one.',
       },
+      {
+        id: 'grant-structure',
+        question: 'How is the grant structured?',
+        answer: (
+          <>
+            The grant is a fellowship grant in support of your AI safety work. It is not a salary or a contract for services. BlueDot is a UK entity, so we don't issue W-2s or 1099s, and the agreement explicitly states there is no employment, worker, or contractor relationship between us.
+            <br />
+            <br />
+            We can't give tax advice, so please check the tax implications with a qualified advisor in your country.
+          </>
+        ),
+        answerText: 'The grant is a fellowship grant in support of your AI safety work. It is not a salary or a contract for services. BlueDot is a UK entity, so we don\'t issue W-2s or 1099s, and the agreement explicitly states there is no employment, worker, or contractor relationship between us. We can\'t give tax advice, so please check the tax implications with a qualified advisor in your country.',
+      },
     ],
   },
   'incubator-week': {


### PR DESCRIPTION
## Summary

- Adds a "How is the grant structured?" FAQ entry to `/programs/career-transition-grant`.
- Clarifies the grant is a fellowship grant (not salary or contract for services), that BlueDot is a UK entity so no W-2/1099 is issued, and that applicants should seek their own tax advice.
- Copy-only change; one new entry in the existing FAQ array.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx vitest run` — 691 passed
- [x] Eyeballed in browser at iPhone 14 viewport — FAQ renders, expands/collapses cleanly, 0 console errors

## Issue

N/A — content update, no linked issue.

## Screenshots

_paste WebP_

🤖 Generated with [Claude Code](https://claude.com/claude-code)