### PR TITLE
Write foreign keys for resource completions and exercise responses directly

### DIFF
--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -5,6 +5,7 @@ import {
   exerciseTable,
   groupTable,
   meetPersonTable,
+  userTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
@@ -80,6 +81,28 @@ describe('exercises.saveExerciseResponse', () => {
       completedAt: null,
     });
     expect(result.id).toBeDefined();
+  });
+
+  test('writes userId on insert when the user exists', async () => {
+    await testDb.insert(userTable, {
+      id: 'user-1', email: CALLER_EMAIL, name: 'Test User',
+    });
+
+    const result = await caller.exercises.saveExerciseResponse({
+      exerciseId: 'exercise-1',
+      response: 'My answer',
+    });
+
+    expect(result.userId).toEqual(['user-1']);
+  });
+
+  test('leaves userId null on insert when the user row is missing', async () => {
+    const result = await caller.exercises.saveExerciseResponse({
+      exerciseId: 'exercise-1',
+      response: 'My answer',
+    });
+
+    expect(result.userId).toBeNull();
   });
 
   test('updates an existing response', async () => {

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -13,6 +13,7 @@ import {
   isNull,
   meetPersonTable,
   or,
+  userTable,
 } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
@@ -52,14 +53,14 @@ export const exercisesRouter = router({
         completedAt = null;
       } // else undefined = "don't change"
 
-      // Fetch the exercise in parallel with the existing-response lookup so the FoAI auto-complete doesn't add latency.
-      const [existingResponse, exercise] = await Promise.all([
+      const [existingResponse, exercise, user] = await Promise.all([
         db.getFirst(exerciseResponseTable, {
           filter: { exerciseId: input.exerciseId, email: ctx.auth.email },
         }),
         input.completed === true
           ? db.getFirst(exerciseTable, { filter: { id: input.exerciseId }, sortBy: 'id' })
           : Promise.resolve(undefined),
+        db.getFirst(userTable, { filter: { email: ctx.auth.email } }),
       ]);
 
       const exerciseResponse = existingResponse
@@ -74,6 +75,7 @@ export const exercisesRouter = router({
           exerciseId: input.exerciseId,
           response: input.response,
           completedAt: completedAt ?? null,
+          userId: user ? [user.id] : null,
         });
 
       const certificateIssued = exercise?.courseId === FOAI_COURSE_ID

--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -1,0 +1,69 @@
+import {
+  courseBuilderUserTable,
+  resourceCompletionTable,
+  unitResourceTable,
+} from '@bluedot/db';
+import { describe, expect, test } from 'vitest';
+import {
+  createCaller,
+  setupTestDb,
+  testAuthContextLoggedIn,
+  testDb,
+} from '../../__tests__/dbTestUtils';
+
+setupTestDb();
+
+const caller = createCaller(testAuthContextLoggedIn);
+const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;
+
+describe('resources.saveResourceCompletion', () => {
+  test('writes resourceId and createdByUserId on insert when both can be resolved', async () => {
+    await testDb.insert(courseBuilderUserTable, { id: 'cb-user-1', email: CALLER_EMAIL });
+    await testDb.insert(unitResourceTable, { id: 'ur-1', resourceId: ['resource-1'] });
+
+    const result = await caller.resources.saveResourceCompletion({
+      unitResourceId: 'ur-1',
+      isCompleted: true,
+    });
+
+    expect(result).toMatchObject({
+      unitResourceId: 'ur-1',
+      isCompleted: true,
+      resourceId: ['resource-1'],
+      createdByUserId: ['cb-user-1'],
+    });
+  });
+
+  test('leaves the FK fields null on insert when the lookups miss', async () => {
+    const result = await caller.resources.saveResourceCompletion({
+      unitResourceId: 'ur-missing',
+      isCompleted: true,
+    });
+
+    expect(result.resourceId).toBeNull();
+    expect(result.createdByUserId).toBeNull();
+  });
+
+  test('updates an existing completion without touching the FK fields', async () => {
+    await testDb.insert(resourceCompletionTable, {
+      id: 'rc-1',
+      email: CALLER_EMAIL,
+      unitResourceId: 'ur-1',
+      isCompleted: false,
+      resourceId: ['resource-original'],
+      createdByUserId: ['cb-user-original'],
+    });
+
+    const result = await caller.resources.saveResourceCompletion({
+      unitResourceId: 'ur-1',
+      isCompleted: true,
+    });
+
+    expect(result).toMatchObject({
+      id: 'rc-1',
+      isCompleted: true,
+      resourceId: ['resource-original'],
+      createdByUserId: ['cb-user-original'],
+    });
+  });
+});

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -1,5 +1,5 @@
 import {
-  and, desc, eq, inArray, resourceCompletionTable,
+  and, courseBuilderUserTable, desc, eq, inArray, resourceCompletionTable, unitResourceTable,
 } from '@bluedot/db';
 import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
 import { z } from 'zod';
@@ -54,12 +54,16 @@ export const resourcesRouter = router({
         .optional(),
     }))
     .mutation(async ({ input, ctx }) => {
-      const resourceCompletion = await db.getFirst(resourceCompletionTable, {
-        filter: {
-          unitResourceId: input.unitResourceId,
-          email: ctx.auth.email,
-        },
-      });
+      const [resourceCompletion, unitResource, cbUser] = await Promise.all([
+        db.getFirst(resourceCompletionTable, {
+          filter: {
+            unitResourceId: input.unitResourceId,
+            email: ctx.auth.email,
+          },
+        }),
+        db.getFirst(unitResourceTable, { filter: { id: input.unitResourceId }, sortBy: 'id' }),
+        db.getFirst(courseBuilderUserTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),
+      ]);
 
       let updatedResourceCompletion;
 
@@ -81,6 +85,8 @@ export const resourcesRouter = router({
           isCompleted: input.isCompleted ?? false,
           feedback: input.feedback ?? '',
           resourceFeedback: input.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
+          resourceId: unitResource?.resourceId ?? null,
+          createdByUserId: cbUser ? [cbUser.id] : null,
         });
       }
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1521,8 +1521,7 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
       pgColumn: text().array(),
       airtableId: 'fldlRVze2fMzrVX6M',
     },
-    // Points at courseBuilderUserTable (the Course-builder-base sync of User), not the
-    // Applications-base userTable — record IDs differ between the two.
+    // Points at courseBuilderUserTable (the Course-builder-base sync of User)
     createdByUserId: {
       pgColumn: text().array(),
       airtableId: 'fldtEFIAKCUctCDhW',


### PR DESCRIPTION
# Description

Replaces these automations (we can turn them off once this is merged, though it's safe to leave them on):
>- Course builder
>  - Resource completion <> Resource
>    - Links resource completion to resource directly, based on existing link to "unit resource"
>  - Link resource completion <> user
>    - Links to user based on email
>  - Link exercise response <> exercise
>    - Link based on "exercise record ID" (seems unnecessary in current system)
>- Applications
>  - Link exercise response <> user
>    - Links to user based on email

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2581 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
