### PR TITLE
Consolidate discussion facilitator/participant determination

### DIFF
--- a/apps/meet/src/pages/api/public/meeting-jwt.ts
+++ b/apps/meet/src/pages/api/public/meeting-jwt.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import jsonwebtoken from 'jsonwebtoken';
 import createHttpError from 'http-errors';
-import { groupDiscussionTable, zoomAccountTable } from '@bluedot/db';
+import { groupDiscussionTable, isDiscussionFacilitator, zoomAccountTable } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db from '../../../lib/api/db';
 import env from '../../../lib/api/env';
@@ -63,11 +63,10 @@ export default makeApiRoute({
 
   const issuedAt = Math.round(Date.now() / 1000);
   const expiresAt = issuedAt + 3600 * 4;
-  const facilitators = groupDiscussion.facilitators || [];
   const oPayload = {
     sdkKey: env.NEXT_PUBLIC_ZOOM_CLIENT_ID,
     mn: meetingNumber,
-    role: body.participantId && facilitators.includes(body.participantId) ? ZOOM_ROLE.HOST : ZOOM_ROLE.PARTICIPANT,
+    role: body.participantId && isDiscussionFacilitator(groupDiscussion, [body.participantId]) ? ZOOM_ROLE.HOST : ZOOM_ROLE.PARTICIPANT,
     iat: issuedAt,
     exp: expiresAt,
     tokenExp: expiresAt,

--- a/apps/meet/src/pages/api/public/meeting-participants.ts
+++ b/apps/meet/src/pages/api/public/meeting-participants.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
-  groupTable, groupDiscussionTable, meetPersonTable, zoomAccountTable,
+  groupTable, groupDiscussionTable, isDiscussionFacilitator, isDiscussionParticipant, meetPersonTable, zoomAccountTable,
 } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db from '../../../lib/api/db';
@@ -82,14 +82,10 @@ export default makeApiRoute({
   // Get zoom account
   const zoomAccount = await db.get(zoomAccountTable, { id: groupDiscussion.zoomAccount });
 
-  // Get facilitators and participants
-  const facilitatorIds = groupDiscussion.facilitators || [];
-  const participantIds = groupDiscussion.participantsExpected || [];
-
-  // Get all people and filter by IDs
+  // Get all people and split into discussion facilitators / participants
   const allPeople = await db.scan(meetPersonTable);
-  const facilitators = allPeople.filter((person) => facilitatorIds.includes(person.id));
-  const participants = allPeople.filter((person) => participantIds.includes(person.id));
+  const facilitators = allPeople.filter((person) => isDiscussionFacilitator(groupDiscussion, [person.id]));
+  const participants = allPeople.filter((person) => isDiscussionParticipant(groupDiscussion, [person.id]));
 
   const { meetingNumber, meetingPassword } = parseZoomLink(zoomAccount.meetingLink);
   const meetingHostKey = zoomAccount.hostKey ?? '';

--- a/apps/website/src/components/courses/DropoutModal.tsx
+++ b/apps/website/src/components/courses/DropoutModal.tsx
@@ -1,6 +1,10 @@
 import {
   CTALinkOrButton, ErrorSection, H1, Modal, P, ProgressDots, Select, Textarea,
 } from '@bluedot/ui';
+/**
+ * Prevents barrel file import errors when importing COURSE_ROLE from @bluedot/db
+ */
+import { COURSE_ROLE } from '@bluedot/db/src/schema';
 import { useMemo, useState } from 'react';
 import type { CourseRound, CourseRoundsData } from '../../server/routers/course-rounds';
 import { ONE_DAY_MS } from '../../lib/constants';
@@ -75,7 +79,7 @@ const DropoutModal: React.FC<DropoutModalProps> = ({
 
   const { data: registrations } = trpc.courseRegistrations.getAll.useQuery();
   const registration = registrations?.find((r) => r.id === applicantId);
-  const allowDeferral = registration?.role !== 'Facilitator';
+  const allowDeferral = registration?.role !== COURSE_ROLE.FACILITATOR;
 
   const isDeferral = dropoutType === 'Deferral';
 

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -1,5 +1,6 @@
 import {
   and,
+  COURSE_ROLE,
   courseRegistrationTable,
   courseTable,
   eq,
@@ -175,7 +176,7 @@ export const certificatesRouter = router({
       return { status: 'not-eligible', hasUpcomingRounds } as const;
     }
 
-    if (meetPerson.role === 'Participant') {
+    if (meetPerson.role === COURSE_ROLE.PARTICIPANT) {
       const { uniqueDiscussionAttendance, numUnits } = meetPerson;
       const hasAttendedEnough
         = uniqueDiscussionAttendance == null
@@ -208,7 +209,7 @@ export const certificatesRouter = router({
       } as const;
     }
 
-    if (meetPerson.role === 'Facilitator') {
+    if (meetPerson.role === COURSE_ROLE.FACILITATOR) {
       return { status: 'is-facilitator' } as const;
     }
 

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -1,5 +1,5 @@
 import {
-  applicationsCourseTable, applicationsRoundTable, courseRegistrationTable, inArray,
+  applicationsCourseTable, applicationsRoundTable, COURSE_ROLE, courseRegistrationTable, inArray,
   eq, and, or, ne, isNull,
 } from '@bluedot/db';
 import z from 'zod';
@@ -81,7 +81,7 @@ export const courseRegistrationsRouter = router({
         return db.insert(courseRegistrationTable, {
           email: ctx.auth.email,
           courseApplicationsBaseId: applicationsCourse.id,
-          role: 'Participant',
+          role: COURSE_ROLE.PARTICIPANT,
           decision: 'Accept',
           source: source ?? null,
         });

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -1,5 +1,5 @@
 import {
-  arrayOverlaps, courseRegistrationTable, dropoutTable, eq,
+  arrayOverlaps, COURSE_ROLE, courseRegistrationTable, dropoutTable, eq,
 } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import z from 'zod';
@@ -70,7 +70,7 @@ export const dropoutRouter = router({
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Deferral is only available once an application decision has been made.' });
       }
 
-      if (courseRegistration.role === 'Facilitator') {
+      if (courseRegistration.role === COURSE_ROLE.FACILITATOR) {
         if (type === 'Deferral') {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'Facilitators cannot defer a course.' });
         }

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -1,6 +1,7 @@
 import {
   and,
   arrayContains,
+  COURSE_ROLE,
   courseRegistrationTable,
   courseTable,
   desc,
@@ -130,7 +131,7 @@ export const exercisesRouter = router({
       const meetPerson = await db.getFirst(meetPersonTable, {
         filter: { applicationsBaseRecordId: courseRegistration.id },
       });
-      if (!meetPerson || meetPerson.role !== 'Facilitator') {
+      if (!meetPerson || meetPerson.role !== COURSE_ROLE.FACILITATOR) {
         // Return null rather than throwing — no groups/responses is a valid empty state, and throwing would trigger
         // retries unnecessarily.
         return null;

--- a/apps/website/src/server/routers/facilitator-applications.ts
+++ b/apps/website/src/server/routers/facilitator-applications.ts
@@ -2,6 +2,7 @@ import {
   and,
   applicationsCourseTable,
   applicationsRoundTable,
+  COURSE_ROLE,
   courseRegistrationTable,
   courseTable,
   eq,
@@ -46,7 +47,7 @@ export const getQuickApplyEligibleCourseIds = async (email: string): Promise<str
       .from(courseRegistrationTable.pg)
       .where(and(
         eq(courseRegistrationTable.pg.email, email),
-        eq(courseRegistrationTable.pg.role, 'Facilitator'),
+        eq(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR),
       )),
     db.pg
       .select({
@@ -142,7 +143,7 @@ const getPriorFacilitatorRegs = async (email: string, courseId: string) => {
     .from(courseRegistrationTable.pg)
     .where(and(
       eq(courseRegistrationTable.pg.email, email),
-      eq(courseRegistrationTable.pg.role, 'Facilitator'),
+      eq(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR),
       eq(courseRegistrationTable.pg.courseId, courseId),
     ));
   // Sorts most recent first; when used for pre-filling, the most recent application is likely the most relevant and helpful to pre-fill from.
@@ -188,7 +189,7 @@ export const facilitatorApplicationsRouter = router({
     const registrations = await db.pg
       .select()
       .from(courseRegistrationTable.pg)
-      .where(and(eq(courseRegistrationTable.pg.email, ctx.auth.email), eq(courseRegistrationTable.pg.role, 'Facilitator')));
+      .where(and(eq(courseRegistrationTable.pg.email, ctx.auth.email), eq(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR)));
 
     if (registrations.length === 0) return [];
 
@@ -251,7 +252,7 @@ export const facilitatorApplicationsRouter = router({
         .from(courseRegistrationTable.pg)
         .where(and(
           eq(courseRegistrationTable.pg.email, ctx.auth.email),
-          eq(courseRegistrationTable.pg.role, 'Facilitator'),
+          eq(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR),
         )),
       db.pg
         .select({ id: courseTable.pg.id, title: courseTable.pg.title, slug: courseTable.pg.slug })
@@ -348,7 +349,7 @@ export const facilitatorApplicationsRouter = router({
         email: ctx.auth.email,
         courseApplicationsBaseId: applicationsCourse.id,
         roundId: input.roundId,
-        role: 'Facilitator',
+        role: COURSE_ROLE.FACILITATOR,
         decision: null,
         source: 'quick-apply',
         numGroupsToFacilitate: input.numGroupsToFacilitate,

--- a/apps/website/src/server/routers/facilitators.ts
+++ b/apps/website/src/server/routers/facilitators.ts
@@ -2,6 +2,7 @@ import {
   and,
   arrayContains,
   asc,
+  COURSE_ROLE,
   courseFeedbackTable,
   eq,
   facilitatorDiscussionSwitchingTable,
@@ -49,7 +50,7 @@ const getNextStepsOptions = async (): Promise<FollowUpOption[]> => {
 
 const getFacilitator = async (roundId: string, facilitatorEmail: string) => {
   const facilitator = await db.getFirst(meetPersonTable, {
-    filter: { round: roundId, email: facilitatorEmail, role: 'Facilitator' },
+    filter: { round: roundId, email: facilitatorEmail, role: COURSE_ROLE.FACILITATOR },
   });
   if (!facilitator) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'No facilitator found for this round' });
@@ -62,7 +63,7 @@ async function verifyFacilitatorById(meetPersonId: string, ctx: { auth: { email:
   const meetPerson = await db.getFirst(meetPersonTable, {
     filter: { id: meetPersonId },
   });
-  if (!meetPerson || meetPerson.role !== 'Facilitator') {
+  if (!meetPerson || meetPerson.role !== COURSE_ROLE.FACILITATOR) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Not found' });
   }
 
@@ -110,7 +111,7 @@ async function getDropInIdsForGroup(groupId: string, participantIds: string[]) {
   const rows = await db.pg
     .select({ id: meetPersonTable.pg.id })
     .from(meetPersonTable.pg)
-    .where(and(inArray(meetPersonTable.pg.id, candidates), eq(meetPersonTable.pg.role, 'Participant')));
+    .where(and(inArray(meetPersonTable.pg.id, candidates), eq(meetPersonTable.pg.role, COURSE_ROLE.PARTICIPANT)));
   return rows.map((r) => r.id);
 }
 
@@ -139,7 +140,7 @@ export const facilitatorRouter = router({
     const facilitators = await db.pg
       .select({ id: meetPersonTable.pg.id, name: meetPersonTable.pg.name })
       .from(meetPersonTable.pg)
-      .where(and(eq(meetPersonTable.pg.round, roundId), eq(meetPersonTable.pg.role, 'Facilitator')));
+      .where(and(eq(meetPersonTable.pg.round, roundId), eq(meetPersonTable.pg.role, COURSE_ROLE.FACILITATOR)));
 
     return facilitators
       .filter((f) => f.id !== currentFacilitator.id)
@@ -274,7 +275,7 @@ export const facilitatorRouter = router({
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'New facilitator must be in the same round' });
       }
 
-      if (newFacilitator.role !== 'Facilitator') {
+      if (newFacilitator.role !== COURSE_ROLE.FACILITATOR) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Selected person is not a facilitator' });
       }
 
@@ -379,7 +380,7 @@ export const facilitatorRouter = router({
       const trimmed = (input.searchTerm ?? '').trim();
       const conditions = [
         eq(meetPersonTable.pg.round, meetPerson.round),
-        eq(meetPersonTable.pg.role, 'Participant'),
+        eq(meetPersonTable.pg.role, COURSE_ROLE.PARTICIPANT),
       ];
       if (excludeIds.length > 0) conditions.push(notInArray(meetPersonTable.pg.id, excludeIds));
       if (trimmed) conditions.push(ilike(meetPersonTable.pg.name, `%${trimmed}%`));
@@ -405,7 +406,7 @@ export const facilitatorRouter = router({
     .mutation(async ({ input, ctx }) => {
       const meetPerson = await verifyFacilitatorById(input.meetPersonId, ctx);
       const target = await db.getFirst(meetPersonTable, { filter: { id: input.participantId } });
-      if (!target || target.role !== 'Participant' || target.round !== meetPerson.round) {
+      if (!target || target.role !== COURSE_ROLE.PARTICIPANT || target.round !== meetPerson.round) {
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Participant is not in your round' });
       }
 

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -6,6 +6,8 @@ import {
   groupDiscussionTable,
   groupTable,
   inArray,
+  isDiscussionFacilitator,
+  isDiscussionParticipant,
   isNull,
   meetPersonTable,
   or,
@@ -170,9 +172,9 @@ export const groupDiscussionsRouter = router({
 
       if (groupDiscussion) {
         const isFacilitator = expectedFacilitatorDiscussionIds.includes(groupDiscussion.id)
-          || participantIds.some((id) => groupDiscussion.facilitators.includes(id));
+          || isDiscussionFacilitator(groupDiscussion, participantIds);
         const isParticipant = expectedParticipantDiscussionIds.includes(groupDiscussion.id)
-          || participantIds.some((id) => groupDiscussion.participantsExpected.includes(id));
+          || isDiscussionParticipant(groupDiscussion, participantIds);
 
         if (isFacilitator) {
           userRole = 'facilitator';

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -1,6 +1,7 @@
 import {
   and,
   arrayContains,
+  COURSE_ROLE,
   groupDiscussionTable,
   groupSwitchingTable,
   groupTable, inArray, meetPersonTable, roundTable,
@@ -184,7 +185,7 @@ export const groupSwitchingRouter = router({
   discussionsAvailable: protectedProcedure
     .input(z.object({ roundId: z.string() }))
     .query(async ({ ctx, input: { roundId } }) => {
-      const participant = await db.getFirst(meetPersonTable, { filter: { round: roundId, email: ctx.auth.email, role: 'Participant' } });
+      const participant = await db.getFirst(meetPersonTable, { filter: { round: roundId, email: ctx.auth.email, role: COURSE_ROLE.PARTICIPANT } });
       if (!participant) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'No participant record found for user in this course round' });
       }
@@ -266,7 +267,7 @@ export const groupSwitchingRouter = router({
       }
 
       const participant = await db.getFirst(meetPersonTable, {
-        filter: { round: roundId, email: ctx.auth.email, role: 'Participant' },
+        filter: { round: roundId, email: ctx.auth.email, role: COURSE_ROLE.PARTICIPANT },
       });
       if (!participant) {
         throw new TRPCError({

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -4,7 +4,7 @@ import {
   COURSE_ROLE,
   groupDiscussionTable,
   groupSwitchingTable,
-  groupTable, inArray, meetPersonTable, roundTable,
+  groupTable, inArray, isDiscussionFacilitator, isDiscussionParticipant, meetPersonTable, roundTable,
   type Group,
   type GroupDiscussion,
 } from '@bluedot/db';
@@ -68,7 +68,7 @@ export function calculateGroupAvailability({
       ? Math.max(0, maxParticipants - otherParticipants.length)
       : null;
 
-    const userIsParticipant = discussion.participantsExpected.includes(participantId);
+    const userIsParticipant = isDiscussionParticipant(discussion, [participantId]);
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const groupName = group.groupName || 'Group [Unknown]';
 
@@ -298,15 +298,16 @@ export const groupSwitchingRouter = router({
           !isManualRequest ? db.get(groupDiscussionTable, { id: inputNewDiscussionId }) : null,
         ]);
 
-        if (oldDiscussion.facilitators.includes(participantId) || newDiscussion?.facilitators.includes(participantId)) {
+        if (isDiscussionFacilitator(oldDiscussion, [participantId])
+          || (newDiscussion != null && isDiscussionFacilitator(newDiscussion, [participantId]))) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: 'Facilitators cannot switch groups by this method' });
         }
 
-        if (!oldDiscussion.participantsExpected.includes(participantId)) {
+        if (!isDiscussionParticipant(oldDiscussion, [participantId])) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: 'User not found in old discussion' });
         }
 
-        if (newDiscussion?.participantsExpected.includes(participantId)) {
+        if (newDiscussion != null && isDiscussionParticipant(newDiscussion, [participantId])) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: 'User is already expected to attend new discussion' });
         }
 

--- a/apps/website/src/server/routers/my-bluedot.ts
+++ b/apps/website/src/server/routers/my-bluedot.ts
@@ -2,6 +2,7 @@ import {
   and,
   applicationsRoundTable,
   arrayOverlaps,
+  COURSE_ROLE,
   courseRegistrationTable,
   courseTable,
   dropoutTable,
@@ -87,7 +88,7 @@ export const myBluedotRouter = router({
         .from(courseRegistrationTable.pg)
         .where(and(
           eq(courseRegistrationTable.pg.email, ctx.auth.email),
-          eq(courseRegistrationTable.pg.role, 'Facilitator'),
+          eq(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR),
           includeWithdrawn
             ? undefined
             : or(
@@ -109,8 +110,8 @@ export const myBluedotRouter = router({
       .where(and(
         eq(courseRegistrationTable.pg.email, email),
         or(
-          // Happy path: role === 'Participant'
-          ne(courseRegistrationTable.pg.role, 'Facilitator'),
+          // Happy path: role === COURSE_ROLE.PARTICIPANT
+          ne(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR),
           isNull(courseRegistrationTable.pg.role),
         ),
         or(
@@ -309,7 +310,7 @@ export const myBluedotRouter = router({
       .from(courseRegistrationTable.pg)
       .where(and(
         eq(courseRegistrationTable.pg.email, email),
-        eq(courseRegistrationTable.pg.role, 'Facilitator'),
+        eq(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR),
         or(
           ne(courseRegistrationTable.pg.decision, 'Withdrawn'),
           isNull(courseRegistrationTable.pg.decision),

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -53,6 +53,7 @@ export {
   peerFeedbackTable,
   vanityUrlsTable,
   RESOURCE_FEEDBACK,
+  COURSE_ROLE,
 } from './schema';
 
 // Type exports
@@ -102,6 +103,7 @@ export type {
   CourseFeedback,
   PeerFeedback,
   VanityUrl,
+  CourseRole,
 } from './schema';
 
 export { getPgAirtableFromIds, PgAirtableTable } from './lib/db-core';

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -105,7 +105,6 @@ export type {
   CourseFeedback,
   PeerFeedback,
   VanityUrl,
-  CourseRole,
 } from './schema';
 
 export { getPgAirtableFromIds, PgAirtableTable } from './lib/db-core';

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -54,6 +54,8 @@ export {
   vanityUrlsTable,
   RESOURCE_FEEDBACK,
   COURSE_ROLE,
+  isDiscussionFacilitator,
+  isDiscussionParticipant,
 } from './schema';
 
 // Type exports

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1646,6 +1646,17 @@ export const COURSE_ROLE = {
 
 export type CourseRole = typeof COURSE_ROLE[keyof typeof COURSE_ROLE];
 
+// Whether a user facilitates/participates in a specific discussion is determined by the discussion's linked records, not by their course-level role.
+export const isDiscussionFacilitator = (
+  discussion: Pick<GroupDiscussion, 'facilitators'>,
+  personIds: string[],
+) => personIds.some((id) => discussion.facilitators.includes(id));
+
+export const isDiscussionParticipant = (
+  discussion: Pick<GroupDiscussion, 'participantsExpected'>,
+  personIds: string[],
+) => personIds.some((id) => discussion.participantsExpected.includes(id));
+
 // Type exports for all tables
 export type Meta = InferSelectModel<typeof metaTable>;
 export type SyncMetadata = InferSelectModel<typeof syncMetadataTable>;

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1638,7 +1638,8 @@ export const vanityUrlsTable = pgAirtable('vanity_urls', {
 });
 
 // Course-level roles we branch on, as stored on `courseRegistrationTable.role` and the synced
-// `meetPersonTable.role`. The field can also be 'TODO', but we don't use that anywhere in our codebase.
+// `meetPersonTable.role`. The field can also be 'TODO' (applied, not yet assigned facilitator or
+// participant), but we don't branch on that anywhere in our codebase.
 export const COURSE_ROLE = {
   FACILITATOR: 'Facilitator',
   PARTICIPANT: 'Participant',

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1645,8 +1645,6 @@ export const COURSE_ROLE = {
   PARTICIPANT: 'Participant',
 } as const;
 
-export type CourseRole = typeof COURSE_ROLE[keyof typeof COURSE_ROLE];
-
 // Whether a user facilitates/participates in a specific discussion is determined by the discussion's linked records, not by their course-level role.
 export const isDiscussionFacilitator = (
   discussion: Pick<GroupDiscussion, 'facilitators'>,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1637,6 +1637,15 @@ export const vanityUrlsTable = pgAirtable('vanity_urls', {
   },
 });
 
+// Course-level roles we branch on, as stored on `courseRegistrationTable.role` and the synced
+// `meetPersonTable.role`. The field can also be 'TODO', but we don't use that anywhere in our codebase.
+export const COURSE_ROLE = {
+  FACILITATOR: 'Facilitator',
+  PARTICIPANT: 'Participant',
+} as const;
+
+export type CourseRole = typeof COURSE_ROLE[keyof typeof COURSE_ROLE];
+
 // Type exports for all tables
 export type Meta = InferSelectModel<typeof metaTable>;
 export type SyncMetadata = InferSelectModel<typeof syncMetadataTable>;


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Standardises how we determine if a user is a facilitator or participant of a discussion. Removes scattered 'Facilitator'/'Participant' magic strings.

No user-visible behaviour change - pure refactor.

Two concerns were tangled together:

1. Discussion-level ("does this person facilitate this discussion") was expressed inline via `discussion.facilitators.includes()`
2. Course/round-level role comparisons repeated the string literals 'Facilitator'/'Participant', which must match Airtable exactly

Notes:

- group-discussions.ts keeps its `expectedDiscussionsFacilitator` OR-fallback. That person-side linkage and the discussion's facilitators array can diverge (a facilitator assigned to a discussion in another round), and an existing test guards it - so the helper covers only the array half. Behavior is identical to before.
- Remaining .role checks are all genuine course/round-level standing (my-courses tabs, dropout rules, feedback authz, certificates), not discussion-facilitation proxies - intentionally left on .role.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #1691

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

