### PR TITLE
[chore] Add createdAt to exercise_response schema

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -163,6 +163,10 @@ export const exerciseResponseTable = pgAirtable('exercise_response', {
       pgColumn: text().notNull(),
       airtableId: 'fld7Qa3JDnRNwCTlH',
     },
+    createdAt: {
+      pgColumn: text(),
+      airtableId: 'fldhcRNA7rhOJpvHH',
+    },
     completedAt: {
       pgColumn: text(),
       airtableId: 'fldmmwUvlAy3Ju2or',


### PR DESCRIPTION
# Description

Surface the existing Airtable \`Created at\` dateTime field on the \`Exercise response\` table as \`createdAt\` on \`exerciseResponseTable\`. Airtable already populates this for every row — we're just adding the local schema mapping.

This is the schema-first PR per the project's 2-PR migration rule. Consumer PR will follow once this has merged and pg-sync has replicated the column.

Used in #2583 to give in-progress responses a real "Started at" timestamp.

## Issue

n/a (prep for #2583)

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories