### PR TITLE
New schema fields for facilitator applications

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1370,6 +1370,34 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       pgColumn: boolean(),
       airtableId: 'fld1KQjHFGoDZKf94',
     },
+    numGroupsToFacilitate: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldqirnvpnxjSzGPY',
+    },
+    formFeedback: {
+      pgColumn: text(),
+      airtableId: 'fldRGBrjMUHyUXRJr',
+    },
+    prevEngagement: {
+      pgColumn: text(),
+      airtableId: 'fldJAKX8Lcl5Qeq1K',
+    },
+    skills: {
+      pgColumn: text(),
+      airtableId: 'fldqNrt2OdsIsulMD',
+    },
+    impressiveProject: {
+      pgColumn: text(),
+      airtableId: 'fldL3qU8ILGYiF4ea',
+    },
+    motivationToFacilitate: {
+      pgColumn: text(),
+      airtableId: 'fldLoKwG59WWf8twB',
+    },
+    prevFacilitationExperience: {
+      pgColumn: text(),
+      airtableId: 'fld7qr6IyUtC4ILkT',
+    },
   },
 });
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

We're moving facilitator (re)applications into the course hub.

These are all optional fields that will be needed for showing previous answers when re-applying.

Tested by syncing locally and seeing new fields populated.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Part of #2528


