### PR TITLE
VKE node pool

### DIFF
--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -27,10 +27,20 @@ export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
 new vultr.KubernetesNodePools('vke-node-pool-main', {
   clusterId: k8sCluster.id,
   label: 'main-node-pool',
-  // Temporarily 2 for VKE k8s upgrade: drain needs a target node to reschedule
-  // single-instance pg pods onto. Revert to 1 once the upgrade completes.
-  nodeQuantity: 2,
+  nodeQuantity: 1,
   // https://api.vultr.com/v2/plans
+  plan: 'vhf-4c-16gb',
+  autoScaler: false,
+});
+
+// TEMPORARY: extra node pool to satisfy the VKE upgrade preflight (single-node
+// clusters can't drain). Added as a second pool rather than bumping the main
+// pool's nodeQuantity, because Vultr rejects in-place node-count updates when
+// autoScaler is disabled. Delete this block (and deploy) once the upgrade is done.
+new vultr.KubernetesNodePools('vke-node-pool-upgrade', {
+  clusterId: k8sCluster.id,
+  label: 'upgrade-node-pool',
+  nodeQuantity: 1,
   plan: 'vhf-4c-16gb',
   autoScaler: false,
 });

--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -36,7 +36,14 @@ new vultr.KubernetesNodePools('vke-node-pool-main', {
 // TEMPORARY: extra node pool to satisfy the VKE upgrade preflight (single-node
 // clusters can't drain). Added as a second pool rather than bumping the main
 // pool's nodeQuantity, because Vultr rejects in-place node-count updates when
-// autoScaler is disabled. Delete this block (and deploy) once the upgrade is done.
+// autoScaler is disabled. Left schedulable (no taint) on purpose: it must accept
+// pods evicted off the main node during the rolling upgrade.
+//
+// Teardown once the upgrade is done: deleting a Vultr node pool hard-deletes the
+// VMs without a graceful drain, so first move workloads off, THEN remove this block:
+//   1. kubectl drain <upgrade-node> --ignore-daemonsets --delete-emptydir-data
+//   2. confirm pods rescheduled and Ready on the main node
+//   3. delete this block and deploy
 new vultr.KubernetesNodePools('vke-node-pool-upgrade', {
   clusterId: k8sCluster.id,
   label: 'upgrade-node-pool',

--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -4,7 +4,7 @@ import * as k8s from '@pulumi/kubernetes';
 export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
   label: 'bluedot-prod',
   region: 'ams',
-  version: 'v1.33.0+3',
+  version: 'v1.33.0+1',
 
   // Initial node pool
   // nodePools: {


### PR DESCRIPTION
I continue to run into difficulties attempting to upgrade k8s. [The latest:](https://github.com/bluedotimpact/bluedot/actions/runs/27491399400/job/81257228762)

* error deleting VKE node pool 520766b4-5c5e-4151-9ff9-6cc5917ce51a : {"is_external_error":false,"error":"You cannot update auto scalar minimum or maximum nodes if `auto_scaler` is disabled.","status":422}

Two changes:

1. Pin k8s version to what is currently live, preventing spurious upgrade of minor version
2. Add a temporary second node pool (`upgrade-node-pool`, 1 node). Added as a new pool rather than bumping the main pool's `nodeQuantity`, because Vultr rejects in-place node-count updates when `autoScaler` is disabled.