### PR TITLE
Read FoAI data from the new `selfServeCourseRegistrations` table

### DIFF
--- a/apps/website/src/__tests__/pages/my-courses.test.tsx
+++ b/apps/website/src/__tests__/pages/my-courses.test.tsx
@@ -124,4 +124,29 @@ describe('bucketCoursesByTab', () => {
       }
     });
   });
+
+  // Future of AI is self-serve: its rows have no round, so roundStatus is always null and decision
+  // is never set. These two are the ONLY states a FoAI course currently surfaces in on My Courses.
+  // The enrolled-but-incomplete state being invisible is the known ~broken behaviour — update these
+  // tests deliberately if/when that changes.
+  describe('Future of AI (self-serve) states', () => {
+    const foaiRow = (certificateCreatedAt: number | null): ParticipantRowProps => makeRow({
+      roundStatus: null,
+      decision: null,
+      certificateCreatedAt,
+      certificateId: certificateCreatedAt ? 'cert-foai' : null,
+    });
+
+    test('enrolled without a certificate → not shown in any tab', () => {
+      const buckets = bucketCoursesByTab([foaiRow(null)]);
+      expect([...buckets.inProgress, ...buckets.upcoming, ...buckets.pastCourses]).toHaveLength(0);
+    });
+
+    test('completed (has certificate) → Past Courses only', () => {
+      const buckets = bucketCoursesByTab([foaiRow(1700000000)]);
+      expect(buckets.pastCourses).toHaveLength(1);
+      expect(buckets.inProgress).toHaveLength(0);
+      expect(buckets.upcoming).toHaveLength(0);
+    });
+  });
 });

--- a/apps/website/src/components/my-courses/CourseListRow.tsx
+++ b/apps/website/src/components/my-courses/CourseListRow.tsx
@@ -12,8 +12,22 @@ import { classifyCourseRegistration, useCourseListRow } from './useCourseListRow
 
 export type CourseListRowMode = 'participant' | 'facilitator';
 
+export type MyCoursesPageCourseRegistration = Pick<
+  CourseRegistration,
+  | 'id'
+  | 'courseId'
+  | 'email'
+  | 'decision'
+  | 'certificateId'
+  | 'certificateCreatedAt'
+  | 'roundId'
+  | 'roundName'
+  | 'roundStatus'
+  | 'availabilityIntervalsUTC'
+>;
+
 type CommonRowProps = {
-  courseRegistration: CourseRegistration;
+  courseRegistration: MyCoursesPageCourseRegistration;
   course: Pick<Course, 'slug' | 'title' | 'applyUrl'>;
   group: Group | null;
   meetPersonId: string | null;

--- a/apps/website/src/components/my-courses/useCourseListRow.tsx
+++ b/apps/website/src/components/my-courses/useCourseListRow.tsx
@@ -1,7 +1,7 @@
 import {
   CTALinkOrButton, addQueryParam, useLatestUtmParams, type OverflowMenuItemProps,
 } from '@bluedot/ui';
-import type { CourseRegistration, GroupDiscussion } from '@bluedot/db';
+import type { GroupDiscussion } from '@bluedot/db';
 import { Fragment, type ReactNode } from 'react';
 import { FaCheck, FaLock } from 'react-icons/fa6';
 import { IoBan } from 'react-icons/io5';
@@ -9,7 +9,9 @@ import { FOAI_COURSE_SLUG } from '../../lib/constants';
 import { ROUTES } from '../../lib/routes';
 import { buildApplicationUrl, buildGroupSlackChannelUrl, getActionPlanUrl } from '../../lib/utils';
 import { buildAvailabilityFormUrl, type SwitchType } from '../courses/GroupSwitchModal';
-import type { CourseListRowProps, FacilitatorRowProps, ParticipantRowProps } from './CourseListRow';
+import type {
+  MyCoursesPageCourseRegistration, CourseListRowProps, FacilitatorRowProps, ParticipantRowProps,
+} from './CourseListRow';
 import type { CourseAction } from './DiscussionListRow';
 import { useCourseModals, type CourseModalTriggers } from './useCourseModals';
 
@@ -20,7 +22,7 @@ export type DropoutStatus = { isDroppedOut: boolean; isDeferred: boolean };
 const NOT_DROPPED: DropoutStatus = { isDroppedOut: false, isDeferred: false };
 
 export const classifyCourseRegistration = (
-  cr: CourseRegistration,
+  cr: MyCoursesPageCourseRegistration,
   status: DropoutStatus = NOT_DROPPED,
 ): CourseRowState => {
   if (status.isDroppedOut && !status.isDeferred) return 'dropped';
@@ -265,7 +267,7 @@ const deriveCourseRowState = (row: CourseListRowProps, utmSource: string | undef
   };
 };
 
-export const getApplicationActionLabel = (cr: CourseRegistration, state: CourseRowState): string => (
+export const getApplicationActionLabel = (cr: MyCoursesPageCourseRegistration, state: CourseRowState): string => (
   state === 'upcoming' && cr.decision === null
     ? 'Withdraw application'
     : 'Drop or defer course'

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -77,7 +77,11 @@ const CourseUnitChunkPage = ({
   }, [courseSlug, unitNumber]);
 
   const { latestUtmParams, isLoading: isUtmLoading } = useLatestUtmParams();
-  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.selfServeCourseRegistrations.ensureExists.useMutation();
+  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.selfServeCourseRegistrations.ensureExists.useMutation({
+    // The User row can lag auth (created by oauth-callback's side-effect), so retry until it exists.
+    retry: (failureCount, error) => failureCount < 5 && error.data?.code === 'PRECONDITION_FAILED',
+    retryDelay: 5000,
+  });
 
   useEffect(() => {
     // FoAI course only: If we're logged in, ensures a course registration is recorded

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -77,11 +77,7 @@ const CourseUnitChunkPage = ({
   }, [courseSlug, unitNumber]);
 
   const { latestUtmParams, isLoading: isUtmLoading } = useLatestUtmParams();
-  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.courseRegistrations.ensureSelfServeRegistrationExists.useMutation({
-    // The User row can lag auth (created by oauth-callback's side-effect), so retry until it exists.
-    retry: (failureCount, error) => failureCount < 5 && error.data?.code === 'PRECONDITION_FAILED',
-    retryDelay: 5000,
-  });
+  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.selfServeCourseRegistrations.ensureExists.useMutation();
 
   useEffect(() => {
     // FoAI course only: If we're logged in, ensures a course registration is recorded

--- a/apps/website/src/server/routers/_app.ts
+++ b/apps/website/src/server/routers/_app.ts
@@ -19,6 +19,7 @@ import { missionsRouter } from './missions';
 import { myBluedotRouter } from './my-bluedot';
 import { programsRouter } from './programs';
 import { resourcesRouter } from './resources';
+import { selfServeCourseRegistrationsRouter } from './self-serve-course-registrations';
 import { subscriptionPreferencesRouter } from './subscription-preferences';
 import { teamMembersRouter } from './teamMembers';
 import { testimonialsRouter } from './testimonials';
@@ -45,6 +46,7 @@ export const appRouter = router({
   myBluedot: myBluedotRouter,
   programs: programsRouter,
   resources: resourcesRouter,
+  selfServeCourseRegistrations: selfServeCourseRegistrationsRouter,
   subscriptionPreferences: subscriptionPreferencesRouter,
   teamMembers: teamMembersRouter,
   testimonials: testimonialsRouter,

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -183,11 +183,10 @@ describe('certificates.getStatus', () => {
       detailsUrl: 'https://example.com/foai',
       units: [],
     });
-    await testDb.insert(courseRegistrationTable, {
+    await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'reg1',
       email: 'test@example.com',
       courseId: FOAI_COURSE_ID,
-      decision: 'Accept',
       certificateId: 'cert-1',
       certificateCreatedAt: 1700000000,
       fullName: 'Dewi Erwan',
@@ -214,11 +213,10 @@ describe('certificates.getStatus', () => {
       title: 'Future of AI',
       units: [],
     });
-    await testDb.insert(courseRegistrationTable, {
+    await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'reg1',
       email: 'test@example.com',
       courseId: FOAI_COURSE_ID,
-      decision: 'Accept',
       certificateId: 'cert-1',
       certificateCreatedAt: 1700000000,
     });
@@ -228,8 +226,8 @@ describe('certificates.getStatus', () => {
   });
 
   test('returns exercises-incomplete for FOAI registrations without a certificate', async () => {
-    await testDb.insert(courseRegistrationTable, {
-      id: 'reg-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID, decision: 'Accept',
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-reg-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID,
     });
 
     const result = await createCaller(testAuthContextLoggedIn).certificates.getStatus({ courseId: FOAI_COURSE_ID });
@@ -361,17 +359,17 @@ describe('issueFoaiCertificateIfComplete', () => {
     expect(legacy.certificateCreatedAt).toBe(selfServe?.certificateCreatedAt);
   });
 
-  test('issues on the legacy row when no self-serve row exists yet', async () => {
+  test('does nothing when no self-serve row exists', async () => {
+    // Self-serve is authoritative post read-switch; a learner without a self-serve row can't be issued to.
     await testDb.insert(courseRegistrationTable, {
       id: 'reg-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID, decision: 'Accept',
     });
     await setupCompletedFoaiExercises('test@example.com');
 
-    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(false);
 
     const legacy = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
-    expect(legacy.certificateId).toBe('reg-foai');
-    expect(await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)).toEqual([]);
+    expect(legacy.certificateId).toBeNull();
   });
 
   test('writes nothing when exercises are incomplete', async () => {

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -44,17 +44,12 @@ async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
 }
 
 export async function issueFoaiCertificateIfComplete(email: string): Promise<boolean> {
-  // In-progress migration to self-serve table (#2526): Prefer the self-serve table, fall back to legacy
   const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
     filter: { email, courseId: FOAI_COURSE_ID },
     sortBy: 'createdAt',
   });
-  const legacyRegistration = await db.getFirst(courseRegistrationTable, {
-    filter: { email, courseId: FOAI_COURSE_ID, decision: 'Accept' },
-  });
 
-  const registration = selfServeRegistration ?? legacyRegistration;
-  if (!registration || registration.certificateId) {
+  if (!selfServeRegistration || selfServeRegistration.certificateId) {
     return false;
   }
 
@@ -63,12 +58,14 @@ export async function issueFoaiCertificateIfComplete(email: string): Promise<boo
   }
 
   const certificateCreatedAt = Math.floor(Date.now() / 1000);
-  const certificateId = registration.id;
+  const certificateId = selfServeRegistration.id;
 
-  if (selfServeRegistration) {
-    await db.update(selfServeCourseRegistrationTable, { id: selfServeRegistration.id, certificateId, certificateCreatedAt });
-  }
+  await db.update(selfServeCourseRegistrationTable, { id: selfServeRegistration.id, certificateId, certificateCreatedAt });
 
+  // Keep the legacy row in sync until it's deleted at the end of the migration (#2526)
+  const legacyRegistration = await db.getFirst(courseRegistrationTable, {
+    filter: { email, courseId: FOAI_COURSE_ID, decision: 'Accept' },
+  });
   if (legacyRegistration && !legacyRegistration.certificateId) {
     await db.update(courseRegistrationTable, { id: legacyRegistration.id, certificateId, certificateCreatedAt });
   }
@@ -173,6 +170,29 @@ export const certificatesRouter = router({
       return { status: 'not-authenticated', hasUpcomingRounds } as const;
     }
 
+    // Future of AI is self-serve: it lives in its own table and never has rounds.
+    if (courseId === FOAI_COURSE_ID) {
+      const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
+        filter: { email: ctx.auth.email, courseId },
+        sortBy: 'createdAt',
+      });
+
+      if (!selfServeRegistration) {
+        return { status: 'not-enrolled', hasUpcomingRounds: false } as const;
+      }
+
+      if (selfServeRegistration.certificateId) {
+        const certificate = await getCertificateData(selfServeRegistration.certificateId);
+        return {
+          status: 'has-certificate' as const,
+          ...certificate,
+        };
+      }
+
+      // FoAI auto-issues certificates when every active exercise is completed (see saveExerciseResponse).
+      return { status: 'exercises-incomplete' } as const;
+    }
+
     const courseRegistration = await db.getFirst(courseRegistrationTable, {
       filter: { email: ctx.auth.email, courseId, decision: 'Accept' },
     });
@@ -188,12 +208,6 @@ export const certificatesRouter = router({
         status: 'has-certificate' as const,
         ...certificate,
       };
-    }
-
-    if (courseRegistration.courseId === FOAI_COURSE_ID) {
-      // FOAI auto-issues certificates when every active exercise is completed (see saveExerciseResponse).
-      // Reaching this branch means the learner is enrolled but hasn't finished all exercises yet.
-      return { status: 'exercises-incomplete' } as const;
     }
 
     const meetPerson = await db.getFirst(meetPersonTable, {

--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -119,39 +119,26 @@ describe('courseRegistrations.getRoundStartDates', () => {
   });
 });
 
-describe('courseRegistrations.ensureExists', () => {
+describe('courseRegistrations.ensureSelfServeRegistrationExists', () => {
   test('rejects unauthenticated callers', async () => {
-    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.ensureSelfServeRegistrationExists({ courseId: otherCourseId }))
+    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID }))
       .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
-  test('returns the existing registration if one already exists', async () => {
-    await testDb.insert(courseRegistrationTable, {
-      id: 'reg-existing', email: 'test@example.com', courseId: otherCourseId, decision: 'Accept',
-    });
-
-    const result = await createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: otherCourseId });
-    expect(result?.id).toBe('reg-existing');
+  test('throws BAD_REQUEST for non-FOAI courses', async () => {
+    await expect(createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: otherCourseId }))
+      .rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
-  test('prefers an existing self-serve registration over the legacy row', async () => {
+  test('returns the existing self-serve registration', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID,
-    });
-    await testDb.insert(courseRegistrationTable, {
-      id: 'legacy-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID, decision: 'Accept',
     });
 
     const result = await createCaller(testAuthContextLoggedIn)
       .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID });
     expect(result?.id).toBe('ss-foai');
-  });
-
-  test('returns null for non-FOAI courses when no registration exists', async () => {
-    const result = await createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: otherCourseId });
-    expect(result).toBeNull();
   });
 
   test('throws NOT_FOUND for FOAI when no applications_course config row exists', async () => {

--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -1,5 +1,5 @@
 import {
-  applicationsCourseTable, applicationsRoundTable, courseRegistrationTable, selfServeCourseRegistrationTable,
+  applicationsRoundTable, courseRegistrationTable, selfServeCourseRegistrationTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {

--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -119,42 +119,16 @@ describe('courseRegistrations.getRoundStartDates', () => {
   });
 });
 
-describe('courseRegistrations.ensureSelfServeRegistrationExists', () => {
-  test('rejects unauthenticated callers', async () => {
-    await expect(createCaller(testAuthContextLoggedOut).courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID }))
-      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-  });
-
-  test('throws BAD_REQUEST for non-FOAI courses', async () => {
-    await expect(createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: otherCourseId }))
-      .rejects.toMatchObject({ code: 'BAD_REQUEST' });
-  });
-
-  test('returns the existing self-serve registration', async () => {
+// Self-serve registration behaviour is tested in self-serve-course-registrations.test.ts; here we
+// only assert the backwards-compatible aliases still route to that procedure.
+describe('courseRegistrations self-serve aliases', () => {
+  test('ensureExists and ensureSelfServeRegistrationExists both return the self-serve registration', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID,
     });
+    const caller = createCaller(testAuthContextLoggedIn);
 
-    const result = await createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID });
-    expect(result?.id).toBe('ss-foai');
+    expect((await caller.courseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))?.id).toBe('ss-foai');
+    expect((await caller.courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID }))?.id).toBe('ss-foai');
   });
-
-  test('throws NOT_FOUND for FOAI when no applications_course config row exists', async () => {
-    await expect(createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID }))
-      .rejects.toMatchObject({ code: 'NOT_FOUND' });
-  });
-
-  test('throws PRECONDITION_FAILED for FOAI when the User record does not exist yet (so the client retries)', async () => {
-    await testDb.insert(applicationsCourseTable, { id: 'foai-app-course', courseBuilderId: FOAI_COURSE_ID });
-
-    await expect(createCaller(testAuthContextLoggedIn)
-      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID }))
-      .rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
-  });
-
-  // The full "creates a new FOAI registration" path isn't unit-testable: both inserts omit `courseId`
-  // (a notNull lookup column the pg test schema rejects, populated by Airtable in prod).
 });

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -1,12 +1,11 @@
 import {
-  applicationsCourseTable, applicationsRoundTable, courseRegistrationTable, inArray,
-  eq, and, or, ne, isNull, selfServeCourseRegistrationTable, userTable,
+  applicationsRoundTable, courseRegistrationTable, inArray,
+  eq, and, or, ne, isNull,
 } from '@bluedot/db';
 import z from 'zod';
-import { TRPCError } from '@trpc/server';
 import db from '../../lib/api/db';
 import { protectedProcedure, router } from '../trpc';
-import { FOAI_COURSE_ID } from '../../lib/constants';
+import { ensureSelfServeRegistrationExistsProcedure } from './self-serve-course-registrations';
 
 export const courseRegistrationsRouter = router({
   getByCourseId: protectedProcedure
@@ -50,38 +49,8 @@ export const courseRegistrationsRouter = router({
       return Object.fromEntries(rounds.map((r) => [r.id, r.firstDiscussionDate])) as Record<string, string | null>;
     }),
 
-  ensureSelfServeRegistrationExists: protectedProcedure
-    .input(z.object({ courseId: z.string(), source: z.string().trim().max(255).optional() }))
-    .mutation(async ({ ctx, input }) => {
-      const { courseId, source } = input;
-
-      if (courseId !== FOAI_COURSE_ID) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Only the Future of AI course supports self-serve registration' });
-      }
-
-      const existingRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
-        filter: { email: ctx.auth.email, courseId },
-        sortBy: 'createdAt',
-      });
-
-      if (existingRegistration) {
-        return existingRegistration;
-      }
-
-      const applicationsCourse = await db.getFirst(applicationsCourseTable, {
-        sortBy: 'id',
-        filter: { courseBuilderId: courseId },
-      });
-      if (!applicationsCourse) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
-      }
-
-      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
-      return db.insert(selfServeCourseRegistrationTable, {
-        userId: user?.id ?? null,
-        courseApplicationsBaseId: applicationsCourse.id,
-        source: source ?? null,
-        createdAt: new Date().toISOString(),
-      });
-    }),
+  // Self-serve registration now lives in selfServeCourseRegistrations.ensureExists; these two are
+  // kept as backwards-compatible aliases for clients on the old routes. These can be deleted after ~2026-06-17
+  ensureExists: ensureSelfServeRegistrationExistsProcedure,
+  ensureSelfServeRegistrationExists: ensureSelfServeRegistrationExistsProcedure,
 });

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -1,5 +1,5 @@
 import {
-  applicationsCourseTable, applicationsRoundTable, COURSE_ROLE, courseRegistrationTable, inArray,
+  applicationsCourseTable, applicationsRoundTable, courseRegistrationTable, inArray,
   eq, and, or, ne, isNull, selfServeCourseRegistrationTable, userTable,
 } from '@bluedot/db';
 import z from 'zod';
@@ -7,68 +7,6 @@ import { TRPCError } from '@trpc/server';
 import db from '../../lib/api/db';
 import { protectedProcedure, router } from '../trpc';
 import { FOAI_COURSE_ID } from '../../lib/constants';
-
-const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
-  .input(z.object({ courseId: z.string(), source: z.string().trim().max(255).optional() }))
-  .mutation(async ({ ctx, input }) => {
-    const { courseId, source } = input;
-
-    // In-progress migration to self-serve table (#2526): Prefer the self-serve table, fall back to legacy
-    const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
-      filter: { email: ctx.auth.email, courseId },
-      sortBy: 'createdAt',
-    });
-    const legacyRegistration = await db.getFirst(courseRegistrationTable, {
-      filter: {
-        email: ctx.auth.email,
-        courseId,
-        decision: 'Accept',
-      },
-    });
-    const existingRegistration = selfServeRegistration ?? legacyRegistration;
-
-    // If the course registration already exists, return it
-    if (existingRegistration) {
-      return existingRegistration;
-    }
-
-    if (courseId === FOAI_COURSE_ID) {
-      const applicationsCourse = await db.getFirst(applicationsCourseTable, {
-        sortBy: 'id',
-        filter: { courseBuilderId: courseId },
-      });
-
-      if (!applicationsCourse) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
-      }
-
-      // The User row is created by a lagging login side-effect (oauth-callback). Fail before writing
-      // anything so the client retries
-      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
-      if (!user) {
-        throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'User record not available yet' });
-      }
-
-      // Legacy first: if the second insert fails, the orphan is a missing self-serve row (harmless
-      // while reads still hit legacy, and healed by the backfill) rather than a missing legacy row.
-      await db.insert(courseRegistrationTable, {
-        email: ctx.auth.email,
-        courseApplicationsBaseId: applicationsCourse.id,
-        role: COURSE_ROLE.PARTICIPANT,
-        decision: 'Accept',
-        source: source ?? null,
-      });
-
-      return db.insert(selfServeCourseRegistrationTable, {
-        userId: user.id,
-        courseApplicationsBaseId: applicationsCourse.id,
-        source: source ?? null,
-        createdAt: new Date().toISOString(),
-      });
-    }
-
-    return null;
-  });
 
 export const courseRegistrationsRouter = router({
   getByCourseId: protectedProcedure
@@ -111,6 +49,39 @@ export const courseRegistrationsRouter = router({
         .where(inArray(applicationsRoundTable.pg.id, input.roundIds));
       return Object.fromEntries(rounds.map((r) => [r.id, r.firstDiscussionDate])) as Record<string, string | null>;
     }),
-  ensureExists: ensureSelfServeRegistrationExistsProcedure,
-  ensureSelfServeRegistrationExists: ensureSelfServeRegistrationExistsProcedure,
+
+  ensureSelfServeRegistrationExists: protectedProcedure
+    .input(z.object({ courseId: z.string(), source: z.string().trim().max(255).optional() }))
+    .mutation(async ({ ctx, input }) => {
+      const { courseId, source } = input;
+
+      if (courseId !== FOAI_COURSE_ID) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Only the Future of AI course supports self-serve registration' });
+      }
+
+      const existingRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
+        filter: { email: ctx.auth.email, courseId },
+        sortBy: 'createdAt',
+      });
+
+      if (existingRegistration) {
+        return existingRegistration;
+      }
+
+      const applicationsCourse = await db.getFirst(applicationsCourseTable, {
+        sortBy: 'id',
+        filter: { courseBuilderId: courseId },
+      });
+      if (!applicationsCourse) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
+      }
+
+      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+      return db.insert(selfServeCourseRegistrationTable, {
+        userId: user?.id ?? null,
+        courseApplicationsBaseId: applicationsCourse.id,
+        source: source ?? null,
+        createdAt: new Date().toISOString(),
+      });
+    }),
 });

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -1,10 +1,12 @@
 import {
   courseRegistrationTable,
   courseTable,
+  eq,
   exerciseResponsePgTable,
   exerciseTable,
   groupTable,
   meetPersonTable,
+  selfServeCourseRegistrationTable,
   userTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
@@ -172,14 +174,20 @@ describe('exercises.saveExerciseResponse', () => {
 });
 
 describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
+  // Self-serve is the authoritative table for FoAI issuance post read-switch (#2526)
   async function seedFoaiRegistration() {
-    await testDb.insert(courseRegistrationTable, {
-      id: 'reg-foai',
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-foai',
       email: CALLER_EMAIL,
       courseId: FOAI_COURSE_ID,
-      decision: 'Accept',
     });
   }
+
+  const getSelfServeFoai = async () => {
+    const [row] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
+      .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-foai'));
+    return row;
+  };
 
   test('auto-issues a certificate when the final FOAI exercise is completed', async () => {
     await seedFoaiRegistration();
@@ -202,9 +210,9 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
 
     expect(result.certificateIssued).toBe(true);
 
-    const reg = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
-    expect(reg.certificateId).toBe('reg-foai');
-    expect(reg.certificateCreatedAt).toBeGreaterThanOrEqual(before);
+    const reg = await getSelfServeFoai();
+    expect(reg?.certificateId).toBe('ss-foai');
+    expect(reg?.certificateCreatedAt).toBeGreaterThanOrEqual(before);
   });
 
   test('does not auto-issue when other FOAI exercises remain incomplete', async () => {
@@ -223,8 +231,8 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
     });
 
     expect(result.certificateIssued).toBe(false);
-    const reg = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
-    expect(reg.certificateId).toBeFalsy();
+    const reg = await getSelfServeFoai();
+    expect(reg?.certificateId).toBeFalsy();
   });
 
   test('does not auto-issue for non-FOAI courses', async () => {
@@ -247,12 +255,11 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
   });
 
   test('is a no-op when the certificate is already issued', async () => {
-    await testDb.insert(courseRegistrationTable, {
-      id: 'reg-foai',
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-foai',
       email: CALLER_EMAIL,
       courseId: FOAI_COURSE_ID,
-      decision: 'Accept',
-      certificateId: 'reg-foai',
+      certificateId: 'ss-foai',
       certificateCreatedAt: 1700000000,
     });
     await testDb.insert(exerciseTable, {
@@ -266,8 +273,8 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
     });
 
     expect(result.certificateIssued).toBe(false);
-    const reg = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
-    expect(reg.certificateCreatedAt).toBe(1700000000);
+    const reg = await getSelfServeFoai();
+    expect(reg?.certificateCreatedAt).toBe(1700000000);
   });
 
   test('does not auto-issue when completed is false (un-marking)', async () => {
@@ -286,8 +293,8 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
     });
 
     expect(result.certificateIssued).toBe(false);
-    const reg = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
-    expect(reg.certificateId).toBeFalsy();
+    const reg = await getSelfServeFoai();
+    expect(reg?.certificateId).toBeFalsy();
   });
 });
 

--- a/apps/website/src/server/routers/my-bluedot.test.ts
+++ b/apps/website/src/server/routers/my-bluedot.test.ts
@@ -6,6 +6,7 @@ import {
   groupDiscussionTable,
   groupTable,
   meetPersonTable,
+  selfServeCourseRegistrationTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
@@ -14,6 +15,7 @@ import {
   testAuthContextLoggedIn,
   testDb,
 } from '../../__tests__/dbTestUtils';
+import { FOAI_COURSE_ID } from '../../lib/constants';
 
 setupTestDb();
 
@@ -602,6 +604,81 @@ describe('myCoursesPage.getOverview', () => {
       const byRegId = Object.fromEntries(result.courses.map((c) => [c.courseRegistration.id, c]));
       expect(byRegId['reg-x']?.rescheduleEligibleUnits).toEqual(['1']);
       expect(byRegId['reg-y']?.rescheduleEligibleUnits).toEqual(['2']);
+    });
+  });
+
+  // Future of AI is self-serve: registrations live in self_serve_course_registration and carry no
+  // round/group/meetPerson data. The server returns them as plain participant rows; whether they're
+  // shown (and in which tab) is decided client-side — see my-courses.test.tsx.
+  describe('Future of AI (self-serve) rows', () => {
+    const seedFoaiCourse = () => testDb.insert(courseTable, {
+      id: FOAI_COURSE_ID,
+      slug: 'future-of-ai',
+      title: 'Future of AI',
+      shortDescription: 'f',
+      units: [],
+      status: 'Active',
+    });
+
+    test('returns a self-serve registration as a participant row with certificate state and no round data', async () => {
+      await seedFoaiCourse();
+      await testDb.insert(selfServeCourseRegistrationTable, {
+        id: 'ss-foai',
+        email: CALLER_EMAIL,
+        courseId: FOAI_COURSE_ID,
+        certificateId: 'ss-foai',
+        certificateCreatedAt: 1700000000,
+      });
+
+      const result = await caller.myBluedot.myCoursesPage();
+      expect(result.courses).toHaveLength(1);
+      const row = result.courses[0]!;
+      expect(row.mode).toBe('participant');
+      expect(row.course.slug).toBe('future-of-ai');
+      expect(row.courseRegistration).toMatchObject({
+        id: 'ss-foai',
+        courseId: FOAI_COURSE_ID,
+        certificateId: 'ss-foai',
+        certificateCreatedAt: 1700000000,
+        roundId: null,
+        roundStatus: null,
+      });
+      expect(row.discussions).toEqual([]);
+      expect(row.meetPersonId).toBeNull();
+      expect(result.nextDiscussion).toBeNull();
+    });
+
+    test('an enrolled-but-incomplete registration is still returned (no certificate)', async () => {
+      await seedFoaiCourse();
+      await testDb.insert(selfServeCourseRegistrationTable, {
+        id: 'ss-foai',
+        email: CALLER_EMAIL,
+        courseId: FOAI_COURSE_ID,
+      });
+
+      const result = await caller.myBluedot.myCoursesPage();
+      expect(result.courses).toHaveLength(1);
+      expect(result.courses[0]!.courseRegistration.certificateCreatedAt).toBeNull();
+    });
+
+    test('does not double-count a learner who still has a legacy FoAI row', async () => {
+      await seedFoaiCourse();
+      await testDb.insert(courseRegistrationTable, {
+        id: 'legacy-foai',
+        email: CALLER_EMAIL,
+        courseId: FOAI_COURSE_ID,
+        decision: 'Accept',
+        role: 'Participant',
+      });
+      await testDb.insert(selfServeCourseRegistrationTable, {
+        id: 'ss-foai',
+        email: CALLER_EMAIL,
+        courseId: FOAI_COURSE_ID,
+      });
+
+      const result = await caller.myBluedot.myCoursesPage();
+      expect(result.courses).toHaveLength(1);
+      expect(result.courses[0]!.courseRegistration.id).toBe('ss-foai');
     });
   });
 });

--- a/apps/website/src/server/routers/my-bluedot.ts
+++ b/apps/website/src/server/routers/my-bluedot.ts
@@ -17,15 +17,39 @@ import {
   ne,
   or,
   roundTable,
+  selfServeCourseRegistrationTable,
   type Unit,
   unitTable,
 } from '@bluedot/db';
 import z from 'zod';
 import type { FacilitatorRowProps, ParticipantRowProps } from '../../components/my-courses/CourseListRow';
 import db from '../../lib/api/db';
+import { FOAI_COURSE_ID } from '../../lib/constants';
 import { parseWeekFromRoundName, unique } from '../../lib/utils';
 import { protectedProcedure, router } from '../trpc';
 import { getAvailableGroupsAndDiscussions } from './group-switching';
+
+// Used for mapping self-serve registrations (where all these fields are empty) into the expected shape
+const EMPTY_PARTICIPANT_ROW = {
+  group: null,
+  facilitatorNames: [],
+  meetPersonId: null,
+  groupsAsParticipant: null,
+  roundId: null,
+  discussions: [],
+  attendedDiscussionIds: [],
+  units: {},
+  roundStartDate: null,
+  roundEndDate: null,
+  rescheduleEligibleUnits: [],
+  numUnits: null,
+  uniqueDiscussionAttendance: null,
+  hasSubmittedActionPlan: false,
+  feedbackFormUrl: null,
+  hasSubmittedFeedback: false,
+  isDroppedOut: false,
+  isDeferred: false,
+} satisfies Omit<ParticipantRowProps, 'mode' | 'course' | 'courseRegistration'>;
 
 const fetchActiveCoursesByIds = async (ids: string[]) => {
   if (ids.length === 0) return [];
@@ -104,31 +128,43 @@ export const myBluedotRouter = router({
     const { email } = ctx.auth;
 
     // Step 1: Fetch data
-    const courseRegistrations = await db.pg
-      .select()
-      .from(courseRegistrationTable.pg)
-      .where(and(
-        eq(courseRegistrationTable.pg.email, email),
-        or(
-          // Happy path: role === COURSE_ROLE.PARTICIPANT
-          ne(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR),
-          isNull(courseRegistrationTable.pg.role),
-        ),
-        or(
-          // Happy path: decision === 'Accept'
-          ne(courseRegistrationTable.pg.decision, 'Withdrawn'),
-          isNull(courseRegistrationTable.pg.decision),
-        ),
-      ));
+    const [facilitatedRegistrations, selfServeRegistrations] = await Promise.all([
+      db.pg
+        .select()
+        .from(courseRegistrationTable.pg)
+        .where(and(
+          eq(courseRegistrationTable.pg.email, email),
+          // FoAI registrations live in self_serve_course_registration now; they're unioned in below
+          ne(courseRegistrationTable.pg.courseId, FOAI_COURSE_ID),
+          or(
+            // Happy path: role === COURSE_ROLE.PARTICIPANT
+            ne(courseRegistrationTable.pg.role, COURSE_ROLE.FACILITATOR),
+            isNull(courseRegistrationTable.pg.role),
+          ),
+          or(
+            // Happy path: decision === 'Accept'
+            ne(courseRegistrationTable.pg.decision, 'Withdrawn'),
+            isNull(courseRegistrationTable.pg.decision),
+          ),
+        )),
+      db.pg
+        .select()
+        .from(selfServeCourseRegistrationTable.pg)
+        .where(eq(selfServeCourseRegistrationTable.pg.email, email)),
+    ]);
 
-    if (courseRegistrations.length === 0) {
+    if (facilitatedRegistrations.length === 0 && selfServeRegistrations.length === 0) {
       return { courses: [], nextDiscussion: null };
     }
 
+    const courseIds = unique([
+      ...facilitatedRegistrations.map((cr) => cr.courseId),
+      ...selfServeRegistrations.map((cr) => cr.courseId),
+    ]);
     const [courses, meetPersons, dropoutStatusByRegId] = await Promise.all([
-      fetchActiveCoursesByIds(unique(courseRegistrations.map((cr) => cr.courseId))),
+      fetchActiveCoursesByIds(courseIds),
       db.pg.select().from(meetPersonTable.pg).where(eq(meetPersonTable.pg.email, email)),
-      fetchDropoutStatusByRegId(courseRegistrations.map((cr) => cr.id)),
+      fetchDropoutStatusByRegId(facilitatedRegistrations.map((cr) => cr.id)),
     ]);
 
     // The user's own groups (needs meetPersons.groupsAsParticipant).
@@ -140,7 +176,7 @@ export const myBluedotRouter = router({
     // Facilitators (from groups), discussions (from meetPersons), rounds (from regs).
     const facilitatorIds = unique(groups.flatMap((g) => g.facilitator ?? []));
     const allExpectedDiscussionIds = unique(meetPersons.flatMap((mp) => mp.expectedDiscussionsParticipant ?? []));
-    const allRoundIds = unique(courseRegistrations.map((cr) => cr.roundId));
+    const allRoundIds = unique(facilitatedRegistrations.map((cr) => cr.roundId));
 
     const [facilitators, discussions, roundRows] = await Promise.all([
       facilitatorIds.length > 0
@@ -204,7 +240,7 @@ export const myBluedotRouter = router({
     const discussionById = new Map(discussions.map((d) => [d.id, d] as const));
     const roundById = new Map(roundRows.map((r) => [r.id, r] as const));
 
-    const perCourse: ParticipantRowProps[] = courseRegistrations.flatMap((cr): ParticipantRowProps[] => {
+    const facilitatedRows: ParticipantRowProps[] = facilitatedRegistrations.flatMap((cr): ParticipantRowProps[] => {
       const course = courses.find((c) => c.id === cr.courseId);
       if (!course) return [];
 
@@ -260,6 +296,33 @@ export const myBluedotRouter = router({
         isDeferred: status.isDeferred,
       }];
     });
+
+    // Self-serve (Future of AI) rows: no round, group, meetPerson or dropout lifecycle, so they
+    // skip all the facilitated machinery above and carry only identity + certificate state.
+    const selfServeRows: ParticipantRowProps[] = selfServeRegistrations.flatMap((reg): ParticipantRowProps[] => {
+      const course = courses.find((c) => c.id === reg.courseId);
+      if (!course) return [];
+
+      return [{
+        mode: 'participant',
+        ...EMPTY_PARTICIPANT_ROW,
+        course,
+        courseRegistration: {
+          id: reg.id,
+          courseId: reg.courseId,
+          email: reg.email ?? '',
+          decision: null,
+          certificateId: reg.certificateId,
+          certificateCreatedAt: reg.certificateCreatedAt,
+          roundId: null,
+          roundName: null,
+          roundStatus: null,
+          availabilityIntervalsUTC: null,
+        },
+      }];
+    });
+
+    const perCourse = [...facilitatedRows, ...selfServeRows];
 
     // Step 3: Calculate results for NextDiscussionCard section
     const courseByDiscussionId = new Map<string, { slug: string; title: string }>();

--- a/apps/website/src/server/routers/self-serve-course-registrations.test.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.test.ts
@@ -1,4 +1,4 @@
-import { selfServeCourseRegistrationTable } from '@bluedot/db';
+import { applicationsCourseTable, selfServeCourseRegistrationTable } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
   createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
@@ -35,6 +35,14 @@ describe('selfServeCourseRegistrations.ensureExists', () => {
     await expect(createCaller(testAuthContextLoggedIn)
       .selfServeCourseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))
       .rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  test('throws PRECONDITION_FAILED for FOAI when the User record does not exist yet (so the client retries)', async () => {
+    await testDb.insert(applicationsCourseTable, { id: 'foai-app-course', courseBuilderId: FOAI_COURSE_ID });
+
+    await expect(createCaller(testAuthContextLoggedIn)
+      .selfServeCourseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))
+      .rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
   });
 
   // The full "creates a new FOAI registration" path isn't unit-testable: the insert omits `courseId`

--- a/apps/website/src/server/routers/self-serve-course-registrations.test.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.test.ts
@@ -1,0 +1,42 @@
+import { selfServeCourseRegistrationTable } from '@bluedot/db';
+import { describe, expect, test } from 'vitest';
+import {
+  createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
+} from '../../__tests__/dbTestUtils';
+import { FOAI_COURSE_ID } from '../../lib/constants';
+
+setupTestDb();
+
+const otherCourseId = 'recOtherCourseId12345';
+
+describe('selfServeCourseRegistrations.ensureExists', () => {
+  test('rejects unauthenticated callers', async () => {
+    await expect(createCaller(testAuthContextLoggedOut).selfServeCourseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))
+      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  test('throws BAD_REQUEST for non-FOAI courses', async () => {
+    await expect(createCaller(testAuthContextLoggedIn)
+      .selfServeCourseRegistrations.ensureExists({ courseId: otherCourseId }))
+      .rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  test('returns the existing self-serve registration', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID,
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn)
+      .selfServeCourseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID });
+    expect(result?.id).toBe('ss-foai');
+  });
+
+  test('throws NOT_FOUND for FOAI when no applications_course config row exists', async () => {
+    await expect(createCaller(testAuthContextLoggedIn)
+      .selfServeCourseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))
+      .rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  // The full "creates a new FOAI registration" path isn't unit-testable: the insert omits `courseId`
+  // (a notNull lookup column the pg test schema rejects, populated by Airtable in prod).
+});

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -1,0 +1,47 @@
+import {
+  applicationsCourseTable, selfServeCourseRegistrationTable, userTable,
+} from '@bluedot/db';
+import z from 'zod';
+import { TRPCError } from '@trpc/server';
+import db from '../../lib/api/db';
+import { protectedProcedure, router } from '../trpc';
+import { FOAI_COURSE_ID } from '../../lib/constants';
+
+export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
+  .input(z.object({ courseId: z.string(), source: z.string().trim().max(255).optional() }))
+  .mutation(async ({ ctx, input }) => {
+    const { courseId, source } = input;
+
+    if (courseId !== FOAI_COURSE_ID) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Only the Future of AI course supports self-serve registration' });
+    }
+
+    const existingRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
+      filter: { email: ctx.auth.email, courseId },
+      sortBy: 'createdAt',
+    });
+
+    if (existingRegistration) {
+      return existingRegistration;
+    }
+
+    const applicationsCourse = await db.getFirst(applicationsCourseTable, {
+      sortBy: 'id',
+      filter: { courseBuilderId: courseId },
+    });
+    if (!applicationsCourse) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
+    }
+
+    const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+    return db.insert(selfServeCourseRegistrationTable, {
+      userId: user?.id ?? null,
+      courseApplicationsBaseId: applicationsCourse.id,
+      source: source ?? null,
+      createdAt: new Date().toISOString(),
+    });
+  });
+
+export const selfServeCourseRegistrationsRouter = router({
+  ensureExists: ensureSelfServeRegistrationExistsProcedure,
+});

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -33,9 +33,15 @@ export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
       throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
     }
 
+    // The User row is created by a lagging login side-effect (oauth-callback). Fail before writing
+    // anything so the client retries
     const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+    if (!user) {
+      throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'User record not available yet' });
+    }
+
     return db.insert(selfServeCourseRegistrationTable, {
-      userId: user?.id ?? null,
+      userId: user.id,
       courseApplicationsBaseId: applicationsCourse.id,
       source: source ?? null,
       createdAt: new Date().toISOString(),

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -1,5 +1,5 @@
 import {
-  applicationsCourseTable, selfServeCourseRegistrationTable, userTable,
+  applicationsCourseTable, COURSE_ROLE, courseRegistrationTable, selfServeCourseRegistrationTable, userTable,
 } from '@bluedot/db';
 import z from 'zod';
 import { TRPCError } from '@trpc/server';
@@ -40,12 +40,29 @@ export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
       throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'User record not available yet' });
     }
 
-    return db.insert(selfServeCourseRegistrationTable, {
+    const selfServeRegistration = await db.insert(selfServeCourseRegistrationTable, {
       userId: user.id,
       courseApplicationsBaseId: applicationsCourse.id,
       source: source ?? null,
       createdAt: new Date().toISOString(),
     });
+
+    // Keep dual-writing the legacy row until the migration to the self-serve table (#2526)
+    // is fully complete
+    const existingLegacy = await db.getFirst(courseRegistrationTable, {
+      filter: { email: ctx.auth.email, courseId, decision: 'Accept' },
+    });
+    if (!existingLegacy) {
+      await db.insert(courseRegistrationTable, {
+        email: ctx.auth.email,
+        courseApplicationsBaseId: applicationsCourse.id,
+        role: COURSE_ROLE.PARTICIPANT,
+        decision: 'Accept',
+        source: source ?? null,
+      });
+    }
+
+    return selfServeRegistration;
   });
 
 export const selfServeCourseRegistrationsRouter = router({


### PR DESCRIPTION
# Description

#2667 started dual-writing FoAI data to both `courseRegistrations` and `selfServeCourseRegistrations`. I have now run a script (#2668) to backfill legacy data into the `selfServeCourseRegistrations` table. This PR does the remaining step to cut over to the new table as far as the website code is concerned: reading FoAI data solely from the new table.

There are meaningful changes in these places:
- `apps/website/src/server/routers/certificates.ts`: explicit carve-out for reading self-serve certificates. It also keeps the dual-write behaviour in `issueFoaiCertificateIfComplete`, but now reads only from the self-serve table (i.e. previously it assumed an existing certificate would either be in just the legacy table, or in both tables. Now it assumes an existing certificate will be in the new table)
- `apps/website/src/server/routers/course-registrations.ts`: split out the one self-serve route into it's own file, `apps/website/src/server/routers/self-serve-course-registrations.ts`, and simplified it to only use the self-serve table
- `apps/website/src/server/routers/my-bluedot.ts`, which feeds the My Courses page: explicitly filter out FoAI records when looking up `courseRegistrations`, and union them back in from the self-serve table at the end

Everywhere else (e.g. group switching modal, dropout modal, rounds, discussion banners) already silently ignores FoAI rows, so no change is required there. The naming convention I'm going for following this change is:
- Anything related to facilitated courses: Just refer to rows as `courseRegistration`, `registration` etc. Don't explicitly call out that it's a _facilitated_ course, unless it's really useful because you are doing something involving both facilitated and self-serve registrations
- Anything related to self-serve (FoAI) courses: _do_ name it e.g. `selfServeRegistration` to call it out

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2526 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
