### PR TITLE
[chore] Bump cloudnative-pg chart 0.26.0 -> 0.28.2

### DIFF
--- a/apps/infra/src/k8s/postgres.ts
+++ b/apps/infra/src/k8s/postgres.ts
@@ -6,7 +6,7 @@ import { provider } from './provider';
 
 export const cloudNativePg = new k8s.helm.v3.Release('cloud-native-pg', {
   chart: 'cloudnative-pg',
-  version: '0.26.0',
+  version: '0.28.2',
   repositoryOpts: {
     repo: 'https://cloudnative-pg.github.io/charts',
   },


### PR DESCRIPTION
## What

Bumps the `cloudnative-pg` Helm chart from `0.26.0` to `0.28.2` (operator → **1.29.1**).

## Why

Prerequisite for #2610 (upgrading VKE off the end-of-life Kubernetes 1.33). We're targeting **1.35.5+1**, deliberately *not* 1.36: even the latest CNPG operator (1.29.1) [doesn't list 1.36 as supported yet](https://cloudnative-pg.io/docs/current/supported_releases/) (supported = 1.33 / 1.34 / 1.35), and CNPG runs our in-cluster databases.

Our current chart (`0.26.0`, operator ~1.26) tops out around k8s 1.33/1.34, so it needs bumping before the cluster moves to 1.35. CNPG is the highest-risk component because it manages the three single-instance in-cluster databases (`keycloak-pg` = login, `grafana-pg`, `airtable-sync-pg`) that get rescheduled when the node reprovisions.

## Impact

Updating the operator may trigger a brief rolling restart of the single-instance databases as the instance manager updates — a short per-DB blip, **no data or Postgres-version change** (see Verification). Best deployed at a quiet time, but far smaller than the k8s-upgrade outage in #2610.

## Verification (checked, not assumed)

- **Chart 0.26.0 → 0.28.2** (GitHub release notes): dependency bumps, CI hardening, an additive RBAC grant (`clusters/status`), optional custom-PodMonitor support, a `pg_replication` query fix. No `values` schema or CRD breaking changes.
- **Operator 1.26 → 1.29** (release notes): CRD schema only *extended* with optional fields (`extensions`, `bin_path`, `env`, `podSelectorRefs`, `serviceAccountName`); our minimal `instances`+`storage` Clusters are not rejected, and there is no mandatory CRD migration.
- **Default Postgres image moved to 18.x** across these versions — but all three Clusters pin `spec.imageName` explicitly (`keycloak-pg` 16.2, `grafana-pg` 17.4, `airtable-sync-pg` 17.5), so the upgraded operator keeps their current Postgres version. No PG 18 surprise.

Output of `pulumi preview --stack prod`:

```
Previewing update (prod):
     Type                              Name             Plan       Info
     pulumi:pulumi:Stack               infra-prod
 ~   └─ kubernetes:helm.sh/v3:Release  cloud-native-pg  update     [diff: ~version]
```

## Before merge

- ⚠️ Helm does **not** upgrade CRDs in `templates/crds`. After deploy, confirm the CNPG CRDs are current and the three `Cluster`s stay healthy.

## Sequencing

**Merge + deploy + verify this before #2610.** The k8s version bump must not land until this operator is live on 1.33 and the databases are confirmed healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
