### PR TITLE
Prefer `getFirst` to `get` for fetching course unit

### DIFF
--- a/apps/website/src/components/courses/GroupDiscussionBanner.test.tsx
+++ b/apps/website/src/components/courses/GroupDiscussionBanner.test.tsx
@@ -365,5 +365,25 @@ describe('GroupDiscussionBanner', () => {
       // Should use fallback unit title when error
       expect(await screen.findByText(/Unit 1/)).toBeInTheDocument();
     });
+
+    test('falls back to page unit when getUnit returns null', async () => {
+      server.use(trpcMsw.courses.getUnit.query(() => null));
+
+      const pageUnit = createMockUnit({ title: 'Page Unit', unitNumber: '2', courseSlug: 'page-course' });
+
+      render(
+        <GroupDiscussionBanner
+          unit={pageUnit}
+          groupDiscussion={mockGroupDiscussion}
+          userRole="participant"
+        />,
+        { wrapper: TrpcProvider },
+      );
+
+      // Title uses the discussion's unitFallback, and the link resolves to the page unit
+      // since the discussion unit could not be loaded.
+      const unitLink = await screen.findByRole('link', { name: /Unit 1: Test Unit/ });
+      expect(unitLink).toHaveAttribute('href', '/courses/page-course/2/1');
+    });
   });
 });

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -194,10 +194,13 @@ export const coursesRouter = router({
     .query(async ({ input }) => {
       const { courseSlug, unitId } = input;
 
-      return db.get(unitTable, {
-        id: unitId,
-        courseSlug,
-        unitStatus: 'Active',
+      return db.getFirst(unitTable, {
+        filter: {
+          id: unitId,
+          courseSlug,
+          unitStatus: 'Active',
+        },
+        sortBy: 'id',
       });
     }),
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

We are seeing a lot of spam of 'website: Error: Failed request on route courses.getUnit'.

`getUnit` filters by the page's `courseSlug`, but `getByCourseSlug` surfaces a user's soonest non-ended discussion across all their registrations. This can belong to a different course than the page being viewed. When a discussion lives in course B but banner renders on course A's page:

{ id: <B's unit>, courseSlug: 'A', unitStatus: 'Active' }  → 0 rows → throw

Evidence (prod PG): 13 of 59 facilitators with upcoming discussions have discussions spanning multiple distinct course slugs. Facilitators viewing course pages = the alert generators.

It's operationally benign. The component already degrades gracefully:

```
const resolvedUnit = discussionUnit || unit;   // falls back to page unit
... `Unit ${groupDiscussion.unitFallback}`      // and to unitFallback text
```

Fix: Switch `getUnit` to `db.getFirst`, which returns null instead of throwing. unitTable has no `autoNumberId`, so `sortBy` is required; the filter is keyed on the unique id, so sortBy: 'id' is a no-op tiebreaker (matching the existing pattern in group-switching.ts).

Return type becomes `Unit | null`. The only caller already treats the result as optional (`discussionUnit || unit`), so nothing else changes