### PR TITLE
Add `toast()`, `toast.success()`, `<Toaster />` components

### DIFF
--- a/libraries/ui/src/Toast.stories.tsx
+++ b/libraries/ui/src/Toast.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+import { Toaster } from './Toast';
+import { toast, useToastStore } from './toastStore';
+
+type DemoArgs = {
+  message: string;
+  description?: string;
+  variant?: 'default' | 'success';
+  closeButton?: boolean;
+  stacked?: boolean;
+};
+
+const Demo = ({ message, description, variant = 'default', closeButton = false, stacked = false }: DemoArgs) => {
+  useEffect(() => {
+    useToastStore.setState({ toasts: [], queue: [], paused: false });
+    const fire = () => {
+      if (stacked) {
+        toast('First', { description: 'Oldest visible toast' });
+        toast('Second', { description: 'Middle of the stack' });
+        toast.success('Third', { description: 'Newest toast' });
+        return;
+      }
+
+      const opts = { description, closeButton };
+      if (variant === 'success') toast.success(message, opts);
+      else toast(message, opts);
+    };
+
+    fire();
+  }, [message, description, variant, closeButton, stacked]);
+
+  return (
+    <div className="p-8">
+      <button
+        type="button"
+        className="cursor-pointer rounded border px-2 py-1 hover:opacity-80"
+        onClick={() => {
+          if (variant === 'success') toast.success(message, { description, closeButton });
+          else toast(message, { description, closeButton });
+        }}
+      >
+        Fire toast
+      </button>
+      <Toaster />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'ui/Toast',
+  component: Demo,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof Demo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { message: 'Saved' },
+};
+
+export const WithDescription: Story = {
+  args: {
+    message: 'Your application has been submitted',
+    description: 'We’ll be in touch shortly.',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    message: 'Your application has been submitted',
+    description: 'We’ll be in touch shortly.',
+    variant: 'success',
+  },
+};
+
+export const WithCloseButton: Story = {
+  args: {
+    message: 'Saved',
+    description: 'Changes have been saved.',
+    closeButton: true,
+  },
+};
+
+export const Stacked: Story = {
+  args: { message: '', stacked: true },
+};
+
+export const Mobile: Story = {
+  args: {
+    message: 'Your application has been submitted',
+    description: 'We’ll be in touch shortly.',
+    variant: 'success',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};

--- a/libraries/ui/src/Toast.test.tsx
+++ b/libraries/ui/src/Toast.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { act } from 'react';
+import {
+  describe, test, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+import { Toaster } from './Toast';
+import {
+  toast, useToastStore, TOAST_DEFAULT_DURATION, TOAST_EXIT_DURATION_MS, TOAST_VISIBLE_CAP,
+} from './toastStore';
+
+const resetStore = () => {
+  useToastStore.setState({ toasts: [], queue: [], paused: false });
+};
+
+describe('toast store', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  test('add() appends visible toast', () => {
+    toast('Hello');
+    const state = useToastStore.getState();
+    expect(state.toasts).toHaveLength(1);
+    expect(state.toasts[0]!.message).toBe('Hello');
+    expect(state.toasts[0]!.variant).toBe('default');
+  });
+
+  test('toast.success() sets success variant', () => {
+    toast.success('Saved');
+    expect(useToastStore.getState().toasts[0]!.variant).toBe('success');
+  });
+
+  test('caps visible at 3 and queues the rest', () => {
+    toast('1');
+    toast('2');
+    toast('3');
+    toast('4');
+    const state = useToastStore.getState();
+    expect(state.toasts).toHaveLength(TOAST_VISIBLE_CAP);
+    expect(state.queue).toHaveLength(1);
+    expect(state.queue[0]!.message).toBe('4');
+  });
+
+  test('remove() promotes from queue', () => {
+    toast('1');
+    toast('2');
+    toast('3');
+    toast('4');
+    useToastStore.getState().remove(useToastStore.getState().toasts[0]!.id);
+    const state = useToastStore.getState();
+    expect(state.toasts).toHaveLength(TOAST_VISIBLE_CAP);
+    expect(state.queue).toHaveLength(0);
+    expect(state.toasts[2]!.message).toBe('4');
+  });
+
+  test('id option dedupes and updates in place', () => {
+    toast('First', { id: 'same' });
+    toast('Second', { id: 'same' });
+    const state = useToastStore.getState();
+    expect(state.toasts).toHaveLength(1);
+    expect(state.toasts[0]!.message).toBe('Second');
+  });
+
+  test('toast() returns id', () => {
+    const id = toast('Hi', { id: 'custom' });
+    expect(id).toBe('custom');
+  });
+});
+
+describe('Toaster', () => {
+  beforeEach(() => {
+    resetStore();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetStore();
+  });
+
+  test('renders message and description', () => {
+    render(<Toaster />);
+    act(() => {
+      toast('Title', { description: 'Body' });
+    });
+    expect(screen.getByText('Title')).toBeTruthy();
+    expect(screen.getByText('Body')).toBeTruthy();
+  });
+
+  test('auto-dismisses after duration', () => {
+    render(<Toaster />);
+    act(() => {
+      toast('Bye');
+    });
+    expect(screen.queryByText('Bye')).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(TOAST_DEFAULT_DURATION + 10);
+    });
+    act(() => {
+      vi.advanceTimersByTime(TOAST_EXIT_DURATION_MS + 10);
+    });
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  test('hover pauses auto-dismiss', () => {
+    render(<Toaster />);
+    act(() => {
+      toast('Hover');
+    });
+    const region = screen.getByRole('region');
+    fireEvent.mouseEnter(region);
+    act(() => {
+      vi.advanceTimersByTime(TOAST_DEFAULT_DURATION + 500);
+    });
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+  });
+
+  test('close button dismisses', () => {
+    render(<Toaster />);
+    act(() => {
+      toast('Close me', { closeButton: true });
+    });
+    const button = screen.getByLabelText('Dismiss notification');
+    fireEvent.click(button);
+    act(() => {
+      vi.advanceTimersByTime(TOAST_EXIT_DURATION_MS + 50);
+    });
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  test('success variant renders check icon', () => {
+    render(<Toaster />);
+    act(() => {
+      toast.success('Saved');
+    });
+    const region = screen.getByRole('region');
+    expect(region.querySelector('svg')).toBeTruthy();
+  });
+});

--- a/libraries/ui/src/Toast.test.tsx
+++ b/libraries/ui/src/Toast.test.tsx
@@ -128,6 +128,48 @@ describe('Toaster', () => {
     expect(useToastStore.getState().toasts).toHaveLength(0);
   });
 
+  test('dedupe with shorter duration resets countdown', () => {
+    render(<Toaster />);
+    act(() => {
+      toast('First', { id: 'x', duration: 4000 });
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    act(() => {
+      toast('Second', { id: 'x', duration: 500 });
+    });
+    act(() => {
+      vi.advanceTimersByTime(450);
+    });
+    expect(useToastStore.getState().toasts[0]!.status).toBe('visible');
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(useToastStore.getState().toasts[0]!.status).toBe('exiting');
+  });
+
+  test('dedupe with longer duration resets countdown', () => {
+    render(<Toaster />);
+    act(() => {
+      toast('First', { id: 'x', duration: 1000 });
+    });
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    act(() => {
+      toast('Second', { id: 'x', duration: 4000 });
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(useToastStore.getState().toasts[0]!.status).toBe('visible');
+    act(() => {
+      vi.advanceTimersByTime(2600);
+    });
+    expect(useToastStore.getState().toasts[0]!.status).toBe('exiting');
+  });
+
   test('success variant renders check icon', () => {
     render(<Toaster />);
     act(() => {

--- a/libraries/ui/src/Toast.test.tsx
+++ b/libraries/ui/src/Toast.test.tsx
@@ -128,6 +128,31 @@ describe('Toaster', () => {
     expect(useToastStore.getState().toasts).toHaveLength(0);
   });
 
+  test('resumes countdown from elapsed time after unpause', () => {
+    render(<Toaster />);
+    act(() => {
+      toast('Hover');
+    });
+    const region = screen.getByRole('region');
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    fireEvent.mouseEnter(region);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    fireEvent.mouseLeave(region);
+    // Only ~1000ms of the original 4000ms remain. 900ms still visible, then exiting.
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(useToastStore.getState().toasts[0]!.status).toBe('visible');
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(useToastStore.getState().toasts[0]!.status).toBe('exiting');
+  });
+
   test('dedupe with shorter duration resets countdown', () => {
     render(<Toaster />);
     act(() => {

--- a/libraries/ui/src/Toast.tsx
+++ b/libraries/ui/src/Toast.tsx
@@ -33,10 +33,18 @@ const ToastItem = ({ toast }: { toast: ToastEntry }) => {
   const startExit = useToastStore((s) => s.startExit);
   const remove = useToastStore((s) => s.remove);
   const remainingRef = useRef(toast.duration);
+  const prevDurationRef = useRef(toast.duration);
   const startedAtRef = useRef<number | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    // Dedupe update: if the same toast id was re-fired with a new duration, reset countdown.
+    if (prevDurationRef.current !== toast.duration) {
+      remainingRef.current = toast.duration;
+      prevDurationRef.current = toast.duration;
+      startedAtRef.current = null;
+    }
+
     if (toast.status === 'exiting') {
       const timer = setTimeout(() => remove(toast.id), TOAST_EXIT_DURATION_MS);
       return () => clearTimeout(timer);
@@ -58,7 +66,7 @@ const ToastItem = ({ toast }: { toast: ToastEntry }) => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     };
-  }, [paused, toast.status, toast.id, remove, startExit]);
+  }, [paused, toast.status, toast.id, toast.duration, remove, startExit]);
 
   const isSuccess = toast.variant === 'success';
 

--- a/libraries/ui/src/Toast.tsx
+++ b/libraries/ui/src/Toast.tsx
@@ -117,9 +117,10 @@ export const Toaster = () => {
         onBlur={() => setPaused(false)}
         className={cn(
           // z-70 sits one step above Modal/BottomDrawerModal (z-60) so toasts surface over dialogs.
+          // Newest toast sits nearest the anchor edge: top on desktop, bottom on mobile.
           'pointer-events-none fixed z-70 flex flex-col gap-2',
-          'right-4 bottom-4 left-4 flex-col-reverse items-center',
-          'md:top-4 md:right-4 md:bottom-auto md:left-auto md:flex-col md:items-end',
+          'right-4 bottom-4 left-4 items-center',
+          'md:top-4 md:right-4 md:bottom-auto md:left-auto md:flex-col-reverse md:items-end',
         )}
       >
         {toasts.map((t) => (

--- a/libraries/ui/src/Toast.tsx
+++ b/libraries/ui/src/Toast.tsx
@@ -100,7 +100,12 @@ export const Toaster = () => {
 
   useEffect(() => {
     setMounted(true);
-  }, []);
+    return () => {
+      // Clear paused state if Toaster unmounts while hovered/focused, otherwise
+      // future toasts after remount would never auto-dismiss.
+      setPaused(false);
+    };
+  }, [setPaused]);
 
   if (!mounted) return null;
 

--- a/libraries/ui/src/Toast.tsx
+++ b/libraries/ui/src/Toast.tsx
@@ -51,20 +51,23 @@ const ToastItem = ({ toast }: { toast: ToastEntry }) => {
     }
 
     if (paused) {
-      if (timeoutRef.current && startedAtRef.current !== null) {
-        clearTimeout(timeoutRef.current);
-        remainingRef.current -= Date.now() - startedAtRef.current;
-        timeoutRef.current = null;
-      }
-
       return undefined;
     }
 
     startedAtRef.current = Date.now();
     timeoutRef.current = setTimeout(() => startExit(toast.id), remainingRef.current);
     return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+
+      // Capture elapsed time so a subsequent resume continues from where it left off
+      // rather than restarting from the full duration.
+      if (startedAtRef.current !== null) {
+        remainingRef.current = Math.max(0, remainingRef.current - (Date.now() - startedAtRef.current));
+        startedAtRef.current = null;
+      }
     };
   }, [paused, toast.status, toast.id, toast.duration, remove, startExit]);
 

--- a/libraries/ui/src/Toast.tsx
+++ b/libraries/ui/src/Toast.tsx
@@ -110,7 +110,6 @@ export const Toaster = () => {
       <div
         role="region"
         aria-label="Notifications"
-        aria-live="polite"
         onMouseEnter={() => setPaused(true)}
         onMouseLeave={() => setPaused(false)}
         onFocus={() => setPaused(true)}

--- a/libraries/ui/src/Toast.tsx
+++ b/libraries/ui/src/Toast.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CircledCheckmarkIcon } from './icons/CircledCheckmarkIcon';
+import { CloseIcon } from './icons/CloseIcon';
+import { TOAST_EXIT_DURATION_MS, useToastStore, type ToastEntry } from './toastStore';
+import { cn } from './utils';
+
+const TOAST_STYLES = `
+@keyframes bd-toast-in-right {
+  from { opacity: 0; transform: translateX(24px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes bd-toast-in-bottom {
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes bd-toast-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+.bd-toast-enter-desktop { animation: bd-toast-in-right 200ms ease-out both; }
+.bd-toast-enter-mobile { animation: bd-toast-in-bottom 200ms ease-out both; }
+.bd-toast-exit { animation: bd-toast-out 150ms ease-in both; }
+/* Reduced motion: drop the slide on enter, keep a plain fade. Exit already fades-only so it's unchanged. */
+@media (prefers-reduced-motion: reduce) {
+  .bd-toast-enter-desktop, .bd-toast-enter-mobile { animation: bd-toast-out 200ms ease-out reverse both; }
+  .bd-toast-exit { animation: bd-toast-out 150ms ease-in both; }
+}
+`;
+
+const ToastItem = ({ toast }: { toast: ToastEntry }) => {
+  const paused = useToastStore((s) => s.paused);
+  const startExit = useToastStore((s) => s.startExit);
+  const remove = useToastStore((s) => s.remove);
+  const remainingRef = useRef(toast.duration);
+  const startedAtRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (toast.status === 'exiting') {
+      const timer = setTimeout(() => remove(toast.id), TOAST_EXIT_DURATION_MS);
+      return () => clearTimeout(timer);
+    }
+
+    if (paused) {
+      if (timeoutRef.current && startedAtRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+        remainingRef.current -= Date.now() - startedAtRef.current;
+        timeoutRef.current = null;
+      }
+
+      return undefined;
+    }
+
+    startedAtRef.current = Date.now();
+    timeoutRef.current = setTimeout(() => startExit(toast.id), remainingRef.current);
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    };
+  }, [paused, toast.status, toast.id, remove, startExit]);
+
+  const isSuccess = toast.variant === 'success';
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        'pointer-events-auto flex items-center gap-3 rounded-[10px] border-[0.5px] px-3 py-4',
+        'w-full leading-normal md:w-[320px]',
+        toast.status === 'exiting' ? 'bd-toast-exit' : 'bd-toast-enter-mobile md:bd-toast-enter-desktop',
+        isSuccess
+          ? 'border-[#1a7a52] bg-[#f2fff8] text-[#1a7a52]'
+          : 'border-bluedot-charcoal-light text-bluedot-navy bg-white',
+      )}
+    >
+      {isSuccess && <CircledCheckmarkIcon size={20} className="shrink-0 text-[#1a7a52]" aria-hidden />}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="text-size-xs font-bold break-words">{toast.message}</p>
+        {toast.description && <p className="text-size-xxs font-normal break-words">{toast.description}</p>}
+      </div>
+      {toast.closeButton && (
+        <button
+          type="button"
+          aria-label="Dismiss notification"
+          onClick={() => startExit(toast.id)}
+          className="shrink-0 cursor-pointer rounded-sm p-1 hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-current"
+        >
+          <CloseIcon size={16} className="stroke-[1.5]" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export const Toaster = () => {
+  const toasts = useToastStore((s) => s.toasts);
+  const setPaused = useToastStore((s) => s.setPaused);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <>
+      <style>{TOAST_STYLES}</style>
+      <div
+        role="region"
+        aria-label="Notifications"
+        aria-live="polite"
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+        onFocus={() => setPaused(true)}
+        onBlur={() => setPaused(false)}
+        className={cn(
+          // z-70 sits one step above Modal/BottomDrawerModal (z-60) so toasts surface over dialogs.
+          'pointer-events-none fixed z-70 flex flex-col gap-2',
+          'right-4 bottom-4 left-4 flex-col-reverse items-center',
+          'md:top-4 md:right-4 md:bottom-auto md:left-auto md:flex-col md:items-end',
+        )}
+      >
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} />
+        ))}
+      </div>
+    </>,
+    document.body,
+  );
+};

--- a/libraries/ui/src/icons/CircledCheckmarkIcon.tsx
+++ b/libraries/ui/src/icons/CircledCheckmarkIcon.tsx
@@ -1,0 +1,23 @@
+import { cn } from '../utils';
+import type { IconProps } from './types';
+
+export const CircledCheckmarkIcon = ({ size = 16, className, ...props }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 16 16"
+    fill="none"
+    width={size}
+    height={size}
+    className={cn('text-bluedot-normal', className)}
+    {...props}
+  >
+    <circle cx="8" cy="8" r="7.375" stroke="currentColor" strokeWidth="1.25" />
+    <path
+      d="M4.5 8L7 10.5L11.5 5"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/libraries/ui/src/icons/types.ts
+++ b/libraries/ui/src/icons/types.ts
@@ -1,0 +1,5 @@
+import type { SVGProps } from 'react';
+
+export type IconProps = SVGProps<SVGSVGElement> & {
+  size?: number | string;
+};

--- a/libraries/ui/src/index.ts
+++ b/libraries/ui/src/index.ts
@@ -82,6 +82,11 @@ export type { TimeAvailabilityGridProps, TimeAvailabilityMap } from './TimeAvail
 export { TimePicker } from './TimePicker';
 export type { TimePickerProps } from './TimePicker';
 
+export { Toaster } from './Toast';
+export {
+  toast, useToastStore, type ToastOptions, type ToastEntry, type ToastVariant,
+} from './toastStore';
+
 export { ToggleSwitch } from './ToggleSwitch';
 export type { ToggleSwitchProps } from './ToggleSwitch';
 

--- a/libraries/ui/src/toastStore.ts
+++ b/libraries/ui/src/toastStore.ts
@@ -1,0 +1,94 @@
+import { create } from 'zustand';
+
+export type ToastVariant = 'default' | 'success';
+
+export type ToastOptions = {
+  id?: string;
+  description?: string;
+  duration?: number;
+  closeButton?: boolean;
+};
+
+export type ToastEntry = {
+  id: string;
+  message: string;
+  description?: string;
+  duration: number;
+  variant: ToastVariant;
+  closeButton: boolean;
+  status: 'visible' | 'exiting';
+};
+
+export const TOAST_VISIBLE_CAP = 3;
+export const TOAST_DEFAULT_DURATION = 4000;
+export const TOAST_EXIT_DURATION_MS = 150;
+
+type ToastStore = {
+  toasts: ToastEntry[];
+  queue: ToastEntry[];
+  paused: boolean;
+  add: (entry: Omit<ToastEntry, 'status'>) => void;
+  startExit: (id: string) => void;
+  remove: (id: string) => void;
+  setPaused: (paused: boolean) => void;
+};
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+  queue: [],
+  paused: false,
+  add: (entry) =>
+    set((state) => {
+      const existingVisible = state.toasts.findIndex((t) => t.id === entry.id);
+      if (existingVisible !== -1) {
+        const next = [...state.toasts];
+        next[existingVisible] = { ...entry, status: 'visible' };
+        return { toasts: next };
+      }
+
+      const existingQueued = state.queue.findIndex((t) => t.id === entry.id);
+      if (existingQueued !== -1) {
+        const next = [...state.queue];
+        next[existingQueued] = { ...entry, status: 'visible' };
+        return { queue: next };
+      }
+
+      if (state.toasts.length >= TOAST_VISIBLE_CAP) {
+        return { queue: [...state.queue, { ...entry, status: 'visible' }] };
+      }
+
+      return { toasts: [...state.toasts, { ...entry, status: 'visible' }] };
+    }),
+  startExit: (id) =>
+    set((state) => ({
+      toasts: state.toasts.map((t) => (t.id === id ? { ...t, status: 'exiting' } : t)),
+    })),
+  remove: (id) =>
+    set((state) => {
+      const toasts = state.toasts.filter((t) => t.id !== id);
+      const queue = [...state.queue];
+      while (toasts.length < TOAST_VISIBLE_CAP && queue.length > 0) {
+        toasts.push(queue.shift()!);
+      }
+
+      return { toasts, queue };
+    }),
+  setPaused: (paused) => set({ paused }),
+}));
+
+const enqueue = (message: string, variant: ToastVariant, opts: ToastOptions = {}): string => {
+  const id = opts.id ?? crypto.randomUUID();
+  useToastStore.getState().add({
+    id,
+    message,
+    description: opts.description,
+    duration: opts.duration ?? TOAST_DEFAULT_DURATION,
+    variant,
+    closeButton: opts.closeButton ?? false,
+  });
+  return id;
+};
+
+export const toast = Object.assign((message: string, opts?: ToastOptions) => enqueue(message, 'default', opts), {
+  success: (message: string, opts?: ToastOptions) => enqueue(message, 'success', opts),
+});


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Creates new toast component and introduces system for handling multiple toasts. Introduces `toastStore` for handling all toast-related state.

This PR only supports default and success toasts. Other styles can be introduced in the future as needed.

Out of scope:

1. `toast.error`, `toast.dismiss`, `toast.promise`, `toast.custom(jsx)`
2. `onDismiss`, `onAutoClose` callbacks
3. Multiple `<Toaster />` components
4. Swip-to-dismiss on mobile
5. `position` prop for controlling toast position
6. Extracting success green text to a custom colour

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2530

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

<img width="2380" height="1078" alt="image" src="https://github.com/user-attachments/assets/406cfd4a-149a-4e08-a632-89acb211f394" />

<img width="640" height="1156" alt="image" src="https://github.com/user-attachments/assets/32cb8047-10a6-4c5e-a0ae-6c69f93f01bb" />

