### PR TITLE
[feat] Add recommended-reading section to advising page

### DIFF
--- a/apps/website/src/components/advising/RecommendedReadingSection.tsx
+++ b/apps/website/src/components/advising/RecommendedReadingSection.tsx
@@ -1,0 +1,67 @@
+import { A, P } from '@bluedot/ui';
+import { pageSectionHeadingClass } from '../PageListRow';
+
+type Reading = {
+  title: string;
+  description: string;
+  url: string;
+};
+
+const READINGS: Reading[] = [
+  {
+    title: 'Your goal isn\'t really to get a job',
+    description: 'Advice from Matt Beard, an 80K advisor, to "get good, be known".',
+    url: 'https://thatvastvariety.substack.com/p/your-goal-isnt-really-to-get-a-job',
+  },
+  {
+    title: 'How to get into AI safety in 3 months',
+    description: 'Another piece by Matt Beard with concrete advice and examples.',
+    url: 'https://80000hours.substack.com/p/how-to-get-into-ai-safety-in-3-months',
+  },
+  {
+    title: 'We asked 10+ AI safety orgs about their hiring needs',
+    description: 'What they need most are people who can hit the ground running.',
+    url: 'https://blog.bluedot.org/p/we-asked-ai-safety-orgs-about-their-hiring-needs',
+  },
+  {
+    title: 'Roadmap through AI safety programs for early career technical researchers',
+    description: 'Provides an opinionated take for which programs to aim for.',
+    url: 'https://www.lesswrong.com/posts/muH6H9i8CtNAubcoo/roadmap-through-ai-safety-programs-for-early-career',
+  },
+  {
+    title: 'I\'m an experienced software engineer. How can I contribute to AI safety\?',
+    description: 'Maps out concrete contributions you can make.',
+    url: 'https://blog.bluedot.org/p/im-an-experienced-swe',
+  },
+];
+
+const RecommendedReadingSection = () => {
+  return (
+    <section className="section section-body advising-recommended-reading-section">
+      <div className="w-full flex flex-col gap-6">
+        <h3 className={pageSectionHeadingClass}>What our best advisees have in common</h3>
+
+        <P>
+          They read these before applying and acted on the advice. The call then builds on what they&apos;ve already tried.
+        </P>
+
+        <ul className="list-disc pl-6 flex flex-col gap-2">
+          {READINGS.map(({ title, description, url }) => (
+            <li key={url} className="text-bluedot-navy/80 leading-[1.6]">
+              <A
+                href={url}
+                target="_blank"
+                className="font-semibold"
+              >
+                {title}
+              </A>
+              {`. ${description}`}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default RecommendedReadingSection;

--- a/apps/website/src/components/advising/RecommendedReadingSection.tsx
+++ b/apps/website/src/components/advising/RecommendedReadingSection.tsx
@@ -29,7 +29,7 @@ const READINGS: Reading[] = [
     url: 'https://www.lesswrong.com/posts/muH6H9i8CtNAubcoo/roadmap-through-ai-safety-programs-for-early-career',
   },
   {
-    title: 'I\'m an experienced software engineer. How can I contribute to AI safety\?',
+    title: 'I\'m an experienced software engineer. How can I contribute to AI safety?',
     description: 'Maps out concrete contributions you can make.',
     url: 'https://blog.bluedot.org/p/im-an-experienced-swe',
   },

--- a/apps/website/src/pages/programs/advising.tsx
+++ b/apps/website/src/pages/programs/advising.tsx
@@ -8,6 +8,7 @@ import GrantCta from '../../components/grants/sections/GrantCta';
 import WhatThisIsForSection from '../../components/advising/WhatThisIsForSection';
 import WhoYouAreSection from '../../components/advising/WhoYouAreSection';
 import WhatToExpectSection from '../../components/advising/WhatToExpectSection';
+import RecommendedReadingSection from '../../components/advising/RecommendedReadingSection';
 import HowItWorksSection from '../../components/advising/HowItWorksSection';
 import AdvisorsSection from '../../components/advising/AdvisorsSection';
 import { ROUTES } from '../../lib/routes';
@@ -48,6 +49,7 @@ const OneOnOneAdvisingPage = ({ programName, programDescription }: ProgramDetail
       <WhatThisIsForSection />
       <WhoYouAreSection />
       <WhatToExpectSection />
+      <RecommendedReadingSection />
       <HowItWorksSection />
       <AdvisorsSection />
       <GrantFaqSection program="advising" />


### PR DESCRIPTION
# Description

The advising page currently surfaces no pre-call resources, so applicants arrive at the 30-minute call with widely varying baselines — and the call ends up covering field-overview questions that good external writing already answers well.

This adds a "What our best advisees have in common" section between "What to expect" and "How it works", linking five articles on AI safety career strategy, hiring needs, and program roadmaps. Framing is identity-based ("advisees who get the most from these calls arrive having read these"), not instructional. It's a soft signal — no gating on the application flow, just a visible cue at the highest-intent moment.

## What changed

1. **`apps/website/src/components/advising/RecommendedReadingSection.tsx`** — new section component. Pure-static (no props, no data fetching), with the section heading, intro paragraph, and a bulleted list of `<A>` links plus descriptions. Uses the same `pageSectionHeadingClass` + `text-bluedot-navy/80 leading-[1.6]` list-item pattern as sibling advising sections.
2. **`apps/website/src/pages/programs/advising.tsx`** — imports the new section and mounts it between `WhatToExpectSection` and `HowItWorksSection`.

## Issue

N/A — content/UX improvement, no linked issue.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) — semantic `<section>`/`<h3>`/`<ul>`/`<li>` structure mirrors the other advising sections; external links go through the shared `<A>` component (target=`_blank`, with `rel="noopener noreferrer"` applied automatically by the underlying `ClickTarget`).
- [x] Considered having snapshot tests / functional tests — declined. The section has no props, no state, no branching, and no data fetching; this matches the convention for `WhatThisIsForSection`, `WhoYouAreSection`, `WhatToExpectSection`, and `HowItWorksSection`, none of which have dedicated tests.
- [x] Considered adding Storybook stories — declined per `apps/website/CLAUDE.md` ("Skip stories for pure-static marketing sections with no props, no data fetching, and no variants — the live page at the corresponding route is already the canonical preview"). Matches sibling static advising sections; only `AdvisorsSection` (which is data-driven via tRPC and has loading/empty/error states) has a story.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8003` in the `anglilian/advising-recommended-reading` worktree, opened in Arc):
- ✅ `/programs/advising` — new section renders between "What to expect" and "How it works", links underlined with the standard `<A>` styling and hover into brand blue, descriptions match the source articles, list order goes general-mindset → tactical-3-month → field-hiring → programs roadmap → SWE-specific.

Lint and full test suite pass:
\`\`\`
npx eslint . --report-unused-disable-directives --max-warnings=0   # clean
npx vitest run                                                     # 820 passed | 1 skipped (118 files)
npx vitest run                                                     # confirmed stable on second run
\`\`\`

Typecheck reproduces a pre-existing `src/__tests__/testUtils.ts` error on clean `origin/master` from the facilitator schema PR (#2563) — unrelated to this change.

## Screenshots

![Uploading CleanShot 2026-05-27 at 22.48.33@2x.png…]()

🤖 Generated with [Claude Code](https://claude.com/claude-code)