### PR TITLE
[fix] Temporarily ignore VKE version to unblock infra CD

### DIFF
--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -13,6 +13,12 @@ export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
   //   plan: 'vc2-1c-2gb',
   //   autoScaler: false,
   // },
+}, {
+  // TEMPORARY: Vultr reports this cluster's version as empty, which breaks upgrade
+  // validation and poisons our state on every read, failing all infra deploys.
+  // Ignoring version stops Pulumi attempting the (rejected) upgrade. Remove once
+  // Vultr repairs the metadata, then resume the upgrade. See #2618.
+  ignoreChanges: ['version'],
 });
 
 // This is a bit hacky, because the Vultr API is annoying


### PR DESCRIPTION
## What

Adds `ignoreChanges: ['version']` to the `vke-cluster` resource, as a **temporary** measure to unblock infra deploys.

## Why

The cluster can't be upgraded: Vultr reports its `version` as an empty string, which breaks upgrade-path validation and **re-poisons our Pulumi state on every read** (the provider reads the empty version back after each operation). The result is that *every* infra deploy — including the revert in #2619 — fails with `422 "invalid upgrade version"` while trying to reconcile the phantom version diff.

State edits don't hold (the read-back undoes them). `ignoreChanges` on the version field stops Pulumi from attempting the rejected upgrade, so unrelated infra changes can deploy again — e.g. #2627 (shadow pg-sync service).

## Why this and not the alternatives

- **vs editing state:** state edits get re-poisoned by the provider's read-back on the next run.
- **vs `pulumi up --exclude` in `deploy:cd`:** that skips the *whole* cluster resource and only fixes CI (a local `pulumi up` would still 422). `ignoreChanges` is scoped to just the `version` field and behaves consistently locally and in CI, and lives next to `version` where it's discoverable.

## Verification

`pulumi preview` against prod: `130 unchanged`, no error, and the cluster no longer appears in the plan at all (no version diff attempted).

## Temporary — remove when Vultr fixes it

This masks version drift on the cluster, so it must be removed once Vultr repairs the metadata. At that point the state self-heals and we resume the upgrade to `v1.35.5+1`. Tracked in #2618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
