### PR TITLE
[feat] speed-review: add Biosecurity rounds, show rounds until first discussion

### DIFF
--- a/apps/speed-review/src/components/RoundPicker.tsx
+++ b/apps/speed-review/src/components/RoundPicker.tsx
@@ -6,7 +6,7 @@ import { type Direction } from '../lib/client/types';
 
 const DIRECTION_STORAGE_KEY = 'speed-review:direction';
 const ROUNDS_PER_COURSE = 3;
-const ALLOWED_COURSES = ['AGI Strategy', 'Technical AI Safety', 'Technical AI Safety Project'];
+const ALLOWED_COURSES = ['AGI Strategy', 'Biosecurity', 'Technical AI Safety', 'Technical AI Safety Project'];
 
 const loadDirection = (): Direction => {
   if (typeof window === 'undefined') return 'top';

--- a/apps/speed-review/src/lib/api/airtable.ts
+++ b/apps/speed-review/src/lib/api/airtable.ts
@@ -155,9 +155,8 @@ export const fetchRounds = async (): Promise<Round[]> => {
     ['Course - Round - Intensity', 'Status', 'fldfi2ZKsbSK6NVTV', 'First discussion'],
   );
 
-  // Hide rounds where the first discussion date is within 5 days.
+  // Hide rounds where the first discussion has already happened.
   const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() + 5);
   cutoff.setHours(0, 0, 0, 0);
 
   return records


### PR DESCRIPTION
## Summary

- **Biosecurity added to the round picker.** `ALLOWED_COURSES` in `RoundPicker.tsx` previously listed only AGI Strategy / Technical AI Safety / Technical AI Safety Project, so Biosecurity rounds returned by `/api/rounds` were filtered out client-side. The June rounds already have AI summaries + Commitment/Impressiveness scores in Airtable, so they're ready to review (Jun W25 Intensive: 61 scored undecided applications; Jun W26 Part-time: 79).
- **Rounds now show until their first discussion has happened.** Previously rounds were hidden once the first discussion was within 5 days (i.e. from the application deadline, which is 4 days before first discussion). Will sometimes needs to review applications later than that at a push, so the cutoff is now start-of-today: a round disappears only once its first discussion date has passed.

## Test plan

- [ ] Round picker shows a Biosecurity section with the Jun W25 Intensive and Jun W26 Part-time rounds
- [ ] Biosecurity rounds load applications sorted by Total score; summary card shows Commitment + Impressiveness pills and no Technical skill pill
- [ ] A round with first discussion today or later still appears; rounds with a past first discussion don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)