### PR TITLE
Set exercise response and resource completion createdAt in code instead of relying on Airtable field default

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -305,5 +305,6 @@ export const createMockResourceCompletion = (overrides: Partial<ResourceCompleti
   unitResourceId: MOCK_RESOURCE_ID,
   resourceId: null,
   createdByUserId: null,
+  createdAt: null,
   ...overrides,
 });

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -145,6 +145,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
               isCompleted: updatedFields.isCompleted ?? false,
               resourceId: null,
               createdByUserId: null,
+              createdAt: new Date().toISOString(),
             });
           }
 

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -81,6 +81,8 @@ describe('exercises.saveExerciseResponse', () => {
       completedAt: null,
     });
     expect(result.id).toBeDefined();
+    // Same format as the Airtable "default to current date" values this replaces, e.g. 2026-06-10T11:03:38.910Z
+    expect(result.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   });
 
   test('writes userId on insert when the user exists', async () => {

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -76,6 +76,8 @@ export const exercisesRouter = router({
           email: ctx.auth.email,
           exerciseId: input.exerciseId,
           response: input.response,
+          // Airtable also defaults this field to now(); set it in code so it survives the move off Airtable
+          createdAt: new Date().toISOString(),
           completedAt: completedAt ?? null,
           userId: user ? [user.id] : null,
         });

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -76,7 +76,6 @@ export const exercisesRouter = router({
           email: ctx.auth.email,
           exerciseId: input.exerciseId,
           response: input.response,
-          // Airtable also defaults this field to now(); set it in code so it survives the move off Airtable
           createdAt: new Date().toISOString(),
           completedAt: completedAt ?? null,
           userId: user ? [user.id] : null,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1479,7 +1479,6 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
       pgColumn: text().array(),
       airtableId: 'fldtEFIAKCUctCDhW',
     },
-    // Airtable's auto-computed "Created" time; read-only in Airtable, so written in code once this table moves off Airtable
     createdAt: {
       pgColumn: text(),
       airtableId: 'fldG9OAIqAYovr56a',

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1479,6 +1479,11 @@ export const resourceCompletionTable = pgAirtable('resource_completion', {
       pgColumn: text().array(),
       airtableId: 'fldtEFIAKCUctCDhW',
     },
+    // Airtable's auto-computed "Created" time; read-only in Airtable, so written in code once this table moves off Airtable
+    createdAt: {
+      pgColumn: text(),
+      airtableId: 'fldG9OAIqAYovr56a',
+    },
   },
 });
 


### PR DESCRIPTION
# Description

Prerequisite for flipping these to postgres-only

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2584

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
