### PR TITLE
[refactor] Remove borderline N+1 in getCurriculumMetadata

### DIFF
--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -1,0 +1,132 @@
+import {
+  chunkTable,
+  courseTable,
+  exerciseTable,
+  unitTable,
+} from '@bluedot/db';
+import { describe, expect, test } from 'vitest';
+import {
+  createCaller,
+  setupTestDb,
+  testAuthContextLoggedIn,
+  testDb,
+} from '../../__tests__/dbTestUtils';
+
+setupTestDb();
+
+const caller = createCaller(testAuthContextLoggedIn);
+
+const seedCourse = (slug: string) => testDb.insert(courseTable, {
+  id: `course-${slug}`, slug, title: slug, shortDescription: slug, units: [], status: 'Active',
+});
+
+const seedUnit = (id: string, courseSlug: string, unitNumber: string, opts: { unitStatus?: string } = {}) =>
+  testDb.insert(unitTable, {
+    id,
+    courseId: `course-${courseSlug}`,
+    courseTitle: courseSlug,
+    courseSlug,
+    title: id,
+    unitNumber,
+    description: id,
+    unitStatus: opts.unitStatus ?? 'Active',
+  });
+
+// estimatedTime defaults to 0 — matching prod, where ~60% of active chunks have no time set.
+const seedChunk = (id: string, unitId: string, opts: {
+  title?: string; estimatedTime?: number; exercises?: string[]; status?: string;
+} = {}) =>
+  testDb.insert(chunkTable, {
+    id,
+    chunkId: id,
+    unitId,
+    chunkTitle: opts.title ?? id,
+    chunkOrder: '1',
+    chunkType: 'Reading',
+    chunkContent: '',
+    estimatedTime: opts.estimatedTime ?? 0,
+    chunkExercises: opts.exercises ?? [],
+    status: opts.status ?? 'Active',
+  });
+
+const seedExercise = (id: string, status = 'Active') => testDb.insert(exerciseTable, { id, status });
+
+// Cases mirror real course-builder data shapes (see gh-2544 prod inspection): most chunks carry no
+// estimatedTime; some chunkExercises reference inactive exercises; alignment/pandemics use
+// "Option N:" alternatives and "(optional)" chunks; some units have no active chunks.
+describe('courses.getCurriculumMetadata', () => {
+  test('typical units: no estimatedTime → null duration; counts only Active exercises; sorted by unitNumber', async () => {
+    await seedCourse('typical');
+    // Insert out of order to verify sorting by unitNumber.
+    await seedUnit('u2', 'typical', '2');
+    await seedUnit('u1', 'typical', '1');
+
+    // u1: reading chunks with no time (the common case), referencing two active + one inactive exercise.
+    await seedChunk('u1-a', 'u1', { title: 'Welcome', exercises: ['ex-a'] });
+    await seedChunk('u1-b', 'u1', { title: 'Core reading', exercises: ['ex-b', 'ex-stale'] });
+    // u2: one chunk, no time, no exercises.
+    await seedChunk('u2-a', 'u2', { title: 'Discussion prep' });
+
+    await seedExercise('ex-a');
+    await seedExercise('ex-b');
+    await seedExercise('ex-stale', 'Archived'); // referenced by a chunk but inactive → not counted
+
+    const result = await caller.courses.getCurriculumMetadata({ courseSlug: 'typical' });
+
+    expect(result).toEqual([
+      {
+        unitId: 'u1', unitNumber: '1', duration: null, exerciseCount: 2,
+      },
+      {
+        unitId: 'u2', unitNumber: '2', duration: null, exerciseCount: 0,
+      },
+    ]);
+  });
+
+  test('duration sums required chunks, takes the max across "Option N:" alternatives, and skips "(optional)"', async () => {
+    await seedCourse('options');
+    await seedUnit('uo', 'options', '1');
+
+    await seedChunk('uo-read', 'uo', { title: 'Required reading', estimatedTime: 20 });
+    await seedChunk('uo-opt1', 'uo', { title: 'Option 1: Faster R&D', estimatedTime: 15 });
+    await seedChunk('uo-opt2', 'uo', { title: 'Option 2: Power concentration', estimatedTime: 40 });
+    await seedChunk('uo-extra', 'uo', { title: 'Go deeper (optional)', estimatedTime: 30 });
+
+    const result = await caller.courses.getCurriculumMetadata({ courseSlug: 'options' });
+
+    // 20 (required) + max(15, 40) across the two options = 60; the (optional) 30 is excluded.
+    expect(result).toEqual([{
+      unitId: 'uo', unitNumber: '1', duration: 60, exerciseCount: 0,
+    }]);
+  });
+
+  test('excludes inactive units and inactive chunks; a unit with no active chunks has null duration', async () => {
+    await seedCourse('edges');
+    await seedUnit('e-active', 'edges', '1');
+    await seedUnit('e-inactive', 'edges', '2', { unitStatus: 'Archived' });
+    await seedUnit('e-empty', 'edges', '3');
+
+    await seedChunk('e-a-live', 'e-active', { estimatedTime: 10, status: 'Active' });
+    await seedChunk('e-a-dead', 'e-active', { estimatedTime: 99, status: 'Archived' }); // excluded from duration
+
+    const result = await caller.courses.getCurriculumMetadata({ courseSlug: 'edges' });
+
+    expect(result).toEqual([
+      {
+        unitId: 'e-active', unitNumber: '1', duration: 10, exerciseCount: 0,
+      },
+      {
+        unitId: 'e-empty', unitNumber: '3', duration: null, exerciseCount: 0,
+      },
+    ]);
+  });
+
+  test('a course with no active units returns an empty array', async () => {
+    await seedCourse('no-active');
+    await seedUnit('na-archived', 'no-active', '1', { unitStatus: 'Archived' });
+
+    const result = await caller.courses.getCurriculumMetadata({ courseSlug: 'no-active' });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -224,44 +224,49 @@ export const coursesRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course "${courseSlug}" not found` });
       }
 
+      // 1. Fetch data
       const allUnits = await db.scan(unitTable, { courseSlug, unitStatus: 'Active' });
+      const unitIds = allUnits.map((u) => u.id);
 
-      // Fetch chunks by unitId (matching course page behavior) instead of using unit.chunks array
-      const unitMetadata = await Promise.all(allUnits.map(async (unit) => {
-        const chunks = await db.scan(chunkTable, { unitId: unit.id, status: 'Active' });
+      const allChunks = await db.pg
+        .select()
+        .from(chunkTable.pg)
+        .where(and(eq(chunkTable.pg.status, 'Active'), inArray(chunkTable.pg.unitId, unitIds)));
 
-        // Calculate duration:
-        // - Skip chunks with "Optional" in title (not required)
-        // - For "Option N:" chunks, take max (they're alternatives)
-        // - Sum the rest
-        const optionPattern = /option\s+\d+/i;
-        const optionalPattern = /optional/i;
+      const referencedExerciseIds = allChunks.flatMap((c) => c.chunkExercises ?? []);
+      const activeExerciseIds = new Set<string>();
+      if (referencedExerciseIds.length > 0) {
+        const activeExercises = await db.pg
+          .select({ id: exerciseTable.pg.id })
+          .from(exerciseTable.pg)
+          .where(and(
+            eq(exerciseTable.pg.status, 'Active'),
+            inArray(exerciseTable.pg.id, referencedExerciseIds),
+          ));
+        for (const e of activeExercises) activeExerciseIds.add(e.id);
+      }
+
+      // Calculate duration:
+      // - Skip chunks with "Optional" in title (not required)
+      // - For "Option N:" chunks, take max (they are alternatives)
+      // - Sum the rest
+      const optionPattern = /option\s+\d+/i;
+      const optionalPattern = /optional/i;
+
+      const unitMetadata = allUnits.map((unit) => {
+        const chunks = allChunks.filter((c) => c.unitId === unit.id);
 
         const requiredChunks = chunks.filter((c) => !optionalPattern.test(c.chunkTitle));
         const optionChunks = requiredChunks.filter((c) => optionPattern.test(c.chunkTitle));
         const regularChunks = requiredChunks.filter((c) => !optionPattern.test(c.chunkTitle));
-
         const optionMaxTime = optionChunks.length > 0
           ? Math.max(...optionChunks.map((c) => c.estimatedTime ?? 0))
           : 0;
         const regularTime = regularChunks.reduce((sum, c) => sum + (c.estimatedTime ?? 0), 0);
         const totalDuration = regularTime + optionMaxTime;
 
-        // Get all exercise IDs from active chunks
-        const allExerciseIds = chunks.flatMap((c) => c.chunkExercises ?? []);
-
-        // Count only active exercises
-        let exerciseCount = 0;
-        if (allExerciseIds.length > 0) {
-          const activeExercises = await db.pg
-            .select({ id: exerciseTable.pg.id })
-            .from(exerciseTable.pg)
-            .where(and(
-              eq(exerciseTable.pg.status, 'Active'),
-              inArray(exerciseTable.pg.id, allExerciseIds),
-            ));
-          exerciseCount = activeExercises.length;
-        }
+        const exerciseCount = [...new Set(chunks.flatMap((c) => c.chunkExercises ?? []))]
+          .filter((id) => activeExerciseIds.has(id)).length;
 
         return {
           unitId: unit.id,
@@ -269,7 +274,7 @@ export const coursesRouter = router({
           duration: totalDuration > 0 ? totalDuration : null,
           exerciseCount,
         };
-      }));
+      });
 
       return unitMetadata.sort((a, b) => Number(a.unitNumber) - Number(b.unitNumber));
     }),

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -228,10 +228,12 @@ export const coursesRouter = router({
       const allUnits = await db.scan(unitTable, { courseSlug, unitStatus: 'Active' });
       const unitIds = allUnits.map((u) => u.id);
 
-      const allChunks = await db.pg
-        .select()
-        .from(chunkTable.pg)
-        .where(and(eq(chunkTable.pg.status, 'Active'), inArray(chunkTable.pg.unitId, unitIds)));
+      const allChunks = unitIds.length > 0
+        ? await db.pg
+          .select()
+          .from(chunkTable.pg)
+          .where(and(eq(chunkTable.pg.status, 'Active'), inArray(chunkTable.pg.unitId, unitIds)))
+        : [];
 
       const referencedExerciseIds = allChunks.flatMap((c) => c.chunkExercises ?? []);
       const activeExerciseIds = new Set<string>();


### PR DESCRIPTION
# Description

`courses.getCurriculumMetadata` previously did a chunk scan plus an exercise query per unit, a `2 + 2N` query pattern (N = number of active units). This collapses it to two batched queries, the behaviour should be unchanged.

This is a borderline N+1 problem discovered as part of #2544. It's not causing any active issues, but I thought it was best to get rid of it just to have no N+1s.

## Issue

Related to #2544

## Developer checklist

- [x] N/A Front-end code follows Component Accessibility Checklist
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories

## Screenshot

N/A