### PR TITLE
[feat] Add completedAt column to resource_completion

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -161,6 +161,8 @@ export const createMockCourseRegistration = (overrides: Partial<CourseRegistrati
   source: null,
   userId: 'user-1',
   acceptedAt: null,
+  rejectedAt: null,
+  withdrawnAt: null,
   createdAt: null,
   posthogSessionId: null,
   posthogDistinctId: null,
@@ -310,5 +312,6 @@ export const createMockResourceCompletion = (overrides: Partial<ResourceCompleti
   resourceId: null,
   createdByUserId: null,
   createdAt: null,
+  completedAt: null,
   ...overrides,
 });

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -146,6 +146,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
               resourceId: null,
               createdByUserId: null,
               createdAt: new Date().toISOString(),
+              completedAt: new Date().toISOString(),
             });
           }
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1517,6 +1517,7 @@ export const resourceCompletionPgTable = pgTable('resource_completion', {
   // Points at courseBuilderUserTable (the Course-builder-base sync of User)
   createdByUserId: text().array(),
   createdAt: text(),
+  completedAt: text(),
 });
 
 export const teamMemberTable = pgAirtable('team_member', {


### PR DESCRIPTION
# Description

For parity with exercise responses, and to allow shipping resource_completed events to PostHog, I'm migrating the `isCompleted` field to `completedAt`

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2679

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories