### PR TITLE
Capture posthog distinct id in application form

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -163,6 +163,7 @@ export const createMockCourseRegistration = (overrides: Partial<CourseRegistrati
   acceptedAt: null,
   createdAt: null,
   posthogSessionId: null,
+  posthogDistinctId: null,
   ...overrides,
 });
 

--- a/apps/website/src/lib/utils.test.ts
+++ b/apps/website/src/lib/utils.test.ts
@@ -8,8 +8,9 @@ import {
 } from 'vitest';
 import { type AxiosError, type AxiosResponse } from 'axios';
 const mockGetSessionId = vi.fn<() => string | null>();
+const mockGetDistinctId = vi.fn<() => string | null>();
 vi.mock('posthog-js', () => ({
-  default: { get_session_id: () => mockGetSessionId() },
+  default: { get_session_id: () => mockGetSessionId(), get_distinct_id: () => mockGetDistinctId() },
 }));
 
 const {
@@ -322,6 +323,7 @@ describe('getInitials', () => {
 describe('buildApplicationUrl', () => {
   beforeEach(() => {
     mockGetSessionId.mockReturnValue(null);
+    mockGetDistinctId.mockReturnValue(null);
   });
 
   it('returns empty string for null / undefined / empty base URL', () => {
@@ -353,5 +355,23 @@ describe('buildApplicationUrl', () => {
   it('preserves existing query params', () => {
     expect(buildApplicationUrl('https://example.com/apply?foo=bar', 'twitter'))
       .toBe('https://example.com/apply?foo=bar&prefill_Source=twitter');
+  });
+
+  it('appends prefill_PostHog Distinct ID (URL-encoded) when the distinct id is anonymous', () => {
+    mockGetDistinctId.mockReturnValue('0190abcd-1234-7000-8000-abcdef012345');
+    expect(buildApplicationUrl('https://example.com/apply', null))
+      .toBe('https://example.com/apply?prefill_PostHog%20Distinct%20ID=0190abcd-1234-7000-8000-abcdef012345');
+  });
+
+  it('does not append the distinct id once it is the email (already identified)', () => {
+    mockGetDistinctId.mockReturnValue('user@example.com');
+    expect(buildApplicationUrl('https://example.com/apply', null)).toBe('https://example.com/apply');
+  });
+
+  it('appends session id and anonymous distinct id together', () => {
+    mockGetSessionId.mockReturnValue('sess-123');
+    mockGetDistinctId.mockReturnValue('anon-abc');
+    expect(buildApplicationUrl('https://example.com/apply', null))
+      .toBe('https://example.com/apply?prefill_PostHog%20Session%20ID=sess-123&prefill_PostHog%20Distinct%20ID=anon-abc');
   });
 });

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -182,7 +182,7 @@ export function getInitials(name: string): string {
 }
 
 /**
- * Build an application form URL with PostHog session and UTM source prefill params
+ * Build an application form URL with PostHog session id, anonymous distinct id, and UTM source prefill params.
  */
 export const buildApplicationUrl = (
   baseUrl: string | null | undefined,
@@ -194,13 +194,21 @@ export const buildApplicationUrl = (
   // new URL() requires an absolute URL; skip relative paths (e.g. internal nav links)
   if (!urlWithUtm.startsWith('http://') && !urlWithUtm.startsWith('https://')) return urlWithUtm;
 
-  const sessionId = posthog.get_session_id?.();
-  if (!sessionId) return urlWithUtm;
-
   const urlObj = new URL(urlWithUtm);
-  urlObj.searchParams.set('prefill_PostHog Session ID', sessionId);
+
+  const sessionId = posthog.get_session_id?.();
+  if (sessionId) urlObj.searchParams.set('prefill_PostHog Session ID', sessionId);
+
+  // Forward the distinct id only while it's still anonymous (a uuid). Once the user is identified
+  // it's their email — which we don't want to leak into the external form, and there is no need
+  // to identify them then anyway.
+  const distinctId = posthog.get_distinct_id?.();
+  if (distinctId && !distinctId.includes('@')) urlObj.searchParams.set('prefill_PostHog Distinct ID', distinctId);
+
   // URLSearchParams encodes spaces as '+', but miniextensions requires '%20'
-  return urlObj.toString().replace('prefill_PostHog+Session+ID', 'prefill_PostHog%20Session%20ID');
+  return urlObj.toString()
+    .replace('prefill_PostHog+Session+ID', 'prefill_PostHog%20Session%20ID')
+    .replace('prefill_PostHog+Distinct+ID', 'prefill_PostHog%20Distinct%20ID');
 };
 
 /**

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1288,6 +1288,13 @@ export const courseRegistrationTable = pgAirtable('course_registration', {
       pgColumn: text(),
       airtableId: 'fld5G27T1IMkkkoGN',
     },
+    // "PostHog Distinct ID" — the PostHog id of the user that submitted the application,
+    // captured via the form prefill. Lets the backend identify that anonymous user as the
+    // owner of the applicant's email
+    posthogDistinctId: {
+      pgColumn: text(),
+      airtableId: 'fldd0jwAHFgywIt7N',
+    },
     role: {
       pgColumn: text(),
       airtableId: 'fld52Y2AyWV8tECDy',


### PR DESCRIPTION
# Description

Populates a new field "PostHog Distinct ID" when someone submits the application form, directly analogous to "PostHog Session ID".

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2677

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories