### PR TITLE
[feat] Add isOptional column to exercise table

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.stories.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.stories.tsx
@@ -18,6 +18,7 @@ const freeTextExercise = {
   unitNumber: null,
   exerciseNumber: null,
   computedNumResponses: null,
+  isOptional: null,
 };
 
 const multipleChoiceExercise = {
@@ -33,6 +34,7 @@ const multipleChoiceExercise = {
   unitNumber: null,
   exerciseNumber: null,
   computedNumResponses: null,
+  isOptional: null,
 };
 
 const savedResponse = {

--- a/apps/website/src/components/courses/exercises/Exercise.test.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.test.tsx
@@ -45,6 +45,7 @@ const freeTextExercise = {
   courseIdRead: 'course-read-1',
   exerciseNumber: null,
   computedNumResponses: null,
+  isOptional: null,
 };
 
 beforeEach(() => {

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1242,6 +1242,10 @@ export const exerciseTable = pgAirtable('exercise', {
       pgColumn: text(),
       airtableId: 'flda5e542i9w1nBzv',
     },
+    isOptional: {
+      pgColumn: boolean(),
+      airtableId: 'fldnzXgcFpPT8WZrI',
+    },
     computedNumResponses: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldhemVjXEA0j4d2d',


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Currently exercises are marked as optional purely through editing the title. This adds a schema-level optional concept. I've already backfilled these values in Airtable.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2648

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
