### PR TITLE
[feat] Add resource_completed PostHog event

### DIFF
--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -562,15 +562,24 @@ describe('resource_completed', () => {
     testDb.insert(unitResourceTable, {
       id, unitId: opts.unitId, resourceName: opts.resourceName, coreFurtherMaybe: opts.coreFurtherMaybe,
     });
-  const completeResource = (id: string, email: string, unitResourceId: string, completedAt: string | null) =>
+  const completeResource = (
+    id: string, email: string | null, unitResourceId: string | null, completedAt: string | null,
+    resourceId?: string,
+  ) =>
     db.pg.insert(resourceCompletionPgTable).values({
-      id, email, unitResourceId, isCompleted: completedAt != null, createdAt: '2026-06-01T00:00:00.000Z', completedAt,
+      id,
+      email,
+      unitResourceId,
+      resourceId: resourceId ? [resourceId] : null,
+      isCompleted: completedAt != null,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      completedAt,
     });
 
   test('emits one event per completed resource, enriched with the unit_resource and unit', async () => {
     await seedUnit('u1', { unitNumber: '2', title: 'What is AGI?' });
     await seedUnitResource('ur1', { unitId: 'u1', resourceName: 'The Bitter Lesson', coreFurtherMaybe: 'Core' });
-    await completeResource('rc1', 'a@x.com', 'ur1', '2026-06-10T10:00:00.000Z');
+    await completeResource('rc1', 'a@x.com', 'ur1', '2026-06-10T10:00:00.000Z', 'res1');
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog();
@@ -580,9 +589,10 @@ describe('resource_completed', () => {
     expect(events[0]!.distinct_id).toBe('a@x.com');
     expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
     expect(events[0]!.properties).toMatchObject({
-      resource_id: 'ur1',
+      resource_id: 'res1',
+      unit_resource_id: 'ur1',
       resource_name: 'The Bitter Lesson',
-      resource_type: 'Core',
+      core_further_maybe: 'Core',
       unit_id: 'u1',
       unit_number: 2,
       unit_name: 'What is AGI?',
@@ -595,6 +605,15 @@ describe('resource_completed', () => {
   test('skips completions without a completedAt', async () => {
     await seedUnitResource('ur1', { unitId: 'u1' });
     await completeResource('rc1', 'a@x.com', 'ur1', null);
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph.events.filter((e) => e.event === 'resource_completed')).toHaveLength(0);
+  });
+
+  test('skips completions without an email (no distinct id to attribute)', async () => {
+    await seedUnitResource('ur1', { unitId: 'u1' });
+    await completeResource('rc1', null, 'ur1', '2026-06-10T10:00:00.000Z');
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog();

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -2,6 +2,7 @@ import {
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable, eq,
   groupDiscussionTable, meetPersonTable, roundTable, unitTable,
   exerciseTable, exerciseResponsePgTable,
+  unitResourceTable, resourceCompletionPgTable,
 } from '@bluedot/db';
 import {
   afterEach, describe, expect, test, vi,
@@ -543,5 +544,83 @@ describe('exercise_completed', () => {
     const ph2 = mockPostHogBackend();
     await forwardAllEventsToPostHog();
     expect(ph2.events.filter((e) => e.event === 'exercise_completed')).toHaveLength(0);
+  });
+});
+
+describe('resource_completed', () => {
+  const seedUnit = (id: string, opts: { courseId?: string; unitNumber?: string; title?: string } = {}) =>
+    testDb.insert(unitTable, {
+      id,
+      courseId: opts.courseId ?? 'c1',
+      courseTitle: 'AGI Strategy',
+      courseSlug: 'agi-strategy',
+      title: opts.title ?? 'Intro to AGI',
+      unitNumber: opts.unitNumber ?? '1',
+      unitStatus: 'Active',
+    });
+  const seedUnitResource = (id: string, opts: { unitId?: string; resourceName?: string; coreFurtherMaybe?: string } = {}) =>
+    testDb.insert(unitResourceTable, {
+      id, unitId: opts.unitId, resourceName: opts.resourceName, coreFurtherMaybe: opts.coreFurtherMaybe,
+    });
+  const completeResource = (id: string, email: string, unitResourceId: string, completedAt: string | null) =>
+    db.pg.insert(resourceCompletionPgTable).values({
+      id, email, unitResourceId, isCompleted: completedAt != null, createdAt: '2026-06-01T00:00:00.000Z', completedAt,
+    });
+
+  test('emits one event per completed resource, enriched with the unit_resource and unit', async () => {
+    await seedUnit('u1', { unitNumber: '2', title: 'What is AGI?' });
+    await seedUnitResource('ur1', { unitId: 'u1', resourceName: 'The Bitter Lesson', coreFurtherMaybe: 'Core' });
+    await completeResource('rc1', 'a@x.com', 'ur1', '2026-06-10T10:00:00.000Z');
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const events = ph.events.filter((e) => e.event === 'resource_completed');
+    expect(events).toHaveLength(1);
+    expect(events[0]!.distinct_id).toBe('a@x.com');
+    expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
+    expect(events[0]!.properties).toMatchObject({
+      resource_id: 'ur1',
+      resource_name: 'The Bitter Lesson',
+      resource_type: 'Core',
+      unit_id: 'u1',
+      unit_number: 2,
+      unit_name: 'What is AGI?',
+      course_id: 'c1',
+      course_name: 'AGI Strategy',
+      course_slug: 'agi-strategy',
+    });
+  });
+
+  test('skips completions without a completedAt', async () => {
+    await seedUnitResource('ur1', { unitId: 'u1' });
+    await completeResource('rc1', 'a@x.com', 'ur1', null);
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph.events.filter((e) => e.event === 'resource_completed')).toHaveLength(0);
+  });
+
+  test('since scans only completions on/after it', async () => {
+    await seedUnitResource('ur1', { unitId: 'u1' });
+    await completeResource('old', 'old@x.com', 'ur1', '2026-01-01T00:00:00.000Z');
+    await completeResource('new', 'new@x.com', 'ur1', '2026-06-01T00:00:00.000Z');
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
+
+    expect(ph.events.filter((e) => e.event === 'resource_completed').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+  });
+
+  test('send-once across runs: a second run re-sends nothing', async () => {
+    await seedUnitResource('ur1', { unitId: 'u1' });
+    await completeResource('rc1', 'a@x.com', 'ur1', '2026-06-10T10:00:00.000Z');
+
+    mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const ph2 = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph2.events.filter((e) => e.event === 'resource_completed')).toHaveLength(0);
   });
 });

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -284,27 +284,30 @@ export const eventProjectionRules: EventProjectionRule[] = [
       const unitResourceById = new Map(unitResources.map((ur) => [ur.id, ur]));
       const unitById = new Map(units.map((u) => [u.id, u]));
 
-      return completions.map((c) => {
-        const unitResource = c.unitResourceId ? unitResourceById.get(c.unitResourceId) : undefined;
-        const unit = unitResource?.unitId ? unitById.get(unitResource.unitId) : undefined;
-        const unitNumber = unit ? Number(unit.unitNumber) : null;
-        return {
-          internalUniqueKey: c.id,
-          distinctId: c.email,
-          // Note: completedAt is mutable (can un-complete and re-complete), the event will
-          // capture the *first time* we saw the resource in a completed state
-          timestampMs: Date.parse(c.completedAt!),
-          properties: {
-            resource_id: c.unitResourceId,
-            ...(unitResource?.resourceName ? { resource_name: unitResource.resourceName } : {}),
-            ...(unitResource?.coreFurtherMaybe ? { resource_type: unitResource.coreFurtherMaybe } : {}),
-            ...(unitResource?.unitId ? { unit_id: unitResource.unitId } : {}),
-            ...(unitNumber != null && Number.isFinite(unitNumber) ? { unit_number: unitNumber } : {}),
-            ...(unit?.title ? { unit_name: unit.title } : {}),
-            ...(unit ? { course_id: unit.courseId, course_name: unit.courseTitle, course_slug: unit.courseSlug } : {}),
-          },
-        };
-      });
+      return completions
+        .filter((c) => c.email) // a null distinctId can't be attributed in PostHog
+        .map((c) => {
+          const unitResource = c.unitResourceId ? unitResourceById.get(c.unitResourceId) : undefined;
+          const unit = unitResource?.unitId ? unitById.get(unitResource.unitId) : undefined;
+          const unitNumber = unit ? Number(unit.unitNumber) : null;
+          return {
+            internalUniqueKey: c.id,
+            distinctId: c.email,
+            // Note: completedAt is mutable (can un-complete and re-complete), the event will
+            // capture the *first time* we saw the resource in a completed state
+            timestampMs: Date.parse(c.completedAt!),
+            properties: {
+              ...(c.resourceId?.[0] ? { resource_id: c.resourceId[0] } : {}),
+              ...(c.unitResourceId ? { unit_resource_id: c.unitResourceId } : {}),
+              ...(unitResource?.resourceName ? { resource_name: unitResource.resourceName } : {}),
+              ...(unitResource?.coreFurtherMaybe ? { core_further_maybe: unitResource.coreFurtherMaybe } : {}),
+              ...(unitResource?.unitId ? { unit_id: unitResource.unitId } : {}),
+              ...(unitNumber != null && Number.isFinite(unitNumber) ? { unit_number: unitNumber } : {}),
+              ...(unit?.title ? { unit_name: unit.title } : {}),
+              ...(unit ? { course_id: unit.courseId, course_name: unit.courseTitle, course_slug: unit.courseSlug } : {}),
+            },
+          };
+        });
     },
   },
 ];

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -2,6 +2,7 @@ import {
   and, gte, isNotNull, inArray,
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable,
   groupDiscussionTable, meetPersonTable, roundTable, unitTable, exerciseTable, exerciseResponsePgTable,
+  unitResourceTable, resourceCompletionPgTable,
   type PgAirtableDb,
 } from '@bluedot/db';
 import type { PgColumn } from 'drizzle-orm/pg-core';
@@ -258,6 +259,49 @@ export const eventProjectionRules: EventProjectionRule[] = [
             ...(exercise?.unitId ? { unit_id: exercise.unitId } : {}),
             ...(exercise?.courseId ? { course_id: exercise.courseId } : {}),
             ...(courseName ? { course_name: courseName } : {}),
+          },
+        };
+      });
+    },
+  },
+  {
+    eventType: 'resource_completed',
+    async calculateEvents(db, { since }) {
+      const completions = await db.pg.select().from(resourceCompletionPgTable)
+        .where(filterGteOrNull(resourceCompletionPgTable.completedAt, since)); // completedAt is ISO text
+      if (completions.length === 0) return [];
+
+      const [unitResources, units] = await Promise.all([
+        db.pg.select({
+          id: unitResourceTable.pg.id, resourceName: unitResourceTable.pg.resourceName,
+          unitId: unitResourceTable.pg.unitId, coreFurtherMaybe: unitResourceTable.pg.coreFurtherMaybe,
+        }).from(unitResourceTable.pg),
+        db.pg.select({
+          id: unitTable.pg.id, courseId: unitTable.pg.courseId, courseTitle: unitTable.pg.courseTitle,
+          courseSlug: unitTable.pg.courseSlug, title: unitTable.pg.title, unitNumber: unitTable.pg.unitNumber,
+        }).from(unitTable.pg),
+      ]);
+      const unitResourceById = new Map(unitResources.map((ur) => [ur.id, ur]));
+      const unitById = new Map(units.map((u) => [u.id, u]));
+
+      return completions.map((c) => {
+        const unitResource = c.unitResourceId ? unitResourceById.get(c.unitResourceId) : undefined;
+        const unit = unitResource?.unitId ? unitById.get(unitResource.unitId) : undefined;
+        const unitNumber = unit ? Number(unit.unitNumber) : null;
+        return {
+          internalUniqueKey: c.id,
+          distinctId: c.email,
+          // Note: completedAt is mutable (can un-complete and re-complete), the event will
+          // capture the *first time* we saw the resource in a completed state
+          timestampMs: Date.parse(c.completedAt!),
+          properties: {
+            resource_id: c.unitResourceId,
+            ...(unitResource?.resourceName ? { resource_name: unitResource.resourceName } : {}),
+            ...(unitResource?.coreFurtherMaybe ? { resource_type: unitResource.coreFurtherMaybe } : {}),
+            ...(unitResource?.unitId ? { unit_id: unitResource.unitId } : {}),
+            ...(unitNumber != null && Number.isFinite(unitNumber) ? { unit_number: unitNumber } : {}),
+            ...(unit?.title ? { unit_name: unit.title } : {}),
+            ...(unit ? { course_id: unit.courseId, course_name: unit.courseTitle, course_slug: unit.courseSlug } : {}),
           },
         };
       });


### PR DESCRIPTION
# Description

Send a `resource_completed` event with the timestamp as completedAt. Note: As with exercise_completed, this is not quite as idempotent as other event types, because completedAt can change if an resource is uncompleted and re-completed. The event is set up to only send once per resource, so we'll retain the first time we saw the resource as completed

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2679

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories