### PR TITLE
[refactor] Drop the testimonial-text filter from getCommunityMembers

### DIFF
--- a/apps/website/src/components/alumni/FeaturedAlumniStories.tsx
+++ b/apps/website/src/components/alumni/FeaturedAlumniStories.tsx
@@ -5,7 +5,7 @@ const FeaturedAlumniStories = () => {
   const { data } = trpc.testimonials.getCommunityMembers.useQuery();
 
   const stories: AlumniStory[] = (data ?? [])
-    .filter((t) => t.storyUrl)
+    .filter((t) => t.storyUrl && t.quote)
     .sort((a, b) => Number(!!b.isPrioritised) - Number(!!a.isPrioritised))
     .map((t) => ({
       name: t.name,

--- a/apps/website/src/components/alumni/FeaturedAlumniStories.tsx
+++ b/apps/website/src/components/alumni/FeaturedAlumniStories.tsx
@@ -5,7 +5,7 @@ const FeaturedAlumniStories = () => {
   const { data } = trpc.testimonials.getCommunityMembers.useQuery();
 
   const stories: AlumniStory[] = (data ?? [])
-    .filter((t) => t.storyUrl && t.quote)
+    .filter((t) => t.storyUrl && t.quote?.trim())
     .sort((a, b) => Number(!!b.isPrioritised) - Number(!!a.isPrioritised))
     .map((t) => ({
       name: t.name,

--- a/apps/website/src/components/alumni/RecentAlumniList.tsx
+++ b/apps/website/src/components/alumni/RecentAlumniList.tsx
@@ -12,7 +12,9 @@ const RecentAlumniList = () => {
   const { data } = trpc.testimonials.getCommunityMembers.useQuery();
   const [expanded, setExpanded] = useState(false);
 
-  const alumni = (data ?? []).filter((t) => !t.storyUrl);
+  const alumni = (data ?? [])
+    .filter((t) => !(t.storyUrl && t.quote))
+    .sort((a, b) => Number(!!b.storyUrl) - Number(!!a.storyUrl));
 
   if (alumni.length === 0) return null;
 
@@ -54,6 +56,8 @@ const RecentAlumniList = () => {
 };
 
 const AlumniRow = ({ alum }: { alum: TransformedTestimonial }) => {
+  const linkHref = alum.storyUrl ?? alum.url;
+
   const content = (
     <div className="flex items-center gap-3 py-3.5 border-b border-bluedot-navy/10">
       <AlumniAvatar
@@ -65,16 +69,16 @@ const AlumniRow = ({ alum }: { alum: TransformedTestimonial }) => {
         <P className="text-size-sm font-semibold leading-tight text-bluedot-navy truncate">{alum.name}</P>
         <P className="text-size-xs text-bluedot-navy/60 truncate">{alum.jobTitle}</P>
       </div>
-      {alum.url && (
+      {linkHref && (
         <span className="text-size-lg text-bluedot-normal flex-shrink-0" aria-hidden="true">→</span>
       )}
     </div>
   );
 
-  if (alum.url) {
+  if (linkHref) {
     return (
       <a
-        href={alum.url}
+        href={linkHref}
         target="_blank"
         rel="noopener noreferrer"
         className={clsx(

--- a/apps/website/src/components/lander/AiSafetyOpsLander.tsx
+++ b/apps/website/src/components/lander/AiSafetyOpsLander.tsx
@@ -28,7 +28,9 @@ const applicationUrl = 'https://forms.bluedot.org/1W29W7atNVeEF3RTkfCX';
 const AiSafetyOpsLander = () => {
   const { data: dbTestimonials } = trpc.testimonials.getCommunityMembers.useQuery();
 
-  const allTestimonials = dbTestimonials?.map((t): Testimonial => ({ ...t, role: t.jobTitle })) ?? [];
+  const allTestimonials = (dbTestimonials ?? [])
+    .filter((t) => t.quote?.trim())
+    .map((t): Testimonial => ({ ...t, role: t.jobTitle }));
 
   return (
     <>

--- a/apps/website/src/server/routers/testimonials.ts
+++ b/apps/website/src/server/routers/testimonials.ts
@@ -65,7 +65,7 @@ function transformTestimonial(t: Testimonial): TransformedTestimonial {
 export const testimonialsRouter = router({
   getCommunityMembers: publicProcedure.query(async () => {
     const all = await db.scan(testimonialTable);
-    const filtered = all.filter((t) => t.name && t.testimonialText?.trim());
+    const filtered = all.filter((t) => t.name);
     return sortTestimonials(filtered).map(transformTestimonial);
   }),
 


### PR DESCRIPTION
## Summary
- The homepage `TestimonialCarousel` runs with `hideQuotes={true}` and the alumni page's `RecentAlumniList` only shows portrait + name + role — neither consumer reads the quote. The server filter was hiding alumni from both surfaces just because their `testimonialText` field was empty.
- `getCommunityMembers`: drop the `t.testimonialText?.trim()` predicate. Now requires only a `name`.
- `FeaturedAlumniStories.tsx`: tighten the consumer filter to `t.storyUrl && t.quote` so the featured carousel still only shows cards with a quote to render (the carousel card visual depends on the quote).
- `getCommunityMembersByCourseSlug` (course landers) is unchanged — course pages still want quoted testimonials.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npx vitest run` — 820 passed | 1 skipped (821)
- [ ] After deploy: alumni without quotes appear on `/alumni` (in "Some of our alumni") and on the homepage community carousel (portrait-only cards)
- [ ] Course landers unchanged (still require a quote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)