### PR TITLE
[refactor] Rename facilitator-feedback route param: [groupId] -> [meetPersonId] (#2487)

### DIFF
--- a/apps/website/src/__tests__/pages/facilitator-feedback/[meetPersonId].test.tsx
+++ b/apps/website/src/__tests__/pages/facilitator-feedback/[meetPersonId].test.tsx
@@ -5,7 +5,7 @@ import {
   beforeEach, describe, expect, type Mock, test, vi,
 } from 'vitest';
 import { useRouter } from 'next/router';
-import FacilitatorFeedbackPage from '../../../pages/facilitator-feedback/[groupId]';
+import FacilitatorFeedbackPage from '../../../pages/facilitator-feedback/[meetPersonId]';
 import { TrpcProvider } from '../../trpcProvider';
 import { server, trpcMsw } from '../../trpcMswSetup';
 
@@ -14,10 +14,10 @@ vi.mock('next/router', () => ({
 }));
 
 const mockRouter = {
-  query: { groupId: 'rec-facilitator' },
+  query: { meetPersonId: 'rec-facilitator' },
   isReady: true,
   asPath: '/facilitator-feedback/rec-facilitator',
-  pathname: '/facilitator-feedback/[groupId]',
+  pathname: '/facilitator-feedback/[meetPersonId]',
   push: vi.fn(),
   replace: vi.fn(),
 };

--- a/apps/website/src/pages/facilitator-feedback/[meetPersonId].tsx
+++ b/apps/website/src/pages/facilitator-feedback/[meetPersonId].tsx
@@ -19,7 +19,8 @@ type ParticipantFeedback =
 
 const FacilitatorFeedbackPage = () => {
   const router = useRouter();
-  const meetPersonId = router.query.groupId as string;
+  // Fallback to old `groupId` param for stale clients mid-deploy. Remove in follow-up PR.
+  const meetPersonId = (router.query.meetPersonId ?? router.query.groupId) as string;
 
   const { data: formData, isLoading, error } = trpc.facilitators.getFeedbackFormData.useQuery(
     { meetPersonId },

--- a/apps/website/src/pages/facilitator-feedback/[meetPersonId]/success.tsx
+++ b/apps/website/src/pages/facilitator-feedback/[meetPersonId]/success.tsx
@@ -19,7 +19,8 @@ const formatNames = (names: string[]): string => {
 
 const FacilitatorFeedbackSuccessPage = () => {
   const router = useRouter();
-  const meetPersonId = router.query.groupId as string;
+  // Fallback to old `groupId` param for stale clients mid-deploy. Remove in follow-up PR.
+  const meetPersonId = (router.query.meetPersonId ?? router.query.groupId) as string;
 
   const { data, isLoading, error } = trpc.facilitators.getFeedbackFormData.useQuery(
     { meetPersonId },


### PR DESCRIPTION
# Description

Every caller of `/facilitator-feedback/[groupId]` passes a meetPerson id (the value comes from `meetPerson.id`, not a group id), so the dynamic-param name is misleading for anyone opening the file. The URL path is unchanged — only the param name (and the page-internal `router.query` read) move.

To keep stale tabs alive during the deploy window, the renamed page reads both names with a fallback: `(router.query.meetPersonId ?? router.query.groupId)`. A follow-up PR removes the fallback once the deploy stabilises.

## Issue

Fixes #2487

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories