### PR TITLE
Bump GH Actions to node24 action runtime

### DIFF
--- a/.github/workflows/auto_label_priority.yml
+++ b/.github/workflows/auto_label_priority.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     steps:
       - name: Add priority label based on form selection
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -20,13 +20,13 @@ jobs:
       affected_deployable_apps: ${{ steps.get_affected_deployable_apps.outputs.deploy_array }}
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 10  # Fetch more history to be likely to find a successful commit when identifying affected apps
 
       - name: Use Node.js
         id: setup-node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -72,10 +72,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -83,7 +83,7 @@ jobs:
 
       - name: Restore node_modules
         id: cache-node-modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -96,7 +96,7 @@ jobs:
         run: npm ci --prefer-offline --audit false --fund false
 
       - name: Cache turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-typecheck-${{ github.sha }}
@@ -112,10 +112,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -123,7 +123,7 @@ jobs:
 
       - name: Restore node_modules
         id: cache-node-modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -136,7 +136,7 @@ jobs:
         run: npm ci --prefer-offline --audit false --fund false
 
       - name: Cache turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-lint-${{ github.sha }}
@@ -152,10 +152,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -163,7 +163,7 @@ jobs:
 
       - name: Restore node_modules
         id: cache-node-modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -176,7 +176,7 @@ jobs:
         run: npm ci --prefer-offline --audit false --fund false
 
       - name: Cache turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-test-${{ github.sha }}
@@ -220,11 +220,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js
         id: setup-node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -232,7 +232,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -250,7 +250,7 @@ jobs:
 
       - name: Cache Next.js build (website)
         if: matrix.app == '@bluedot/website'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: apps/website/.next/cache
           key: ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/website/**/*.{js,jsx,ts,tsx,mdx,md,json,css}', '!apps/website/node_modules/**', '!apps/website/.next/**', '!apps/website/dist/**') }}
@@ -258,7 +258,7 @@ jobs:
             ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-
 
       - name: Cache turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-cd-${{ matrix.app }}-${{ github.sha }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,12 +26,12 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Wait for CI/CD to pass
         if: ${{ !inputs.skip_ci_check }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // The matching ci_cd run for this SHA may still be running when the
@@ -79,11 +79,11 @@ jobs:
             }
 
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js
         id: setup-node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -91,7 +91,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -108,7 +108,7 @@ jobs:
         run: npm run postinstall --workspaces --if-present
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: apps/website/.next/cache
           key: ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/website/**/*.{js,jsx,ts,tsx,mdx,md,json,css}', '!apps/website/node_modules/**', '!apps/website/.next/**', '!apps/website/dist/**') }}
@@ -116,7 +116,7 @@ jobs:
             ${{ runner.os }}-nextjs-website-${{ hashFiles('package-lock.json') }}-
 
       - name: Cache turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-website-prod-${{ github.sha }}


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Bumps first-party actions to majors running on the node24 [action runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), before node20 is removed from runners.

- `checkout` v4→v5, `setup-node` v4→v5, `cache`(+`/restore`) v4→v5, `github-script` v7→v8
- Across `ci_cd`, `website_deploy_production`, `claude`, `auto_label_priority`

Changes the **action runtime**, not the job `node-version` (stays 22, matches `engines: ^22`). `github-script@v8` verified safe - scripts use only stable octokit REST + `setTimeout`.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2594 


