### PR TITLE
My Courses & Facilitated Courses: empty states

### DIFF
--- a/apps/website/src/components/icons/BooksIcon.tsx
+++ b/apps/website/src/components/icons/BooksIcon.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@bluedot/ui';
+import type { IconProps } from './types';
+
+// Empty-state illustration icon (two books). Natural size is 80×80; strokes use currentColor.
+type BooksIconProps = Omit<IconProps, 'size'> & { size?: number };
+
+export const BooksIcon = ({ size = 80, className, ...props }: BooksIconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 80 80"
+    fill="none"
+    width={size}
+    height={size}
+    className={cn(className)}
+    {...props}
+  >
+    <path
+      d="M16.6666 16.6663C16.6666 15.7823 17.0178 14.9344 17.6429 14.3093C18.2681 13.6842 19.1159 13.333 20 13.333H26.6666C27.5507 13.333 28.3985 13.6842 29.0236 14.3093C29.6488 14.9344 30 15.7823 30 16.6663V63.333C30 64.2171 29.6488 65.0649 29.0236 65.69C28.3985 66.3152 27.5507 66.6663 26.6666 66.6663H20C19.1159 66.6663 18.2681 66.3152 17.6429 65.69C17.0178 65.0649 16.6666 64.2171 16.6666 63.333V16.6663Z"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M30 16.6663C30 15.7823 30.3512 14.9344 30.9763 14.3093C31.6014 13.6842 32.4493 13.333 33.3333 13.333H40C40.8841 13.333 41.7319 13.6842 42.357 14.3093C42.9821 14.9344 43.3333 15.7823 43.3333 16.6663V63.333C43.3333 64.2171 42.9821 65.0649 42.357 65.69C41.7319 66.3152 40.8841 66.6663 40 66.6663H33.3333C32.4493 66.6663 31.6014 66.3152 30.9763 65.69C30.3512 65.0649 30 64.2171 30 63.333V16.6663Z"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M16.6666 26.667H30" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M30 53.333H43.3333" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+    <path
+      d="M53.29 13.4338L46.01 15.2005L45.5667 15.3371C44.7715 15.6294 44.1141 16.208 43.7232 16.9596C43.3323 17.7112 43.2361 18.5816 43.4533 19.4005L55.77 64.1271C56.2667 65.9338 58.17 67.0171 60.0433 66.5671L67.3233 64.8005L67.7667 64.6638C68.5618 64.3715 69.2193 63.793 69.6102 63.0414C70.0011 62.2898 70.0973 61.4193 69.88 60.6005L57.5633 15.8738C57.0667 14.0671 55.1633 12.9838 53.29 13.4338Z"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M46.6666 30.0003L60 26.667" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M53.3334 53.3331L66.41 50.0664" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);

--- a/apps/website/src/components/icons/BooksIcon.tsx
+++ b/apps/website/src/components/icons/BooksIcon.tsx
@@ -1,7 +1,6 @@
 import { cn } from '@bluedot/ui';
 import type { IconProps } from './types';
 
-// Empty-state illustration icon (two books). Natural size is 80×80; strokes use currentColor.
 type BooksIconProps = Omit<IconProps, 'size'> & { size?: number };
 
 export const BooksIcon = ({ size = 80, className, ...props }: BooksIconProps) => (

--- a/apps/website/src/components/icons/index.ts
+++ b/apps/website/src/components/icons/index.ts
@@ -18,6 +18,7 @@ export type { IconProps } from './types';
 
 export { ArrowDownIcon } from './ArrowDownIcon';
 export { ArrowRightIcon } from './ArrowRightIcon';
+export { BooksIcon } from './BooksIcon';
 export { CheckIcon } from './CheckIcon';
 export { CheckmarkIcon } from './CheckmarkIcon';
 export { ChevronRightIcon } from './ChevronRightIcon';

--- a/apps/website/src/components/my-courses/CourseList.tsx
+++ b/apps/website/src/components/my-courses/CourseList.tsx
@@ -2,7 +2,6 @@ import CourseListRow, { type CourseListRowProps } from './CourseListRow';
 
 type CourseListProps = {
   courses: CourseListRowProps[];
-  emptyMessage?: string;
   expandedById?: Record<string, boolean>;
   onToggleExpand?: (id: string) => void;
 };
@@ -12,29 +11,22 @@ export const courseListRowKey = (c: CourseListRowProps): string =>
 
 const CourseList = ({
   courses,
-  emptyMessage = 'No courses to show.',
   expandedById = {},
   onToggleExpand,
-}: CourseListProps) => {
-  if (courses.length === 0) {
-    return <p className="text-size-sm text-gray-500">{emptyMessage}</p>;
-  }
-
-  return (
-    <div className="flex flex-col gap-6">
-      {courses.map((c) => {
-        const id = courseListRowKey(c);
-        return (
-          <CourseListRow
-            key={id}
-            {...c}
-            isExpanded={expandedById[id] ?? false}
-            onToggleExpand={() => onToggleExpand?.(id)}
-          />
-        );
-      })}
-    </div>
-  );
-};
+}: CourseListProps) => (
+  <div className="flex flex-col gap-6">
+    {courses.map((c) => {
+      const id = courseListRowKey(c);
+      return (
+        <CourseListRow
+          key={id}
+          {...c}
+          isExpanded={expandedById[id] ?? false}
+          onToggleExpand={() => onToggleExpand?.(id)}
+        />
+      );
+    })}
+  </div>
+);
 
 export default CourseList;

--- a/apps/website/src/components/my-courses/EmptyCourseList.stories.tsx
+++ b/apps/website/src/components/my-courses/EmptyCourseList.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import EmptyCourseList from './EmptyCourseList';
+
+const meta = {
+  title: 'website/my-courses/EmptyCourseList',
+  component: EmptyCourseList,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof EmptyCourseList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Participant tabs: "Browse courses" CTA.
+export const Participant: Story = {
+  args: {
+    title: 'No active courses',
+    description: 'You\'re not currently enrolled in any active courses.',
+    cta: { label: 'Browse courses', href: '/courses' },
+  },
+};
+
+// Facilitator tabs: "Apply now to facilitate" CTA.
+export const Facilitator: Story = {
+  args: {
+    title: 'No active courses',
+    description: 'You\'re not facilitating any active courses right now.',
+    cta: { label: 'Apply now to facilitate', href: '/join-us/facilitate' },
+  },
+};
+
+export const TitleOnly: Story = {
+  args: { title: 'No past courses' },
+};

--- a/apps/website/src/components/my-courses/EmptyCourseList.test.tsx
+++ b/apps/website/src/components/my-courses/EmptyCourseList.test.tsx
@@ -15,7 +15,7 @@ describe('EmptyCourseList', () => {
     expect(screen.getByRole('link', { name: 'Browse courses' })).toHaveAttribute('href', '/courses');
   });
 
-  test('renders no button when no CTA is provided (e.g. facilitator states)', () => {
+  test('renders no button when no CTA is provided', () => {
     render(<EmptyCourseList title="No past courses" description="Courses you've facilitated will appear here." />);
     expect(screen.queryByRole('link')).toBeNull();
     expect(screen.queryByRole('button')).toBeNull();

--- a/apps/website/src/components/my-courses/EmptyCourseList.test.tsx
+++ b/apps/website/src/components/my-courses/EmptyCourseList.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EmptyCourseList from './EmptyCourseList';
+
+describe('EmptyCourseList', () => {
+  test('renders the title and description', () => {
+    render(<EmptyCourseList title="No active courses" description="You're not enrolled in any active courses." />);
+    expect(screen.getByText('No active courses')).toBeInTheDocument();
+    expect(screen.getByText('You\'re not enrolled in any active courses.')).toBeInTheDocument();
+  });
+
+  test('renders the CTA link when one is provided', () => {
+    render(<EmptyCourseList title="No active courses" cta={{ label: 'Browse courses', href: '/courses' }} />);
+    expect(screen.getByRole('link', { name: 'Browse courses' })).toHaveAttribute('href', '/courses');
+  });
+
+  test('renders no button when no CTA is provided (e.g. facilitator states)', () => {
+    render(<EmptyCourseList title="No past courses" description="Courses you've facilitated will appear here." />);
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/apps/website/src/components/my-courses/EmptyCourseList.tsx
+++ b/apps/website/src/components/my-courses/EmptyCourseList.tsx
@@ -1,0 +1,27 @@
+import { CTALinkOrButton } from '@bluedot/ui';
+import { type ReactNode } from 'react';
+import { BooksIcon } from '../icons';
+
+export type EmptyCourseListProps = {
+  title: string;
+  description?: string;
+  cta?: { label: string; href: string };
+  icon?: ReactNode;
+};
+
+const EmptyCourseList = ({
+  title, description, cta, icon = <BooksIcon aria-hidden />,
+}: EmptyCourseListProps) => (
+  <div className="flex flex-col items-center gap-3 py-12 text-center">
+    <div className="text-bluedot-normal">{icon}</div>
+    <p className="text-size-md font-semibold text-bluedot-navy">{title}</p>
+    {description && <p className="max-w-[40ch] text-size-sm text-bluedot-navy/60">{description}</p>}
+    {cta && (
+      <CTALinkOrButton variant="primary" size="small" url={cta.href} className="text-size-xxs">
+        {cta.label}
+      </CTALinkOrButton>
+    )}
+  </div>
+);
+
+export default EmptyCourseList;

--- a/apps/website/src/pages/facilitated-courses.tsx
+++ b/apps/website/src/pages/facilitated-courses.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useMemo, useState } from 'react';
 import MyBlueDotLayout from '../components/my-bluedot/MyBlueDotLayout';
 import CourseList, { courseListRowKey } from '../components/my-courses/CourseList';
+import EmptyCourseList, { type EmptyCourseListProps } from '../components/my-courses/EmptyCourseList';
 import {
   TABS, type CourseTab, isCourseTab, isAutoExpandCandidate, bucketCoursesByTab,
 } from '../components/my-courses/useCourseListRow';
@@ -14,10 +15,24 @@ import { trpc } from '../utils/trpc';
 
 const CURRENT_ROUTE = ROUTES.facilitatedCourses;
 
-const EMPTY_MESSAGE: Record<CourseTab, string> = {
-  inProgress: 'You are not facilitating any active courses.',
-  upcoming: 'No upcoming facilitator assignments.',
-  pastCourses: 'No past facilitator assignments.',
+const APPLY_TO_FACILITATE = { label: 'Apply now to facilitate', href: '/join-us/facilitate' };
+
+const EMPTY_STATE: Record<CourseTab, EmptyCourseListProps> = {
+  inProgress: {
+    title: 'No active courses',
+    description: 'You\'re not facilitating any active courses right now.',
+    cta: APPLY_TO_FACILITATE,
+  },
+  upcoming: {
+    title: 'No upcoming courses',
+    description: 'You have no upcoming facilitation assignments.',
+    cta: APPLY_TO_FACILITATE,
+  },
+  pastCourses: {
+    title: 'No past courses',
+    description: 'Courses you\'ve facilitated will appear here.',
+    cta: APPLY_TO_FACILITATE,
+  },
 };
 
 type NextDiscussionItem = { discussion: { startDateTime: number } };
@@ -120,13 +135,16 @@ const FacilitatedCoursesPage = () => {
                 value={activeTab}
                 onChange={setActiveTab}
               />
-              <CourseList
-                key={activeTab}
-                courses={visibleCourses}
-                emptyMessage={EMPTY_MESSAGE[activeTab]}
-                expandedById={expandedById}
-                onToggleExpand={handleToggleExpand}
-              />
+              {visibleCourses.length === 0 ? (
+                <EmptyCourseList {...EMPTY_STATE[activeTab]} />
+              ) : (
+                <CourseList
+                  key={activeTab}
+                  courses={visibleCourses}
+                  expandedById={expandedById}
+                  onToggleExpand={handleToggleExpand}
+                />
+              )}
             </>
           )}
         </div>

--- a/apps/website/src/pages/my-courses.tsx
+++ b/apps/website/src/pages/my-courses.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import MyBlueDotLayout from '../components/my-bluedot/MyBlueDotLayout';
 import InactiveCourseBanners from '../components/courses/InactiveCourseBanners';
 import CourseList, { courseListRowKey } from '../components/my-courses/CourseList';
+import EmptyCourseList, { type EmptyCourseListProps } from '../components/my-courses/EmptyCourseList';
 import { type CourseListRowProps } from '../components/my-courses/CourseListRow';
 import {
   TABS, type CourseTab, isCourseTab, isAutoExpandCandidate, bucketCoursesByTab as bucketRowsByTab,
@@ -16,10 +17,24 @@ import { trpc } from '../utils/trpc';
 
 const CURRENT_ROUTE = ROUTES.myCourses;
 
-const EMPTY_MESSAGE: Record<CourseTab, string> = {
-  inProgress: 'You are not enrolled in any active courses.',
-  upcoming: 'No upcoming courses to show.',
-  pastCourses: 'No past courses to show.',
+const BROWSE_COURSES = { label: 'Browse courses', href: ROUTES.courses.url };
+
+const EMPTY_STATE: Record<CourseTab, EmptyCourseListProps> = {
+  inProgress: {
+    title: 'No active courses',
+    description: 'You\'re not currently enrolled in any active courses.',
+    cta: BROWSE_COURSES,
+  },
+  upcoming: {
+    title: 'No upcoming courses',
+    description: 'You have no upcoming courses.',
+    cta: BROWSE_COURSES,
+  },
+  pastCourses: {
+    title: 'No past courses',
+    description: 'Courses you\'ve completed will appear here.',
+    cta: BROWSE_COURSES,
+  },
 };
 
 // Participants see rejected applications only while the round is still Future, and rows must have a
@@ -109,13 +124,16 @@ const MyCoursesPage = () => {
                 value={activeTab}
                 onChange={setActiveTab}
               />
-              <CourseList
-                key={activeTab}
-                courses={visibleCourses}
-                emptyMessage={EMPTY_MESSAGE[activeTab]}
-                expandedById={expandedById}
-                onToggleExpand={handleToggleExpand}
-              />
+              {visibleCourses.length === 0 ? (
+                <EmptyCourseList {...EMPTY_STATE[activeTab]} />
+              ) : (
+                <CourseList
+                  key={activeTab}
+                  courses={visibleCourses}
+                  expandedById={expandedById}
+                  onToggleExpand={handleToggleExpand}
+                />
+              )}
             </>
           )}
         </div>


### PR DESCRIPTION
# Description

Implements the new empty states for the My Courses and Facilitated Courses pages. These are rendered by a small configurable `EmptyCourseList` component (under `my-courses`); each page renders it in place of the course list when the active tab has no courses. Participant tabs link to "Browse courses", and facilitator tabs link to "Apply now to facilitate".

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2532

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

Screenshots show the In Progress tab. Upcoming and Past Courses differ only in copy — see all six states (participant and facilitator) in the [`EmptyCourseList` story](https://bluedot-storybook-preview-pr-2548.onrender.com/?path=/story/website-my-courses-emptycourselist--participant).

**My Courses (participant)**

| 📸 | Before | After |
|---------|---|---|
| 📱 | <img width="672" height="1486" alt="Screenshot 2026-05-25 at 16 51 52" src="https://github.com/user-attachments/assets/f8be0c1d-f4b2-4fb3-b7b4-a44943913e66" /> | <img width="612" height="1356" alt="Screenshot 2026-05-25 at 16 49 25" src="https://github.com/user-attachments/assets/a35d30b2-0038-4ea1-9a5e-48a95570dc6e" /> |
| 🖥️ | <img width="2450" height="1384" alt="Screenshot 2026-05-25 at 16 51 28" src="https://github.com/user-attachments/assets/14b54f7e-40d9-4efa-9069-4f10e309e089" /> | <img width="3014" height="1380" alt="Screenshot 2026-05-25 at 16 48 56" src="https://github.com/user-attachments/assets/cfb1b535-8915-4e1d-bae7-6df14fab513c" /> |

**Facilitated Courses (facilitator)**

| 📸 | Before | After |
|---------|---|---|
| 📱 | <img width="672" height="1486" alt="Screenshot 2026-05-25 at 16 51 37" src="https://github.com/user-attachments/assets/964800e3-4ff1-417d-bc85-25642dfc3920" /> | <img width="612" height="1356" alt="Screenshot 2026-05-25 at 16 49 38" src="https://github.com/user-attachments/assets/cfc7e15f-c50b-4b8e-b16a-24524217e4a1" /> |
| 🖥️ | <img width="2450" height="1384" alt="Screenshot 2026-05-25 at 16 51 33" src="https://github.com/user-attachments/assets/88472280-d51d-41dc-8235-cd8e9ef3739f" /> | <img width="2330" height="1384" alt="Screenshot 2026-05-25 at 16 49 50" src="https://github.com/user-attachments/assets/dfdb6f51-2bb0-42d1-8e4f-3c35eb18691a" /> |
