### PR TITLE
Off-Vultr backup of managed PG

### DIFF
--- a/apps/infra/src/k8s/backups.ts
+++ b/apps/infra/src/k8s/backups.ts
@@ -16,8 +16,9 @@
 // - Restore it using restic, password 'pass': restic -r ./backup-files restore latest --target ./restored-files
 
 import * as k8s from '@pulumi/kubernetes';
-import { provider } from './provider';
 import { config } from '../config';
+import { appPgConnectionDetails } from './postgres';
+import { provider } from './provider';
 
 const NAMESPACES_TO_BACKUP = ['default', 'monitoring'];
 
@@ -146,3 +147,47 @@ NAMESPACES_TO_BACKUP.forEach((namespace) => {
     },
   }, { provider, dependsOn: [gcsSecret, resticPasswordSecret, podConfig, k8upOperator] });
 });
+
+// Off-Vultr backup of our managed Postgres (issue #2576). It has no PVC in the cluster, so the
+// volume backups above miss it. k8up execs the `backupcommand` annotation in a running pod and
+// streams stdout into the same restic repo, so the daily Schedule captures a pg_dump too.
+const pgDumpLabels = { app: 'app-pg-dump' };
+new k8s.apps.v1.Deployment('app-pg-dump', {
+  metadata: {
+    name: 'app-pg-dump',
+    namespace: 'default',
+  },
+  spec: {
+    replicas: 1,
+    selector: { matchLabels: pgDumpLabels },
+    template: {
+      metadata: {
+        labels: pgDumpLabels,
+        annotations: {
+          // sh -c so the shell expands $PG_URI (k8up shellword-splits the annotation).
+          'k8up.io/backupcommand': 'sh -c \'pg_dump "$PG_URI"\'',
+          'k8up.io/file-extension': '.sql',
+        },
+      },
+      spec: {
+        containers: [
+          {
+            name: 'pg-dump',
+            image: 'postgres:18-alpine',
+            command: ['sleep', 'infinity'],
+            env: [
+              {
+                name: 'PG_URI',
+                valueFrom: appPgConnectionDetails.uri,
+              },
+            ],
+            resources: {
+              requests: { cpu: '10m', memory: '32Mi' },
+              limits: { memory: '128Mi' },
+            },
+          },
+        ],
+      },
+    },
+  },
+}, { provider });

--- a/apps/infra/src/k8s/backups.ts
+++ b/apps/infra/src/k8s/backups.ts
@@ -170,6 +170,7 @@ new k8s.apps.v1.Deployment('app-pg-dump', {
         },
       },
       spec: {
+        automountServiceAccountToken: false,
         containers: [
           {
             name: 'pg-dump',

--- a/apps/infra/src/k8s/backups.ts
+++ b/apps/infra/src/k8s/backups.ts
@@ -173,6 +173,8 @@ new k8s.apps.v1.Deployment('app-pg-dump', {
         containers: [
           {
             name: 'pg-dump',
+            // Keep this major version in sync with databaseEngineVersion in src/vultr/appPostgres.ts.
+            // pg_dump client must be >= the server version.
             image: 'postgres:18-alpine',
             command: ['sleep', 'infinity'],
             env: [


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

This adds a small idle `postgres:18-alpine` pod in `default`, annotated with `k8up.io/backupcommand: pg_dump`. The daily `daily-backup` Schedule execs it and streams the dump into the same restic repo → GCS `bluedot-backups:/k8s/default`, on the same cadence and 28-day retention as everything else.

Note:

Keep the image major in sync with `databaseEngineVersion` in `src/vultr/appPostgres.ts` (pg_dump must be ≥ server).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2576

