### PR TITLE
Attempt to fix pg-sync-service outage: Remove AbortSignal

### DIFF
--- a/libraries/computed-posthog-events/src/core.ts
+++ b/libraries/computed-posthog-events/src/core.ts
@@ -162,7 +162,6 @@ export async function forwardEventTypeToPostHog({
           historical_migration: historicalMigration,
           batch: prepared.map((p) => p.event),
         }),
-        signal: AbortSignal.timeout(60_000), // don't let a hung request hold the cron's reentry guard
       });
       if (!res.ok) {
         throw new Error(`PostHog /batch failed: ${res.status} ${res.statusText} ${await res.text().catch(() => '')}`);


### PR DESCRIPTION
# Description

There is an outage in `pg-sync-service` currently, with errors like `Expected signal to be an instanceof AbortSignal` originating from deep within the official `airtable` package. This appears to be ultimately due to a polyfill version of Abort signal failing this check: `proto.constructor.name === "AbortSignal"`, because it uses the name `AbortSignal3` instead.

Hypothesis: Adding a use of AbortSignal in code caused the bundler to add this polyfill, so removing it will fix it. We don't actually need this AbortSignal, it was just nice-to-have.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
