### PR TITLE
[feat] Add storyUrl column to testimonialTable

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -917,6 +917,10 @@ export const testimonialTable = pgAirtable('testimonial', {
       pgColumn: text(),
       airtableId: 'fldVnQirLcMiPta5A',
     },
+    storyUrl: {
+      pgColumn: text(),
+      airtableId: 'fldsfYjbeOTtWNqZX',
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- Adds a `storyUrl` column to `testimonialTable` in `libraries/db/src/schema.ts`, mapped to Airtable field `fldsfYjbeOTtWNqZX` ("Story link", url type)
- Separates the alum's LinkedIn post URL (story to read) from their personal profile URL — previously both were crammed into `profileUrl`
- Schema-only PR per the two-step database workflow; consumer code follows in a separate PR once pg-sync has materialised the column

## Test plan
- [x] `tsc --noEmit` clean from `apps/website/`
- [x] No existing consumers reference the new column, so no behavioural change today
- [ ] After merge: confirm pg-sync materialises `story_url` on staging, then ship the consumer PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)