### PR TITLE
[chore] infra: remove temporary VKE upgrade node pool

### DIFF
--- a/apps/infra/src/k8s/postgres.ts
+++ b/apps/infra/src/k8s/postgres.ts
@@ -22,9 +22,10 @@ export const keycloakPg = new k8s.apiextensions.CustomResource('keycloak-pg', {
   },
   spec: {
     instances: 1,
-    // Temporarily disabled for VKE k8s upgrade: single-instance CNPG creates a
-    // primary PDB with minAvailable 1, which blocks node drain entirely. Revert
-    // to default (remove this line) once the upgrade completes.
+    // Disabled deliberately. With instances: 1 there's no replica to fail over to,
+    // so the default primary PDB (minAvailable 1) provides no availability and only
+    // blocks node drains - it broke a VKE k8s upgrade once. Re-enable (remove this
+    // line) only if/when this cluster goes multi-instance.
     enablePDB: false,
     storage: {
       size: '5Gi',
@@ -41,7 +42,7 @@ export const grafanaPg = new k8s.apiextensions.CustomResource('grafana-pg', {
   },
   spec: {
     instances: 1,
-    // Temporarily disabled for VKE k8s upgrade. See keycloak-pg note above.
+    // Disabled deliberately. See keycloak-pg note above.
     enablePDB: false,
     storage: {
       size: '5Gi',
@@ -57,7 +58,7 @@ export const airtableSyncPg = new k8s.apiextensions.CustomResource('airtable-syn
   },
   spec: {
     instances: 1,
-    // Temporarily disabled for VKE k8s upgrade. See keycloak-pg note above.
+    // Disabled deliberately. See keycloak-pg note above.
     enablePDB: false,
     storage: {
       size: '10Gi',

--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -33,25 +33,6 @@ new vultr.KubernetesNodePools('vke-node-pool-main', {
   autoScaler: false,
 });
 
-// TEMPORARY: extra node pool to satisfy the VKE upgrade preflight (single-node
-// clusters can't drain). Added as a second pool rather than bumping the main
-// pool's nodeQuantity, because Vultr rejects in-place node-count updates when
-// autoScaler is disabled. Left schedulable (no taint) on purpose: it must accept
-// pods evicted off the main node during the rolling upgrade.
-//
-// Teardown once the upgrade is done: deleting a Vultr node pool hard-deletes the
-// VMs without a graceful drain, so first move workloads off, THEN remove this block:
-//   1. kubectl drain <upgrade-node> --ignore-daemonsets --delete-emptydir-data
-//   2. confirm pods rescheduled and Ready on the main node
-//   3. delete this block and deploy
-new vultr.KubernetesNodePools('vke-node-pool-upgrade', {
-  clusterId: k8sCluster.id,
-  label: 'upgrade-node-pool',
-  nodeQuantity: 1,
-  plan: 'vhf-4c-16gb',
-  autoScaler: false,
-});
-
 export const k8sConfig = k8sCluster.kubeConfig.apply((s) => Buffer.from(s, 'base64').toString('utf8'));
 
 // Export a Kubernetes provider instance that uses our cluster from above.


### PR DESCRIPTION
## What

Post-upgrade cleanup for the VKE `v1.33.0+1 → v1.35.5+1` upgrade.

- **Remove `vke-node-pool-upgrade`.** It was a temporary second node pool added so the single-node cluster had a drain target during the rolling upgrade. The node has already been **manually drained** (`kubectl drain ... --ignore-daemonsets --delete-emptydir-data`) and workloads rescheduled onto the main node, so this just deletes an empty, cordoned VM.
- **Keep `enablePDB: false` permanently** on the three single-instance CNPG clusters (keycloak-pg, grafana-pg, airtable-sync-pg). A `minAvailable: 1` PDB on a one-replica cluster provides no availability (no replica to fail over to) and only blocks node drains — it was the original upgrade preflight blocker. Comments updated to explain; re-enable only if these go multi-instance.

## Sequencing (already done manually before merge)

Deleting a Vultr node pool hard-deletes the VMs without a graceful drain, so the node was drained by hand first. The pg pods were on the main node and stayed put — no DB disruption. On merge, CI's `pulumi up` removes the now-empty pool.

## Verification

- `npx tsc --noEmit` in `apps/infra` — passes.
- Cluster post-drain: 2 nodes on `v1.35.5` (one cordoned/empty awaiting this deletion), all 3 pg clusters `Cluster in healthy state`, website/login/ingress recovered.

## Follow-ups (not in this PR)

Today's upgrade caused a multi-minute outage because every deployment is single-replica and Vultr replaced both nodes at once. Worth separate PRs:
- 2 replicas on critical deployments (website, login, ingress) so a node roll drains gracefully instead of taking the site down.
- GH issue #2661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
