### PR TITLE
Add course_dropped_out, course_deferred, and application_withdrawn PostHog events

### DIFF
--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -2,7 +2,7 @@ import {
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable, eq,
   groupDiscussionTable, meetPersonTable, roundTable, unitTable,
   exerciseTable, exerciseResponsePgTable, projectSubmissionTable,
-  unitResourceTable, resourceCompletionPgTable,
+  unitResourceTable, resourceCompletionPgTable, dropoutTable,
 } from '@bluedot/db';
 import {
   afterEach, describe, expect, test, vi,
@@ -761,5 +761,142 @@ describe('project_submitted', () => {
     const ph2 = mockPostHogBackend();
     await forwardAllEventsToPostHog();
     expect(ph2.events.filter((e) => e.event === 'project_submitted')).toHaveLength(0);
+  });
+});
+
+describe('application_withdrawn', () => {
+  const seedWithdrawn = (id: string, email: string, withdrawnAt: string | null) => testDb.insert(courseRegistrationTable, {
+    id, courseId: 'c1', email, roundId: 'rd1', roundName: 'AGI Strategy (2026 Mar W14) - Intensive', withdrawnAt,
+  });
+
+  test('emits at withdrawnAt, enriched with course and round', async () => {
+    await testDb.insert(courseTable, {
+      id: 'c1', slug: 'agi-strategy', shortDescription: 'x', title: 'AGI Strategy', units: [], status: 'Active',
+    });
+    await seedWithdrawn('cr1', 'a@x.com', '2026-06-10T10:00:00.000Z');
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const events = ph.events.filter((e) => e.event === 'application_withdrawn');
+    expect(events).toHaveLength(1);
+    expect(events[0]!.distinct_id).toBe('a@x.com');
+    expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
+    expect(events[0]!.properties).toMatchObject({
+      course_id: 'c1',
+      course_name: 'AGI Strategy',
+      round_id: 'rd1',
+      round_name: 'AGI Strategy (2026 Mar W14) - Intensive',
+    });
+  });
+
+  test('emits only for rows with a withdrawnAt timestamp', async () => {
+    await seedWithdrawn('cr1', 'pending@x.com', null);
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph.events.filter((e) => e.event === 'application_withdrawn')).toHaveLength(0);
+  });
+
+  test('since scans only rows withdrawn on/after it', async () => {
+    await seedWithdrawn('old', 'old@x.com', '2026-01-01T00:00:00.000Z');
+    await seedWithdrawn('new', 'new@x.com', '2026-06-01T00:00:00.000Z');
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
+    expect(ph.events.filter((e) => e.event === 'application_withdrawn').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+  });
+
+  test('send-once across runs: a second run re-sends nothing', async () => {
+    await seedWithdrawn('cr1', 'a@x.com', '2026-06-10T10:00:00.000Z');
+
+    mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const ph2 = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph2.events.filter((e) => e.event === 'application_withdrawn')).toHaveLength(0);
+  });
+});
+
+describe('course_dropped_out / course_deferred', () => {
+  const seedCourseAndRegistration = async () => {
+    await testDb.insert(courseTable, {
+      id: 'c1', slug: 'agi-strategy', shortDescription: 'x', title: 'AGI Strategy', units: [], status: 'Active',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'cr1', courseId: 'c1', email: 'a@x.com', roundId: 'rd1', roundName: 'AGI Strategy (2026 Mar W14) - Intensive',
+    });
+  };
+
+  const seedDropout = (id: string, type: string, opts: { applicantId?: string; createdAt?: string } = {}) => testDb.insert(dropoutTable, {
+    id,
+    type,
+    applicantId: opts.applicantId ? [opts.applicantId] : null,
+    createdAt: opts.createdAt ?? '2026-06-10T10:00:00.000Z',
+  });
+
+  test('course_dropped_out: emits at the dropout createdAt, enriched via the linked application', async () => {
+    await seedCourseAndRegistration();
+    await seedDropout('do1', 'Drop out', { applicantId: 'cr1', createdAt: '2026-06-10T10:00:00.000Z' });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const events = ph.events.filter((e) => e.event === 'course_dropped_out');
+    expect(events).toHaveLength(1);
+    expect(events[0]!.distinct_id).toBe('a@x.com');
+    expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
+    expect(events[0]!.properties).toMatchObject({
+      course_id: 'c1',
+      course_name: 'AGI Strategy',
+      round_id: 'rd1',
+      round_name: 'AGI Strategy (2026 Mar W14) - Intensive',
+    });
+  });
+
+  test('drop-out and deferral are separated by type, each at its own row', async () => {
+    await seedCourseAndRegistration();
+    await seedDropout('do1', 'Drop out', { applicantId: 'cr1', createdAt: '2026-06-10T10:00:00.000Z' });
+    await seedDropout('df1', 'Deferral', { applicantId: 'cr1', createdAt: '2026-06-12T10:00:00.000Z' });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const dropped = ph.events.filter((e) => e.event === 'course_dropped_out');
+    const deferred = ph.events.filter((e) => e.event === 'course_deferred');
+    expect(dropped.map((e) => e.timestamp)).toEqual(['2026-06-10T10:00:00.000Z']);
+    expect(deferred.map((e) => e.timestamp)).toEqual(['2026-06-12T10:00:00.000Z']);
+    expect(deferred[0]!.distinct_id).toBe('a@x.com');
+  });
+
+  test('skips a dropout whose application cannot be resolved (no email to attribute)', async () => {
+    await seedDropout('do1', 'Drop out', { applicantId: 'missing' });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph.events.filter((e) => e.event === 'course_dropped_out')).toHaveLength(0);
+  });
+
+  test('since scans only dropouts created on/after it', async () => {
+    await seedCourseAndRegistration();
+    await seedDropout('old', 'Drop out', { applicantId: 'cr1', createdAt: '2026-01-01T00:00:00.000Z' });
+    await seedDropout('new', 'Drop out', { applicantId: 'cr1', createdAt: '2026-06-01T00:00:00.000Z' });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
+    expect(ph.events.filter((e) => e.event === 'course_dropped_out').map((e) => e.timestamp)).toEqual(['2026-06-01T00:00:00.000Z']);
+  });
+
+  test('send-once across runs: a second run re-sends nothing', async () => {
+    await seedCourseAndRegistration();
+    await seedDropout('do1', 'Drop out', { applicantId: 'cr1' });
+
+    mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const ph2 = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph2.events.filter((e) => e.event === 'course_dropped_out')).toHaveLength(0);
   });
 });

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -1,8 +1,8 @@
 import {
-  and, gte, isNotNull, inArray,
+  and, eq, gte, isNotNull, inArray,
   courseRegistrationTable, selfServeCourseRegistrationTable, courseTable,
   groupDiscussionTable, meetPersonTable, roundTable, unitTable, exerciseTable, exerciseResponsePgTable,
-  unitResourceTable, resourceCompletionPgTable, projectSubmissionTable,
+  unitResourceTable, resourceCompletionPgTable, projectSubmissionTable, dropoutTable,
   type PgAirtableDb,
 } from '@bluedot/db';
 import type { PgColumn } from 'drizzle-orm/pg-core';
@@ -85,6 +85,51 @@ const calculateDiscussionAttendanceEvents = async (
   return events;
 };
 
+const calculateDropoutEvents = async (
+  db: PgAirtableDb,
+  { since }: { since?: string },
+  type: 'Drop out' | 'Deferral',
+): Promise<Event[]> => {
+  // createdAt is Airtable's createdTime: set once when the dropout row is created, immutable.
+  const rows = await db.pg.select().from(dropoutTable.pg)
+    .where(and(filterGteOrNull(dropoutTable.pg.createdAt, since), eq(dropoutTable.pg.type, type)));
+  if (rows.length === 0) return [];
+
+  // Identity, course and round come off the linked application, not the dropout table's own email lookup.
+  const registrationIds = [...new Set(rows.flatMap((r) => r.applicantId ?? []))];
+  const registrations = registrationIds.length
+    ? await db.pg.select({
+      id: courseRegistrationTable.pg.id,
+      email: courseRegistrationTable.pg.email,
+      courseId: courseRegistrationTable.pg.courseId,
+      roundId: courseRegistrationTable.pg.roundId,
+      roundName: courseRegistrationTable.pg.roundName,
+    }).from(courseRegistrationTable.pg).where(inArray(courseRegistrationTable.pg.id, registrationIds))
+    : [];
+  const registrationById = new Map(registrations.map((r) => [r.id, r] as const));
+
+  const courses = registrations.length
+    ? await db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg)
+    : [];
+  const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
+
+  return rows.map((row) => {
+    const registration = row.applicantId?.[0] ? registrationById.get(row.applicantId[0]) : undefined;
+    const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
+    return {
+      internalUniqueKey: row.id,
+      distinctId: registration?.email ?? null,
+      timestampMs: Date.parse(row.createdAt!),
+      properties: {
+        ...(registration?.courseId ? { course_id: registration.courseId } : {}),
+        ...(courseName ? { course_name: courseName } : {}),
+        ...(registration?.roundId ? { round_id: registration.roundId } : {}),
+        ...(registration?.roundName ? { round_name: registration.roundName } : {}),
+      },
+    };
+  });
+};
+
 export const eventProjectionRules: EventProjectionRule[] = [
   {
     eventType: 'application_submitted',
@@ -164,6 +209,30 @@ export const eventProjectionRules: EventProjectionRule[] = [
           internalUniqueKey: `reject:${r.id}`,
           distinctId: r.email,
           timestampMs: Date.parse(r.rejectedAt!),
+          properties: {
+            course_id: r.courseId,
+            ...(courseName ? { course_name: courseName } : {}),
+            ...(r.roundId ? { round_id: r.roundId } : {}),
+            ...(r.roundName ? { round_name: r.roundName } : {}),
+          },
+        };
+      });
+    },
+  },
+  {
+    eventType: 'application_withdrawn',
+    async calculateEvents(db, { since }) {
+      const courses = await db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg);
+      const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
+      const rows = await db.pg.select().from(courseRegistrationTable.pg)
+        .where(filterGteOrNull(courseRegistrationTable.pg.withdrawnAt, since)); // withdrawnAt is ISO text
+
+      return rows.map((r) => {
+        const courseName = courseTitleById.get(r.courseId);
+        return {
+          internalUniqueKey: `withdraw:${r.id}`,
+          distinctId: r.email,
+          timestampMs: Date.parse(r.withdrawnAt!),
           properties: {
             course_id: r.courseId,
             ...(courseName ? { course_name: courseName } : {}),
@@ -365,5 +434,13 @@ export const eventProjectionRules: EventProjectionRule[] = [
         };
       }));
     },
+  },
+  {
+    eventType: 'course_dropped_out',
+    calculateEvents: (db, opts) => calculateDropoutEvents(db, opts, 'Drop out'),
+  },
+  {
+    eventType: 'course_deferred',
+    calculateEvents: (db, opts) => calculateDropoutEvents(db, opts, 'Deferral'),
   },
 ];


### PR DESCRIPTION
# Description

- `course_deferred` will be sent whenever a user defers via the on-site modal. We will then be able to pick up the thread of their progress in PostHog via other events like `exercise_completed` and `certificate_created`, which will use the same course registration (just with a new round).
- `course_dropped_out` will be sent whenever a user drops out via the on-site modal (at any point).
- `application_withdrawn` will additionally be sent if they drop out before being accepted. This is added mainly for completeness to cover the three possible decisions (`application_accepted`, `application_rejected`, `application_withdrawn`)

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2679

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
