### PR TITLE
Temporarily disable PDBs to attempt to upgrade k8s

### DIFF
--- a/apps/infra/src/k8s/postgres.ts
+++ b/apps/infra/src/k8s/postgres.ts
@@ -22,6 +22,10 @@ export const keycloakPg = new k8s.apiextensions.CustomResource('keycloak-pg', {
   },
   spec: {
     instances: 1,
+    // Temporarily disabled for VKE k8s upgrade: single-instance CNPG creates a
+    // primary PDB with minAvailable 1, which blocks node drain entirely. Revert
+    // to default (remove this line) once the upgrade completes.
+    enablePDB: false,
     storage: {
       size: '5Gi',
     },
@@ -37,6 +41,8 @@ export const grafanaPg = new k8s.apiextensions.CustomResource('grafana-pg', {
   },
   spec: {
     instances: 1,
+    // Temporarily disabled for VKE k8s upgrade. See keycloak-pg note above.
+    enablePDB: false,
     storage: {
       size: '5Gi',
     },
@@ -51,6 +57,8 @@ export const airtableSyncPg = new k8s.apiextensions.CustomResource('airtable-syn
   },
   spec: {
     instances: 1,
+    // Temporarily disabled for VKE k8s upgrade. See keycloak-pg note above.
+    enablePDB: false,
     storage: {
       size: '10Gi',
     },

--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -27,7 +27,9 @@ export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
 new vultr.KubernetesNodePools('vke-node-pool-main', {
   clusterId: k8sCluster.id,
   label: 'main-node-pool',
-  nodeQuantity: 1,
+  // Temporarily 2 for VKE k8s upgrade: drain needs a target node to reschedule
+  // single-instance pg pods onto. Revert to 1 once the upgrade completes.
+  nodeQuantity: 2,
   // https://api.vultr.com/v2/plans
   plan: 'vhf-4c-16gb',
   autoScaler: false,


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

I attempted to upgrade k8s and got this error:

Upgrade Status:
Failed to start upgrade: Validation error: Cannot upgrade vke cluster at this time: PDB does not allow disruptions: preflight checks failed (4 errors): 1. check pdb default/airtable-sync-pg-primary: does not allow disruptions (allowed: 0): no disruptions allowed 2. check pdb default/keycloak-pg-primary: does not allow disruptions (allowed: 0): no disruptions allowed 3. check pdb monitoring/grafana-pg-primary: does not allow disruptions (allowed: 0): no disruptions allowed 4. check cluster ready-nodes: operations may cause service disruption: single node cluster
Upgrade bluedot-prod's Kubernetes version from v1.33.0+1 to v1.35.5+1

This is an attempt to unblock