### PR TITLE
Set completedAt on resource completion write path

### DIFF
--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -67,4 +67,48 @@ describe('resources.saveResourceCompletion', () => {
       createdByUserId: ['cb-user-original'],
     });
   });
+
+  test('sets completedAt when isCompleted is true', async () => {
+    const result = await caller.resources.saveResourceCompletion({
+      unitResourceId: 'ur-1',
+      isCompleted: true,
+    });
+
+    expect(result.completedAt).toBeTruthy();
+    expect(new Date(result.completedAt!).getTime()).not.toBeNaN();
+  });
+
+  test('clears completedAt when isCompleted is false', async () => {
+    await testDb.pg.insert(resourceCompletionPgTable).values({
+      id: 'rc-1',
+      email: CALLER_EMAIL,
+      unitResourceId: 'ur-1',
+      isCompleted: true,
+      completedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await caller.resources.saveResourceCompletion({
+      unitResourceId: 'ur-1',
+      isCompleted: false,
+    });
+
+    expect(result.completedAt).toBeNull();
+  });
+
+  test('preserves completedAt when isCompleted is omitted', async () => {
+    await testDb.pg.insert(resourceCompletionPgTable).values({
+      id: 'rc-1',
+      email: CALLER_EMAIL,
+      unitResourceId: 'ur-1',
+      isCompleted: true,
+      completedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await caller.resources.saveResourceCompletion({
+      unitResourceId: 'ur-1',
+      feedback: 'some feedback',
+    });
+
+    expect(result.completedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
 });

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -55,6 +55,13 @@ export const resourcesRouter = router({
         .optional(),
     }))
     .mutation(async ({ input, ctx }) => {
+      let completedAt: string | null | undefined;
+      if (input.isCompleted === true) {
+        completedAt = new Date().toISOString();
+      } else if (input.isCompleted === false) {
+        completedAt = null;
+      } // else undefined = "don't change"
+
       const [resourceCompletion, unitResource, cbUser] = await Promise.all([
         getFirstFromPg(db.pg, resourceCompletionPgTable, {
           filter: {
@@ -72,6 +79,7 @@ export const resourcesRouter = router({
           .update(resourceCompletionPgTable)
           .set({
             isCompleted: input.isCompleted ?? resourceCompletion.isCompleted,
+            completedAt: completedAt !== undefined ? completedAt : resourceCompletion.completedAt,
             feedback: input.feedback ?? resourceCompletion.feedback,
             resourceFeedback: input.resourceFeedback ?? resourceCompletion.resourceFeedback,
           })
@@ -83,6 +91,7 @@ export const resourcesRouter = router({
             email: ctx.auth.email,
             unitResourceId: input.unitResourceId,
             isCompleted: input.isCompleted ?? false,
+            completedAt: completedAt ?? null,
             feedback: input.feedback ?? '',
             resourceFeedback: input.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
             resourceId: unitResource?.resourceId ?? null,

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -55,13 +55,6 @@ export const resourcesRouter = router({
         .optional(),
     }))
     .mutation(async ({ input, ctx }) => {
-      let completedAt: string | null | undefined;
-      if (input.isCompleted === true) {
-        completedAt = new Date().toISOString();
-      } else if (input.isCompleted === false) {
-        completedAt = null;
-      } // else undefined = "don't change"
-
       const [resourceCompletion, unitResource, cbUser] = await Promise.all([
         getFirstFromPg(db.pg, resourceCompletionPgTable, {
           filter: {
@@ -73,6 +66,13 @@ export const resourcesRouter = router({
         db.getFirst(unitResourceTable, { filter: { id: input.unitResourceId }, sortBy: 'id' }),
         db.getFirst(courseBuilderUserTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),
       ]);
+
+      let completedAt: string | null | undefined;
+      if (input.isCompleted === true && resourceCompletion?.isCompleted !== true) {
+        completedAt = new Date().toISOString();
+      } else if (input.isCompleted === false) {
+        completedAt = null;
+      } // else undefined = "don't change"
 
       const [updatedResourceCompletion] = resourceCompletion
         ? await db.pg


### PR DESCRIPTION
# Description

Continuing the migration from `isCompleted` to `completedAt` started in #2684.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2679

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories