### PR TITLE
[chore] Bump app Docker base images node 20 -> 22 (off EOL)

### DIFF
--- a/apps/app-template/Dockerfile
+++ b/apps/app-template/Dockerfile
@@ -4,7 +4,7 @@
 # - Add client-side env vars to .env.production (you might need to create this)
 # If you came here to change the build process, edit the `npm run build` script in package.json instead
 
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/availability/Dockerfile
+++ b/apps/availability/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/course-demos/Dockerfile
+++ b/apps/course-demos/Dockerfile
@@ -4,7 +4,7 @@
 # - Add client-side env vars to .env.production (you might need to create this)
 # If you came here to change the build process, edit the `npm run build` script in package.json instead
 
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/editor/Dockerfile
+++ b/apps/editor/Dockerfile
@@ -4,7 +4,7 @@
 # - Add client-side env vars to .env.production (you might need to create this)
 # If you came here to change the build process, edit the `npm run build` script in package.json instead
 
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/frontend-example/Dockerfile
+++ b/apps/frontend-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/meet/Dockerfile
+++ b/apps/meet/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/pg-sync-service/Dockerfile
+++ b/apps/pg-sync-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/room/Dockerfile
+++ b/apps/room/Dockerfile
@@ -4,7 +4,7 @@
 # - Add client-side env vars to .env.production (you might need to create this)
 # If you came here to change the build process, edit the `npm run build` script in package.json instead
 
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/speed-review/Dockerfile
+++ b/apps/speed-review/Dockerfile
@@ -4,7 +4,7 @@
 # - Add client-side env vars to .env.production (you might need to create this)
 # If you came here to change the build process, edit the `npm run build` script in package.json instead
 
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 

--- a/apps/website/Dockerfile
+++ b/apps/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:7a91aa397f2e2dfbfcdad2e2d72599f374e0b0172be1d86eeb73f1d33f36a4b2 AS base
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS base
 
 RUN apk update && apk add --no-cache dumb-init
 


### PR DESCRIPTION
## What

Bumps all 10 node-based app Dockerfiles from `node:20-alpine` → `node:22-alpine` (digest-pinned). Node 20 hit EOL ~Apr 2026, so **production has been running an EOL runtime**. Node 22 EOL is ~Apr 2027 (~10mo runway).

This is distinct from #2594 (GitHub Actions runtime). That covers CI action versions; this is the node our containers actually run.

Apps: website, meet, availability, editor, course-demos, speed-review, room, pg-sync-service, app-template, frontend-example. (`login`/`posthog-proxy`/`storybook`/`website-proxy` are not node-based and untouched.)

## Why 22 (not 24)

`engines: ^22` already, and CI builds/tests on node 22, so app code is de-facto validated. 22 is the smallest safe hop off EOL with zero engines/CI churn. 24 (newest LTS) is a reasonable fast-follow once this lands.

## Validation

No `sharp`/native deps in any package.json, so runtime risk is low. Built + boot-checked the 3 representative apps locally (Colima, docker 28.4):

- **pg-sync-service** — the only app running `npm ci` in-image; resolved cleanly on node 22; runtime reports `v22.22.3`.
- **website** — Next.js standalone; image builds, server boots to `v22.22.3` (only 500s on missing local secrets, unrelated to the bump).
- **meet** — Zoom Web SDK; builds, runtime `v22.22.3`.

The other 7 are COPY-and-run clones of the same base; covered by the CI build/deploy matrix.

## Rollout

- Merge auto-deploys **9 apps straight to prod** (their `deploy:cd` = single env). Plan: monitor the `cd_*` matrix + app health on merge; revert is a one-line digest swap.
- **website** deploys to staging on merge only; prod needs a `website/vX.Y.Z` release tag. I'll cut that release as the final step. **EOL fix is not complete for website until that release ships.**

Closes #2622
