### PR TITLE
Set up shadow pg-sync-service instance to populate managed db

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -1,7 +1,9 @@
 import { jsonStringify } from '@pulumi/pulumi';
 import { type core } from '@pulumi/kubernetes/types/input';
 import { envVarSources } from './secrets';
-import { getConnectionDetails, keycloakPg, airtableSyncPg } from './postgres';
+import {
+  getConnectionDetails, keycloakPg, airtableSyncPg, appPgConnectionDetails,
+} from './postgres';
 import {
   minioPvc, mcpAggregatorDataPvc, mcpAshbyDataPvc, mcpGoogleDataPvc,
 } from './pvc';
@@ -292,20 +294,6 @@ export const services: ServiceDefinition[] = [
     },
     hosts: ['speed-review.k8s.bluedot.org'],
   },
-  // {
-  //   name: 'bluedot-backend',
-  //   spec: {
-  //     containers: [{
-  //       name: 'bluedot-backend',
-  //       image: 'ghcr.io/bluedotimpact/bluedot-backend:latest',
-  //       env: [{
-  //         name: 'DATABASE_CONNECTION_STRING',
-  //         value: pulumi.all([databaseInstance.publicIpAddress, cloudSqlPassword]).apply(([ip, password]) => `postgresql://postgres:${password}@${ip}:5432/postgres?sslmode=no-verify`),
-  //       }],
-  //     }],
-  //   },
-  //   hosts: ['backend.bluedot.org'],
-  // },
   {
     name: 'bluedot-login',
     spec: {
@@ -347,6 +335,36 @@ export const services: ServiceDefinition[] = [
           { name: 'INFO_SLACK_CHANNEL_ID', value: INFO_SLACK_CHANNEL_ID },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
           { name: 'PROD_ONLY_WEBHOOK_DELETION', valueFrom: envVarSources.prodOnlyWebhookDeletion },
+        ],
+      }],
+    },
+  },
+  // Shadow instance: populates the new managed Postgres (appPg) so we can cut over
+  // the website from the in-cluster `airtableSyncPg` to the managed DB without a
+  // sync gap. Shares Airtable webhooks with the primary pg-sync-service — each
+  // instance keeps its own in-memory cursor.
+  //
+  // Differences from the primary above:
+  //   - APP_NAME override
+  //   - PG_URL points at the managed DB secret
+  //   - PROD_ONLY_WEBHOOK_DELETION omitted for safety. Unclear if it could cause issues but one
+  //     could imagine the two instances fighting each other over webhook deletion
+  //
+  // Delete once the website has been cut over to the managed DB and the primary
+  // `bluedot-pg-sync-service` is pointed at the managed DB.
+  {
+    name: 'bluedot-pg-sync-shadow',
+    spec: {
+      containers: [{
+        name: 'bluedot-pg-sync-shadow',
+        image: 'ghcr.io/bluedotimpact/bluedot-pg-sync-service:latest',
+        env: [
+          { name: 'APP_NAME', value: 'pg-sync-service-shadow' },
+          { name: 'AIRTABLE_PERSONAL_ACCESS_TOKEN', valueFrom: envVarSources.airtablePat },
+          { name: 'PG_URL', valueFrom: appPgConnectionDetails.uri },
+          { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
+          { name: 'INFO_SLACK_CHANNEL_ID', value: INFO_SLACK_CHANNEL_ID },
+          { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
         ],
       }],
     },


### PR DESCRIPTION
# Description
See inline comment:

>   // Shadow instance: populates the new managed Postgres (appPg) so we can cut over
>  // the website from the in-cluster `airtableSyncPg` to the managed DB without a
>  // sync gap. Shares Airtable webhooks with the primary pg-sync-service — each
>  // instance keeps its own in-memory cursor.
>  //
>  // Differences from the primary above:
>  //   - APP_NAME override
>  //   - PG_URL points at the managed DB secret
>  //   - PROD_ONLY_WEBHOOK_DELETION omitted for safety. Unclear if it could cause issues but one
>  //     could imagine the two instances fighting each other over webhook deletion
>  //
>  // Delete once the website has been cut over to the managed DB and the primary
>  // `bluedot-pg-sync-service` is pointed at the managed DB.

In practice when we deprecate the dual-database setup, we'll probably delete the old bluedot-pg-sync-service but keep and rename this one.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2624

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
