### PR TITLE
[fix] Revert VKE target to v1.33.0+3 to unblock infra CD

### DIFF
--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
   label: 'bluedot-prod',
   region: 'ams',
-  version: 'v1.35.5+1',
+  version: 'v1.33.0+3',
 
   // Initial node pool
   // nodePools: {


### PR DESCRIPTION
## What

Reverts the VKE target in `vke.ts` from `v1.35.5+1` back to `v1.33.0+3`.

## Why

The upgrade merged in #2610 **cannot apply** — Vultr reports the cluster's `version` metadata as empty (`""`), which breaks upgrade-path validation everywhere:
- Pulumi/provider → `422 "Validation error: invalid upgrade version"`
- raw API → same
- Vultr dashboard "Start Upgrade" → silent no-op / reverts

So master currently has `v1.35.5+1` while Pulumi state and the live cluster are still `v1.33.0+3`. Every infra deploy re-attempts the doomed upgrade and the `cd` job fails.

This reverts the code to match state + reality. `pulumi preview` should show **no change** (no-op), so infra CD goes green again instead of failing on every run.

## Not a no-op forever

This is a temporary step-back, **not** abandoning the upgrade. Re-apply the `v1.35.5+1` bump once Vultr repairs the cluster's version metadata.

Blocker tracked in #2618 (Vultr support). Prereq CNPG bump already merged (#2611). Prod is healthy on 1.33 throughout — no user impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
