### PR TITLE
[feat] A/B test skip Future of AI landing page via PostHog flag

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -40,6 +40,7 @@ const CoursePage = ({
   courseSlug, courseData, courseOgImage, soonestDeadline,
 }: CoursePageProps) => {
   const router = useRouter();
+  // A/B test: skip the landing page for the 'skip-lander' variant (short-lived experiment, see PR #2607)
   const skipLanderVariant = useFeatureFlagVariantKey('future-of-ai-skip-lander');
 
   useEffect(() => {

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -4,6 +4,9 @@ import {
   useLatestUtmParams,
 } from '@bluedot/ui';
 import Head from 'next/head';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useFeatureFlagVariantKey } from 'posthog-js/react';
 import { type GetStaticProps, type GetStaticPaths } from 'next';
 
 import { ROUTES } from '../../../lib/routes';
@@ -36,6 +39,15 @@ type CoursePageProps = {
 const CoursePage = ({
   courseSlug, courseData, courseOgImage, soonestDeadline,
 }: CoursePageProps) => {
+  const router = useRouter();
+  const skipLanderVariant = useFeatureFlagVariantKey('future-of-ai-skip-lander');
+
+  useEffect(() => {
+    if (courseSlug === 'future-of-ai' && skipLanderVariant === 'skip-lander') {
+      void router.replace(FUTURE_OF_AI_START_URL);
+    }
+  }, [courseSlug, skipLanderVariant, router]);
+
   return (
     <div>
       {renderCoursePage({


### PR DESCRIPTION
## Summary
- Adds a PostHog feature flag check to the Future of AI course landing page (`/courses/future-of-ai`)
- Users assigned to the `skip-lander` variant of the `future-of-ai-skip-lander` experiment are immediately redirected to `/courses/future-of-ai/1/1`, bypassing the landing page entirely
- Control group (50%) sees the landing page as normal
- Goal metric: reaching `/courses/future-of-ai/4/1` (section 4 of the course)

## Test plan
- [ ] Vitest suite passes (`cd apps/website && npm test`)
- [ ] `npx tsc --noEmit` clean ✅ (verified locally)
- [ ] On Render preview: open `/courses/future-of-ai`, run `posthog.featureFlags.override({'future-of-ai-skip-lander': 'skip-lander'})` in console, refresh — should redirect to `/courses/future-of-ai/1/1`
- [ ] On Render preview: with no override, landing page should render normally

## Notes
- Local testing was limited — Postgres credentials are restricted per team policy. TypeScript typecheck passed clean.
- The PostHog experiment is set up in draft mode and will be launched manually after this merges and is verified on staging.
- No new dependencies introduced — `posthog-js/react` is already used in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)