### PR TITLE
[fix] Match group-switch eligibility on exact Human opinion

### DIFF
--- a/apps/website/src/server/routers/group-switching.test.ts
+++ b/apps/website/src/server/routers/group-switching.test.ts
@@ -370,8 +370,8 @@ describe('getAvailableGroupsAndDiscussions', () => {
     expect(result.groupsAvailable.map((g) => g.group.id)).toEqual(['g-own']);
   });
 
-  test.each([null, 'TODO', 'Strong no'])('falls back to \'Neutral\' when humanOpinion is %j', (humanOpinion) => {
-    // Group requires Neutral; participant has null/invalid opinion. Should still match.
+  test.each([null, 'TODO'])('falls back to \'Neutral\' when humanOpinion is %j', (humanOpinion) => {
+    // Group requires Neutral; participant has no opinion (null) or an unreviewed one (TODO). Should still match.
     const neutralGroup = createMockGroup({ id: 'g-neutral', participants: [], whoCanSwitchIntoThisGroup: ['Neutral'] });
     const strongYesGroup = createMockGroup({ id: 'g-strong', participants: [], whoCanSwitchIntoThisGroup: ['Strong yes'] });
 
@@ -384,6 +384,22 @@ describe('getAvailableGroupsAndDiscussions', () => {
     });
 
     expect(result.allowedGroups.map((g) => g.id)).toEqual(['g-neutral']);
+  });
+
+  test.each(['Weak no', 'Strong no'])('matches humanOpinion %j exactly, so it does not fall back to Neutral', (humanOpinion) => {
+    // No group lists this opinion, so the participant matches nothing (and isn't in any group here).
+    const neutralGroup = createMockGroup({ id: 'g-neutral', participants: [], whoCanSwitchIntoThisGroup: ['Neutral'] });
+    const strongYesGroup = createMockGroup({ id: 'g-strong', participants: [], whoCanSwitchIntoThisGroup: ['Strong yes'] });
+
+    const result = getAvailableGroupsAndDiscussions({
+      allGroupsInRound: [neutralGroup, strongYesGroup],
+      allGroupDiscussionsInRound: [],
+      participantId,
+      participantHumanOpinion: humanOpinion,
+      maxParticipants: 5,
+    });
+
+    expect(result.allowedGroups.map((g) => g.id)).toEqual([]);
   });
 });
 
@@ -731,7 +747,7 @@ describe('groupSwitching.discussionsAvailable', () => {
     expect(groupIds).toEqual(['my-group', 'neutral-group']);
   });
 
-  test.each(['Weak no', 'TODO', 'Strong no'])('humanOpinion "%s" is treated as Neutral', async (invalidOpinion) => {
+  const seedRoundWithNeutralGroup = async (humanOpinion: string) => {
     await testDb.insert(courseTable, {
       id: 'course-1',
       slug: 'test-course',
@@ -760,7 +776,7 @@ describe('groupSwitching.discussionsAvailable', () => {
       applicationsBaseRecordId: 'reg-1',
       round: 'round-1',
       role: 'Participant',
-      humanOpinion: invalidOpinion,
+      humanOpinion,
     });
 
     await testDb.insert(groupTable, {
@@ -781,11 +797,23 @@ describe('groupSwitching.discussionsAvailable', () => {
       facilitators: ['fac-1'],
       participantsExpected: ['someone-else'],
     });
+  };
+
+  test('humanOpinion "TODO" is treated as Neutral', async () => {
+    await seedRoundWithNeutralGroup('TODO');
 
     const result = await caller.groupSwitching.discussionsAvailable({ roundId: 'round-1' });
 
     expect(result.groupsAvailable).toHaveLength(1);
     expect(result.groupsAvailable[0]!.group.id).toBe('neutral-group');
+  });
+
+  test.each(['Weak no', 'Strong no'])('humanOpinion "%s" matches exactly and is not treated as Neutral', async (noOpinion) => {
+    await seedRoundWithNeutralGroup(noOpinion);
+
+    const result = await caller.groupSwitching.discussionsAvailable({ roundId: 'round-1' });
+
+    expect(result.groupsAvailable).toHaveLength(0);
   });
 
   test('returns null spotsLeftIfKnown when round has no max', async () => {

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -13,8 +13,6 @@ import db from '../../lib/api/db';
 import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
 import { protectedProcedure, router } from '../trpc';
 
-export const VALID_HUMAN_OPINIONS = ['Strong yes', 'Weak yes', 'Neutral'] as const;
-
 export type DiscussionsAvailable = inferRouterOutputs<typeof groupSwitchingRouter>['discussionsAvailable'];
 
 type DiscussionsByUnit = Record<string, {
@@ -127,9 +125,9 @@ function getAllowedGroupsForParticipant({
   participantId: string;
   participantHumanOpinion: string | null;
 }): Group[] {
-  const opinion = participantHumanOpinion && (VALID_HUMAN_OPINIONS as readonly string[]).includes(participantHumanOpinion)
-    ? participantHumanOpinion
-    : 'Neutral';
+  const opinion = (!participantHumanOpinion || participantHumanOpinion === 'TODO')
+    ? 'Neutral'
+    : participantHumanOpinion;
   return allGroups.filter((group) => (
     (group.participants ?? []).includes(participantId)
     || (group.whoCanSwitchIntoThisGroup ?? []).includes(opinion)


### PR DESCRIPTION
# Description

The group-switching self-serve flow on the Course Hub decides which discussion groups to offer a participant by comparing their **Human opinion** against each group's **Who can switch into group** allow-list. Previously it collapsed any Human opinion value outside `Strong yes` / `Weak yes` / `Neutral` down to `Neutral` before matching.

That collapse had two unintended effects: participants marked `Strong no` or `Weak no` were treated as `Neutral`, so they could self-switch into any Neutral-admitting group; and `[tmp] CG` participants were sent to Neutral groups rather than matched to `[tmp] CG` groups.

Now the participant's Human opinion is matched literally against the group's allow-list. Only a blank/unset opinion or the unreviewed `TODO` state falls back to `Neutral`. Every explicit value — including `Strong no` / `Weak no` and `[tmp] CG` — is matched exactly. A participant whose opinion no group admits sees only their own current group and cannot self-switch (the router already logs a warning in this case).

## What changed

1. **`apps/website/src/server/routers/group-switching.ts`** — replaced the `VALID_HUMAN_OPINIONS`-based collapse in `getAllowedGroupsForParticipant` with a literal match: blank/`null` or `TODO` falls back to `Neutral`, everything else is used as-is. Removed the now-unused `VALID_HUMAN_OPINIONS` constant.
2. **`apps/website/src/server/routers/group-switching.test.ts`** — split the tests that asserted the old collapse: `null`/`TODO` still expect the Neutral fallback; added cases asserting `Weak no`/`Strong no` are matched exactly and therefore match no group.

## Issue

N/A — behaviour fix on the group-switching eligibility filter, no linked issue.

## Developer checklist

- [x] Considered having snapshot tests / functional tests — extended the existing router unit + integration tests to cover the new matching behaviour.
- [x] Considered adding Storybook stories — N/A, backend logic change, no component surface.

No DB schema changes.

## Verification

Backend logic change, no UI surface — no screenshots.

```
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 844 passed, 1 skipped (115 files) — run twice, stable
```

Targeted: `group-switching.test.ts` — 48/48 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
