### PR TITLE
Course page schedule respects course accent colour

### DIFF
--- a/apps/website/src/components/courses/CourseSchedule.tsx
+++ b/apps/website/src/components/courses/CourseSchedule.tsx
@@ -8,8 +8,8 @@ import {
   useEffect, useMemo, useState,
 } from 'react';
 import { CourseIcon } from './CourseIcon';
-import { COURSE_CONFIG } from '../../lib/constants';
 import { buildApplicationUrl } from '../../lib/utils';
+import { getCourseAccentColor } from '../../lib/courseColors';
 import RoundGroup from '../shared/RoundGroup';
 import { trpc } from '../../utils/trpc';
 
@@ -20,11 +20,6 @@ const COURSE_DISPLAY_ORDER = [
   'technical-ai-safety',
   'technical-ai-safety-project',
 ];
-
-const getCourseAccentColor = (courseSlug: string): string => {
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  return COURSE_CONFIG[courseSlug]?.accentColor || 'var(--bluedot-normal)';
-};
 
 const sortByDisplayOrder = (items: Course[]) => [...items].sort((a, b) => {
   const aIndex = COURSE_DISPLAY_ORDER.indexOf(a.slug);

--- a/apps/website/src/components/lander/components/ScheduleListSection.stories.tsx
+++ b/apps/website/src/components/lander/components/ScheduleListSection.stories.tsx
@@ -55,7 +55,7 @@ const meta = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: 'A list-style schedule section that fetches upcoming course rounds and renders them as `PageListRow` entries grouped into intensive and part-time. Falls back to a CTA when no rounds are open.',
+        component: 'A schedule section that fetches upcoming course rounds and renders them with the shared `RoundGroup` (course-accent left bar) grouped into intensive and part-time. Falls back to a CTA when no rounds are open.',
       },
     },
   },

--- a/apps/website/src/components/lander/components/ScheduleListSection.tsx
+++ b/apps/website/src/components/lander/components/ScheduleListSection.tsx
@@ -1,8 +1,9 @@
 import { CTALinkOrButton, P } from '@bluedot/ui';
 import { type ReactNode } from 'react';
+import { getCourseAccentColor } from '../../../lib/courseColors';
 import { trpc } from '../../../utils/trpc';
-import { PageListGroup, PageListRow, pageSectionHeadingClass } from '../../PageListRow';
-import { buildRoundApplyUrl } from '../../shared/RoundItem';
+import { pageSectionHeadingClass } from '../../PageListRow';
+import RoundGroup from '../../shared/RoundGroup';
 
 export type ScheduleListSectionProps = {
   id?: string;
@@ -13,8 +14,6 @@ export type ScheduleListSectionProps = {
   fallbackText?: ReactNode;
   fallbackCtaText?: string;
 };
-
-const groupLabelClass = 'text-size-xs font-semibold uppercase tracking-[0.08em] text-bluedot-navy/72';
 
 const ScheduleListSection = ({
   id,
@@ -27,22 +26,11 @@ const ScheduleListSection = ({
 }: ScheduleListSectionProps) => {
   const { data: rounds, isLoading } = trpc.courseRounds.getRoundsForCourse.useQuery({ courseSlug });
 
-  const intenseRounds = (rounds?.intense ?? []).filter((r) => r.numberOfUnits != null).slice(0, 3);
-  const partTimeRounds = (rounds?.partTime ?? []).filter((r) => r.numberOfUnits != null).slice(0, 3);
+  const intenseRounds = (rounds?.intense ?? []).filter((r) => r.numberOfUnits != null);
+  const partTimeRounds = (rounds?.partTime ?? []).filter((r) => r.numberOfUnits != null);
   const hasRounds = intenseRounds.length > 0 || partTimeRounds.length > 0;
 
-  const intenseLabel = intenseRounds[0]?.numberOfUnits != null
-    ? `Intensive · ${intenseRounds[0].numberOfUnits} days · 5h/day`
-    : 'Intensive';
-  const partTimeLabel = partTimeRounds[0]?.numberOfUnits != null
-    ? `Part-time · ${partTimeRounds[0].numberOfUnits} weeks · 5h/week`
-    : 'Part-time';
-
-  const buildSubtitle = (round: { applicationDeadlineDetailed?: string | null; applicationDeadline?: string | null }) => {
-    if (round.applicationDeadlineDetailed) return `Applications close ${round.applicationDeadlineDetailed}`;
-    if (round.applicationDeadline) return `Applications close ${round.applicationDeadline} at 23:59 UTC`;
-    return 'Applications open';
-  };
+  const accentColor = getCourseAccentColor(courseSlug);
 
   return (
     <section id={id} className="w-full bg-white">
@@ -72,40 +60,22 @@ const ScheduleListSection = ({
           )}
 
           {!isLoading && hasRounds && (
-            <div className="flex flex-col gap-8">
+            <div className="flex flex-col gap-16">
               {intenseRounds.length > 0 && (
-                <div className="flex flex-col gap-4">
-                  <p className={groupLabelClass}>{intenseLabel}</p>
-                  <PageListGroup>
-                    {intenseRounds.map((round) => (
-                      <PageListRow
-                        key={round.id}
-                        href={buildRoundApplyUrl(applicationUrl, round.id)}
-                        title={round.dateRange}
-                        summary={buildSubtitle(round)}
-                        ctaLabel="Apply now"
-                        external
-                      />
-                    ))}
-                  </PageListGroup>
-                </div>
+                <RoundGroup
+                  type="intensive"
+                  rounds={intenseRounds}
+                  applicationUrl={applicationUrl}
+                  accentColor={accentColor}
+                />
               )}
               {partTimeRounds.length > 0 && (
-                <div className="flex flex-col gap-4">
-                  <p className={groupLabelClass}>{partTimeLabel}</p>
-                  <PageListGroup>
-                    {partTimeRounds.map((round) => (
-                      <PageListRow
-                        key={round.id}
-                        href={buildRoundApplyUrl(applicationUrl, round.id)}
-                        title={round.dateRange}
-                        summary={buildSubtitle(round)}
-                        ctaLabel="Apply now"
-                        external
-                      />
-                    ))}
-                  </PageListGroup>
-                </div>
+                <RoundGroup
+                  type="part-time"
+                  rounds={partTimeRounds}
+                  applicationUrl={applicationUrl}
+                  accentColor={accentColor}
+                />
               )}
             </div>
           )}

--- a/apps/website/src/components/lander/components/ScheduleRounds.tsx
+++ b/apps/website/src/components/lander/components/ScheduleRounds.tsx
@@ -5,7 +5,7 @@ type ScheduleRoundsProps = {
   courseSlug: string;
   applicationUrl: string;
   fallbackContent?: React.ReactNode;
-  /** Accent color for bars and "Apply now" links. Defaults to bluedot-normal */
+  /** Accent color for bars. Defaults to bluedot-normal */
   accentColor?: string;
 };
 

--- a/apps/website/src/components/lander/components/ScheduleRounds.tsx
+++ b/apps/website/src/components/lander/components/ScheduleRounds.tsx
@@ -1,11 +1,5 @@
-import type { inferRouterOutputs } from '@trpc/server';
 import { trpc } from '../../../utils/trpc';
-import type { AppRouter } from '../../../server/routers/_app';
-import { RoundItem, buildRoundApplyUrl } from '../../../components/shared/RoundItem';
-
-type RouterOutput = inferRouterOutputs<AppRouter>;
-type CourseRounds = RouterOutput['courseRounds']['getRoundsForCourse'];
-type Round = CourseRounds['intense'][number];
+import RoundGroup from '../../shared/RoundGroup';
 
 type ScheduleRoundsProps = {
   courseSlug: string;
@@ -26,7 +20,7 @@ export const ScheduleRounds = ({
   const hasIntenseRounds = !!(rounds?.intense && rounds.intense.length > 0);
   const hasPartTimeRounds = !!(rounds?.partTime && rounds.partTime.length > 0);
 
-  // Check if rounds have valid numberOfUnits
+  // Only show rounds with a known duration; landers read awkwardly otherwise.
   const intenseHasUnits = hasIntenseRounds && rounds.intense[0]?.numberOfUnits != null;
   const partTimeHasUnits = hasPartTimeRounds && rounds.partTime[0]?.numberOfUnits != null;
 
@@ -45,22 +39,11 @@ export const ScheduleRounds = ({
     return fallbackContent ?? null;
   }
 
-  // Calculate descriptions based on numberOfUnits
-  const intenseDescription = intenseHasUnits && rounds.intense[0]
-    ? `${rounds.intense[0].numberOfUnits} day course (5h/day)`
-    : '';
-  const partTimeDescription = partTimeHasUnits && rounds.partTime[0]
-    ? `${rounds.partTime[0].numberOfUnits} week course (5h/week)`
-    : '';
-
   return (
     <div className="flex flex-col gap-16">
       {intenseHasUnits && (
         <RoundGroup
-          labelShort="INTENSIVE:"
-          labelLong="INTENSIVE COURSE:"
-          descriptionLong={intenseDescription}
-          descriptionShort={intenseDescription}
+          type="intensive"
           rounds={rounds.intense}
           applicationUrl={applicationUrl}
           accentColor={accentColor}
@@ -69,72 +52,12 @@ export const ScheduleRounds = ({
 
       {partTimeHasUnits && (
         <RoundGroup
-          labelShort="PART-TIME:"
-          labelLong="PART-TIME COURSE:"
-          descriptionLong={partTimeDescription}
-          descriptionShort={partTimeDescription}
+          type="part-time"
           rounds={rounds.partTime}
           applicationUrl={applicationUrl}
           accentColor={accentColor}
         />
       )}
-    </div>
-  );
-};
-
-type RoundGroupProps = {
-  labelShort: string;
-  labelLong: string;
-  descriptionLong: string;
-  descriptionShort: string;
-  rounds: Round[];
-  applicationUrl: string;
-  accentColor?: string;
-};
-
-const RoundGroup = ({
-  labelShort,
-  labelLong,
-  descriptionLong,
-  descriptionShort,
-  rounds,
-  applicationUrl,
-  accentColor,
-}: RoundGroupProps) => {
-  // Limit to max 3 upcoming rounds displayed
-  const displayedRounds = rounds.slice(0, 3);
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col bd-md:flex-row bd-md:items-end gap-1 text-size-sm text-bluedot-navy">
-        <span className="font-semibold uppercase tracking-[0.45px] leading-tight">
-          <span className="bd-md:hidden">{labelShort}</span>
-          <span className="hidden bd-md:inline min-[1024px]:hidden min-[1440px]:inline">{labelShort}</span>
-          <span className="hidden min-[1024px]:inline min-[1440px]:hidden">{labelLong}</span>
-        </span>
-        <span className="opacity-80 font-normal leading-tight">
-          <span className="bd-md:hidden">{descriptionShort}</span>
-          <span className="hidden bd-md:inline">{descriptionLong}</span>
-        </span>
-      </div>
-
-      <ul className="list-none flex flex-col gap-5">
-        {displayedRounds.map((round, index) => (
-          <li key={round.id}>
-            <RoundItem
-              title={round.dateRange}
-              subtitle={`Applications close ${round.applicationDeadlineDetailed ?? `${round.applicationDeadline} at 23:59 UTC`}`}
-              href={buildRoundApplyUrl(applicationUrl, round.id)}
-              accentColor={accentColor}
-              ctaColor={accentColor}
-            />
-            {index < displayedRounds.length - 1 && (
-              <div className="relative mt-5">
-                <div className="absolute inset-x-0 h-px bg-bluedot-navy/10" />
-              </div>
-            )}
-          </li>
-        ))}
-      </ul>
     </div>
   );
 };

--- a/apps/website/src/components/shared/RoundGroup.stories.tsx
+++ b/apps/website/src/components/shared/RoundGroup.stories.tsx
@@ -77,3 +77,13 @@ export const ShowAll: Story = {
     maxRounds: Infinity,
   },
 };
+
+// Course-themed surfaces accent the left bar with the course colour; the CTA
+// stays brand-blue everywhere.
+export const Accented: Story = {
+  args: {
+    type: 'intensive',
+    rounds: intensiveRounds,
+    accentColor: '#9177dc',
+  },
+};

--- a/apps/website/src/components/shared/RoundGroup.tsx
+++ b/apps/website/src/components/shared/RoundGroup.tsx
@@ -3,6 +3,12 @@ import { buildRoundApplyUrl, RoundItem } from './RoundItem';
 
 const DEFAULT_MAX_ROUNDS = 3;
 
+const buildDeadlineSubtitle = (round: CourseRound): string => {
+  if (round.applicationDeadlineDetailed) return `Applications close ${round.applicationDeadlineDetailed}`;
+  if (round.applicationDeadline) return `Applications close ${round.applicationDeadline} at 23:59 UTC`;
+  return 'Applications open';
+};
+
 type RoundGroupProps = {
   type: 'intensive' | 'part-time';
   rounds: CourseRound[];
@@ -36,7 +42,7 @@ export default function RoundGroup({
           <li key={round.id}>
             <RoundItem
               title={round.dateRange}
-              subtitle={`Applications close ${round.applicationDeadlineDetailed ?? `${round.applicationDeadline} at 23:59 UTC`}`}
+              subtitle={buildDeadlineSubtitle(round)}
               href={buildRoundApplyUrl(applicationUrl, round.id)}
               accentColor={accentColor}
             />

--- a/apps/website/src/lib/courseColors.ts
+++ b/apps/website/src/lib/courseColors.ts
@@ -108,3 +108,11 @@ export const COURSE_COLORS = {
 } as const satisfies Record<string, CourseColors>;
 
 export type CourseColorSlug = keyof typeof COURSE_COLORS;
+
+/**
+ * Resolves a course's accent colour for schedule rounds, hero accents, etc.
+ * Falls back to the brand blue for courses without a registered palette.
+ */
+export const getCourseAccentColor = (courseSlug: string): string => {
+  return COURSE_COLORS[courseSlug as CourseColorSlug]?.full ?? 'var(--bluedot-normal)';
+};


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Course schedules now show the course accent colour on the individual course landers, matching the `/courses` index page.

Previously the 4 flagship landers (biosecurity, technical-ai-safety, ai-governance, agi-strategy) rendered their schedule through `ScheduleListSection` → `PageListRow`, which hardcoded brand blue . The `/courses` index uses a different component (`RoundGroup`) that does show the accent.

Changes:

- Consolidated all schedule rendering onto the shared `RoundGroup`:
  - `ScheduleListSection` now uses `RoundGroup` instead of `PageListRow`
  - `ScheduleRounds` dropped its duplicate internal `RoundGroup` and now wraps the shared one.
- Lifted `getCourseAccentColor(slug)` into `lib/courseColors.ts` so every consumer resolves accent from one place (`COURSE_COLORS[slug].full`).
- Only the left accent bar carries the course colour; the "Apply now" CTA stays brand blue everywhere.
- Moved the application-deadline subtitle logic into `RoundGroup` with a proper null fallback ("Applications open"). Preserves the guard `ScheduleListSection` had, and fixes a latent "Applications close null at 23:59 UTC" bug that `RoundGroup` consumers (the `/courses` index, TASP lander) already had when both deadline fields are null.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2392

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="878" height="403" alt="image" src="https://github.com/user-attachments/assets/087ec00a-d96f-40fe-952d-a8902958c669" /> | <img width="862" height="438" alt="image" src="https://github.com/user-attachments/assets/2677e36f-82c8-4981-bfe8-60922c285b1a" /> |
