### PR TITLE
Rename selfServeCourseRegistrationTable fields to match courseRegistrationTable

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1365,11 +1365,12 @@ export const selfServeCourseRegistrationTable = pgAirtable('self_serve_course_re
       pgColumn: text(),
       airtableId: 'fldsS2lCVlk1WDSDw',
     },
-    courseBuilderCourseId: {
-      pgColumn: text(),
+    // Note: This is the id of the course in the COURSE_BUILDER base and not in the APPLICATIONS base
+    courseId: {
+      pgColumn: text().notNull(),
       airtableId: 'fldNo8YC59IfZByoO',
     },
-    applicationsBaseCourseId: {
+    courseApplicationsBaseId: {
       pgColumn: text(),
       airtableId: 'fld0yIgammvJ0rTyt',
     },


### PR DESCRIPTION
# Description

When I added this table in #2664, I used different names for two fields relative to `courseRegistrationTable`. Upon implementing the dual-write PR outline in #2664, I realised this complicates some of the certificate routes because they have to map between the two names, so I'm switching to the same names as `courseRegistrationTable` here.

Because this table isn't used yet, I'm not going to do a two-step deploy. I'm just going to delete the old columns and then merge this to add the new ones.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2526

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
