### PR TITLE
Set Decision to Withdraw when a user drops out before a decision is made on their application

### DIFF
--- a/apps/website/src/server/routers/dropout.test.ts
+++ b/apps/website/src/server/routers/dropout.test.ts
@@ -1,10 +1,18 @@
-import { courseRegistrationTable } from '@bluedot/db';
+import { courseRegistrationTable, eq } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
   createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
 
 setupTestDb();
+
+const getDecision = async (id: string) => {
+  const [reg] = await testDb.pg
+    .select({ decision: courseRegistrationTable.pg.decision })
+    .from(courseRegistrationTable.pg)
+    .where(eq(courseRegistrationTable.pg.id, id));
+  return reg?.decision ?? null;
+};
 
 const insertRegistration = (overrides: Record<string, unknown>) => testDb.insert(courseRegistrationTable, {
   id: 'reg-1',
@@ -36,13 +44,32 @@ describe('dropout.dropoutOrDeferral', () => {
     })).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
-  test('lets a facilitator withdraw before acceptance (decision = null)', async () => {
+  test('lets a facilitator withdraw before acceptance (decision = null) and sets decision to Withdrawn', async () => {
     await insertRegistration({ role: 'Facilitator', decision: null });
 
     const result = await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
       applicantId: 'reg-1', type: 'Drop out',
     });
     expect(result).toBeTruthy();
+    expect(await getDecision('reg-1')).toBe('Withdrawn');
+  });
+
+  test('sets decision to Withdrawn when a participant withdraws a pre-decision application', async () => {
+    await insertRegistration({ role: 'Participant', decision: null });
+
+    await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Drop out',
+    });
+    expect(await getDecision('reg-1')).toBe('Withdrawn');
+  });
+
+  test('leaves the decision untouched when dropping out post-decision', async () => {
+    await insertRegistration({ role: 'Participant', decision: 'Accept' });
+
+    await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Drop out',
+    });
+    expect(await getDecision('reg-1')).toBe('Accept');
   });
 
   test('lets a participant defer once accepted', async () => {
@@ -52,6 +79,7 @@ describe('dropout.dropoutOrDeferral', () => {
       applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-2',
     });
     expect(result).toBeTruthy();
+    expect(await getDecision('reg-1')).toBe('Accept');
   });
 
   test('rejects a pre-decision participant deferral', async () => {

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -82,12 +82,19 @@ export const dropoutRouter = router({
 
       const oldRoundId = courseRegistration.roundId ?? null;
 
-      return db.insert(dropoutTable, {
+      const dropout = await db.insert(dropoutTable, {
         applicantId: [applicantId],
         reason: reason ?? null,
         type,
         newRoundId: type === 'Deferral' && newRoundId ? [newRoundId] : null,
         oldRoundId: type === 'Deferral' && oldRoundId ? [oldRoundId] : null,
       });
+
+      // A pre-decision application moves to "Withdrawn" so it's no longer evaluated (and potentially accepted) in review.
+      if (type === 'Drop out' && courseRegistration.decision === null) {
+        await db.update(courseRegistrationTable, { id: applicantId, decision: 'Withdrawn' });
+      }
+
+      return dropout;
     }),
 });


### PR DESCRIPTION
# Description

Previously, dropping out of an application before a decision was made left the Decision field blank, which meant the record still came up in the speed-review app (and there were cases of applications subsequently being accepted). This changes it to set the Decision to "Withdrawn" ("Withdrawn" is already in use, and is the intended value for this case).

Note: A side effect of this is that the application disappears from the UI. I think this is reasonable behaviour (it doesn't make sense to have an application for a course you never started to hang around).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2687

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot

There was already a special modal for this case. As a reminder this is what it looks like:

<img width="1014" height="562" alt="Screenshot 2026-06-23 at 17 27 30" src="https://github.com/user-attachments/assets/48f9d9c0-4a62-4113-b80e-97d556708f99" />