### PR TITLE
[feat] Add courseRelationship column to testimonialTable

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -913,6 +913,10 @@ export const testimonialTable = pgAirtable('testimonial', {
       pgColumn: text(),
       airtableId: 'fldSBm8bIIR5JAaeo',
     },
+    courseRelationship: {
+      pgColumn: text(),
+      airtableId: 'fldVnQirLcMiPta5A',
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- Adds a `courseRelationship` column to `testimonialTable` in `libraries/db/src/schema.ts`, mapped to Airtable field `fldVnQirLcMiPta5A` ("Course relationship", singleLineText)
- Schema-only PR per the two-step database workflow — consumer code (alumni page display) follows in a separate PR once pg-sync has materialised the column

## Test plan
- [x] `tsc --noEmit` clean from `apps/website/`
- [x] No existing consumers reference the new column, so no behavioural change today
- [ ] After merge: confirm pg-sync materialises `course_relationship` on staging before shipping the consumer PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)