### PR TITLE
Dual-write FoAI data to new `selfServeCourseRegistrations` table

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -77,7 +77,7 @@ const CourseUnitChunkPage = ({
   }, [courseSlug, unitNumber]);
 
   const { latestUtmParams, isLoading: isUtmLoading } = useLatestUtmParams();
-  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.courseRegistrations.ensureExists.useMutation();
+  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.courseRegistrations.ensureSelfServeRegistrationExists.useMutation();
 
   useEffect(() => {
     // FoAI course only: If we're logged in, ensures a course registration is recorded

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -30,13 +30,13 @@ const TEST_CERT_TOKEN = 'test-token-secret';
 
 setupTestDb();
 
-describe('certificates.create (Airtable-script callable, shared-secret auth)', () => {
+describe('certificates.createFacilitatedCourseCertificate (Airtable-script callable, shared-secret auth)', () => {
   test('throws UNAUTHORIZED when token is the wrong length (length mismatch short-circuits before timingSafeEqual)', async () => {
     await testDb.insert(courseRegistrationTable, {
       id: 'reg1', email: 'test@example.com', courseId: 'c1',
     });
 
-    await expect(createCaller(testAuthContextLoggedOut).certificates.create({
+    await expect(createCaller(testAuthContextLoggedOut).certificates.createFacilitatedCourseCertificate({
       courseRegistrationId: 'reg1',
       publicToken: 'wrong',
     })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
@@ -48,7 +48,7 @@ describe('certificates.create (Airtable-script callable, shared-secret auth)', (
     });
 
     const sameLengthWrong = 'X'.repeat(TEST_CERT_TOKEN.length);
-    await expect(createCaller(testAuthContextLoggedOut).certificates.create({
+    await expect(createCaller(testAuthContextLoggedOut).certificates.createFacilitatedCourseCertificate({
       courseRegistrationId: 'reg1',
       publicToken: sameLengthWrong,
     })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
@@ -69,7 +69,7 @@ describe('certificates.create (Airtable-script callable, shared-secret auth)', (
       certificateCreatedAt: 1700000000,
     });
 
-    const result = await createCaller(testAuthContextLoggedOut).certificates.create({
+    const result = await createCaller(testAuthContextLoggedOut).certificates.createFacilitatedCourseCertificate({
       courseRegistrationId: 'reg1',
       publicToken: TEST_CERT_TOKEN,
     });
@@ -85,7 +85,7 @@ describe('certificates.create (Airtable-script callable, shared-secret auth)', (
     });
 
     const before = Math.floor(Date.now() / 1000);
-    const result = await createCaller(testAuthContextLoggedOut).certificates.create({
+    const result = await createCaller(testAuthContextLoggedOut).certificates.createFacilitatedCourseCertificate({
       courseRegistrationId: 'reg1',
       publicToken: TEST_CERT_TOKEN,
     });

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -1,5 +1,6 @@
 import {
-  applicationsRoundTable, courseRegistrationTable, courseTable, meetPersonTable, roundTable,
+  applicationsRoundTable, courseRegistrationTable, courseTable, eq, exerciseResponsePgTable, exerciseTable,
+  meetPersonTable, roundTable, selfServeCourseRegistrationTable,
 } from '@bluedot/db';
 import {
   describe, expect, test, vi,
@@ -8,6 +9,7 @@ import {
   createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
 import { FOAI_COURSE_ID } from '../../lib/constants';
+import { issueFoaiCertificateIfComplete } from './certificates';
 
 vi.mock('../../lib/api/env', () => ({
   default: {
@@ -103,11 +105,21 @@ describe('certificates.verifyOwnership', () => {
       .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
-  // Note: when no matching registration exists for the certificateId, the router uses
-  // db.get(...) which throws AirtableTsError(RESOURCE_NOT_FOUND) rather than returning undefined.
-  // The router code at certificates.ts:66 reads `registration?.email`, expecting undefined — so
-  // the "no record" case currently surfaces as a thrown error rather than `{ isOwner: false }`.
-  // Same root cause as the dead-code note in `certificates.create` above.
+  test('returns { isOwner: false } when no certificate matches the id', async () => {
+    const result = await createCaller(testAuthContextLoggedIn)
+      .certificates.verifyOwnership({ certificateId: 'nonexistent' });
+    expect(result).toEqual({ isOwner: false });
+  });
+
+  test('finds certificates on the self-serve table, matching email case-insensitively', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-reg-1', email: 'TEST@Example.com', courseId: FOAI_COURSE_ID, certificateId: 'cert-ss',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn)
+      .certificates.verifyOwnership({ certificateId: 'cert-ss' });
+    expect(result).toEqual({ isOwner: true });
+  });
 
   // `id` and `certificateId` are deliberately distinct in these fixtures so the test proves the
   // router is actually filtering on the certificateId column, not implicitly resolving by primary key.
@@ -316,5 +328,64 @@ describe('certificates.getStatus', () => {
       numUnits: 5,
       isLastDiscussionSoonOrPassed: true,
     });
+  });
+});
+
+describe('issueFoaiCertificateIfComplete', () => {
+  const setupCompletedFoaiExercises = async (email: string) => {
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Ex 1', exerciseNumber: '1',
+    });
+    await testDb.pg.insert(exerciseResponsePgTable).values({
+      id: 'resp-1', email, exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+    });
+  };
+
+  test('issues the certificate on the self-serve row and mirrors it to legacy', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-1', email: 'test@example.com', courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID, decision: 'Accept',
+    });
+    await setupCompletedFoaiExercises('test@example.com');
+
+    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+
+    const [selfServe] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
+      .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
+    expect(selfServe?.certificateId).toBe('ss-1');
+
+    const legacy = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
+    expect(legacy.certificateId).toBe('ss-1');
+    expect(legacy.certificateCreatedAt).toBe(selfServe?.certificateCreatedAt);
+  });
+
+  test('issues on the legacy row when no self-serve row exists yet', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID, decision: 'Accept',
+    });
+    await setupCompletedFoaiExercises('test@example.com');
+
+    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+
+    const legacy = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
+    expect(legacy.certificateId).toBe('reg-foai');
+    expect(await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)).toEqual([]);
+  });
+
+  test('writes nothing when exercises are incomplete', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID, decision: 'Accept',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Ex 1', exerciseNumber: '1',
+    });
+
+    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(false);
+
+    const legacy = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
+    expect(legacy.certificateId).toBeNull();
+    expect(await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)).toEqual([]);
   });
 });

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -79,7 +79,7 @@ export async function issueFoaiCertificateIfComplete(email: string): Promise<boo
 export type CertificateData = inferRouterOutputs<AppRouter>['certificates']['getStatus'];
 
 export async function getCertificateData(certificateId: string) {
-  const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' })
+  const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' });
   const facilitatedRegistration = await db.getFirst(courseRegistrationTable, { filter: { certificateId } });
 
   const registration = selfServeRegistration ?? facilitatedRegistration;
@@ -104,7 +104,7 @@ export async function getCertificateData(certificateId: string) {
 
 export const certificatesRouter = router({
   // This is a public procedure because it's called from an Airtable script, not from within the app
-  create: publicProcedure
+  createFacilitatedCourseCertificate: publicProcedure
     .input(z.object({ courseRegistrationId: z.string(), publicToken: z.string().min(1) }))
     .mutation(async ({ input: { courseRegistrationId, publicToken } }) => {
       // Authenticated by a shared secret rather than a user session. Allows certificate creation
@@ -125,6 +125,11 @@ export const certificatesRouter = router({
 
       if (!courseRegistration) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Course registration not found' });
+      }
+
+      // Facilitated courses only — FoAI certificates are issued automatically on completion, not here
+      if (courseRegistration.courseId === FOAI_COURSE_ID) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'This endpoint does not issue Future of AI certificates' });
       }
 
       const now = Math.floor(Date.now() / 1000);
@@ -153,7 +158,7 @@ export const certificatesRouter = router({
   verifyOwnership: protectedProcedure
     .input(z.object({ certificateId: z.string() }))
     .query(async ({ ctx, input: { certificateId } }) => {
-      const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' })
+      const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' });
       const facilitatedRegistration = await db.getFirst(courseRegistrationTable, { filter: { certificateId } });
 
       const registration = selfServeRegistration ?? facilitatedRegistration;

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -9,7 +9,7 @@ import {
   inArray,
   meetPersonTable,
   roundTable,
-  type CourseRegistration,
+  selfServeCourseRegistrationTable,
 } from '@bluedot/db';
 import { TRPCError, type inferRouterOutputs } from '@trpc/server';
 import { timingSafeEqual } from 'crypto';
@@ -44,11 +44,17 @@ async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
 }
 
 export async function issueFoaiCertificateIfComplete(email: string): Promise<boolean> {
-  const courseRegistration = await db.getFirst(courseRegistrationTable, {
+  // In-progress migration to self-serve table (#2526): Prefer the self-serve table, fall back to legacy
+  const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
+    filter: { email, courseId: FOAI_COURSE_ID },
+    sortBy: 'createdAt',
+  });
+  const legacyRegistration = await db.getFirst(courseRegistrationTable, {
     filter: { email, courseId: FOAI_COURSE_ID, decision: 'Accept' },
   });
 
-  if (!courseRegistration || courseRegistration.certificateId) {
+  const registration = selfServeRegistration ?? legacyRegistration;
+  if (!registration || registration.certificateId) {
     return false;
   }
 
@@ -56,24 +62,38 @@ export async function issueFoaiCertificateIfComplete(email: string): Promise<boo
     return false;
   }
 
-  await db.update(courseRegistrationTable, {
-    id: courseRegistration.id,
-    certificateId: courseRegistration.id,
-    certificateCreatedAt: Math.floor(Date.now() / 1000),
-  });
+  const certificateCreatedAt = Math.floor(Date.now() / 1000);
+  const certificateId = registration.id;
+
+  if (selfServeRegistration) {
+    await db.update(selfServeCourseRegistrationTable, { id: selfServeRegistration.id, certificateId, certificateCreatedAt });
+  }
+
+  if (legacyRegistration && !legacyRegistration.certificateId) {
+    await db.update(courseRegistrationTable, { id: legacyRegistration.id, certificateId, certificateCreatedAt });
+  }
+
   return true;
 }
 
 export type CertificateData = inferRouterOutputs<AppRouter>['certificates']['getStatus'];
 
-export async function getCertificateData(certificateId: string, existingCourseRegistration?: CourseRegistration) {
-  const courseRegistration = existingCourseRegistration ?? (await db.get(courseRegistrationTable, { certificateId }));
-  const course = await db.get(courseTable, { id: courseRegistration.courseId });
+export async function getCertificateData(certificateId: string) {
+  const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' })
+  const facilitatedRegistration = await db.getFirst(courseRegistrationTable, { filter: { certificateId } });
+
+  const registration = selfServeRegistration ?? facilitatedRegistration;
+
+  if (!registration) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Certificate not found' });
+  }
+
+  const course = await db.get(courseTable, { id: registration.courseId });
 
   return {
     certificateId,
-    certificateCreatedAt: courseRegistration.certificateCreatedAt ?? Math.floor(Date.now() / 1000),
-    recipientName: courseRegistration.fullName ?? '',
+    certificateCreatedAt: registration.certificateCreatedAt ?? Math.floor(Date.now() / 1000),
+    recipientName: registration.fullName ?? '',
     courseName: course.title,
     courseSlug: course.slug,
     courseDetailsUrl: course.detailsUrl ?? '',
@@ -133,8 +153,12 @@ export const certificatesRouter = router({
   verifyOwnership: protectedProcedure
     .input(z.object({ certificateId: z.string() }))
     .query(async ({ ctx, input: { certificateId } }) => {
-      const registration = await db.get(courseRegistrationTable, { certificateId });
-      const isOwner = registration?.email.toLowerCase() === ctx.auth.email.toLowerCase();
+      const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' })
+      const facilitatedRegistration = await db.getFirst(courseRegistrationTable, { filter: { certificateId } });
+
+      const registration = selfServeRegistration ?? facilitatedRegistration;
+
+      const isOwner = registration?.email?.toLowerCase() === ctx.auth.email.toLowerCase();
       return { isOwner };
     }),
 
@@ -154,7 +178,7 @@ export const certificatesRouter = router({
     }
 
     if (courseRegistration.certificateId) {
-      const certificate = await getCertificateData(courseRegistration.certificateId, courseRegistration);
+      const certificate = await getCertificateData(courseRegistration.certificateId);
       return {
         status: 'has-certificate' as const,
         ...certificate,

--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -1,5 +1,5 @@
 import {
-  applicationsRoundTable, courseRegistrationTable,
+  applicationsRoundTable, courseRegistrationTable, selfServeCourseRegistrationTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
@@ -135,6 +135,19 @@ describe('courseRegistrations.ensureExists', () => {
     expect(result?.id).toBe('reg-existing');
   });
 
+  test('prefers an existing self-serve registration over the legacy row', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID,
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'legacy-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID, decision: 'Accept',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID });
+    expect(result?.id).toBe('ss-foai');
+  });
+
   test('returns null for non-FOAI courses when no registration exists', async () => {
     const result = await createCaller(testAuthContextLoggedIn)
       .courseRegistrations.ensureExists({ courseId: otherCourseId });
@@ -147,9 +160,6 @@ describe('courseRegistrations.ensureExists', () => {
       .rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
-  // Note: The "creates a new FOAI registration" path can't be exercised in this test setup.
-  // The router's insert (course-registrations.ts L81-87) omits `courseId`, but the courseId column is `notNull()`
-  // in the pg schema. This either reveals a real bug in the router, or a difference between the
-  // pg test schema and Airtable's actual behaviour (likely a formula/lookup populating courseId from
-  // courseApplicationsBaseId). Flagging as a follow-up rather than asserting against a known failing path.
+  // The full "creates a new FOAI registration" path isn't unit-testable: both inserts omit `courseId`
+  // (a notNull lookup column the pg test schema rejects, populated by Airtable in prod).
 });

--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -121,7 +121,7 @@ describe('courseRegistrations.getRoundStartDates', () => {
 
 describe('courseRegistrations.ensureExists', () => {
   test('rejects unauthenticated callers', async () => {
-    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.ensureExists({ courseId: otherCourseId }))
+    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.ensureSelfServeRegistrationExists({ courseId: otherCourseId }))
       .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
@@ -131,7 +131,7 @@ describe('courseRegistrations.ensureExists', () => {
     });
 
     const result = await createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureExists({ courseId: otherCourseId });
+      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: otherCourseId });
     expect(result?.id).toBe('reg-existing');
   });
 
@@ -144,19 +144,19 @@ describe('courseRegistrations.ensureExists', () => {
     });
 
     const result = await createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID });
+      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID });
     expect(result?.id).toBe('ss-foai');
   });
 
   test('returns null for non-FOAI courses when no registration exists', async () => {
     const result = await createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureExists({ courseId: otherCourseId });
+      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: otherCourseId });
     expect(result).toBeNull();
   });
 
   test('throws NOT_FOUND for FOAI when no applications_course config row exists', async () => {
     await expect(createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))
+      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID }))
       .rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -1,6 +1,6 @@
 import {
   applicationsCourseTable, applicationsRoundTable, COURSE_ROLE, courseRegistrationTable, inArray,
-  eq, and, or, ne, isNull,
+  eq, and, or, ne, isNull, selfServeCourseRegistrationTable, userTable,
 } from '@bluedot/db';
 import z from 'zod';
 import { TRPCError } from '@trpc/server';
@@ -55,17 +55,24 @@ export const courseRegistrationsRouter = router({
     // This mutation will create a course registration if one doesn't already exist for FOAI course.
     .mutation(async ({ ctx, input }) => {
       const { courseId, source } = input;
-      const courseRegistration = await db.getFirst(courseRegistrationTable, {
+
+      // In-progress migration to self-serve table (#2526): Prefer the self-serve table, fall back to legacy
+      const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
+        filter: { email: ctx.auth.email, courseId },
+        sortBy: 'createdAt',
+      });
+      const legacyRegistration = await db.getFirst(courseRegistrationTable, {
         filter: {
           email: ctx.auth.email,
           courseId,
           decision: 'Accept',
         },
       });
+      const existingRegistration = selfServeRegistration ?? legacyRegistration;
 
       // If the course registration already exists, return it
-      if (courseRegistration) {
-        return courseRegistration;
+      if (existingRegistration) {
+        return existingRegistration;
       }
 
       if (courseId === FOAI_COURSE_ID) {
@@ -78,13 +85,24 @@ export const courseRegistrationsRouter = router({
           throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
         }
 
-        return db.insert(courseRegistrationTable, {
+        // Insert the self-serve row first so a retry (the existence check now reads self-serve first) can't duplicate it
+        const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+        const newRegistration = await db.insert(selfServeCourseRegistrationTable, {
+          userId: user?.id ?? null,
+          courseApplicationsBaseId: applicationsCourse.id,
+          source: source ?? null,
+          createdAt: new Date().toISOString(),
+        });
+
+        await db.insert(courseRegistrationTable, {
           email: ctx.auth.email,
           courseApplicationsBaseId: applicationsCourse.id,
           role: COURSE_ROLE.PARTICIPANT,
           decision: 'Accept',
           source: source ?? null,
         });
+
+        return newRegistration;
       }
 
       return null;

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -8,6 +8,63 @@ import db from '../../lib/api/db';
 import { protectedProcedure, router } from '../trpc';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 
+const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
+  .input(z.object({ courseId: z.string(), source: z.string().trim().max(255).optional() }))
+  .mutation(async ({ ctx, input }) => {
+    const { courseId, source } = input;
+
+    // In-progress migration to self-serve table (#2526): Prefer the self-serve table, fall back to legacy
+    const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
+      filter: { email: ctx.auth.email, courseId },
+      sortBy: 'createdAt',
+    });
+    const legacyRegistration = await db.getFirst(courseRegistrationTable, {
+      filter: {
+        email: ctx.auth.email,
+        courseId,
+        decision: 'Accept',
+      },
+    });
+    const existingRegistration = selfServeRegistration ?? legacyRegistration;
+
+    // If the course registration already exists, return it
+    if (existingRegistration) {
+      return existingRegistration;
+    }
+
+    if (courseId === FOAI_COURSE_ID) {
+      const applicationsCourse = await db.getFirst(applicationsCourseTable, {
+        sortBy: 'id',
+        filter: { courseBuilderId: courseId },
+      });
+
+      if (!applicationsCourse) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
+      }
+
+      // Insert the self-serve row first so a retry (the existence check now reads self-serve first) can't duplicate it
+      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+      const newRegistration = await db.insert(selfServeCourseRegistrationTable, {
+        userId: user?.id ?? null,
+        courseApplicationsBaseId: applicationsCourse.id,
+        source: source ?? null,
+        createdAt: new Date().toISOString(),
+      });
+
+      await db.insert(courseRegistrationTable, {
+        email: ctx.auth.email,
+        courseApplicationsBaseId: applicationsCourse.id,
+        role: COURSE_ROLE.PARTICIPANT,
+        decision: 'Accept',
+        source: source ?? null,
+      });
+
+      return newRegistration;
+    }
+
+    return null;
+  });
+
 export const courseRegistrationsRouter = router({
   getByCourseId: protectedProcedure
     .input(z.object({ courseId: z.string() }))
@@ -49,62 +106,6 @@ export const courseRegistrationsRouter = router({
         .where(inArray(applicationsRoundTable.pg.id, input.roundIds));
       return Object.fromEntries(rounds.map((r) => [r.id, r.firstDiscussionDate])) as Record<string, string | null>;
     }),
-
-  ensureExists: protectedProcedure
-    .input(z.object({ courseId: z.string(), source: z.string().trim().max(255).optional() }))
-    // This mutation will create a course registration if one doesn't already exist for FOAI course.
-    .mutation(async ({ ctx, input }) => {
-      const { courseId, source } = input;
-
-      // In-progress migration to self-serve table (#2526): Prefer the self-serve table, fall back to legacy
-      const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
-        filter: { email: ctx.auth.email, courseId },
-        sortBy: 'createdAt',
-      });
-      const legacyRegistration = await db.getFirst(courseRegistrationTable, {
-        filter: {
-          email: ctx.auth.email,
-          courseId,
-          decision: 'Accept',
-        },
-      });
-      const existingRegistration = selfServeRegistration ?? legacyRegistration;
-
-      // If the course registration already exists, return it
-      if (existingRegistration) {
-        return existingRegistration;
-      }
-
-      if (courseId === FOAI_COURSE_ID) {
-        const applicationsCourse = await db.getFirst(applicationsCourseTable, {
-          sortBy: 'id',
-          filter: { courseBuilderId: courseId },
-        });
-
-        if (!applicationsCourse) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
-        }
-
-        // Insert the self-serve row first so a retry (the existence check now reads self-serve first) can't duplicate it
-        const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
-        const newRegistration = await db.insert(selfServeCourseRegistrationTable, {
-          userId: user?.id ?? null,
-          courseApplicationsBaseId: applicationsCourse.id,
-          source: source ?? null,
-          createdAt: new Date().toISOString(),
-        });
-
-        await db.insert(courseRegistrationTable, {
-          email: ctx.auth.email,
-          courseApplicationsBaseId: applicationsCourse.id,
-          role: COURSE_ROLE.PARTICIPANT,
-          decision: 'Accept',
-          source: source ?? null,
-        });
-
-        return newRegistration;
-      }
-
-      return null;
-    }),
+  ensureExists: ensureSelfServeRegistrationExistsProcedure,
+  ensureSelfServeRegistrationExists: ensureSelfServeRegistrationExistsProcedure,
 });

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -42,15 +42,8 @@ const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
       }
 
-      // Insert the self-serve row first so a retry (the existence check now reads self-serve first) can't duplicate it
-      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
-      const newRegistration = await db.insert(selfServeCourseRegistrationTable, {
-        userId: user?.id ?? null,
-        courseApplicationsBaseId: applicationsCourse.id,
-        source: source ?? null,
-        createdAt: new Date().toISOString(),
-      });
-
+      // Legacy first: if the second insert fails, the orphan is a missing self-serve row (harmless
+      // while reads still hit legacy, and healed by the backfill) rather than a missing legacy row.
       await db.insert(courseRegistrationTable, {
         email: ctx.auth.email,
         courseApplicationsBaseId: applicationsCourse.id,
@@ -59,7 +52,13 @@ const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
         source: source ?? null,
       });
 
-      return newRegistration;
+      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+      return db.insert(selfServeCourseRegistrationTable, {
+        userId: user?.id ?? null,
+        courseApplicationsBaseId: applicationsCourse.id,
+        source: source ?? null,
+        createdAt: new Date().toISOString(),
+      });
     }
 
     return null;


### PR DESCRIPTION
# Description

1. New FoAI data will be written to _both_ `selfServeCourseRegistrations` and `courseRegistrations`
2. Consumers still read solely from `courseRegistrations`, apart from in the routes where the writes actually take place
3. Following this, I will run a script to backfill existing FoAI records into the new table

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2526, follows on from PR #2664

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
