### PR TITLE
[feat] Add initials fallback for testimonials without a headshot

### DIFF
--- a/apps/website/src/components/alumni/AlumniAvatar.tsx
+++ b/apps/website/src/components/alumni/AlumniAvatar.tsx
@@ -1,0 +1,35 @@
+import clsx from 'clsx';
+import { getInitials } from '../../lib/utils';
+
+type Props = {
+  name: string;
+  imageSrc?: string;
+  className?: string;
+};
+
+const AlumniAvatar = ({ name, imageSrc, className }: Props) => {
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt={name}
+        className={clsx('rounded-full object-cover shrink-0', className)}
+      />
+    );
+  }
+
+  return (
+    <div
+      role="img"
+      aria-label={name}
+      className={clsx(
+        'rounded-full bg-bluedot-normal flex items-center justify-center text-white font-bold shrink-0',
+        className,
+      )}
+    >
+      {getInitials(name)}
+    </div>
+  );
+};
+
+export default AlumniAvatar;

--- a/apps/website/src/components/alumni/RecentAlumniList.tsx
+++ b/apps/website/src/components/alumni/RecentAlumniList.tsx
@@ -3,6 +3,7 @@ import { CTALinkOrButton, H2, P } from '@bluedot/ui';
 import clsx from 'clsx';
 import { trpc } from '../../utils/trpc';
 import type { TransformedTestimonial } from '../../server/routers/testimonials';
+import AlumniAvatar from './AlumniAvatar';
 
 const COLLAPSED_ROWS = 3;
 const COLS_LG = 3;
@@ -55,10 +56,10 @@ const RecentAlumniList = () => {
 const AlumniRow = ({ alum }: { alum: TransformedTestimonial }) => {
   const content = (
     <div className="flex items-center gap-3 py-3.5 border-b border-bluedot-navy/10">
-      <img
-        src={alum.imageSrc}
-        alt={alum.name}
-        className="size-11 rounded-full object-cover flex-shrink-0"
+      <AlumniAvatar
+        name={alum.name}
+        imageSrc={alum.imageSrc}
+        className="size-11 text-size-xs"
       />
       <div className="flex-1 min-w-0">
         <P className="text-size-sm font-semibold leading-tight text-bluedot-navy truncate">{alum.name}</P>

--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -122,7 +122,9 @@ const CourseLander = ({
 
   const { data: dbTestimonials } = trpc.testimonials.getCommunityMembersByCourseSlug.useQuery({ courseSlug });
 
-  const testimonials = dbTestimonials?.map((t): TestimonialMember => ({ ...t }));
+  const testimonials = (dbTestimonials ?? [])
+    .filter((t) => t.imageSrc)
+    .map((t): TestimonialMember => ({ ...t }));
   const shouldShowTestimonials = Boolean(testimonials && testimonials.length > 0 && !content.hideTestimonials);
   const testimonialsSection = shouldShowTestimonials ? (
     <>

--- a/apps/website/src/components/lander/components/AlumniStoryCarousel.tsx
+++ b/apps/website/src/components/lander/components/AlumniStoryCarousel.tsx
@@ -8,6 +8,7 @@ import {
 import Link from 'next/link';
 import { H2, P } from '@bluedot/ui';
 import clsx from 'clsx';
+import AlumniAvatar from '../../alumni/AlumniAvatar';
 
 export type AlumniStory = {
   name: string;
@@ -307,10 +308,10 @@ const AlumniStoryCardContent = ({ story }: { story: AlumniStory }) => (
   <>
     {/* Top section with image and info */}
     <div className="flex items-start gap-4 p-5 bd-md:p-6 border-b border-bluedot-navy/6">
-      <img
-        src={story.imageSrc}
-        alt={story.name}
-        className="size-16 bd-md:size-20 rounded-full object-cover flex-shrink-0"
+      <AlumniAvatar
+        name={story.name}
+        imageSrc={story.imageSrc}
+        className="size-16 bd-md:size-20 text-size-md bd-md:text-size-lg"
       />
       <div className="flex flex-col gap-1 min-w-0 pt-1">
         <P className="text-size-md font-semibold leading-[130%] text-bluedot-navy truncate">

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -15,7 +15,9 @@ const LINK_PREVIEW_IMAGE = 'https://bluedot.org/images/logo/link-preview-fallbac
 const HomePage = () => {
   const { data: dbTestimonials } = trpc.testimonials.getCommunityMembers.useQuery();
 
-  const testimonials = dbTestimonials?.map((t): TestimonialMember => ({ ...t })) ?? [];
+  const testimonials = (dbTestimonials ?? [])
+    .filter((t) => t.imageSrc)
+    .map((t): TestimonialMember => ({ ...t }));
 
   return (
     <div>

--- a/apps/website/src/server/routers/testimonials.ts
+++ b/apps/website/src/server/routers/testimonials.ts
@@ -65,9 +65,7 @@ function transformTestimonial(t: Testimonial): TransformedTestimonial {
 export const testimonialsRouter = router({
   getCommunityMembers: publicProcedure.query(async () => {
     const all = await db.scan(testimonialTable);
-    const filtered = all.filter((t) => t.name
-      && getFirstHeadshotUrl(t.headshotAttachmentUrls)
-      && t.testimonialText?.trim());
+    const filtered = all.filter((t) => t.name && t.testimonialText?.trim());
     return sortTestimonials(filtered).map(transformTestimonial);
   }),
 
@@ -76,7 +74,6 @@ export const testimonialsRouter = router({
     .query(async ({ input }) => {
       const all = await db.scan(testimonialTable);
       const filtered = all.filter((t) => t.name
-        && getFirstHeadshotUrl(t.headshotAttachmentUrls)
         && t.testimonialText?.trim()
         && t.displayOnCourseSlugs?.includes(input.courseSlug));
       return sortTestimonials(filtered).map(transformTestimonial);


### PR DESCRIPTION
# Description

Testimonials in the Airtable table don't always have a headshot attached. Until now we filtered those rows out entirely on the server. The recent batch of alumni (ERA Cambridge fellows + SPAR/GovAI researchers) was sitting hidden in `/alumni` because nobody had uploaded photos yet.

This change adds an initials fallback so those rows can appear on the alumni page while photos catch up.

## What changed

1. **`apps/website/src/components/alumni/AlumniAvatar.tsx`** — new helper. Renders `<img>` when `imageSrc` is set, else a `bg-bluedot-normal` circle with white-bold initials. Reuses `getInitials` from `lib/utils.ts:169` and matches the visual treatment already used by `ParticipantRow`.
2. **`AlumniStoryCarousel.tsx`** — swap the header `<img>` for `<AlumniAvatar>` (size-16 / bd-md:size-20).
3. **`RecentAlumniList.tsx`** — same swap on the grid row (size-11).
4. **`testimonials.ts` router** — drop the photo requirement from `getCommunityMembers` (and the by-course variant) so headshot-less rows flow through.
5. **`pages/index.tsx`** — homepage's `TestimonialCarousel` keeps the photo requirement via a `.filter((t) => t.imageSrc)` on the consumer side. Homepage card layout is photo-led and wouldn't read well with initials at that size.

## Issue

N/A.

## Developer checklist

- [x] Front-end code follows the Component Accessibility Checklist — `role="img"` + `aria-label` on the initials div.
- [x] Considered snapshot/functional tests — no new snapshots needed; existing rows with photos are unchanged.
- [x] Considered Storybook stories — `AlumniAvatar` is a tiny internal helper; live `/alumni` is the canonical preview.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8002`):
- ✅ `/alumni` — alumni without headshots appear with initials in the Featured carousel and "Some of our alumni" grid.
- ✅ `/` — homepage community carousel unchanged; still only shows alumni with photos.

Type check + lint + full test suite all pass (monorepo-wide, including \`libraries/ui\`):
\`\`\`
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 820 passed | 1 skipped (821)
npm run test --workspaces --if-present  # all packages green
\`\`\`

## Screenshots

_paste WebP_

🤖 Generated with [Claude Code](https://claude.com/claude-code)