### PR TITLE
Fix user/course registration race condition

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -77,7 +77,11 @@ const CourseUnitChunkPage = ({
   }, [courseSlug, unitNumber]);
 
   const { latestUtmParams, isLoading: isUtmLoading } = useLatestUtmParams();
-  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.courseRegistrations.ensureSelfServeRegistrationExists.useMutation();
+  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.courseRegistrations.ensureSelfServeRegistrationExists.useMutation({
+    // The User row can lag auth (created by oauth-callback's side-effect), so retry until it exists.
+    retry: (failureCount, error) => failureCount < 5 && error.data?.code === 'PRECONDITION_FAILED',
+    retryDelay: 5000,
+  });
 
   useEffect(() => {
     // FoAI course only: If we're logged in, ensures a course registration is recorded

--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -1,5 +1,5 @@
 import {
-  applicationsRoundTable, courseRegistrationTable, selfServeCourseRegistrationTable,
+  applicationsCourseTable, applicationsRoundTable, courseRegistrationTable, selfServeCourseRegistrationTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
@@ -158,6 +158,14 @@ describe('courseRegistrations.ensureExists', () => {
     await expect(createCaller(testAuthContextLoggedIn)
       .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID }))
       .rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  test('throws PRECONDITION_FAILED for FOAI when the User record does not exist yet (so the client retries)', async () => {
+    await testDb.insert(applicationsCourseTable, { id: 'foai-app-course', courseBuilderId: FOAI_COURSE_ID });
+
+    await expect(createCaller(testAuthContextLoggedIn)
+      .courseRegistrations.ensureSelfServeRegistrationExists({ courseId: FOAI_COURSE_ID }))
+      .rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
   });
 
   // The full "creates a new FOAI registration" path isn't unit-testable: both inserts omit `courseId`

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -42,6 +42,13 @@ const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
       }
 
+      // The User row is created by a lagging login side-effect (oauth-callback). Fail before writing
+      // anything so the client retries
+      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+      if (!user) {
+        throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'User record not available yet' });
+      }
+
       // Legacy first: if the second insert fails, the orphan is a missing self-serve row (harmless
       // while reads still hit legacy, and healed by the backfill) rather than a missing legacy row.
       await db.insert(courseRegistrationTable, {
@@ -52,9 +59,8 @@ const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
         source: source ?? null,
       });
 
-      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
       return db.insert(selfServeCourseRegistrationTable, {
-        userId: user?.id ?? null,
+        userId: user.id,
         courseApplicationsBaseId: applicationsCourse.id,
         source: source ?? null,
         createdAt: new Date().toISOString(),


### PR DESCRIPTION
# Description

#2667 changed the behaviour of `ensureExists` for FoAI records:
- Previously it wrote email to the `courseRegistration` row directly, based on the `auth` object
- Now (for `selfServeCourseRegistrations`, which will become the sole source of truth soon), it writes `userId`, and relies on an Airtable lookup to fill in the email

There is a race condition when someone signs up from the FoAI page: the User object itself is via an `ensureExists` callback in `apps/website/src/pages/login/oauth-callback.tsx`. The course registration `ensureExists` can complete before this, meaning rows could be written with `userId: null`. This happened in 2 out of ~500 (0.25%) cases since #2667 was deployed.

Writing `userId` rather than `email` is the right direction to go in, in light of the plan to deprecate email-as-foreign-key (#2459), so this PR keeps the `userId` write, and just throws an error if the user is not found, which prompts the client to retry. The `oauth-callback` mutation that creates the user should resolve fairly quickly, so retrying after 5s should almost always fix it.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2526 

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
