### PR TITLE
Support database server identity verification on dev machines

### DIFF
--- a/libraries/db/src/lib/client.test.ts
+++ b/libraries/db/src/lib/client.test.ts
@@ -228,7 +228,12 @@ describe('pgConnectionConfig', () => {
     expect(pgConnectionConfig(connString)).toEqual({ connectionString: connString });
   });
 
-  test.each(['require', 'verify-ca', 'verify-full'])('sslmode=%s strips the param and attaches the Vultr CA plus system roots', (sslmode) => {
+  test('passes through sslmode=verify-ca (its no-hostname-check semantics are not supported)', () => {
+    const connString = 'postgres://user:pass@db.vultrdb.com:16751/app?sslmode=verify-ca';
+    expect(pgConnectionConfig(connString)).toEqual({ connectionString: connString });
+  });
+
+  test.each(['require', 'verify-full'])('sslmode=%s strips the param and attaches the Vultr CA plus system roots', (sslmode) => {
     const config = pgConnectionConfig(`postgres://user:pass@db.vultrdb.com:16751/app?sslmode=${sslmode}`);
 
     expect(config.connectionString).toBe('postgres://user:pass@db.vultrdb.com:16751/app');

--- a/libraries/db/src/lib/client.test.ts
+++ b/libraries/db/src/lib/client.test.ts
@@ -12,6 +12,7 @@ import {
   type TestPgAirtableDb,
   userTable,
 } from '../index';
+import { pgConnectionConfig, VULTR_PROJECT_CA } from './pg-ssl';
 
 let db: PgAirtableDb;
 let testDb: TestPgAirtableDb;
@@ -208,5 +209,38 @@ describe('getFirstFromPg (direct)', () => {
 
   test('throws when table has no autoNumberId and no sortBy is provided', async () => {
     await expect(getFirstFromPg(db.pg, personTable.pg)).rejects.toThrow(/autoNumberId for default sorting/);
+  });
+});
+
+describe('pgConnectionConfig', () => {
+  test('passes through a connection string with no sslmode', () => {
+    const connString = 'postgres://user:pass@localhost:5432/bluedot_dev';
+    expect(pgConnectionConfig(connString)).toEqual({ connectionString: connString });
+  });
+
+  test('passes through sslmode=no-verify (production posture)', () => {
+    const connString = 'postgres://user:pass@db.example.com:5432/app?sslmode=no-verify';
+    expect(pgConnectionConfig(connString)).toEqual({ connectionString: connString });
+  });
+
+  test('passes through a non-URI connection string', () => {
+    const connString = 'host=localhost dbname=app';
+    expect(pgConnectionConfig(connString)).toEqual({ connectionString: connString });
+  });
+
+  test.each(['require', 'verify-ca', 'verify-full'])('sslmode=%s strips the param and attaches the Vultr CA plus system roots', (sslmode) => {
+    const config = pgConnectionConfig(`postgres://user:pass@db.vultrdb.com:16751/app?sslmode=${sslmode}`);
+
+    expect(config.connectionString).toBe('postgres://user:pass@db.vultrdb.com:16751/app');
+    const { ca } = config.ssl as { ca: string[] };
+    expect(ca[0]).toBe(VULTR_PROJECT_CA);
+    expect(ca.length).toBeGreaterThan(1);
+  });
+
+  test('sslmode=require preserves credentials and other query params', () => {
+    const config = pgConnectionConfig('postgres://user:p%40ss@db.vultrdb.com:16751/app?application_name=x&sslmode=require');
+
+    expect(config.connectionString).toBe('postgres://user:p%40ss@db.vultrdb.com:16751/app?application_name=x');
+    expect(config.ssl).toBeDefined();
   });
 });

--- a/libraries/db/src/lib/client.ts
+++ b/libraries/db/src/lib/client.ts
@@ -10,6 +10,7 @@ import { type AirtableItemFromColumnsMap, type BasePgTableType, type PgAirtableC
 import {
   buildWhereClause, getFirstFromPg, type Filter, type PgDatabase,
 } from './pg-query';
+import { pgConnectionConfig } from './pg-ssl';
 import env from './env';
 
 export { type Filter, type PgDatabase } from './pg-query';
@@ -119,7 +120,7 @@ export class PgAirtableDb {
       onWarning,
     });
 
-    this.pgUnrestricted = pgClient ?? drizzle(pgConnString);
+    this.pgUnrestricted = pgClient ?? drizzle({ connection: pgConnectionConfig(pgConnString) });
     this.pg = this.pgUnrestricted as RestrictedPgDatabase;
   }
 

--- a/libraries/db/src/lib/pg-ssl.ts
+++ b/libraries/db/src/lib/pg-ssl.ts
@@ -57,8 +57,10 @@ export const pgConnectionConfig = (connString: string): PgPoolConfig => {
     return { connectionString: connString };
   }
 
+  // verify-ca is deliberately excluded: its libpq semantics skip hostname checks, which this
+  // transformation can't preserve (Node TLS would enforce them).
   const sslmode = url.searchParams.get('sslmode');
-  if (sslmode === null || !['require', 'verify-ca', 'verify-full'].includes(sslmode)) {
+  if (sslmode === null || !['require', 'verify-full'].includes(sslmode)) {
     return { connectionString: connString };
   }
 

--- a/libraries/db/src/lib/pg-ssl.ts
+++ b/libraries/db/src/lib/pg-ssl.ts
@@ -1,0 +1,70 @@
+import tls from 'node:tls';
+
+/** The subset of node-postgres `PoolConfig` we produce (`pg` ships no types of its own). */
+type PgPoolConfig = {
+  connectionString: string;
+  ssl?: { ca: string[] };
+};
+
+/**
+ * CA certificate for our Vultr managed Postgres databases. Valid until 2036-05-19.
+ *
+ * This is public-key material (the server sends it to every client during the TLS handshake),
+ * so it is safe to commit.
+ *
+ * To refresh (e.g. if the Vultr account is ever recreated): Vultr console → the database →
+ * Connection Details → "Download Signed Certificate", or fetch it from the server itself:
+ */
+export const VULTR_PROJECT_CA = `-----BEGIN CERTIFICATE-----
+MIIERDCCAqygAwIBAgIUF44kku5ijnmaMUps1a/9AlHKrNcwDQYJKoZIhvcNAQEM
+BQAwOjE4MDYGA1UEAwwvMTFhNzQyODItNmIyYS00ZWVkLWE1OGItNWNlNmNkMjk5
+YTY2IFByb2plY3QgQ0EwHhcNMjYwNTIyMTczMTU5WhcNMzYwNTE5MTczMTU5WjA6
+MTgwNgYDVQQDDC8xMWE3NDI4Mi02YjJhLTRlZWQtYTU4Yi01Y2U2Y2QyOTlhNjYg
+UHJvamVjdCBDQTCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBALITF+vO
+sH98hcqX6W98aCDGebkg26c9wPy7ktws6Ravyn/YCdHEJn1HbsJJEzU5Lv5H2Z5a
+KJkzVVsk7fNGARvNtuoxnTHF08xYfylksjl8PbSlcGCru+U8T7x0foIDj6WVIg/E
+y2iQngUMBvk/4sEiaGm90Z046WlvPRGikiQM3U9yjLHm+SFNC8ibeXmhPtH4tJqp
+Iy7zSq8Ja30hnvBFZEHXyWZloXmg++OPsCxty7fzsHuMusxsJXSvdZegtbjcW3QE
+ADTGBnNcqb/dIGFpjZuzjRDkrShaxae4lCuRyAvMJVMYJEsIJq/KKqdmeDobW1lf
+utSsPUTnOnyBdk/MTOQZ8jebvnEWstZPWjWGPM/Zpkr1VukIepDs1ntJ4MoGMc+V
+/B9C347ggrwZKP/x4g75w6FH9pUlPHZKB2/S83QL0uvSd0cwZG7kOLJvfzTk/6+B
+gPGFSgcQHvnUvdN1QF6/QCtvqlVyKuo8vE3K0vnuuVcU50AqF1i9Phk8JwIDAQAB
+o0IwQDAdBgNVHQ4EFgQUUYRlGxyByLrJY/gW2/MUICpig8AwEgYDVR0TAQH/BAgw
+BgEB/wIBADALBgNVHQ8EBAMCAQYwDQYJKoZIhvcNAQEMBQADggGBAJVd8Uy1bwMO
+js5mLXC9nMAVYFhstecjRd2OFDsdb8iVWswOOu9x9dKVGjVPRKEjQME1VsXvT17J
+sgIoqs5JKx6Bu3qWvP4XpPldwlSSK7kAHWH6JFKXGuSyiL9bg/m9BX9L5B6aplLx
+YkR5pR1Us01IbqJ+18y3laV/eSPTCrM8GNn7iYgSI7svLc/b5td4+sHP0dhNe7lq
+NaoPNtUs7rOu39b7IsmYXP8iuDcwJPpGhihDprmmaIct/UBoLAnBUvnljtB6ucuM
+ssO0IcUd4cp3AsN+S33qT+cb7fugYdfkkKvoFa8G3RpGaUx1OOOCUh2Fu6T0O937
+eOsTUbNrBCoPHo4huJjUTKwsuGoGA+8MytRAkqEPzGNvBgdd22qtkG8tpJm6u9Hk
+Jem7Jywr1gPfr0AW7jY/jQNdivXecpBnWMobYpLFa4WPqBtA0JTkmr46Fz5z+D4a
+sCZJJb8XeXOLXzB+kG5OwbbB2X4dKnYLJ+f+65KE7trhBE81GhRXfw==
+-----END CERTIFICATE-----
+`;
+
+/**
+ * Builds the node-postgres config for a connection string. For `sslmode`s that require
+ * attaching the Vultr CA (alongside the system roots), patch in the VULTR_PROJECT_CA
+ * but drop the `sslmode` parameter, to avoid SELF_SIGNED_CERT_IN_CHAIN. This still
+ * achieves the security benefit of sending the cert (avoiding man-in-the-middle attacks).
+ */
+export const pgConnectionConfig = (connString: string): PgPoolConfig => {
+  let url: URL;
+  try {
+    url = new URL(connString);
+  } catch {
+    // Not a URI-style connection string, let pg interpret it as-is.
+    return { connectionString: connString };
+  }
+
+  const sslmode = url.searchParams.get('sslmode');
+  if (sslmode === null || !['require', 'verify-ca', 'verify-full'].includes(sslmode)) {
+    return { connectionString: connString };
+  }
+
+  url.searchParams.delete('sslmode');
+  return {
+    connectionString: url.toString(),
+    ssl: { ca: [VULTR_PROJECT_CA, ...tls.rootCertificates] },
+  };
+};


### PR DESCRIPTION
# Description

Per #2586, we want to start using `sslmode=require` for dev connections to the database. This prevents man-in-the-middle attacks, and requires having the expected public certificate locally to check against the one received from the database.

This is just some fiddly setup to:
- Add the certificate to the codebase
- Send it in a way that doesn't trigger `SELF_SIGNED_CERT_IN_CHAIN` errors

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2586

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories