### PR TITLE
Quick apply redirects to facilitator applications

### DIFF
--- a/apps/website/src/components/courses/SidebarFacilitateAgainPanel.test.tsx
+++ b/apps/website/src/components/courses/SidebarFacilitateAgainPanel.test.tsx
@@ -19,47 +19,34 @@ const course = (overrides: Partial<EligibleRoundsCourse> = {}): EligibleRoundsCo
 });
 
 describe('SidebarFacilitateAgainPanel', () => {
-  test('links to the first (soonest) open round for the matching course', async () => {
-    server.use(trpcMsw.facilitatorApplications.eligibleRounds.query(() => [
-      course({
-        rounds: [
-          {
-            id: 'round-early', label: 'Week 28', firstDiscussionDate: '2026-04-07', lastDiscussionDate: '2026-04-14',
-          },
-          {
-            id: 'round-late', label: 'Week 30', firstDiscussionDate: '2026-04-21', lastDiscussionDate: '2026-04-28',
-          },
-        ],
-      }),
-    ]));
+  test('links to the facilitator applications page when the course has an eligible round', async () => {
+    server.use(trpcMsw.facilitatorApplications.eligibleRounds.query(() => [course()]));
 
     render(<SidebarFacilitateAgainPanel courseSlug="agi-strategy" />, { wrapper: TrpcProvider });
 
     const link = await screen.findByRole('link', { name: /quick apply to facilitate again/i });
-    expect(link).toHaveAttribute('href', '/facilitator-applications/quick-apply?round=round-early');
+    expect(link).toHaveAttribute('href', '/facilitator-applications');
   });
 
-  // Decoy course first: a panel that ignored courseSlug and took rounds[0] would link to
-  // the wrong course's round, so the href assertion catches a broken filter deterministically.
-  test('links to the round for the current course, not another eligible course', async () => {
+  // Render an eligible panel alongside a no-rounds course and a slug with no entry. The eligible
+  // link appearing proves the shared query resolved; a single link then proves the other two
+  // panels rendered nothing (i.e. the panel gates on the current slug having an open round).
+  test('renders nothing for a course with no open rounds or no matching entry', async () => {
     server.use(trpcMsw.facilitatorApplications.eligibleRounds.query(() => [
-      course({
-        courseId: 'course-other',
-        courseSlug: 'other-course',
-        rounds: [{
-          id: 'round-other', label: 'Week 1', firstDiscussionDate: '2026-01-06', lastDiscussionDate: '2026-01-13',
-        }],
-      }),
-      course({
-        rounds: [{
-          id: 'round-agi', label: 'Week 28', firstDiscussionDate: '2026-04-07', lastDiscussionDate: '2026-04-14',
-        }],
-      }),
+      course(),
+      course({ courseId: 'course-empty', courseSlug: 'empty-course', rounds: [] }),
     ]));
 
-    render(<SidebarFacilitateAgainPanel courseSlug="agi-strategy" />, { wrapper: TrpcProvider });
+    render(
+      <>
+        <SidebarFacilitateAgainPanel courseSlug="agi-strategy" />
+        <SidebarFacilitateAgainPanel courseSlug="empty-course" />
+        <SidebarFacilitateAgainPanel courseSlug="missing-course" />
+      </>,
+      { wrapper: TrpcProvider },
+    );
 
-    const link = await screen.findByRole('link', { name: /quick apply to facilitate again/i });
-    expect(link).toHaveAttribute('href', '/facilitator-applications/quick-apply?round=round-agi');
+    await screen.findByRole('link', { name: /quick apply to facilitate again/i });
+    expect(screen.getAllByRole('link', { name: /quick apply to facilitate again/i })).toHaveLength(1);
   });
 });

--- a/apps/website/src/components/courses/SidebarFacilitateAgainPanel.tsx
+++ b/apps/website/src/components/courses/SidebarFacilitateAgainPanel.tsx
@@ -9,15 +9,14 @@ type SidebarFacilitateAgainPanelProps = {
 
 export const SidebarFacilitateAgainPanel = ({ courseSlug }: SidebarFacilitateAgainPanelProps) => {
   const { data } = trpc.facilitatorApplications.eligibleRounds.useQuery();
-  // Rounds arrive earliest-first from the server, so [0] is the soonest open round.
-  const round = data?.find((course) => course.courseSlug === courseSlug)?.rounds[0];
-  if (!round) return null;
+  const hasEligibleRound = data?.some((course) => course.courseSlug === courseSlug && course.rounds.length > 0);
+  if (!hasEligibleRound) return null;
 
   return (
     <div className="relative p-4 md:p-6">
       <div className="border-t-hairline absolute inset-x-2 top-0 border-bluedot-navy/20 md:inset-x-[24px]" />
       <A
-        href={`${ROUTES.quickApply.url}?round=${round.id}`}
+        href={ROUTES.facilitatorApplications.url}
         className="border-bluedot-normal text-bluedot-normal hover:bg-bluedot-lighter flex items-center gap-3 rounded-[10px] border-hairline border-solid px-3 py-4 no-underline transition-colors duration-200"
       >
         <p className="text-size-sm min-w-0 flex-1 leading-[1.5] font-bold">


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

When I built this, I assumed that the panel should redirect to the first upcoming round.  This was incorrect. It should rather redirect to the facilitator-applications route. 
