### PR TITLE
[refactor] Drop groupId fallback in facilitator-feedback page (follow-up to #2592)

### DIFF
--- a/apps/website/src/pages/facilitator-feedback/[meetPersonId].tsx
+++ b/apps/website/src/pages/facilitator-feedback/[meetPersonId].tsx
@@ -19,8 +19,7 @@ type ParticipantFeedback =
 
 const FacilitatorFeedbackPage = () => {
   const router = useRouter();
-  // Fallback to old `groupId` param for stale clients mid-deploy. Remove in follow-up PR.
-  const meetPersonId = (router.query.meetPersonId ?? router.query.groupId) as string;
+  const meetPersonId = router.query.meetPersonId as string;
 
   const { data: formData, isLoading, error } = trpc.facilitators.getFeedbackFormData.useQuery(
     { meetPersonId },

--- a/apps/website/src/pages/facilitator-feedback/[meetPersonId]/success.tsx
+++ b/apps/website/src/pages/facilitator-feedback/[meetPersonId]/success.tsx
@@ -19,8 +19,7 @@ const formatNames = (names: string[]): string => {
 
 const FacilitatorFeedbackSuccessPage = () => {
   const router = useRouter();
-  // Fallback to old `groupId` param for stale clients mid-deploy. Remove in follow-up PR.
-  const meetPersonId = (router.query.meetPersonId ?? router.query.groupId) as string;
+  const meetPersonId = router.query.meetPersonId as string;
 
   const { data, isLoading, error } = trpc.facilitators.getFeedbackFormData.useQuery(
     { meetPersonId },


### PR DESCRIPTION
# Description

Follow-up to #2592 — drops the `?? router.query.groupId` fallback that was added to keep stale tabs working across the rename deploy. By the time this lands (after #2592 is merged + deployed to production), no client is sending the old param name.

**Don't merge until #2592 has been in production for long enough that any stale tabs have closed/refreshed**, I suggest next Monday (2025-06-01)

## Issue

Follows up #2487 / #2592

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories