### PR TITLE
Quick apply via '/facilitated-courses'

### DIFF
--- a/apps/website/src/components/my-courses/QuickApplyBanner.stories.tsx
+++ b/apps/website/src/components/my-courses/QuickApplyBanner.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { loggedInStory } from '@bluedot/ui/src/utils/storybook';
+import { QuickApplyBanner } from './QuickApplyBanner';
+import type { EligibleRoundsCourse } from '../../server/routers/facilitator-applications';
+import { trpcStorybookMsw } from '../../__tests__/trpcMswSetup.browser';
+
+const eligibleCourses: EligibleRoundsCourse[] = [
+  {
+    courseId: 'course-agi',
+    courseTitle: 'AGI Strategy',
+    courseSlug: 'agi-strategy',
+    rounds: [
+      {
+        id: 'round-1',
+        label: 'Week 28 Intensive',
+        firstDiscussionDate: '2026-04-07',
+        lastDiscussionDate: '2026-04-14',
+      },
+    ],
+  },
+];
+
+const eligibleRoundsHandler = (courses: EligibleRoundsCourse[]) =>
+  trpcStorybookMsw.facilitatorApplications.eligibleRounds.query(() => courses);
+
+const meta = {
+  title: 'My Courses/QuickApplyBanner',
+  component: QuickApplyBanner,
+  parameters: { layout: 'padded' },
+  ...loggedInStory(),
+} satisfies Meta<typeof QuickApplyBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Facilitator wrapping up a course with an open round to apply to: the banner renders.
+export const Default: Story = {
+  parameters: {
+    msw: { handlers: [eligibleRoundsHandler(eligibleCourses)] },
+  },
+};
+
+// No eligible round: the banner renders nothing.
+export const NotEligible: Story = {
+  parameters: {
+    msw: { handlers: [eligibleRoundsHandler([])] },
+  },
+};

--- a/apps/website/src/components/my-courses/QuickApplyBanner.stories.tsx
+++ b/apps/website/src/components/my-courses/QuickApplyBanner.stories.tsx
@@ -1,8 +1,9 @@
-import type { Meta, StoryObj } from '@storybook/react';
 import { loggedInStory } from '@bluedot/ui/src/utils/storybook';
-import { QuickApplyBanner } from './QuickApplyBanner';
-import type { EligibleRoundsCourse } from '../../server/routers/facilitator-applications';
+import type { Meta, StoryObj } from '@storybook/react';
 import { trpcStorybookMsw } from '../../__tests__/trpcMswSetup.browser';
+import type { EligibleRoundsCourse } from '../../server/routers/facilitator-applications';
+import { useQuickApplyBannerStore } from '../../stores/quickApplyBanner';
+import { QuickApplyBanner } from './QuickApplyBanner';
 
 const eligibleCourses: EligibleRoundsCourse[] = [
   {
@@ -27,6 +28,15 @@ const meta = {
   title: 'My Courses/QuickApplyBanner',
   component: QuickApplyBanner,
   parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => {
+      useQuickApplyBannerStore.setState({ dismissedKeys: {} });
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem('bluedot_quick_apply_banner');
+      }
+      return <Story />;
+    },
+  ],
   ...loggedInStory(),
 } satisfies Meta<typeof QuickApplyBanner>;
 

--- a/apps/website/src/components/my-courses/QuickApplyBanner.stories.tsx
+++ b/apps/website/src/components/my-courses/QuickApplyBanner.stories.tsx
@@ -34,6 +34,7 @@ const meta = {
       if (typeof window !== 'undefined') {
         window.localStorage.removeItem('bluedot_quick_apply_banner');
       }
+
       return <Story />;
     },
   ],

--- a/apps/website/src/components/my-courses/QuickApplyBanner.tsx
+++ b/apps/website/src/components/my-courses/QuickApplyBanner.tsx
@@ -1,0 +1,46 @@
+import { CTALinkOrButton } from '@bluedot/ui';
+import { FaRegFileLines } from 'react-icons/fa6';
+import { ROUTES } from '../../lib/routes';
+import { useQuickApplyBannerStore } from '../../stores/quickApplyBanner';
+import { trpc } from '../../utils/trpc';
+
+export const QuickApplyBanner = () => {
+  const { data } = trpc.facilitatorApplications.eligibleRounds.useQuery();
+
+  // Key the dismissal by the set of currently-eligible rounds, so hiding sticks for this
+  // opportunity but the banner returns when the facilitator is wrapping up a new course.
+  const eligibleRoundIds = (data ?? []).flatMap((course) => course.rounds.map((round) => round.id)).sort();
+  const dismissKey = eligibleRoundIds.join('|');
+
+  const isDismissed = useQuickApplyBannerStore((s) => Boolean(s.dismissedKeys[dismissKey]));
+  const dismiss = useQuickApplyBannerStore((s) => s.dismiss);
+
+  if (eligibleRoundIds.length === 0 || isDismissed) return null;
+
+  return (
+    <div className="border-bluedot-normal/10 bg-bluedot-normal/5 rounded-md border border-solid p-4 sm:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+        <div className="min-w-0 flex-1 text-bluedot-normal">
+          <div className="flex items-center gap-2">
+            <FaRegFileLines className="size-4 shrink-0" />
+            <p className="text-size-sm font-bold">Quick Apply (~2 min)</p>
+          </div>
+          <p className="text-size-xs mt-1 text-pretty">
+            Thanks for facilitating with BlueDot. If you want to facilitate the same course again, as a return
+            facilitator, quick applying only takes 2 min!
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-3">
+          <CTALinkOrButton variant="secondary" size="small" onClick={() => dismiss(dismissKey)}>
+            Hide
+          </CTALinkOrButton>
+          <CTALinkOrButton variant="primary" size="small" url={ROUTES.facilitatorApplications.url}>
+            Quick apply
+          </CTALinkOrButton>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuickApplyBanner;

--- a/apps/website/src/pages/facilitated-courses.tsx
+++ b/apps/website/src/pages/facilitated-courses.tsx
@@ -9,6 +9,7 @@ import {
   TABS, type CourseTab, isCourseTab, isAutoExpandCandidate, bucketCoursesByTab,
 } from '../components/my-courses/useCourseListRow';
 import NextDiscussionCard from '../components/my-courses/NextDiscussionCard';
+import { QuickApplyBanner } from '../components/my-courses/QuickApplyBanner';
 import TabPills from '../components/my-courses/TabPills';
 import { ROUTES } from '../lib/routes';
 import { trpc } from '../utils/trpc';
@@ -129,6 +130,7 @@ const FacilitatedCoursesPage = () => {
                   </div>
                 </div>
               )}
+              <QuickApplyBanner />
               <TabPills
                 ariaLabel="Course filter"
                 tabs={TABS}

--- a/apps/website/src/stores/quickApplyBanner.ts
+++ b/apps/website/src/stores/quickApplyBanner.ts
@@ -13,6 +13,5 @@ export const useQuickApplyBannerStore = create<{
   }),
   {
     name: 'bluedot_quick_apply_banner',
-    version: 20260608,
   },
 ));

--- a/apps/website/src/stores/quickApplyBanner.ts
+++ b/apps/website/src/stores/quickApplyBanner.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const useQuickApplyBannerStore = create<{
+  dismissedKeys: Record<string, boolean>;
+  dismiss: (key: string) => void;
+}>()(persist(
+  (set) => ({
+    dismissedKeys: {},
+    dismiss: (key: string) => set((state) => ({
+      dismissedKeys: { ...state.dismissedKeys, [key]: true },
+    })),
+  }),
+  {
+    name: 'bluedot_quick_apply_banner',
+    version: 20260608,
+  },
+));


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Adds a new panel to the 'facilitated courses' route that redirects users to 'facilitated applications' where they can quickly reapply to facilitate again.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2608

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

<img width="1309" height="353" alt="image" src="https://github.com/user-attachments/assets/ef5d3109-fb60-456c-a98d-d940a1fbe66e" />
<img width="377" height="590" alt="image" src="https://github.com/user-attachments/assets/1d60a4ec-283b-4a90-b477-adbd403fb45a" />

