### PR TITLE
Fix endpoint missing scheme for GH action

### DIFF
--- a/apps/infra/Pulumi.yaml
+++ b/apps/infra/Pulumi.yaml
@@ -5,4 +5,4 @@ config:
     - kubernetes
     - minio
 backend:
-  url: s3://bluedot-pulumi-backend/bluedot?endpoint=ams1.vultrobjects.com&s3ForcePathStyle=true&region=vultr&profile=vultr-object-storage
+  url: s3://bluedot-pulumi-backend/bluedot?endpoint=https://ams1.vultrobjects.com&s3ForcePathStyle=true&region=vultr&profile=vultr-object-storage


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

https://github.com/bluedotimpact/bluedot/actions/runs/27490635113/job/81255890209

We are seeing: error: read ".pulumi/meta.yaml": blob (key ".pulumi/meta.yaml") (code=Unknown): operation error S3: GetObject, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get "/ams1.vultrobjects.com/bluedot-pulumi-backend/bluedot/.pulumi/meta.yaml?x-id=GetObject": unsupported protocol scheme ""

Claude things this might be because Pulumi CLI isn't pinned and there was an upgrade.

I'm setting `https` to see if this unblocks
