### PR TITLE
Stop dual-writing Future of AI registrations

### DIFF
--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -339,7 +339,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     });
   };
 
-  test('issues the certificate on the self-serve row only (legacy writes have stopped)', async () => {
+  test('issues the certificate on the self-serve row only', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss-1', email: 'test@example.com', courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
     });

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -339,7 +339,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     });
   };
 
-  test('issues the certificate on the self-serve row and mirrors it to legacy', async () => {
+  test('issues the certificate on the self-serve row only (legacy writes have stopped)', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss-1', email: 'test@example.com', courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
     });
@@ -355,8 +355,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     expect(selfServe?.certificateId).toBe('ss-1');
 
     const legacy = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
-    expect(legacy.certificateId).toBe('ss-1');
-    expect(legacy.certificateCreatedAt).toBe(selfServe?.certificateCreatedAt);
+    expect(legacy.certificateId).toBeNull();
   });
 
   test('does nothing when no self-serve row exists', async () => {

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -62,14 +62,6 @@ export async function issueFoaiCertificateIfComplete(email: string): Promise<boo
 
   await db.update(selfServeCourseRegistrationTable, { id: selfServeRegistration.id, certificateId, certificateCreatedAt });
 
-  // Keep the legacy row in sync until it's deleted at the end of the migration (#2526)
-  const legacyRegistration = await db.getFirst(courseRegistrationTable, {
-    filter: { email, courseId: FOAI_COURSE_ID, decision: 'Accept' },
-  });
-  if (legacyRegistration && !legacyRegistration.certificateId) {
-    await db.update(courseRegistrationTable, { id: legacyRegistration.id, certificateId, certificateCreatedAt });
-  }
-
   return true;
 }
 

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -1,5 +1,5 @@
 import {
-  applicationsCourseTable, COURSE_ROLE, courseRegistrationTable, selfServeCourseRegistrationTable, userTable,
+  applicationsCourseTable, selfServeCourseRegistrationTable, userTable,
 } from '@bluedot/db';
 import z from 'zod';
 import { TRPCError } from '@trpc/server';
@@ -40,29 +40,12 @@ export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
       throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'User record not available yet' });
     }
 
-    const selfServeRegistration = await db.insert(selfServeCourseRegistrationTable, {
+    return db.insert(selfServeCourseRegistrationTable, {
       userId: user.id,
       courseApplicationsBaseId: applicationsCourse.id,
       source: source ?? null,
       createdAt: new Date().toISOString(),
     });
-
-    // Keep dual-writing the legacy row until the migration to the self-serve table (#2526)
-    // is fully complete
-    const existingLegacy = await db.getFirst(courseRegistrationTable, {
-      filter: { email: ctx.auth.email, courseId, decision: 'Accept' },
-    });
-    if (!existingLegacy) {
-      await db.insert(courseRegistrationTable, {
-        email: ctx.auth.email,
-        courseApplicationsBaseId: applicationsCourse.id,
-        role: COURSE_ROLE.PARTICIPANT,
-        decision: 'Accept',
-        source: source ?? null,
-      });
-    }
-
-    return selfServeRegistration;
   });
 
 export const selfServeCourseRegistrationsRouter = router({


### PR DESCRIPTION
# Description

As of #2669, we are reading and writing FoAI rows from/to the new `selfServeCourseRegistrations` table. This PR stops writing them to the old `courseRegistrations` table.

I'll wait until tomorrow for ~a day of data fully using the new table, to check for any issues. Then I'll merge this PR, and (#2672) delete the records from the old table.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2526

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
