### PR TITLE
[chore] Make dev server ports configurable via PORT env var

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "storybook dev -p 6006",
+    "start": "storybook dev -p ${PORT:-6006}",
     "start:docker": "docker-scripts start",
     "build": "storybook build --output-dir dist",
     "lint": "eslint . --report-unused-disable-directives --max-warnings=0",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "postinstall": "shx cp -n .env.local.template .env.local",
-    "start": "next dev -p 8000",
+    "start": "next dev -p ${PORT:-8000}",
     "start:docker": "docker-scripts start",
     "typecheck": "tsc --noEmit",
     "build": "next build",


### PR DESCRIPTION
# Description

The `start` script in both `apps/website` and `apps/storybook` hardcoded the dev-server port (`-p 8000` / `-p 6006`), so a second checkout/worktree couldn't run its own dev server without clashing on the port. This makes the port configurable via the `PORT` env var, keeping the current values as defaults.

## Issue

Fixes #2547

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

N/A