### PR TITLE
Point pg-sync-service at managed postgres, remove shadow instance

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -2,7 +2,7 @@ import { jsonStringify } from '@pulumi/pulumi';
 import { type core } from '@pulumi/kubernetes/types/input';
 import { envVarSources } from './secrets';
 import {
-  getConnectionDetails, keycloakPg, airtableSyncPg, appPgConnectionDetails,
+  getConnectionDetails, keycloakPg, appPgConnectionDetails,
 } from './postgres';
 import {
   minioPvc, mcpAggregatorDataPvc, mcpAshbyDataPvc, mcpGoogleDataPvc,
@@ -330,41 +330,11 @@ export const services: ServiceDefinition[] = [
         image: 'ghcr.io/bluedotimpact/bluedot-pg-sync-service:latest',
         env: [
           { name: 'AIRTABLE_PERSONAL_ACCESS_TOKEN', valueFrom: envVarSources.airtablePat },
-          { name: 'PG_URL', valueFrom: getConnectionDetails(airtableSyncPg).uri },
-          { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
-          { name: 'INFO_SLACK_CHANNEL_ID', value: INFO_SLACK_CHANNEL_ID },
-          { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
-          { name: 'PROD_ONLY_WEBHOOK_DELETION', valueFrom: envVarSources.prodOnlyWebhookDeletion },
-        ],
-      }],
-    },
-  },
-  // Shadow instance: populates the new managed Postgres (appPg) so we can cut over
-  // the website from the in-cluster `airtableSyncPg` to the managed DB without a
-  // sync gap. Shares Airtable webhooks with the primary pg-sync-service — each
-  // instance keeps its own in-memory cursor.
-  //
-  // Differences from the primary above:
-  //   - APP_NAME override
-  //   - PG_URL points at the managed DB secret
-  //   - PROD_ONLY_WEBHOOK_DELETION omitted for safety. Unclear if it could cause issues but one
-  //     could imagine the two instances fighting each other over webhook deletion
-  //
-  // Delete once the website has been cut over to the managed DB and the primary
-  // `bluedot-pg-sync-service` is pointed at the managed DB.
-  {
-    name: 'bluedot-pg-sync-shadow',
-    spec: {
-      containers: [{
-        name: 'bluedot-pg-sync-shadow',
-        image: 'ghcr.io/bluedotimpact/bluedot-pg-sync-service:latest',
-        env: [
-          { name: 'APP_NAME', value: 'pg-sync-service-shadow' },
-          { name: 'AIRTABLE_PERSONAL_ACCESS_TOKEN', valueFrom: envVarSources.airtablePat },
           { name: 'PG_URL', valueFrom: appPgConnectionDetails.uri },
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
           { name: 'INFO_SLACK_CHANNEL_ID', value: INFO_SLACK_CHANNEL_ID },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
+          { name: 'PROD_ONLY_WEBHOOK_DELETION', valueFrom: envVarSources.prodOnlyWebhookDeletion },
         ],
       }],
     },


### PR DESCRIPTION
# Description

I'm doing this all in one go, which may in principle cause a short gap where the new managed Postgres database isn't being synced. But this will be at most a minute or two, and as soon as it's deployed to production, I will force a full sync to bring it up to date.

Leaving the old postgres instance is deliberate: Some devs will still be connected to it and may take ~a day to switch over, and if we discover a serious bug in the next couple of days it will be nice to still have the old database there.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2572, #2580

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
