### PR TITLE
Add statementsRequireFullSync filter to schema-sync

### DIFF
--- a/apps/pg-sync-service/src/lib/schema-sync.test.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'vitest';
+import { PgAirtableTable, isTable } from '@bluedot/db';
+import { pushSchema } from 'drizzle-kit/api';
+import * as schema from '@bluedot/db/src/schema';
+import { statementsRequireFullSync } from './schema-sync';
+import { db } from './db';
+
+describe('statementsRequireFullSync', () => {
+  test('given no statements, returns false', () => {
+    expect(statementsRequireFullSync([])).toBe(false);
+  });
+
+  test('given only a SET DEFAULT statement, returns false', () => {
+    expect(statementsRequireFullSync([
+      'ALTER TABLE "exercise_response" ALTER COLUMN "id" SET DEFAULT gen_random_uuid()::text',
+    ])).toBe(false);
+  });
+
+  test('given only a DROP DEFAULT statement, returns false', () => {
+    expect(statementsRequireFullSync([
+      'ALTER TABLE "exercise_response" ALTER COLUMN "id" DROP DEFAULT',
+    ])).toBe(false);
+  });
+
+  test('given only SET DEFAULT statements across tables, returns false', () => {
+    expect(statementsRequireFullSync([
+      'ALTER TABLE "exercise_response" ALTER COLUMN "id" SET DEFAULT gen_random_uuid()::text',
+      'ALTER TABLE "resource_completion" ALTER COLUMN "id" SET DEFAULT gen_random_uuid()::text',
+    ])).toBe(false);
+  });
+
+  test('given a CREATE TABLE statement, returns true', () => {
+    expect(statementsRequireFullSync([
+      'CREATE TABLE "new_table" ("id" text PRIMARY KEY NOT NULL)',
+    ])).toBe(true);
+  });
+
+  test('given an ADD COLUMN statement, returns true', () => {
+    expect(statementsRequireFullSync([
+      'ALTER TABLE "x" ADD COLUMN "y" text',
+    ])).toBe(true);
+  });
+
+  test('given a mix of SET DEFAULT and ADD COLUMN, returns true', () => {
+    expect(statementsRequireFullSync([
+      'ALTER TABLE "exercise_response" ALTER COLUMN "id" SET DEFAULT gen_random_uuid()::text',
+      'ALTER TABLE "x" ADD COLUMN "y" text',
+    ])).toBe(true);
+  });
+
+  // --- Adversarial cases probing for FALSE NEGATIVES (a backfill-requiring
+  // statement wrongly classified as default churn) and false positives. ---
+
+  describe('ADD COLUMN with a DEFAULT clause must still require a full sync', () => {
+    // Postgres ADD COLUMN uses a bare `DEFAULT`, never `SET DEFAULT`, so the
+    // regex (which requires SET/DROP immediately before DEFAULT) must not match.
+    // This is the highest-risk case: a missed match here means a new column
+    // never gets backfilled.
+    test('ADD COLUMN ... text DEFAULT \'z\' returns true', () => {
+      expect(statementsRequireFullSync([
+        'ALTER TABLE "x" ADD COLUMN "y" text DEFAULT \'z\'',
+      ])).toBe(true);
+    });
+
+    test('ADD COLUMN ... NOT NULL DEFAULT gen_random_uuid() returns true', () => {
+      expect(statementsRequireFullSync([
+        'ALTER TABLE "x" ADD COLUMN "y" text NOT NULL DEFAULT gen_random_uuid()',
+      ])).toBe(true);
+    });
+  });
+
+  test('CREATE TABLE whose body contains a DEFAULT clause returns true', () => {
+    expect(statementsRequireFullSync([
+      'CREATE TABLE "new_table" ("id" text PRIMARY KEY NOT NULL DEFAULT gen_random_uuid()::text, "n" integer DEFAULT 0)',
+    ])).toBe(true);
+  });
+
+  describe('identifiers containing the substring "default" must not be misclassified as churn', () => {
+    // The regex anchors on whitespace before SET/DROP and a word boundary after
+    // DEFAULT, so a column/table whose *name* contains the word should not be
+    // mistaken for a `SET DEFAULT` / `DROP DEFAULT` churn statement.
+    test('ADD COLUMN on a column literally named "set_default" returns true', () => {
+      expect(statementsRequireFullSync([
+        'ALTER TABLE "x" ADD COLUMN "set_default" text',
+      ])).toBe(true);
+    });
+
+    test('ADD COLUMN on a table literally named "default_settings" returns true', () => {
+      expect(statementsRequireFullSync([
+        'ALTER TABLE "default_settings" ADD COLUMN "y" text',
+      ])).toBe(true);
+    });
+  });
+
+  describe('whitespace / casing variants of the churn pattern', () => {
+    // Drizzle-kit emits canonical single-space, uppercase `SET DEFAULT` (see the
+    // real-output integration test below). These assert the regex's behaviour on
+    // off-canonical spacing so that any future change in drizzle's formatting
+    // would surface here rather than silently flipping the classification.
+    test('lowercase "set default" is still treated as churn (returns false)', () => {
+      expect(statementsRequireFullSync([
+        'ALTER TABLE "x" ALTER COLUMN "id" set default gen_random_uuid()::text',
+      ])).toBe(false);
+    });
+
+    test('a newline between SET and DEFAULT is still treated as churn (returns false)', () => {
+      expect(statementsRequireFullSync([
+        'ALTER TABLE "x" ALTER COLUMN "id" SET\nDEFAULT 1',
+      ])).toBe(false);
+    });
+
+    test('multiple spaces between SET and DEFAULT are NOT matched, so it errs toward a full sync (returns true)', () => {
+      // `\s` matches a single whitespace char, so `SET  DEFAULT` does not match.
+      // This is the safe direction: an unrecognised statement triggers a full
+      // sync rather than risking a missed backfill. Drizzle does not emit this
+      // form in practice, so it has no real-world cost.
+      expect(statementsRequireFullSync([
+        'ALTER TABLE "x" ALTER COLUMN "id" SET  DEFAULT 1',
+      ])).toBe(true);
+    });
+  });
+});
+
+describe('statementsRequireFullSync against real drizzle-kit push output', () => {
+  // The global beforeAll (src/test-setup.ts) has already pushed the full schema
+  // to the in-memory PGlite DB. Drizzle-kit's pushSchema is non-idempotent for
+  // certain defaults (notably `gen_random_uuid()::text` and numeric defaults):
+  // re-pushing an *unchanged* schema re-emits `SET DEFAULT` statements every
+  // time. This is the exact churn the fix exists to ignore. We re-push here and
+  // assert that the churn does NOT trigger a full sync — guarding the regex
+  // against drift in drizzle's real output format, not just hand-written strings.
+  test('re-pushing the unchanged schema produces only default churn and requires no full sync', async () => {
+    const pgTables = Object.fromEntries(Object.entries(schema)
+      .filter(([, value]) => value instanceof PgAirtableTable || isTable(value))
+      .map(([name, value]) => [
+        name,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value instanceof PgAirtableTable ? ((value as any).pgWithDeprecatedColumns ?? value.pg) : value,
+      ]));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await pushSchema(pgTables as any, db.pg as any);
+
+    // Sanity: this test only means something if drizzle is actually re-emitting
+    // churn. If drizzle ever becomes idempotent here the list is empty, which
+    // also (correctly) requires no full sync.
+    if (result.statementsToExecute.length > 0) {
+      // Every churn statement must be a SET/DROP DEFAULT.
+      for (const statement of result.statementsToExecute) {
+        expect(statement).toMatch(/\s(SET|DROP)\sDEFAULT\b/i);
+      }
+    }
+
+    expect(statementsRequireFullSync(result.statementsToExecute)).toBe(false);
+  });
+});

--- a/apps/pg-sync-service/src/lib/schema-sync.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.ts
@@ -56,9 +56,15 @@ async function cleanupRemovedColumns(pgTables: Record<string, PgAirtableTable['p
   }
 }
 
+export function statementsRequireFullSync(statements: string[]): boolean {
+  // SET DEFAULT / DROP DEFAULT statements are filtered out: drizzle-kit emits
+  // them non-idempotently (e.g. for `gen_random_uuid()::text` defaults)
+  return statements.some((statement) => !/\s(SET|DROP)\sDEFAULT\b/i.test(statement));
+}
+
 /**
  * Wraps pushSchema with a timeout to prevent hanging migrations
- * Returns true if schema changes were applied, false otherwise
+ * Returns true if schema changes warranting a full data sync were applied, false otherwise
  */
 async function pushSchemaWithTimeout(pgTables: Record<string, PgAirtableTable['pg']>): Promise<boolean> {
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -72,8 +78,9 @@ async function pushSchemaWithTimeout(pgTables: Record<string, PgAirtableTable['p
     const result = await pushSchema(pgTables, db.pg as any);
     await result.apply();
     if (result.statementsToExecute.length > 0) {
-      logger.info(`[schema-sync] Schema pushed with ${result.statementsToExecute.length} statements`);
-      return true;
+      const needsFullSync = statementsRequireFullSync(result.statementsToExecute);
+      logger.info(`[schema-sync] Schema pushed with ${result.statementsToExecute.length} statements${needsFullSync ? '' : ' (default-only churn, no full sync)'}`);
+      return needsFullSync;
     }
 
     return false;


### PR DESCRIPTION
# Description

Filter out `SET DEFAULT` and `DROP DEFAULT` statements, which are generated non-idempotently by drizzle

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2652

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
