### PR TITLE
[fix] Disable buildkit provenance/sbom so ghcr push doesn't fail

### DIFF
--- a/libraries/docker-scripts/src/deploy.sh
+++ b/libraries/docker-scripts/src/deploy.sh
@@ -7,8 +7,10 @@ IMAGE_NAME="bluedot-$APP_NAME"
 VERSION_TAG="$(TZ=UTC date +'%Y%m%d.%H%M%S').$(git rev-parse --short HEAD)"
 
 # Build
+# --provenance=false --sbom=false: otherwise buildkit emits an OCI image index with
+# attestation manifests, which ghcr rejects on push with "unknown blob".
 APP_NAME=$APP_NAME VERSION_TAG=$VERSION_TAG npm run build --if-present
-docker build --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
+docker build --provenance=false --sbom=false --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
 
 # Tag and push to registry
 docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:$VERSION_TAG

--- a/libraries/docker-scripts/src/multistage/deploy-production.sh
+++ b/libraries/docker-scripts/src/multistage/deploy-production.sh
@@ -10,8 +10,10 @@ VERSION_TAG="$(TZ=UTC date +'%Y%m%d.%H%M%S').$(git rev-parse --short HEAD)"
 cp .env.production.template .env.production.local
 
 # Build
+# --provenance=false --sbom=false: otherwise buildkit emits an OCI image index with
+# attestation manifests, which ghcr rejects on push with "unknown blob".
 APP_NAME=$APP_NAME VERSION_TAG=$VERSION_TAG npm run build --if-present
-docker build --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
+docker build --provenance=false --sbom=false --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
 
 # Tag and push to registry
 docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:$VERSION_TAG

--- a/libraries/docker-scripts/src/multistage/deploy-staging.sh
+++ b/libraries/docker-scripts/src/multistage/deploy-staging.sh
@@ -15,8 +15,10 @@ echo "User-agent: *
 Disallow: /" > public/robots.txt
 
 # Build
+# --provenance=false --sbom=false: otherwise buildkit emits an OCI image index with
+# attestation manifests, which ghcr rejects on push with "unknown blob".
 APP_NAME=$APP_NAME VERSION_TAG=$VERSION_TAG npm run build --if-present
-docker build --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
+docker build --provenance=false --sbom=false --platform="linux/amd64" -t $IMAGE_NAME --build-arg APP_NAME="$APP_NAME" --build-arg VERSION_TAG="$VERSION_TAG" .
 
 # Tag and push to registry
 docker tag $IMAGE_NAME $REPO_URL/$IMAGE_NAME:$VERSION_TAG


### PR DESCRIPTION
## Problem

After the node 20→22 base bump (#2636) merged, CD started failing on `docker push` to ghcr with `unknown blob` for several apps (course-demos, editor, frontend-example, pg-sync-service). All image **layers** push fine ("Pushed" / "Layer already exists"); the failure is at the **manifest** push.

## Root cause

Modern buildkit attaches **provenance** and **SBOM** attestations to builds by default. That turns the output into an **OCI image index** referencing two manifests — the real image manifest plus an attestation manifest — instead of a single image manifest. ghcr rejects the attestation-bearing index on push with `unknown blob`.

The node bump didn't introduce the buildkit behaviour, but it forced a **fresh manifest push for every app** (previously, unchanged apps were no-op pushes that found everything already in ghcr), which exposed this latent issue.

Note: pinning a platform-specific base digest would **not** fix this — the attestation manifest is attached to the *built* image regardless of base image type.

## Fix

Add `--provenance=false --sbom=false` to `docker build` in the three deploy scripts that push to ghcr (`deploy.sh`, `multistage/deploy-staging.sh`, `multistage/deploy-production.sh`). The build then emits a single clean manifest. `test.sh`/`start.sh` don't push, so they're untouched.

## Validation

Local (Colima, docker 28.4):
- **Default build** → `exporting attestation manifest` + `exporting manifest list` (the OCI index ghcr rejects).
- **`--provenance=false --sbom=false`** → single `exporting manifest`, no index.

Attestations are supply-chain metadata, not required to run the image; disabling them is the standard remedy for registries that don't accept attestation manifests.
