### PR TITLE
[chore] db: drop long-deprecated columns on exercise_response and resource_completion tabls

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -180,13 +180,6 @@ export const exerciseResponseTable = pgAirtable('exercise_response', {
       airtableId: 'fldiis2fuPC0Q0smM',
     },
   },
-  deprecatedColumns: {
-    completed: {
-      pgColumn: boolean(),
-      airtableId: 'fldz8rocQd7Ws9s2q',
-      deprecated: true,
-    },
-  },
 });
 
 export const formConfigurationTable = pgAirtable('form_configuration', {
@@ -1548,13 +1541,6 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
     createdByUserId: {
       pgColumn: text().array(),
       airtableId: 'fldtEFIAKCUctCDhW',
-    },
-  },
-  deprecatedColumns: {
-    rating: {
-      pgColumn: numeric({ mode: 'number' }),
-      airtableId: 'fldq6J5taZX4xLDfD',
-      deprecated: true,
     },
   },
 });


### PR DESCRIPTION
# Description

In preparation for flipping these tables to Postgres-only

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A
