### PR TITLE
[fix] Facilitators can only withdraw an application before it is accepted

### DIFF
--- a/apps/website/src/components/courses/DropoutModal.stories.tsx
+++ b/apps/website/src/components/courses/DropoutModal.stories.tsx
@@ -105,6 +105,33 @@ export const NoUpcomingRounds: Story = {
   },
 };
 
+export const Withdraw: Story = {
+  args: {
+    handleClose() {},
+    applicantId: 'rec123456789',
+    courseSlug: 'agi-safety-fundamentals',
+    currentRoundId: null,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        courseRoundsHandler,
+        trpcStorybookMsw.courseRegistrations.getAll.query(() => [
+          createMockCourseRegistration({ id: 'rec123456789', decision: null }),
+        ]),
+        trpcStorybookMsw.dropout.dropoutOrDeferral.mutation(async ({ input }) => ({
+          id: 'new-dropout-id',
+          applicantId: [input.applicantId],
+          reason: input.reason ?? null,
+          type: input.type,
+          newRoundId: null,
+          oldRoundId: null,
+        })),
+      ],
+    },
+  },
+};
+
 export const Facilitator: Story = {
   args: {
     handleClose() {},

--- a/apps/website/src/components/courses/DropoutModal.test.tsx
+++ b/apps/website/src/components/courses/DropoutModal.test.tsx
@@ -148,4 +148,49 @@ describe('DropoutModal', () => {
     });
     expect(submittedType).toBe('Drop out');
   });
+
+  it('renders the withdraw confirm for a pre-decision registration', async () => {
+    const user = userEvent.setup();
+    let submittedType: string | undefined;
+
+    server.use(
+      trpcMsw.courseRegistrations.getAll.query(() => [
+        createMockCourseRegistration({ id: 'reg-pre', decision: null }),
+      ]),
+      trpcMsw.dropout.dropoutOrDeferral.mutation(({ input }) => {
+        submittedType = input.type;
+        return {
+          id: 'new-dropout-id',
+          applicantId: [input.applicantId],
+          reason: input.reason ?? null,
+          type: input.type,
+          newRoundId: null,
+          oldRoundId: null,
+        };
+      }),
+    );
+
+    render(
+      <DropoutModal
+        applicantId="reg-pre"
+        courseSlug="ai-safety"
+        currentRoundId={null}
+        handleClose={vi.fn()}
+      />,
+      { wrapper: TrpcProvider },
+    );
+
+    // No chooser is rendered; just Cancel + Confirm.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Action type' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Your application has been withdrawn/)).toBeInTheDocument();
+    });
+    expect(submittedType).toBe('Drop out');
+  });
 });

--- a/apps/website/src/components/courses/DropoutModal.tsx
+++ b/apps/website/src/components/courses/DropoutModal.tsx
@@ -1,5 +1,5 @@
 import {
-  CTALinkOrButton, H1, Modal, P, ProgressDots, Select, Textarea,
+  CTALinkOrButton, ErrorSection, H1, Modal, P, ProgressDots, Select, Textarea,
 } from '@bluedot/ui';
 import { useMemo, useState } from 'react';
 import type { CourseRound, CourseRoundsData } from '../../server/routers/course-rounds';
@@ -74,7 +74,8 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
   const { data: courseRounds } = trpc.courseRounds.getRoundsForCourse.useQuery({ courseSlug });
 
   const { data: registrations } = trpc.courseRegistrations.getAll.useQuery();
-  const allowDeferral = registrations?.find((r) => r.id === applicantId)?.role !== 'Facilitator';
+  const registration = registrations?.find((r) => r.id === applicantId);
+  const allowDeferral = registration?.role !== 'Facilitator';
 
   const isDeferral = dropoutType === 'Deferral';
 
@@ -82,6 +83,11 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
     'Part-time': courseRounds ? filterFutureRounds(courseRounds.partTime) : [],
     Intensive: courseRounds ? filterFutureRounds(courseRounds.intense) : [],
   }), [courseRounds]);
+
+  // Pre-decision registrations get a simple "withdraw application" confirm, not the drop/defer chooser.
+  if (registration?.decision === null) {
+    return <WithdrawConfirm applicantId={applicantId} handleClose={handleClose} />;
+  }
 
   const effectiveIntensity: Intensity = intensity
     ?? intensityOfRound(courseRounds, currentRoundId)
@@ -271,6 +277,74 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
         <form className="flex flex-col gap-8" onSubmit={(e) => e.preventDefault()}>
           {dropoutMutation.isSuccess ? renderSuccess() : renderForm()}
         </form>
+      </div>
+    </Modal>
+  );
+};
+
+const WithdrawConfirm: React.FC<{ applicantId: string; handleClose: () => void }> = ({
+  applicantId, handleClose,
+}) => {
+  const utils = trpc.useUtils();
+  const mutation = trpc.dropout.dropoutOrDeferral.useMutation();
+
+  const handleCloseWithInvalidation = () => {
+    if (mutation.isSuccess) {
+      void utils.meetPerson.getInactiveCourseRegistrations.invalidate();
+      void utils.dropout.getStatusForUser.invalidate();
+      void utils.courseRegistrations.getAll.invalidate();
+      void utils.myBluedot.myCoursesPage.invalidate();
+      void utils.myBluedot.facilitatedCoursesPage.invalidate();
+    }
+
+    handleClose();
+  };
+
+  const handleConfirm = () => mutation.mutate({ applicantId, type: 'Drop out' });
+
+  return (
+    <Modal
+      isOpen
+      setIsOpen={(open: boolean) => !open && handleCloseWithInvalidation()}
+      title={(
+        <div className="flex w-full items-center justify-center gap-2">
+          <div className="text-size-md font-semibold">
+            {mutation.isSuccess ? 'Application withdrawn' : 'Withdraw application'}
+          </div>
+        </div>
+      )}
+      bottomDrawerOnMobile
+      desktopHeaderClassName="border-b border-charcoal-light pt-6 pb-3"
+    >
+      <div className="flex w-full flex-col gap-4 md:w-[400px]">
+        {mutation.isSuccess ? (
+          <>
+            <div className="bg-bluedot-normal/10 self-center rounded-full p-4">
+              <CheckIcon className="text-bluedot-normal" />
+            </div>
+            <P className="text-bluedot-navy/80 text-center text-pretty">
+              Your application has been withdrawn. If this was a mistake, please email us.
+            </P>
+            <CTALinkOrButton className="bg-bluedot-normal w-full" onClick={handleCloseWithInvalidation}>
+              Close
+            </CTALinkOrButton>
+          </>
+        ) : (
+          <>
+            <P className="text-bluedot-navy/80 text-pretty">
+              Are you sure? You&apos;ll need to re-apply if you change your mind.
+            </P>
+            {mutation.isError && <ErrorSection error={mutation.error} />}
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <CTALinkOrButton variant="secondary" className="w-full sm:w-auto" onClick={handleCloseWithInvalidation} disabled={mutation.isPending}>
+                Cancel
+              </CTALinkOrButton>
+              <CTALinkOrButton className="bg-bluedot-normal w-full sm:w-auto" onClick={handleConfirm} disabled={mutation.isPending}>
+                Confirm
+              </CTALinkOrButton>
+            </div>
+          </>
+        )}
       </div>
     </Modal>
   );

--- a/apps/website/src/components/my-courses/CourseListRow.stories.tsx
+++ b/apps/website/src/components/my-courses/CourseListRow.stories.tsx
@@ -291,6 +291,23 @@ const facilitatorPendingArgs = stubFacilitator({
   meetPersonId: 'mp-fac-pending',
 });
 
+// Facilitator application still in review (Future + decision: null). Overflow should offer "Withdraw application".
+const facilitatorInReviewArgs = stubFacilitator({
+  courseRegistration: {
+    id: 'reg-fac-in-review',
+    roundStatus: 'Future',
+    decision: null,
+    roundId: 'round-fac-in-review',
+    roundName: 'Technical AI Safety (2026 May W21) - Intensive',
+  } as FacilitatorRowProps['courseRegistration'],
+  course: { slug: 'technical-ai-safety', title: 'Technical AI Safety', applyUrl: null },
+  group: null,
+  roundStartDate: '2026-05-18',
+  roundEndDate: '2026-05-25',
+  roundIntensity: 'Intensive',
+  meetPersonId: 'mp-fac-in-review',
+});
+
 const facilitatorPastNeedFeedbackArgs = stubFacilitator({
   courseRegistration: {
     id: 'reg-fac-past-need',
@@ -351,6 +368,7 @@ const ALL_FACILITATOR = [
   { id: 'fac-in-progress-parttime', args: facilitatorInProgressPartTimeArgs },
   { id: 'fac-upcoming', args: facilitatorUpcomingArgs },
   { id: 'fac-pending', args: facilitatorPendingArgs },
+  { id: 'fac-in-review', args: facilitatorInReviewArgs },
   { id: 'fac-past-need-feedback', args: facilitatorPastNeedFeedbackArgs },
   { id: 'fac-past-feedback-submitted', args: facilitatorPastFeedbackSubmittedArgs },
 ];
@@ -392,5 +410,6 @@ export const FacilitatorInProgressIntensive: Story = { args: facilitatorInProgre
 export const FacilitatorInProgressPartTime: Story = { args: facilitatorInProgressPartTimeArgs };
 export const FacilitatorUpcoming: Story = { args: facilitatorUpcomingArgs };
 export const FacilitatorPending: Story = { args: facilitatorPendingArgs };
+export const FacilitatorInReview: Story = { args: facilitatorInReviewArgs };
 export const FacilitatorPastNeedFeedback: Story = { args: facilitatorPastNeedFeedbackArgs };
 export const FacilitatorPastFeedbackSubmitted: Story = { args: facilitatorPastFeedbackSubmittedArgs };

--- a/apps/website/src/components/my-courses/CourseListRow.test.tsx
+++ b/apps/website/src/components/my-courses/CourseListRow.test.tsx
@@ -507,7 +507,7 @@ describe('CourseListRow actions', () => {
       test('no participant-only overflow items', () => {
         const { container } = renderFacRow(facProps());
         const items = openOverflowItems(container);
-        expect(items).not.toContain('Drop out');
+        expect(items).not.toContain('Withdraw application');
         expect(items).not.toContain('Switch group permanently');
       });
 
@@ -566,11 +566,6 @@ describe('CourseListRow actions', () => {
         expect(inlineLabels(container)).toContain('Edit your availability');
       });
 
-      test('overflow offers only "Drop out"', () => {
-        const { container } = renderFacRow(pending());
-        expect(openOverflowItems(container)).toEqual(['Drop out']);
-      });
-
       test('no availability CTA when application was rejected', () => {
         const { container } = renderFacRow(pending({
           courseRegistration: createMockCourseRegistration({ roundStatus: 'Future', decision: 'Reject', role: 'Facilitator' }),
@@ -579,30 +574,31 @@ describe('CourseListRow actions', () => {
         expect(labels).not.toContain('Share availability');
         expect(labels).not.toContain('Edit your availability');
       });
-
-      test('no "Drop out" when application was rejected', () => {
-        const { container } = renderFacRow(pending({
-          courseRegistration: createMockCourseRegistration({ roundStatus: 'Future', decision: 'Reject', role: 'Facilitator' }),
-        }));
-        expect(openOverflowItems(container)).not.toContain('Drop out');
-      });
     });
 
-    describe('Drop out (facilitators cannot defer)', () => {
-      test('shown on a pending application (upcoming, no group assigned yet)', () => {
+    describe('Withdraw application', () => {
+      test('shown while the application is in review on an upcoming round', () => {
+        const { container } = renderFacRow(facProps({
+          courseRegistration: createMockCourseRegistration({ roundStatus: 'Future', decision: null, role: 'Facilitator' }),
+          group: null,
+        }));
+        expect(openOverflowItems(container)).toContain('Withdraw application');
+      });
+
+      test('hidden once the application is accepted', () => {
         const { container } = renderFacRow(facProps({
           courseRegistration: createMockCourseRegistration({ roundStatus: 'Future', decision: 'Accept', role: 'Facilitator' }),
           group: null,
         }));
-        expect(openOverflowItems(container)).toContain('Drop out');
+        expect(openOverflowItems(container)).not.toContain('Withdraw application');
       });
 
-      test('hidden once a group is assigned, even before the round starts', () => {
+      test('hidden when the application was rejected', () => {
         const { container } = renderFacRow(facProps({
-          courseRegistration: createMockCourseRegistration({ roundStatus: 'Future', decision: 'Accept', role: 'Facilitator' }),
-          // facProps default supplies a group
+          courseRegistration: createMockCourseRegistration({ roundStatus: 'Future', decision: 'Reject', role: 'Facilitator' }),
+          group: null,
         }));
-        expect(openOverflowItems(container)).not.toContain('Drop out');
+        expect(openOverflowItems(container)).not.toContain('Withdraw application');
       });
     });
 
@@ -614,7 +610,7 @@ describe('CourseListRow actions', () => {
           isDroppedOut: true,
         }));
         expect(container.textContent).toContain('Dropped');
-        expect(openOverflowItems(container)).not.toContain('Drop out');
+        expect(openOverflowItems(container)).not.toContain('Withdraw application');
       });
     });
 
@@ -641,12 +637,12 @@ describe('CourseListRow actions', () => {
         expect(labels).not.toContain('Edit feedback');
       });
 
-      test('past overflow keeps doc/slack/participants but drops Update discussion time and Drop out', () => {
+      test('past overflow keeps doc/slack/participants but drops Update discussion time and Withdraw application', () => {
         const { container } = renderFacRow(past());
         const items = openOverflowItems(container);
         expect(items).toEqual(expect.arrayContaining(['Open discussion doc', 'Open Slack group', 'View participants']));
         expect(items).not.toContain('Update discussion time');
-        expect(items).not.toContain('Drop out');
+        expect(items).not.toContain('Withdraw application');
       });
     });
 

--- a/apps/website/src/components/my-courses/CourseListRow.test.tsx
+++ b/apps/website/src/components/my-courses/CourseListRow.test.tsx
@@ -373,10 +373,10 @@ describe('CourseListRow actions', () => {
       expect(openOverflowItems(container)).toContain('Drop or defer course');
     });
 
-    test('shown on upcoming + null decision (in-review applicants can withdraw, matching legacy)', () => {
+    test('shown as "Withdraw application" on upcoming + null decision (in-review applicants)', () => {
       const upcomingPending = createMockCourseRegistration({ roundStatus: 'Future', decision: null });
       const { container } = renderRow(baseProps({ courseRegistration: upcomingPending }));
-      expect(openOverflowItems(container)).toContain('Drop or defer course');
+      expect(openOverflowItems(container)).toContain('Withdraw application');
     });
 
     test('hidden on upcoming + Reject (rejected applicants do not see drop)', () => {

--- a/apps/website/src/components/my-courses/useCourseListRow.tsx
+++ b/apps/website/src/components/my-courses/useCourseListRow.tsx
@@ -265,6 +265,12 @@ const deriveCourseRowState = (row: CourseListRowProps, utmSource: string | undef
   };
 };
 
+export const getApplicationActionLabel = (cr: CourseRegistration, state: CourseRowState): string => (
+  state === 'upcoming' && cr.decision === null
+    ? 'Withdraw application'
+    : 'Drop or defer course'
+);
+
 const getParticipantActions = (
   row: ParticipantRowProps,
   derived: CourseRowDerivedState,
@@ -396,7 +402,9 @@ const getParticipantActions = (
       isVisible: state === 'in-progress' || (state === 'upcoming' && courseRegistration.decision !== 'Reject'),
       variant: 'overflow',
       overflow: {
-        id: 'drop', label: 'Drop or defer course', onAction: triggers.openDropout,
+        id: 'drop',
+        label: getApplicationActionLabel(courseRegistration, state),
+        onAction: triggers.openDropout,
       },
     },
   ];
@@ -513,7 +521,7 @@ const getFacilitatorActions = (
       isVisible: state === 'upcoming' && courseRegistration.decision === null,
       variant: 'overflow',
       overflow: {
-        id: 'withdraw', label: 'Withdraw application', onAction: triggers.openDropout,
+        id: 'withdraw', label: getApplicationActionLabel(courseRegistration, state), onAction: triggers.openDropout,
       },
     },
   ];

--- a/apps/website/src/components/my-courses/useCourseListRow.tsx
+++ b/apps/website/src/components/my-courses/useCourseListRow.tsx
@@ -509,12 +509,11 @@ const getFacilitatorActions = (
       },
     },
     {
-      // Pending => no group. Once a facilitator has a group assigned, don't let them drop out (they would need to ask via Slack)
-      id: 'drop',
-      isVisible: isPending && courseRegistration.decision !== 'Reject',
+      id: 'withdraw',
+      isVisible: state === 'upcoming' && courseRegistration.decision === null,
       variant: 'overflow',
       overflow: {
-        id: 'drop', label: 'Drop out', onAction: triggers.openDropout,
+        id: 'withdraw', label: 'Withdraw application', onAction: triggers.openDropout,
       },
     },
   ];

--- a/apps/website/src/server/routers/dropout.test.ts
+++ b/apps/website/src/server/routers/dropout.test.ts
@@ -45,12 +45,20 @@ describe('dropout.dropoutOrDeferral', () => {
     expect(result).toBeTruthy();
   });
 
-  test('lets a participant defer', async () => {
-    await insertRegistration({ role: 'Participant' });
+  test('lets a participant defer once accepted', async () => {
+    await insertRegistration({ role: 'Participant', decision: 'Accept' });
 
     const result = await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
       applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-2',
     });
     expect(result).toBeTruthy();
+  });
+
+  test('rejects a pre-decision participant deferral', async () => {
+    await insertRegistration({ role: 'Participant', decision: null });
+
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-2',
+    })).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 });

--- a/apps/website/src/server/routers/dropout.test.ts
+++ b/apps/website/src/server/routers/dropout.test.ts
@@ -28,8 +28,16 @@ describe('dropout.dropoutOrDeferral', () => {
     })).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
-  test('lets a facilitator drop out', async () => {
-    await insertRegistration({ role: 'Facilitator' });
+  test('rejects a drop-out from a facilitator once accepted', async () => {
+    await insertRegistration({ role: 'Facilitator', decision: 'Accept' });
+
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Drop out',
+    })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  test('lets a facilitator withdraw before acceptance (decision = null)', async () => {
+    await insertRegistration({ role: 'Facilitator', decision: null });
 
     const result = await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
       applicantId: 'reg-1', type: 'Drop out',

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -66,8 +66,14 @@ export const dropoutRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Course registration not found' });
       }
 
-      if (type === 'Deferral' && courseRegistration.role === 'Facilitator') {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Facilitators cannot defer a course.' });
+      if (courseRegistration.role === 'Facilitator') {
+        if (type === 'Deferral') {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Facilitators cannot defer a course.' });
+        }
+
+        if (courseRegistration.decision !== null) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Facilitators can only withdraw an application that has not yet been accepted.' });
+        }
       }
 
       const oldRoundId = courseRegistration.roundId ?? null;

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -66,13 +66,17 @@ export const dropoutRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Course registration not found' });
       }
 
+      if (type === 'Deferral' && courseRegistration.decision === null) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Deferral is only available once an application decision has been made.' });
+      }
+
       if (courseRegistration.role === 'Facilitator') {
         if (type === 'Deferral') {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'Facilitators cannot defer a course.' });
         }
 
         if (courseRegistration.decision !== null) {
-          throw new TRPCError({ code: 'FORBIDDEN', message: 'Facilitators can only withdraw an application that has not yet been accepted.' });
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Facilitators can only withdraw an application that is still pending.' });
         }
       }
 


### PR DESCRIPTION
# Description

- Previously: Facilitators could withdraw before they were _assigned to a group_, both facilitators and participants were shown the full "Drop out or defer" modal
- Now:
  - Facilitators can only withdraw before they are _accepted_
  - For the case before someone is accepted, a simpler "Withdraw application" modal is shown (to both facilitators and participants). Behind the scenes this does the same thing as "Drop out"

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2551

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

_Focusing on the withdraw-before-start case_

Note: I am aware the padding is a little ugly on the modal. This is coming from the outer `Modal` component so is fiddly to change.

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="662" height="1462" alt="Screenshot 2026-05-31 at 11 47 49" src="https://github.com/user-attachments/assets/c6c16168-5501-4724-9a27-8818d8abdb27" /> | <img width="664" height="1468" alt="Screenshot 2026-05-31 at 11 46 30" src="https://github.com/user-attachments/assets/0ae43ef5-03b8-4b4c-b8ff-12be41134e5a" /> |
| | <img width="662" height="1462" alt="Screenshot 2026-05-31 at 11 47 53" src="https://github.com/user-attachments/assets/d7ee870b-1a60-42c1-adc8-e3972fe00c81" /> | <img width="664" height="1468" alt="Screenshot 2026-05-31 at 11 46 42" src="https://github.com/user-attachments/assets/a89165e7-aa1c-4d10-8a80-d7aa123bba81" /> |
| | | <img width="654" height="1462" alt="Screenshot 2026-05-31 at 11 50 57" src="https://github.com/user-attachments/assets/bb192dd1-d1ef-4d40-ac86-9f78a94e9b17" /> |
| 🖥️ | <img width="2524" height="1256" alt="Screenshot 2026-05-31 at 11 47 22" src="https://github.com/user-attachments/assets/eb7c40da-e266-40ec-9c05-62837be050c4" /> | <img width="2520" height="1334" alt="Screenshot 2026-05-31 at 11 46 11" src="https://github.com/user-attachments/assets/89236ae0-172e-4fd5-9d44-c6029e496134" /> |
| | <img width="2524" height="1640" alt="Screenshot 2026-05-31 at 11 47 31" src="https://github.com/user-attachments/assets/46812b89-6943-49ef-88bb-97f8ea910fb5" /> | <img width="2520" height="1334" alt="Screenshot 2026-05-31 at 11 46 21" src="https://github.com/user-attachments/assets/5b312d0f-ca82-462c-a8d3-aabbc4c55d15" /> |
| | | <img width="1704" height="1462" alt="Screenshot 2026-05-31 at 11 50 47" src="https://github.com/user-attachments/assets/c6a6bf98-0b6d-4d30-87c4-4dc811e75dcc" /> |
