### PR TITLE
Add exercise_completed PostHog event

### DIFF
--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -1,6 +1,7 @@
 import {
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable, eq,
   groupDiscussionTable, meetPersonTable, roundTable, unitTable,
+  exerciseTable, exerciseResponsePgTable,
 } from '@bluedot/db';
 import {
   afterEach, describe, expect, test, vi,
@@ -434,5 +435,78 @@ describe('discussion_attended / discussion_absent', () => {
     const ph2 = mockPostHogBackend();
     await forwardAllEventsToPostHog({ now: NOW });
     expect(ph2.events.filter((e) => e.event.startsWith('discussion_'))).toHaveLength(0);
+  });
+});
+
+describe('exercise_completed', () => {
+  const seedCourse = (id: string, title: string) => testDb.insert(courseTable, {
+    id, slug: id, title, shortDescription: title, units: [], status: 'Active',
+  });
+  const seedExercise = (id: string, opts: { courseId?: string; unitId?: string; title?: string; type?: string } = {}) =>
+    testDb.insert(exerciseTable, {
+      id, courseId: opts.courseId, unitId: opts.unitId, title: opts.title, type: opts.type, status: 'Active',
+    });
+  const completeExercise = (id: string, email: string, exerciseId: string, completedAt: string | null) =>
+    db.pg.insert(exerciseResponsePgTable).values({
+      id, email, exerciseId, response: 'an answer', createdAt: '2026-06-01T00:00:00.000Z', completedAt,
+    });
+
+  test('emits one event per completed response, enriched with the exercise and course', async () => {
+    await seedCourse('c1', 'AGI Strategy');
+    await seedExercise('ex2', {
+      courseId: 'c1', unitId: 'u1', title: 'Quiz', type: 'Multiple choice',
+    });
+    await completeExercise('r1', 'a@x.com', 'ex2', '2026-06-10T10:00:00.000Z');
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const events = ph.events.filter((e) => e.event === 'exercise_completed');
+    expect(events).toHaveLength(1);
+    expect(events[0]!.distinct_id).toBe('a@x.com');
+    expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
+    expect(events[0]!.properties).toMatchObject({
+      exercise_id: 'ex2',
+      exercise_name: 'Quiz',
+      exercise_type: 'Multiple choice',
+      unit_id: 'u1',
+      course_id: 'c1',
+      course_name: 'AGI Strategy',
+    });
+  });
+
+  test('skips responses without a completedAt', async () => {
+    await seedCourse('c1', 'AGI Strategy');
+    await seedExercise('ex1', { courseId: 'c1' });
+    await completeExercise('r1', 'a@x.com', 'ex1', null);
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph.events.filter((e) => e.event === 'exercise_completed')).toHaveLength(0);
+  });
+
+  test('since scans only responses completed on/after it', async () => {
+    await seedCourse('c1', 'AGI Strategy');
+    await seedExercise('ex1', { courseId: 'c1' });
+    await completeExercise('old', 'old@x.com', 'ex1', '2026-01-01T00:00:00.000Z');
+    await completeExercise('new', 'new@x.com', 'ex1', '2026-06-01T00:00:00.000Z');
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
+
+    expect(ph.events.filter((e) => e.event === 'exercise_completed').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+  });
+
+  test('send-once across runs: a second run re-sends nothing', async () => {
+    await seedCourse('c1', 'AGI Strategy');
+    await seedExercise('ex1', { courseId: 'c1' });
+    await completeExercise('r1', 'a@x.com', 'ex1', '2026-06-10T10:00:00.000Z');
+
+    mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const ph2 = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph2.events.filter((e) => e.event === 'exercise_completed')).toHaveLength(0);
   });
 });

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -1,7 +1,7 @@
 import {
   and, gte, isNotNull, inArray,
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable,
-  groupDiscussionTable, meetPersonTable, roundTable, unitTable,
+  groupDiscussionTable, meetPersonTable, roundTable, unitTable, exerciseTable, exerciseResponsePgTable,
   type PgAirtableDb,
 } from '@bluedot/db';
 import type { PgColumn } from 'drizzle-orm/pg-core';
@@ -200,5 +200,43 @@ export const eventProjectionRules: EventProjectionRule[] = [
   {
     eventType: 'discussion_absent',
     calculateEvents: (db, opts) => calculateDiscussionAttendanceEvents(db, opts, 'absent'),
+  },
+  {
+    eventType: 'exercise_completed',
+    async calculateEvents(db, { since }) {
+      const responses = await db.pg.select().from(exerciseResponsePgTable)
+        .where(filterGteOrNull(exerciseResponsePgTable.completedAt, since)); // completedAt is ISO text
+      if (responses.length === 0) return [];
+
+      const [courses, exercises] = await Promise.all([
+        db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg),
+        db.pg.select({
+          id: exerciseTable.pg.id, courseId: exerciseTable.pg.courseId, title: exerciseTable.pg.title,
+          type: exerciseTable.pg.type, unitId: exerciseTable.pg.unitId,
+        }).from(exerciseTable.pg),
+      ]);
+      const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
+      const exerciseById = new Map(exercises.map((e) => [e.id, e]));
+
+      return responses.map((r) => {
+        const exercise = exerciseById.get(r.exerciseId);
+        const courseName = exercise?.courseId ? courseTitleById.get(exercise.courseId) : undefined;
+        return {
+          internalUniqueKey: r.id,
+          distinctId: r.email,
+          // Note: completedAt is mutable (can un-complete and re-complete), the event will
+          // capture the *first time* we saw the response in a completed state
+          timestampMs: Date.parse(r.completedAt!),
+          properties: {
+            exercise_id: r.exerciseId,
+            ...(exercise?.title ? { exercise_name: exercise.title } : {}),
+            ...(exercise?.type ? { exercise_type: exercise.type } : {}),
+            ...(exercise?.unitId ? { unit_id: exercise.unitId } : {}),
+            ...(exercise?.courseId ? { course_id: exercise.courseId } : {}),
+            ...(courseName ? { course_name: courseName } : {}),
+          },
+        };
+      });
+    },
   },
 ];


### PR DESCRIPTION
# Description

Send an `exercise_completed` event with the timestamp as `completedAt`. Note: This is not quite as idempotent as other event types, because `completedAt` can change if an exercise is uncompleted and re-completed. The event is set up to only send once per exercise, so we'll retain the _first_ time we saw the exercise as completed

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2679

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->
