### PR TITLE
Add computed Airtable fields to db schema

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.stories.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.stories.tsx
@@ -17,6 +17,7 @@ const freeTextExercise = {
   status: null,
   unitNumber: null,
   exerciseNumber: null,
+  computedNumResponses: null,
 };
 
 const multipleChoiceExercise = {
@@ -31,6 +32,7 @@ const multipleChoiceExercise = {
   status: null,
   unitNumber: null,
   exerciseNumber: null,
+  computedNumResponses: null,
 };
 
 const savedResponse = {

--- a/apps/website/src/components/courses/exercises/Exercise.test.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.test.tsx
@@ -44,6 +44,7 @@ const freeTextExercise = {
   courseIdWrite: 'course-write-1',
   courseIdRead: 'course-read-1',
   exerciseNumber: null,
+  computedNumResponses: null,
 };
 
 beforeEach(() => {

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -30,6 +30,7 @@ export {
   chunkTable,
   unitTable,
   unitResourceTable,
+  resourceTable,
   exerciseTable,
   applicationsCourseTable,
   courseRegistrationTable,
@@ -49,6 +50,7 @@ export {
   courseFeedbackTable,
   peerFeedbackTable,
   vanityUrlsTable,
+  RESOURCE_FEEDBACK,
 } from './schema';
 
 // Type exports
@@ -78,6 +80,7 @@ export type {
   Chunk,
   Unit,
   UnitResource,
+  Resource,
   Exercise,
   ApplicationsCourse,
   CourseRegistration,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1227,6 +1227,21 @@ export const unitResourceTable = pgAirtable('unit_resource', {
   },
 });
 
+export const resourceTable = pgAirtable('resource', {
+  baseId: COURSE_BUILDER_BASE_ID,
+  tableId: 'tblmcJcHQp1uKOK4q',
+  columns: {
+    computedNumCompletions: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldXyNixYfqrJ8XYw',
+    },
+    computedAverageRating: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldheVLDg4q4zFjI5',
+    },
+  },
+});
+
 export const exerciseTable = pgAirtable('exercise', {
   baseId: COURSE_BUILDER_BASE_ID,
   tableId: 'tbla7lc2MtSSbWVvS',
@@ -1266,6 +1281,10 @@ export const exerciseTable = pgAirtable('exercise', {
     status: {
       pgColumn: text(),
       airtableId: 'flda5e542i9w1nBzv',
+    },
+    computedNumResponses: {
+      pgColumn: numeric({ mode: 'number' }),
+      airtableId: 'fldhemVjXEA0j4d2d',
     },
   },
   deprecatedColumns: {
@@ -1733,6 +1752,7 @@ export type OneOnOneAdvisingApplication = InferSelectModel<typeof oneOnOneAdvisi
 export type Chunk = InferSelectModel<typeof chunkTable.pg>;
 export type Unit = InferSelectModel<typeof unitTable.pg>;
 export type UnitResource = InferSelectModel<typeof unitResourceTable.pg>;
+export type Resource = InferSelectModel<typeof resourceTable.pg>;
 export type Exercise = InferSelectModel<typeof exerciseTable.pg>;
 export type ApplicationsCourse = InferSelectModel<typeof applicationsCourseTable.pg>;
 export type CourseRegistration = InferSelectModel<typeof courseRegistrationTable.pg>;

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1227,7 +1227,6 @@ export const unitResourceTable = pgAirtable('unit_resource', {
   },
 });
 
-// Touch to retrigger preview build
 export const resourceTable = pgAirtable('resource', {
   baseId: COURSE_BUILDER_BASE_ID,
   tableId: 'tblmcJcHQp1uKOK4q',

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1227,6 +1227,7 @@ export const unitResourceTable = pgAirtable('unit_resource', {
   },
 });
 
+// Touch to retrigger preview build
 export const resourceTable = pgAirtable('resource', {
   baseId: COURSE_BUILDER_BASE_ID,
   tableId: 'tblmcJcHQp1uKOK4q',


### PR DESCRIPTION
## Description
- add Resource table mapping for computed Airtable fields only
- add computed response count field to Exercise
- export Resource/resourceTable and RESOURCE_FEEDBACK from @bluedot/db

## Issue

#2582