### PR TITLE
[refactor] db: drop redundant transaction wrap in ensureReplicated

### DIFF
--- a/libraries/db/src/lib/client.ts
+++ b/libraries/db/src/lib/client.ts
@@ -464,37 +464,34 @@ export class PgAirtableDb {
     /** Must be passed explicitly for a record to be deleted. */
     isDelete?: boolean;
   }): Promise<BasePgTableType<TTableName, TColumnsMap>['$inferSelect'] | undefined> {
-    return this.pgUnrestricted.transaction(async (tx) => {
-      if (isDelete) {
-        const deletedResults = await tx.delete(table.pg).where(eq(table.pg.id, id)).returning();
-        const deletedResult = Array.isArray(deletedResults) ? deletedResults[0] : undefined;
+    if (isDelete) {
+      const deletedResults = await this.pgUnrestricted.delete(table.pg).where(eq(table.pg.id, id)).returning();
+      const deletedResult = Array.isArray(deletedResults) ? deletedResults[0] : undefined;
 
-        if (!deletedResult) {
-          return undefined;
-        }
-
-        return deletedResult;
+      if (!deletedResult) {
+        return undefined;
       }
 
-      const data = fullData ?? await this.airtableClient.get(table.airtable, id);
+      return deletedResult;
+    }
 
-      if (!data) {
-        throw new Error('No data found for upsert operation');
-      }
+    const data = fullData ?? await this.airtableClient.get(table.airtable, id);
 
-      // TODO For updates, check if there are changes with SELECT first to avoid acquiring a lock
-      const rows = await tx.insert(table.pg).values(data as PgInsertValue<typeof table.pg>).onConflictDoUpdate({
-        target: table.pg.id,
-        set: data as PgUpdateSetSource<typeof table.pg>,
-      }).returning();
+    if (!data) {
+      throw new Error('No data found for upsert operation');
+    }
 
-      const result = Array.isArray(rows) ? rows[0] : undefined;
+    const rows = await this.pgUnrestricted.insert(table.pg).values(data as PgInsertValue<typeof table.pg>).onConflictDoUpdate({
+      target: table.pg.id,
+      set: data as PgUpdateSetSource<typeof table.pg>,
+    }).returning();
 
-      if (!result) {
-        throw new Error('Unexpected error: Nothing returned from upsert operation');
-      }
+    const result = Array.isArray(rows) ? rows[0] : undefined;
 
-      return result;
-    });
+    if (!result) {
+      throw new Error('Unexpected error: Nothing returned from upsert operation');
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
# Description

The `pgUnrestricted.transaction(...)` wrap in `ensureReplicated` was redundant: each branch (delete, or upsert) executes exactly one SQL statement. The explicit BEGIN/COMMIT added 2 PG round trips per row with no atomicity benefit.

Discovered as part of [#2544](https://github.com/bluedotimpact/bluedot/issues/2544#issuecomment-4564020063)

## Issue

Related to #2544.

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories