### PR TITLE
Always sort resource completions and exercise responses by createdAt

### DIFF
--- a/apps/website/src/server/routers/admin.ts
+++ b/apps/website/src/server/routers/admin.ts
@@ -213,7 +213,7 @@ export const adminRouter = router({
         .leftJoin(unitTable.pg, eq(exerciseTable.pg.unitId, unitTable.pg.id))
         .where(where)
         // Sort by "most recent activity": completedAt when set, else createdAt (when the draft was started).
-        .orderBy(sql`COALESCE(${exerciseResponseTable.pg.completedAt}, ${exerciseResponseTable.pg.createdAt}) DESC NULLS LAST`, desc(exerciseResponseTable.pg.createdAt))
+        .orderBy(sql`COALESCE(${exerciseResponseTable.pg.completedAt}, ${exerciseResponseTable.pg.createdAt}) DESC NULLS LAST`, desc(exerciseResponseTable.pg.createdAt), desc(exerciseResponseTable.pg.id))
         .limit(input.limit + 1)
         .offset(input.cursor);
 

--- a/apps/website/src/server/routers/admin.ts
+++ b/apps/website/src/server/routers/admin.ts
@@ -204,7 +204,6 @@ export const adminRouter = router({
             response: exerciseResponseTable.pg.response,
             completedAt: exerciseResponseTable.pg.completedAt,
             createdAt: exerciseResponseTable.pg.createdAt,
-            autoNumberId: exerciseResponseTable.pg.autoNumberId,
           },
           exercise: exerciseTable.pg,
           unit: unitTable.pg,
@@ -214,7 +213,7 @@ export const adminRouter = router({
         .leftJoin(unitTable.pg, eq(exerciseTable.pg.unitId, unitTable.pg.id))
         .where(where)
         // Sort by "most recent activity": completedAt when set, else createdAt (when the draft was started).
-        .orderBy(sql`COALESCE(${exerciseResponseTable.pg.completedAt}, ${exerciseResponseTable.pg.createdAt}) DESC NULLS LAST`, desc(exerciseResponseTable.pg.autoNumberId))
+        .orderBy(sql`COALESCE(${exerciseResponseTable.pg.completedAt}, ${exerciseResponseTable.pg.createdAt}) DESC NULLS LAST`, desc(exerciseResponseTable.pg.createdAt))
         .limit(input.limit + 1)
         .offset(input.cursor);
 

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -95,7 +95,7 @@ const getUserCompletions = async (coreResourceIds: string[], activeExerciseIds: 
         inArray(resourceCompletionTable.pg.unitResourceId, coreResourceIds),
         eq(resourceCompletionTable.pg.isCompleted, true), // Only fetch completed resources
       ))
-      .orderBy(desc(resourceCompletionTable.pg.autoNumberId)),
+      .orderBy(desc(resourceCompletionTable.pg.createdAt)),
 
     db.pg
       .select({
@@ -108,7 +108,7 @@ const getUserCompletions = async (coreResourceIds: string[], activeExerciseIds: 
         inArray(exerciseResponseTable.pg.exerciseId, activeExerciseIds),
         isNotNull(exerciseResponseTable.pg.completedAt), // Only fetch completed exercises
       ))
-      .orderBy(desc(exerciseResponseTable.pg.autoNumberId)),
+      .orderBy(desc(exerciseResponseTable.pg.createdAt)),
   ]);
 
   // Deduplicate by unitResourceId, keeping only the first occurrence.

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -36,6 +36,7 @@ export const exercisesRouter = router({
     .query(async ({ input, ctx }) => {
       const exerciseResponse = await getFirstFromPg(db.pg, exerciseResponseTable.pg, {
         filter: { exerciseId: input.exerciseId, email: ctx.auth.email },
+        sortBy: { field: 'createdAt', direction: 'desc' },
       });
 
       return exerciseResponse;
@@ -58,6 +59,7 @@ export const exercisesRouter = router({
       const [existingResponse, exercise, user] = await Promise.all([
         getFirstFromPg(db.pg, exerciseResponseTable.pg, {
           filter: { exerciseId: input.exerciseId, email: ctx.auth.email },
+          sortBy: { field: 'createdAt', direction: 'desc' },
         }),
         input.completed === true
           ? db.getFirst(exerciseTable, { filter: { id: input.exerciseId }, sortBy: 'id' })

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -17,7 +17,7 @@ export const resourcesRouter = router({
           inArray(resourceCompletionTable.pg.unitResourceId, input.unitResourceIds),
           eq(resourceCompletionTable.pg.email, ctx.auth.email),
         ))
-        .orderBy(desc(resourceCompletionTable.pg.autoNumberId));
+        .orderBy(desc(resourceCompletionTable.pg.createdAt));
 
       // Deduplicate by unitResourceId, keeping only the first occurrence.
       // Although we should only have one resource completion for a resource per user, it is possible to have multiple
@@ -60,6 +60,7 @@ export const resourcesRouter = router({
             unitResourceId: input.unitResourceId,
             email: ctx.auth.email,
           },
+          sortBy: { field: 'createdAt', direction: 'desc' },
         }),
         db.getFirst(unitResourceTable, { filter: { id: input.unitResourceId }, sortBy: 'id' }),
         db.getFirst(courseBuilderUserTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),


### PR DESCRIPTION
# Description

A minor additional discovery regarding flipping these tables to postgres (#2616): `autoNumberId` will stop working. We have createdAt for all time for both tables, so we can equivalently use that instead.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2580

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
