### PR TITLE
Support discussion_attended and discussion_absent PostHog events

### DIFF
--- a/libraries/computed-posthog-events/src/core.ts
+++ b/libraries/computed-posthog-events/src/core.ts
@@ -32,7 +32,7 @@ export type Event = TrackEvent | IdentifyEvent;
 /** One event type and how to derive it. */
 export type EventProjectionRule = {
   eventType: string;
-  calculateEvents: (db: PgAirtableDb, opts: { since?: string; now: string }) => Promise<Event[]>;
+  calculateEvents: (db: PgAirtableDb, opts: { since?: string; now?: string }) => Promise<Event[]>;
 };
 
 /** What we POST to PostHog. distinct_id + uuid are top-level (requirement for PostHog to join to user and dedup internally). */

--- a/libraries/computed-posthog-events/src/core.ts
+++ b/libraries/computed-posthog-events/src/core.ts
@@ -32,7 +32,7 @@ export type Event = TrackEvent | IdentifyEvent;
 /** One event type and how to derive it. */
 export type EventProjectionRule = {
   eventType: string;
-  calculateEvents: (db: PgAirtableDb, opts: { since?: string }) => Promise<Event[]>;
+  calculateEvents: (db: PgAirtableDb, opts: { since?: string; now: string }) => Promise<Event[]>;
 };
 
 /** What we POST to PostHog. distinct_id + uuid are top-level (requirement for PostHog to join to user and dedup internally). */
@@ -95,7 +95,7 @@ export async function forwardEventTypeToPostHog({
   };
 
   // Step 1: Calculate events, dropping invalid ones
-  const candidateEvents = await eventProjectionRule.calculateEvents(db, { since });
+  const candidateEvents = await eventProjectionRule.calculateEvents(db, { since, now });
   result.candidates = candidateEvents.length;
 
   const validCandidateEvents = candidateEvents.filter((c) => {

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -1,5 +1,6 @@
 import {
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable, eq,
+  groupDiscussionTable, meetPersonTable, roundTable, unitTable,
 } from '@bluedot/db';
 import {
   afterEach, describe, expect, test, vi,
@@ -283,5 +284,155 @@ describe('application_submitted (one per registration, accepted or not)', () => 
       expect(second).toMatchObject({ sent: 0, alreadySent: 2 });
       expect(ph2.events).toHaveLength(0);
     });
+  });
+});
+
+describe('discussion_attended / discussion_absent', () => {
+  const NOW = '2026-07-01T00:00:00.000Z';
+  const nowSec = Math.floor(Date.parse(NOW) / 1000);
+
+  const insertDiscussion = (d: {
+    id: string;
+    participantsExpected: string[];
+    attendees?: string[];
+    startSec: number;
+    endSec: number;
+    group?: string;
+    courseBuilderUnitRecordId?: string;
+    unitNumber?: number;
+    unitFallback?: string;
+  }) => testDb.insert(groupDiscussionTable, {
+    id: d.id,
+    facilitators: [],
+    participantsExpected: d.participantsExpected,
+    attendees: d.attendees,
+    startDateTime: d.startSec,
+    endDateTime: d.endSec,
+    group: d.group ?? 'g1',
+    courseBuilderUnitRecordId: d.courseBuilderUnitRecordId,
+    unitNumber: d.unitNumber,
+    unitFallback: d.unitFallback,
+  });
+
+  const seedPeople = async () => {
+    await testDb.insert(roundTable, { id: 'rd1', title: 'AGI Strategy (2026 Jun W26) - Part-time' });
+    await testDb.insert(unitTable, {
+      id: 'u1', courseId: 'c1', courseTitle: 'AGI Strategy', courseSlug: 'agi-strategy', title: 'Intro to AGI', unitNumber: '1', unitStatus: 'Active',
+    });
+    await testDb.insert(meetPersonTable, {
+      id: 'mp1', email: 'attendee@x.com', round: 'rd1', numUnits: 8,
+    });
+    await testDb.insert(meetPersonTable, {
+      id: 'mp2', email: 'absentee@x.com', round: 'rd1', numUnits: 8,
+    });
+  };
+
+  test('attended for those in attendees, absent for the rest once the discussion has ended', async () => {
+    await seedPeople();
+    await insertDiscussion({
+      id: 'd1',
+      participantsExpected: ['mp1', 'mp2'],
+      attendees: ['mp1'],
+      startSec: nowSec - 7200,
+      endSec: nowSec - 3600, // ended an hour ago
+      courseBuilderUnitRecordId: 'u1',
+      unitNumber: 1,
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ now: NOW });
+
+    const attended = ph.events.filter((e) => e.event === 'discussion_attended');
+    const absent = ph.events.filter((e) => e.event === 'discussion_absent');
+    expect(attended.map((e) => e.distinct_id)).toEqual(['attendee@x.com']);
+    expect(absent.map((e) => e.distinct_id)).toEqual(['absentee@x.com']);
+
+    // both attended and absent are timestamped at the discussion's scheduled start
+    expect(attended[0]!.timestamp).toBe(new Date((nowSec - 7200) * 1000).toISOString());
+    expect(absent[0]!.timestamp).toBe(new Date((nowSec - 7200) * 1000).toISOString());
+    expect(attended[0]!.properties).toMatchObject({
+      discussion_id: 'd1',
+      course_id: 'c1',
+      course_name: 'AGI Strategy',
+      course_slug: 'agi-strategy',
+      round_id: 'rd1',
+      round_name: 'AGI Strategy (2026 Jun W26) - Part-time',
+      unit_number: 1,
+      unit_name: 'Intro to AGI',
+      group_id: 'g1',
+      num_discussions: 8,
+    });
+  });
+
+  test('no absent within the 15-minute grace, nor for live/upcoming discussions', async () => {
+    await seedPeople();
+    await insertDiscussion({
+      id: 'recent', participantsExpected: ['mp2'], attendees: [], startSec: nowSec - 3900, endSec: nowSec - 300, // ended 5 min ago
+    });
+    await insertDiscussion({
+      id: 'upcoming', participantsExpected: ['mp2'], attendees: [], startSec: nowSec + 3600, endSec: nowSec + 7200,
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ now: NOW });
+
+    expect(ph.events.filter((e) => e.event === 'discussion_absent')).toHaveLength(0);
+  });
+
+  test('attended emits even while the discussion is live (not gated by the grace)', async () => {
+    await seedPeople();
+    await insertDiscussion({
+      id: 'live', participantsExpected: ['mp1'], attendees: ['mp1'], startSec: nowSec - 600, endSec: nowSec + 3000,
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ now: NOW });
+
+    const attended = ph.events.filter((e) => e.event === 'discussion_attended');
+    expect(attended.map((e) => e.distinct_id)).toEqual(['attendee@x.com']);
+  });
+
+  test('skips expected participants we cannot resolve an email for', async () => {
+    await testDb.insert(meetPersonTable, { id: 'mp1', email: 'attendee@x.com', round: 'rd1' });
+    await testDb.insert(meetPersonTable, { id: 'noEmail' }); // no email -> skipped
+    await insertDiscussion({
+      id: 'd1', participantsExpected: ['mp1', 'noEmail'], attendees: ['mp1'], startSec: nowSec - 7200, endSec: nowSec - 3600,
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ now: NOW });
+
+    expect(ph.events.filter((e) => e.event === 'discussion_attended').map((e) => e.distinct_id)).toEqual(['attendee@x.com']);
+    expect(ph.events.filter((e) => e.event === 'discussion_absent')).toHaveLength(0);
+  });
+
+  test('since scans only discussions ending on/after it', async () => {
+    await seedPeople();
+    await insertDiscussion({
+      id: 'old', participantsExpected: ['mp2'], attendees: [], startSec: nowSec - (100 * 86400), endSec: nowSec - (100 * 86400) + 3600,
+    });
+    await insertDiscussion({
+      id: 'recentEnded', participantsExpected: ['mp2'], attendees: [], startSec: nowSec - 7200, endSec: nowSec - 3600,
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ now: NOW, since: new Date((nowSec - 86400) * 1000).toISOString() });
+
+    const absent = ph.events.filter((e) => e.event === 'discussion_absent');
+    expect(absent.map((e) => e.properties.discussion_id)).toEqual(['recentEnded']);
+  });
+
+  test('send-once across runs: a second run re-sends nothing', async () => {
+    await seedPeople();
+    await insertDiscussion({
+      id: 'd1', participantsExpected: ['mp1', 'mp2'], attendees: ['mp1'], startSec: nowSec - 7200, endSec: nowSec - 3600,
+    });
+
+    mockPostHogBackend();
+    await forwardAllEventsToPostHog({ now: NOW });
+
+    const ph2 = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ now: NOW });
+    expect(ph2.events.filter((e) => e.event.startsWith('discussion_'))).toHaveLength(0);
   });
 });

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -1,14 +1,88 @@
 import {
-  and, gte, isNotNull,
+  and, gte, isNotNull, inArray,
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable,
+  groupDiscussionTable, meetPersonTable, roundTable, unitTable,
+  type PgAirtableDb,
 } from '@bluedot/db';
 import type { PgColumn } from 'drizzle-orm/pg-core';
-import type { EventProjectionRule } from './core';
+import type { Event, EventProjectionRule } from './core';
 
 const filterGteOrNull = (col: PgColumn, sinceValue: number | string | undefined) => (
   sinceValue == null ? isNotNull(col) : and(isNotNull(col), gte(col, sinceValue))
 );
 const isoDateToEpochSeconds = (sinceIso?: string) => (sinceIso == null ? undefined : Math.floor(Date.parse(sinceIso) / 1000));
+
+// Mirrors the my-courses UI (deriveStatus in useDiscussionActions.tsx): a participant is `attended` when
+// their meet_person id is in the discussion's attendees, and `absent` once the discussion has ended without it.
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+
+const calculateDiscussionAttendanceEvents = async (
+  db: PgAirtableDb,
+  { since, now }: { since?: string; now: string },
+  kind: 'attended' | 'absent',
+): Promise<Event[]> => {
+  const nowMs = Date.parse(now);
+  // discussion datetimes are epoch seconds; `since` bounds work only — the emitted-events log keeps delivery send-once.
+  const discussions = await db.pg.select().from(groupDiscussionTable.pg)
+    .where(filterGteOrNull(groupDiscussionTable.pg.endDateTime, isoDateToEpochSeconds(since)));
+
+  const meetPersonIds = [...new Set(discussions.flatMap((d) => d.participantsExpected ?? []))];
+  if (meetPersonIds.length === 0) return [];
+  const meetPersons = await db.pg.select().from(meetPersonTable.pg).where(inArray(meetPersonTable.pg.id, meetPersonIds));
+  const meetPersonById = new Map(meetPersons.map((mp) => [mp.id, mp] as const));
+
+  const roundIds = [...new Set(meetPersons.map((mp) => mp.round).filter((r): r is string => !!r))];
+  const rounds = roundIds.length
+    ? await db.pg.select({ id: roundTable.pg.id, title: roundTable.pg.title }).from(roundTable.pg).where(inArray(roundTable.pg.id, roundIds))
+    : [];
+  const roundTitleById = new Map(rounds.map((r) => [r.id, r.title] as const));
+
+  const unitIds = [...new Set(discussions.map((d) => d.courseBuilderUnitRecordId).filter((u): u is string => !!u))];
+  const units = unitIds.length
+    ? await db.pg.select().from(unitTable.pg).where(inArray(unitTable.pg.id, unitIds))
+    : [];
+  const unitById = new Map(units.map((u) => [u.id, u] as const));
+
+  const events: Event[] = [];
+  for (const d of discussions) {
+    // absent only materialises once a discussion has comfortably ended; attended emits as soon as recorded.
+    const hasEnded = d.endDateTime * 1000 <= nowMs - FIFTEEN_MINUTES_MS;
+    if (kind === 'absent' && !hasEnded) continue;
+
+    const attendedSet = new Set(d.attendees ?? []);
+    const unit = d.courseBuilderUnitRecordId ? unitById.get(d.courseBuilderUnitRecordId) : undefined;
+    const unitNumber = d.unitNumber ?? (unit ? Number(unit.unitNumber) : null);
+    const unitName = unit?.title ?? d.unitFallback ?? null;
+
+    for (const meetPersonId of d.participantsExpected ?? []) {
+      const isAttended = attendedSet.has(meetPersonId);
+      if (kind === 'attended' ? !isAttended : isAttended) continue;
+
+      const meetPerson = meetPersonById.get(meetPersonId);
+      if (!meetPerson?.email) continue;
+      const roundName = meetPerson.round ? roundTitleById.get(meetPerson.round) : undefined;
+
+      events.push({
+        internalUniqueKey: `${meetPersonId}:${d.id}`,
+        distinctId: meetPerson.email,
+        timestampMs: d.startDateTime * 1000,
+        properties: {
+          discussion_id: d.id,
+          ...(unit ? { course_id: unit.courseId, course_name: unit.courseTitle, course_slug: unit.courseSlug } : {}),
+          ...(meetPerson.round ? { round_id: meetPerson.round } : {}),
+          ...(roundName ? { round_name: roundName } : {}),
+          ...(unitNumber != null && Number.isFinite(unitNumber) ? { unit_number: unitNumber } : {}),
+          ...(unitName ? { unit_name: unitName } : {}),
+          ...(d.group ? { group_id: d.group } : {}),
+          // total discussions in the course (attendance denominator: certificate needs all but one)
+          ...(meetPerson.numUnits != null ? { num_discussions: meetPerson.numUnits } : {}),
+        },
+      });
+    }
+  }
+
+  return events;
+};
 
 export const eventProjectionRules: EventProjectionRule[] = [
   {
@@ -118,5 +192,13 @@ export const eventProjectionRules: EventProjectionRule[] = [
         }),
       ];
     },
+  },
+  {
+    eventType: 'discussion_attended',
+    calculateEvents: (db, opts) => calculateDiscussionAttendanceEvents(db, opts, 'attended'),
+  },
+  {
+    eventType: 'discussion_absent',
+    calculateEvents: (db, opts) => calculateDiscussionAttendanceEvents(db, opts, 'absent'),
   },
 ];

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -18,10 +18,10 @@ const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
 
 const calculateDiscussionAttendanceEvents = async (
   db: PgAirtableDb,
-  { since, now }: { since?: string; now: string },
+  { since, now }: { since?: string; now?: string },
   kind: 'attended' | 'absent',
 ): Promise<Event[]> => {
-  const nowMs = Date.parse(now);
+  const nowMs = now ? Date.parse(now) : Date.now();
   // discussion datetimes are epoch seconds; `since` bounds work only — the emitted-events log keeps delivery send-once.
   const discussions = await db.pg.select().from(groupDiscussionTable.pg)
     .where(filterGteOrNull(groupDiscussionTable.pg.endDateTime, isoDateToEpochSeconds(since)));


### PR DESCRIPTION
# Description

Part of issue #2679 to ship user funnel events into posthog. Add `discussion_attended` and `discussion_absent` for participants only.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2679

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
