### PR TITLE
[refactor] Deprecate `unitTable.content`

### DIFF
--- a/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitNumber].test.tsx
+++ b/apps/website/src/__tests__/pages/courses/[courseSlug]/units/[unitNumber].test.tsx
@@ -65,10 +65,10 @@ describe('CourseUnitPage', () => {
     } as unknown as NextRouter);
 
     const mockUnits = [
-      createMockUnit({ unitNumber: '0', title: 'Icebreaker', content: 'Welcome to the course' }),
-      createMockUnit({ unitNumber: '1', title: 'Unit 1', content: 'First unit content' }),
-      createMockUnit({ unitNumber: '2', title: 'Unit 2', content: 'Second unit content' }),
-      createMockUnit({ unitNumber: '3', title: 'Unit 3', content: 'Third unit content' }),
+      createMockUnit({ unitNumber: '0', title: 'Icebreaker' }),
+      createMockUnit({ unitNumber: '1', title: 'Unit 1' }),
+      createMockUnit({ unitNumber: '2', title: 'Unit 2' }),
+      createMockUnit({ unitNumber: '3', title: 'Unit 3' }),
     ];
 
     const mockChunk = createMockChunk({ unitId: mockUnits[0]!.id });
@@ -109,10 +109,10 @@ describe('CourseUnitPage', () => {
     } as unknown as NextRouter);
 
     const mockUnits = [
-      createMockUnit({ unitNumber: '0', title: 'Icebreaker', content: 'Welcome to the course' }),
-      createMockUnit({ unitNumber: '1', title: 'Unit 1', content: 'First unit content' }),
-      createMockUnit({ unitNumber: '2', title: 'Unit 2', content: 'Second unit content' }),
-      createMockUnit({ unitNumber: '3', title: 'Unit 3', content: 'Third unit content' }),
+      createMockUnit({ unitNumber: '0', title: 'Icebreaker' }),
+      createMockUnit({ unitNumber: '1', title: 'Unit 1' }),
+      createMockUnit({ unitNumber: '2', title: 'Unit 2' }),
+      createMockUnit({ unitNumber: '3', title: 'Unit 3' }),
     ];
 
     const mockChunk = createMockChunk({ unitId: mockUnits[3]!.id });
@@ -153,10 +153,10 @@ describe('CourseUnitPage', () => {
     } as unknown as NextRouter);
 
     const mockUnits = [
-      createMockUnit({ unitNumber: '1', title: 'Unit 1', content: 'First unit content' }),
-      createMockUnit({ unitNumber: '2', title: 'Unit 2', content: 'Second unit content' }),
-      createMockUnit({ unitNumber: '3', title: 'Unit 3', content: 'Third unit content' }),
-      createMockUnit({ unitNumber: '4', title: 'Unit 4', content: 'Fourth unit content' }),
+      createMockUnit({ unitNumber: '1', title: 'Unit 1' }),
+      createMockUnit({ unitNumber: '2', title: 'Unit 2' }),
+      createMockUnit({ unitNumber: '3', title: 'Unit 3' }),
+      createMockUnit({ unitNumber: '4', title: 'Unit 4' }),
     ];
 
     const mockChunk = createMockChunk({ unitId: mockUnits[2]!.id });
@@ -197,9 +197,9 @@ describe('CourseUnitPage', () => {
     } as unknown as NextRouter);
 
     const mockUnits = [
-      createMockUnit({ unitNumber: '1', title: 'Unit 1', content: 'First unit content' }),
-      createMockUnit({ unitNumber: '3', title: 'Unit 3', content: 'Third unit content' }),
-      createMockUnit({ unitNumber: '4', title: 'Unit 4', content: 'Fourth unit content' }),
+      createMockUnit({ unitNumber: '1', title: 'Unit 1' }),
+      createMockUnit({ unitNumber: '3', title: 'Unit 3' }),
+      createMockUnit({ unitNumber: '4', title: 'Unit 4' }),
     ];
 
     const mockChunk = createMockChunk({ unitId: mockUnits[1]!.id });
@@ -242,9 +242,9 @@ describe('CourseUnitPage', () => {
     } as unknown as NextRouter);
 
     const mockUnits = [
-      createMockUnit({ unitNumber: '1', title: 'Unit 1', content: 'First unit content' }),
-      createMockUnit({ unitNumber: '2', title: 'Unit 2', content: 'Second unit content' }),
-      createMockUnit({ unitNumber: '3', title: 'Unit 3', content: 'Third unit content' }),
+      createMockUnit({ unitNumber: '1', title: 'Unit 1' }),
+      createMockUnit({ unitNumber: '2', title: 'Unit 2' }),
+      createMockUnit({ unitNumber: '3', title: 'Unit 3' }),
     ];
 
     const mockChunk = createMockChunk({ unitId: mockUnits[2]!.id, metaDescription: 'Test chunk meta description' });

--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -158,7 +158,6 @@ export const createMockCourseRegistration = (overrides: Partial<CourseRegistrati
 
 export const createMockUnit = (overrides: Partial<Unit> = {}): Unit => ({
   chunks: ['recuC87TILbjW4eF4'],
-  content: null,
   courseId: MOCK_COURSE_ID,
   courseSlug: 'test-course',
   courseTitle: 'Test Course',

--- a/apps/website/src/components/courses/SideBar.test.tsx
+++ b/apps/website/src/components/courses/SideBar.test.tsx
@@ -14,27 +14,22 @@ import type { BasicChunk } from '../../server/routers/courses';
 const COURSE_UNITS = [
   createMockUnit({
     title: 'Basic Principles of Fish',
-    content: '## Welcome to the deep end! \nThis unit explores the core concepts that _every_ fish enthusiast needs to understand, from basic anatomy to the physics of water movement.\nWe\'ll explore how fish \n[ ] communicate,\n[ ] navigate,\n[ ] and survive in their watery world\n...with special attention to the unique adaptations that make each species special.\nThrough hands-on exercises and detailed study materials, you\'ll develop a strong foundation in **_[ichthyology](https://en.wikipedia.org/wiki/Ichthyology)_** (that\'s fish science for those who don\'t speak fluent marine biologist).\n',
     unitNumber: '1',
   }),
   createMockUnit({
     title: 'What Fish Are People Catching, and Why?',
-    content: 'Ever wondered why some fishermen chase tuna while others pursue cod? This unit dives into the complex world of modern fishing practices, from traditional line-fishing to industrial-scale operations. We\'ll examine the technological innovations driving the industry, the economic forces at play, and the eternal question of why that one weird fish at the bottom of the ocean looks like that. Through case studies and practical examples, you\'ll understand the delicate balance between feeding humanity and keeping our oceans stocked with sufficiently sassy fish.\n',
     unitNumber: '2',
   }),
   createMockUnit({
     title: 'The Promise of Fish',
-    content: 'Fish: they\'re not just for dinner anymore. This unit explores the untapped potential of our scaly friends in solving global challenges. From fish-powered renewable energy to underwater real estate development, we\'ll examine how piscine innovations are reshaping our world. We\'ll also delve into fish-based social networks (Fishbook), fish-inspired fashion trends, and why salmon make excellent financial advisors. Special attention will be paid to the emerging field of fish-human diplomacy.\n',
     unitNumber: '3',
   }),
   createMockUnit({
     title: 'The Risks of Fish',
-    content: 'Not all that glitters is goldfish. This unit examines the darker side of piscine potential, from the threat of fish becoming too self-aware to the risks of sharks learning to use smartphones. Through careful analysis and possibly paranoid speculation, we\'ll prepare for worst-case scenarios like fish developing opposable fins or deciding to implement their own cryptocurrency. Includes emergency protocols for dealing with fish uprising scenarios.\n',
     unitNumber: '4',
   }),
   createMockUnit({
     title: 'Contributing to Fish Safety',
-    content: '### The future of fish-human relations depends on you! \nThis capstone unit brings together everything we\'ve learned about our aquatic [overlords-in-waiting](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBWqLpd7QgEtYIur4g48rq8PhAApbpOuO2fwoRB1aPvZpijMnS) and channels it into practical action. \nWe\'ll explore how to make the world a safer place for fish while maintaining appropriate species boundaries. \nThrough \n- case studies,\n- hands-on projects,\n- and possibly underwater meditation sessions,\n\nyou\'ll learn to bridge the gap between gill and lung breathers. \n\n> Warning: May cause increased empathy for tuna sandwiches.\n',
     unitNumber: '5',
   }),
 ];

--- a/apps/website/src/components/courses/UnitLayout.stories.tsx
+++ b/apps/website/src/components/courses/UnitLayout.stories.tsx
@@ -11,7 +11,6 @@ const mockUnits = [
     title: 'Introduction to AI Safety',
     courseTitle: 'AI Safety Fundamentals',
     unitNumber: '1',
-    content: 'Welcome to the introduction unit.',
   }),
   createMockUnit({
     id: 'unit-2',

--- a/apps/website/src/components/courses/UnitLayout.test.tsx
+++ b/apps/website/src/components/courses/UnitLayout.test.tsx
@@ -22,28 +22,23 @@ vi.mock('next/router', () => ({
 const COURSE_UNITS = [
   createMockUnit({
     title: 'Basic Principles of Fish',
-    content: '## Welcome to the deep end! \nThis unit explores the core concepts that _every_ fish enthusiast needs to understand, from basic anatomy to the physics of water movement.\nWe\'ll explore how fish \n[ ] communicate,\n[ ] navigate,\n[ ] and survive in their watery world\n...with special attention to the unique adaptations that make each species special.\nThrough hands-on exercises and detailed study materials, you\'ll develop a strong foundation in **_[ichthyology](https://en.wikipedia.org/wiki/Ichthyology)_** (that\'s fish science for those who don\'t speak fluent marine biologist).\n',
     courseTitle: 'What the fish [Test Course]',
     unitNumber: '1',
   }),
   createMockUnit({
     title: 'What Fish Are People Catching, and Why?',
-    content: 'Ever wondered why some fishermen chase tuna while others pursue cod? This unit dives into the complex world of modern fishing practices, from traditional line-fishing to industrial-scale operations. We\'ll examine the technological innovations driving the industry, the economic forces at play, and the eternal question of why that one weird fish at the bottom of the ocean looks like that. Through case studies and practical examples, you\'ll understand the delicate balance between feeding humanity and keeping our oceans stocked with sufficiently sassy fish.\n',
     unitNumber: '2',
   }),
   createMockUnit({
     title: 'The Promise of Fish',
-    content: 'Fish: they\'re not just for dinner anymore. This unit explores the untapped potential of our scaly friends in solving global challenges. From fish-powered renewable energy to underwater real estate development, we\'ll examine how piscine innovations are reshaping our world. We\'ll also delve into fish-based social networks (Fishbook), fish-inspired fashion trends, and why salmon make excellent financial advisors. Special attention will be paid to the emerging field of fish-human diplomacy.\n',
     unitNumber: '3',
   }),
   createMockUnit({
     title: 'The Risks of Fish',
-    content: 'Not all that glitters is goldfish. This unit examines the darker side of piscine potential, from the threat of fish becoming too self-aware to the risks of sharks learning to use smartphones. Through careful analysis and possibly paranoid speculation, we\'ll prepare for worst-case scenarios like fish developing opposable fins or deciding to implement their own cryptocurrency. Includes emergency protocols for dealing with fish uprising scenarios.\n',
     unitNumber: '4',
   }),
   createMockUnit({
     title: 'Contributing to Fish Safety',
-    content: '### The future of fish-human relations depends on you! \nThis capstone unit brings together everything we\'ve learned about our aquatic [overlords-in-waiting](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBWqLpd7QgEtYIur4g48rq8PhAApbpOuO2fwoRB1aPvZpijMnS) and channels it into practical action. \nWe\'ll explore how to make the world a safer place for fish while maintaining appropriate species boundaries. \nThrough \n- case studies,\n- hands-on projects,\n- and possibly underwater meditation sessions,\n\nyou\'ll learn to bridge the gap between gill and lung breathers. \n\n> Warning: May cause increased empathy for tuna sandwiches.\n',
     unitNumber: '5',
   }),
 ];

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -209,12 +209,9 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
             <NextStepsChunk />
           ) : (
             <>
-              {/* chunk content → unit content if no chunks - Only render if there's actual content */}
-              {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-              {(chunk?.chunkContent || unit.content) && (
+              {chunk?.chunkContent && (
                 <MarkdownExtendedRenderer className="mt-8 md:mt-6">
-                  {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-                  {chunk?.chunkContent || unit.content || ''}
+                  {chunk.chunkContent}
                 </MarkdownExtendedRenderer>
               )}
 
@@ -225,7 +222,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
                   exercises={chunk.exercises || []}
                   unitTitle={unit.title}
                   unitNumber={unitNumber}
-                  className={clsx((chunk?.chunkContent || unit.content) ? 'mt-8 md:mt-6' : 'mt-4')}
+                  className={clsx(chunk?.chunkContent ? 'mt-8 md:mt-6' : 'mt-4')}
                   courseSlug={courseSlug}
                   chunkIndex={chunkIndex}
                 />

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1097,10 +1097,6 @@ export const unitTable = pgAirtable('unit', {
       pgColumn: text().notNull(),
       airtableId: 'fldN9BV8GGUHFu9sz',
     },
-    content: {
-      pgColumn: text(),
-      airtableId: 'fldF9hjDhZpLbBIUV',
-    },
     duration: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldGdibgcMgRbnuvp',
@@ -1131,6 +1127,11 @@ export const unitTable = pgAirtable('unit', {
     path: {
       pgColumn: text(),
       airtableId: 'fldEY7ZHZtXrBL3nv',
+      deprecated: true,
+    },
+    content: {
+      pgColumn: text(),
+      airtableId: 'fldF9hjDhZpLbBIUV',
       deprecated: true,
     },
   },


### PR DESCRIPTION
Closes part of #2535.

## User-visible impact

Course unit pages render the same. `unit.content` Markdown field was previously a fallback when a chunk had no content of its own; that fallback has been dead since the Airtable `Content` field was deleted upstream, so removing it is a no-op for users and silences a recurring pg-sync-service warning in production logs.

## Summary

- Drop `chunk?.chunkContent || unit.content` fallback in `UnitLayout.tsx`. Render only `chunk.chunkContent`.
- Move `unitTable.content` to `deprecatedColumns` in `libraries/db/src/schema.ts`. Already nullable, no constraint change.
- Strip `content:` from test/story fixtures and from `createMockUnit` in `testUtils.ts`.

## Follow-up

Per 2-PR deprecation workflow: after this lands and ships to **production** (`website/vX.Y.Z` tag), a follow-up PR deletes `content` from `deprecatedColumns` and drops the postgres column.

## Test plan

- [x] `npm test` in `apps/website` (one unrelated FreeTextResponse timer flake; passes on rerun)
- [x] `npx tsc --noEmit` in `apps/website`
- [x] `npm run lint` in `apps/website`
- [ ] Manual: load a course unit page in staging, confirm chunk content still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)
