### PR TITLE
Add project_submitted PostHog event

### DIFF
--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -700,6 +700,23 @@ describe('project_submitted', () => {
     expect(event.properties).not.toHaveProperty('round_id');
   });
 
+  test('group projects fan out: one event per participant, each keyed and attributed separately', async () => {
+    await seedRegisteredParticipant(); // mp1 -> a@x.com (course c1, round rd1)
+    await testDb.insert(meetPersonTable, { id: 'mp2', email: 'b@x.com', applicationsBaseRecordId: 'cr1' });
+    await testDb.insert(projectSubmissionTable, {
+      id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', projectTitle: 'Group plan', participant: ['mp1', 'mp2'],
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const events = ph.events.filter((e) => e.event === 'project_submitted');
+    expect(events.map((e) => e.distinct_id).sort()).toEqual(['a@x.com', 'b@x.com']);
+    // distinct uuids (derived from the per-participant internalUniqueKey) so neither is dropped as a duplicate
+    expect(new Set(events.map((e) => e.uuid)).size).toBe(2);
+    expect(events.every((e) => e.properties.project_title === 'Group plan' && e.properties.course_id === 'c1')).toBe(true);
+  });
+
   test('skips submissions whose participant resolves to no email (nothing to attribute to)', async () => {
     await testDb.insert(projectSubmissionTable, {
       id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', link: 'https://example.com/p', participant: ['unknown'],

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -1,7 +1,7 @@
 import {
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable, eq,
   groupDiscussionTable, meetPersonTable, roundTable, unitTable,
-  exerciseTable, exerciseResponsePgTable,
+  exerciseTable, exerciseResponsePgTable, projectSubmissionTable,
   unitResourceTable, resourceCompletionPgTable,
 } from '@bluedot/db';
 import {
@@ -641,5 +641,108 @@ describe('resource_completed', () => {
     const ph2 = mockPostHogBackend();
     await forwardAllEventsToPostHog();
     expect(ph2.events.filter((e) => e.event === 'resource_completed')).toHaveLength(0);
+  });
+});
+
+describe('project_submitted', () => {
+  // distinct id (email) and course/round are all resolved via the participant link, not stored on the row:
+  // submission.participant -> meetPerson.email, and meetPerson.applicationsBaseRecordId -> course_registration.
+  const seedRegisteredParticipant = async () => {
+    await testDb.insert(courseTable, {
+      id: 'c1', slug: 'agi-strategy', shortDescription: 'x', title: 'AGI Strategy', units: [], status: 'Active',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'cr1', courseId: 'c1', email: 'a@x.com', roundId: 'rd1', roundName: 'AGI Strategy (2026 Mar W14) - Intensive',
+    });
+    await testDb.insert(meetPersonTable, { id: 'mp1', email: 'a@x.com', applicationsBaseRecordId: 'cr1' });
+  };
+
+  test('emits one event per submission at its createdAt, enriched with course/round via the participant link', async () => {
+    await seedRegisteredParticipant();
+    await testDb.insert(projectSubmissionTable, {
+      id: 'ps1',
+      createdAt: '2026-06-08T01:10:28.000Z',
+      projectTitle: 'My action plan',
+      link: 'https://docs.google.com/document/d/abc',
+      participant: ['mp1'],
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const events = ph.events.filter((e) => e.event === 'project_submitted');
+    expect(events).toHaveLength(1);
+    expect(events[0]!.distinct_id).toBe('a@x.com');
+    expect(events[0]!.timestamp).toBe('2026-06-08T01:10:28.000Z');
+    expect(events[0]!.properties).toMatchObject({
+      course_id: 'c1',
+      course_name: 'AGI Strategy',
+      round_id: 'rd1',
+      round_name: 'AGI Strategy (2026 Mar W14) - Intensive',
+      project_name: 'My action plan',
+      project_url: 'https://docs.google.com/document/d/abc',
+    });
+  });
+
+  test('emits with email but no course/round when the participant has no registration', async () => {
+    await testDb.insert(meetPersonTable, { id: 'mp2', email: 'solo@x.com' }); // no applicationsBaseRecordId
+    await testDb.insert(projectSubmissionTable, {
+      id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', link: 'https://example.com/p', participant: ['mp2'],
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const event = ph.events.find((e) => e.event === 'project_submitted')!;
+    expect(event.distinct_id).toBe('solo@x.com');
+    expect(event.properties).toMatchObject({ project_url: 'https://example.com/p' });
+    expect(event.properties).not.toHaveProperty('course_id');
+    expect(event.properties).not.toHaveProperty('round_id');
+  });
+
+  test('skips submissions whose participant resolves to no email (nothing to attribute to)', async () => {
+    await testDb.insert(projectSubmissionTable, {
+      id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', link: 'https://example.com/p', participant: ['unknown'],
+    });
+
+    const ph = mockPostHogBackend();
+    const result = await forwardEventTypeToPostHog({
+      db,
+      posthogCredentials: POSTHOG_CREDS,
+      eventProjectionRule: eventProjectionRules.find((p) => p.eventType === 'project_submitted')!,
+      now: '2026-07-01T00:00:00.000Z',
+    });
+    expect(result).toMatchObject({ candidates: 1, skipped: 1, sent: 0 });
+    expect(ph.events.filter((e) => e.event === 'project_submitted')).toHaveLength(0);
+  });
+
+  test('since scans only submissions created on/after it', async () => {
+    await seedRegisteredParticipant();
+    await testDb.insert(projectSubmissionTable, {
+      id: 'old', createdAt: '2026-01-01T00:00:00.000Z', participant: ['mp1'],
+    });
+    await testDb.insert(meetPersonTable, { id: 'mp2', email: 'new@x.com' });
+    await testDb.insert(projectSubmissionTable, {
+      id: 'new', createdAt: '2026-06-01T00:00:00.000Z', participant: ['mp2'],
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
+
+    expect(ph.events.filter((e) => e.event === 'project_submitted').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+  });
+
+  test('send-once across runs: a second run re-sends nothing', async () => {
+    await seedRegisteredParticipant();
+    await testDb.insert(projectSubmissionTable, {
+      id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', participant: ['mp1'],
+    });
+
+    mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const ph2 = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph2.events.filter((e) => e.event === 'project_submitted')).toHaveLength(0);
   });
 });

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -679,7 +679,7 @@ describe('project_submitted', () => {
       course_name: 'AGI Strategy',
       round_id: 'rd1',
       round_name: 'AGI Strategy (2026 Mar W14) - Intensive',
-      project_name: 'My action plan',
+      project_title: 'My action plan',
       project_url: 'https://docs.google.com/document/d/abc',
     });
   });

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -2,7 +2,7 @@ import {
   and, gte, isNotNull, inArray,
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable,
   groupDiscussionTable, meetPersonTable, roundTable, unitTable, exerciseTable, exerciseResponsePgTable,
-  unitResourceTable, resourceCompletionPgTable,
+  unitResourceTable, resourceCompletionPgTable, projectSubmissionTable,
   type PgAirtableDb,
 } from '@bluedot/db';
 import type { PgColumn } from 'drizzle-orm/pg-core';
@@ -308,6 +308,59 @@ export const eventProjectionRules: EventProjectionRule[] = [
             },
           };
         });
+    },
+  },
+  {
+    eventType: 'project_submitted',
+    async calculateEvents(db, { since }) {
+      // createdAt is Airtable's createdTime: set once when the submission row is created, immutable.
+      const submissions = await db.pg.select().from(projectSubmissionTable.pg)
+        .where(filterGteOrNull(projectSubmissionTable.pg.createdAt, since));
+      if (submissions.length === 0) return [];
+
+      // The form links each submission to a meet_person (participant). The email and the course/round
+      // both come off that link: meetPerson.email is the distinct id; meetPerson.applicationsBaseRecordId
+      // -> course_registration gives the course and round.
+      const participantIds = [...new Set(submissions.flatMap((s) => s.participant ?? []))];
+      const meetPersons = participantIds.length
+        ? await db.pg.select({
+          id: meetPersonTable.pg.id, email: meetPersonTable.pg.email, applicationsBaseRecordId: meetPersonTable.pg.applicationsBaseRecordId,
+        }).from(meetPersonTable.pg).where(inArray(meetPersonTable.pg.id, participantIds))
+        : [];
+      const meetPersonById = new Map(meetPersons.map((m) => [m.id, m] as const));
+
+      const registrationIds = [...new Set(meetPersons.map((m) => m.applicationsBaseRecordId).filter((id): id is string => !!id))];
+      const registrations = registrationIds.length
+        ? await db.pg.select({
+          id: courseRegistrationTable.pg.id,
+          courseId: courseRegistrationTable.pg.courseId,
+          roundId: courseRegistrationTable.pg.roundId,
+          roundName: courseRegistrationTable.pg.roundName,
+        }).from(courseRegistrationTable.pg).where(inArray(courseRegistrationTable.pg.id, registrationIds))
+        : [];
+      const registrationById = new Map(registrations.map((r) => [r.id, r] as const));
+
+      const courses = await db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg);
+      const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
+
+      return submissions.map((s) => {
+        const meetPerson = s.participant?.[0] ? meetPersonById.get(s.participant[0]) : undefined;
+        const registration = meetPerson?.applicationsBaseRecordId ? registrationById.get(meetPerson.applicationsBaseRecordId) : undefined;
+        const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
+        return {
+          internalUniqueKey: s.id,
+          distinctId: meetPerson?.email ?? null,
+          timestampMs: Date.parse(s.createdAt!),
+          properties: {
+            ...(registration?.courseId ? { course_id: registration.courseId } : {}),
+            ...(courseName ? { course_name: courseName } : {}),
+            ...(registration?.roundId ? { round_id: registration.roundId } : {}),
+            ...(registration?.roundName ? { round_name: registration.roundName } : {}),
+            ...(s.projectTitle ? { project_name: s.projectTitle } : {}),
+            ...(s.link ? { project_url: s.link } : {}),
+          },
+        };
+      });
     },
   },
 ];

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -343,12 +343,13 @@ export const eventProjectionRules: EventProjectionRule[] = [
       const courses = await db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg);
       const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
 
-      return submissions.map((s) => {
-        const meetPerson = s.participant?.[0] ? meetPersonById.get(s.participant[0]) : undefined;
+      // Group projects link several participants; emit one event per participant so each gets credited.
+      return submissions.flatMap((s) => (s.participant ?? []).map((participantId) => {
+        const meetPerson = meetPersonById.get(participantId);
         const registration = meetPerson?.applicationsBaseRecordId ? registrationById.get(meetPerson.applicationsBaseRecordId) : undefined;
         const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
         return {
-          internalUniqueKey: s.id,
+          internalUniqueKey: `${s.id}:${participantId}`,
           distinctId: meetPerson?.email ?? null,
           timestampMs: Date.parse(s.createdAt!),
           properties: {
@@ -360,7 +361,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
             ...(s.link ? { project_url: s.link } : {}),
           },
         };
-      });
+      }));
     },
   },
 ];

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -356,7 +356,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
             ...(courseName ? { course_name: courseName } : {}),
             ...(registration?.roundId ? { round_id: registration.roundId } : {}),
             ...(registration?.roundName ? { round_name: registration.roundName } : {}),
-            ...(s.projectTitle ? { project_name: s.projectTitle } : {}),
+            ...(s.projectTitle ? { project_title: s.projectTitle } : {}),
             ...(s.link ? { project_url: s.link } : {}),
           },
         };

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -340,7 +340,9 @@ export const eventProjectionRules: EventProjectionRule[] = [
         : [];
       const registrationById = new Map(registrations.map((r) => [r.id, r] as const));
 
-      const courses = await db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg);
+      const courses = registrations.length
+        ? await db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg)
+        : [];
       const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
 
       // Group projects link several participants; emit one event per participant so each gets credited.


### PR DESCRIPTION
# Description

Adds a `project_submitted` event (covering e.g. action plans for AGI Strategy, projects for the Technical AI Safety course), which fits into the funnel of events showing a user's progress through courses.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2679

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->