### PR TITLE
Prevent optional exercises from counting towards course completion

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.test.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.test.tsx
@@ -6,7 +6,7 @@ import {
 } from 'vitest';
 import { server, trpcMsw } from '../../../__tests__/trpcMswSetup';
 import { TrpcProvider } from '../../../__tests__/trpcProvider';
-import Exercise from './Exercise';
+import Exercise, { maybeApplyOptionalPrefix } from './Exercise';
 
 // Mock next/router
 vi.mock('next/router', () => ({
@@ -181,5 +181,24 @@ describe('Exercise', () => {
       expect(savedResponse).toContain('new draft');
       expect(savedResponse).not.toBe('Old saved text');
     });
+  });
+});
+
+describe('maybeApplyOptionalPrefix', () => {
+  test('leaves non-optional titles untouched', () => {
+    expect(maybeApplyOptionalPrefix({ title: 'Comprehension questions', isOptional: false })).toBe('Comprehension questions');
+    expect(maybeApplyOptionalPrefix({ title: 'Comprehension questions', isOptional: null })).toBe('Comprehension questions');
+  });
+
+  test('prepends [Optional] to optional titles without an existing marker', () => {
+    expect(maybeApplyOptionalPrefix({ title: 'Comprehension questions', isOptional: true })).toBe('[Optional] Comprehension questions');
+  });
+
+  test('does not double up when the title already starts with an optional marker', () => {
+    expect(maybeApplyOptionalPrefix({ title: '(Optional) Comprehension questions', isOptional: true })).toBe('(Optional) Comprehension questions');
+    expect(maybeApplyOptionalPrefix({ title: '[Optional] Reflection', isOptional: true })).toBe('[Optional] Reflection');
+    expect(maybeApplyOptionalPrefix({ title: '(Optional:) Additional prompts', isOptional: true })).toBe('(Optional:) Additional prompts');
+    expect(maybeApplyOptionalPrefix({ title: '(Optional, recommended) Historical efforts', isOptional: true })).toBe('(Optional, recommended) Historical efforts');
+    expect(maybeApplyOptionalPrefix({ title: 'Optional reading', isOptional: true })).toBe('Optional reading');
   });
 });

--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -97,7 +97,7 @@ const Exercise: React.FC<ExerciseProps> = ({
         userId: previousResponse?.userId ?? null,
       });
 
-      const previousCourseProgress = newData.completed !== undefined ? await optimisticallyUpdateCourseProgress(utils, courseSlug, unitNumber, chunkIndex, newData.completed ? 1 : -1) : undefined;
+      const previousCourseProgress = newData.completed !== undefined && !exerciseData?.isOptional ? await optimisticallyUpdateCourseProgress(utils, courseSlug, unitNumber, chunkIndex, newData.completed ? 1 : -1) : undefined;
       return { previousResponse, previousCourseProgress };
     },
     onError(_err, _variables, mutationResult) {

--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -21,6 +21,16 @@ type ExerciseProps = {
   chunkIndex?: number;
 };
 
+export function maybeApplyOptionalPrefix({ title, isOptional }: { title: string; isOptional: boolean | null | undefined }): string {
+  if (!isOptional) {
+    return title;
+  }
+
+  const [firstToken = ''] = title.trim().split(/\s+/);
+  const firstWord = firstToken.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '').toLowerCase();
+  return firstWord === 'optional' ? title : `[Optional] ${title}`;
+}
+
 const Exercise: React.FC<ExerciseProps> = ({
   exerciseId, courseSlug, unitNumber, chunkIndex,
 }) => {
@@ -150,6 +160,8 @@ const Exercise: React.FC<ExerciseProps> = ({
   }
 
   const showGroupResponses = !!facilitatorGroupResponses && showGroupResponsesIfFacilitator;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const displayTitle = maybeApplyOptionalPrefix({ title: exerciseData.title || '', isOptional: exerciseData.isOptional });
 
   // Free text completion checkbox (positioned outside the card)
   const hasResponse = editorHasText || !!(responseData?.response?.trim());
@@ -235,8 +247,7 @@ const Exercise: React.FC<ExerciseProps> = ({
         {/* Conditional padding: GroupResponses needs edge-to-edge for its blue background */}
         <div className={cn('container-lined bg-white flex flex-col gap-5', !showGroupResponses && 'p-8')}>
           <div className={cn('flex flex-col gap-2', showGroupResponses && 'px-8 pt-8')}>
-            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-            <p className="bluedot-h4 not-prose">{exerciseData.title || ''}</p>
+            <p className="bluedot-h4 not-prose">{displayTitle}</p>
             {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             <MarkdownExtendedRenderer>{exerciseData.description || ''}</MarkdownExtendedRenderer>
           </div>

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -385,4 +385,26 @@ describe('issueFoaiCertificateIfComplete', () => {
     expect(legacy.certificateId).toBeNull();
     expect(await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)).toEqual([]);
   });
+
+  test('issues the certificate even when an optional exercise is incomplete', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-1', email: 'test@example.com', courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Required', exerciseNumber: '1',
+    });
+    await testDb.pg.insert(exerciseResponsePgTable).values({
+      id: 'resp-1', email: 'test@example.com', exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+    });
+    // Optional exercise with no completed response — must not block the certificate.
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-opt', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Optional', exerciseNumber: '2', isOptional: true,
+    });
+
+    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+
+    const [selfServe] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
+      .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
+    expect(selfServe?.certificateId).toBe('ss-1');
+  });
 });

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -7,7 +7,9 @@ import {
   exerciseResponsePgTable,
   exerciseTable,
   inArray,
+  isNull,
   meetPersonTable,
+  or,
   roundTable,
   selfServeCourseRegistrationTable,
 } from '@bluedot/db';
@@ -22,8 +24,15 @@ import type { AppRouter } from './_app';
 import { hasUpcomingRoundsForCourseId } from './course-rounds';
 
 async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
-  const activeExercises = await db.scan(exerciseTable, { courseId: FOAI_COURSE_ID, status: 'Active' });
-  const requiredExercises = activeExercises.filter((exercise) => !exercise.isOptional);
+  // Non-optional exercises sync as isOptional = null (not false), so match both.
+  const requiredExercises = await db.pg
+    .select({ id: exerciseTable.pg.id })
+    .from(exerciseTable.pg)
+    .where(and(
+      eq(exerciseTable.pg.courseId, FOAI_COURSE_ID),
+      eq(exerciseTable.pg.status, 'Active'),
+      or(eq(exerciseTable.pg.isOptional, false), isNull(exerciseTable.pg.isOptional)),
+    ));
   if (requiredExercises.length === 0) {
     return false;
   }

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -24,7 +24,6 @@ import type { AppRouter } from './_app';
 import { hasUpcomingRoundsForCourseId } from './course-rounds';
 
 async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
-  // Non-optional exercises sync as isOptional = null (not false), so match both.
   const requiredExercises = await db.pg
     .select({ id: exerciseTable.pg.id })
     .from(exerciseTable.pg)

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -22,8 +22,9 @@ import type { AppRouter } from './_app';
 import { hasUpcomingRoundsForCourseId } from './course-rounds';
 
 async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
-  const allExercises = await db.scan(exerciseTable, { courseId: FOAI_COURSE_ID, status: 'Active' });
-  if (allExercises.length === 0) {
+  const activeExercises = await db.scan(exerciseTable, { courseId: FOAI_COURSE_ID, status: 'Active' });
+  const requiredExercises = activeExercises.filter((exercise) => !exercise.isOptional);
+  if (requiredExercises.length === 0) {
     return false;
   }
 
@@ -34,13 +35,13 @@ async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
     .from(exerciseResponsePgTable)
     .where(and(
       eq(exerciseResponsePgTable.email, email),
-      inArray(exerciseResponsePgTable.exerciseId, allExercises.map((e) => e.id)),
+      inArray(exerciseResponsePgTable.exerciseId, requiredExercises.map((e) => e.id)),
     ));
 
   const completedExerciseIds = new Set(exerciseResponses
     .filter((resp) => resp.completedAt != null)
     .map((resp) => resp.exerciseId));
-  return allExercises.every((exercise) => completedExerciseIds.has(exercise.id));
+  return requiredExercises.every((exercise) => completedExerciseIds.has(exercise.id));
 }
 
 export async function issueFoaiCertificateIfComplete(email: string): Promise<boolean> {

--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -1,6 +1,7 @@
 import {
   chunkTable,
   courseTable,
+  exerciseResponsePgTable,
   exerciseTable,
   unitTable,
 } from '@bluedot/db';
@@ -48,7 +49,7 @@ const seedChunk = (id: string, unitId: string, opts: {
     status: opts.status ?? 'Active',
   });
 
-const seedExercise = (id: string, status = 'Active') => testDb.insert(exerciseTable, { id, status });
+const seedExercise = (id: string, status = 'Active', isOptional = false) => testDb.insert(exerciseTable, { id, status, isOptional });
 
 // Cases mirror real course-builder data shapes (see gh-2544 prod inspection): most chunks carry no
 // estimatedTime; some chunkExercises reference inactive exercises; alignment/pandemics use
@@ -127,5 +128,38 @@ describe('courses.getCurriculumMetadata', () => {
     const result = await caller.courses.getCurriculumMetadata({ courseSlug: 'no-active' });
 
     expect(result).toEqual([]);
+  });
+
+  test('optional exercises are excluded from the exercise count', async () => {
+    await seedCourse('opt');
+    await seedUnit('uo1', 'opt', '1');
+    await seedChunk('uo1-a', 'uo1', { title: 'Reading', exercises: ['ex-req', 'ex-opt'] });
+    await seedExercise('ex-req');
+    await seedExercise('ex-opt', 'Active', true);
+
+    const result = await caller.courses.getCurriculumMetadata({ courseSlug: 'opt' });
+
+    expect(result).toEqual([{
+      unitId: 'uo1', unitNumber: '1', duration: null, exerciseCount: 1,
+    }]);
+  });
+});
+
+describe('courses.getCourseProgress', () => {
+  test('optional exercises count towards neither the total nor completion', async () => {
+    await seedCourse('prog');
+    await seedUnit('up', 'prog', '1');
+    await seedChunk('up-a', 'up', { exercises: ['ex-req', 'ex-opt'] });
+    await seedExercise('ex-req');
+    await seedExercise('ex-opt', 'Active', true);
+
+    // Complete the optional exercise; it must not move the progress numbers.
+    await testDb.pg.insert(exerciseResponsePgTable).values({
+      id: 'r-opt', email: 'test@example.com', exerciseId: 'ex-opt', response: 'x', completedAt: '2026-01-01',
+    });
+
+    const { courseProgress } = await caller.courses.getCourseProgress({ courseSlug: 'prog' });
+
+    expect(courseProgress).toEqual({ totalCount: 1, completedCount: 0, percentage: 0 });
   });
 });

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -8,6 +8,8 @@ import {
   exerciseTable,
   inArray,
   isNotNull,
+  isNull,
+  or,
   resourceCompletionPgTable,
   unitResourceTable,
   unitTable,
@@ -18,6 +20,12 @@ import z from 'zod';
 import db from '../../lib/api/db';
 import { removeInactiveChunkIdsFromUnits } from '../../lib/api/utils';
 import { protectedProcedure, publicProcedure, router } from '../trpc';
+
+// Non-optional exercises sync as isOptional = null (not false), so match both.
+const exerciseIsRequired = or(
+  eq(exerciseTable.pg.isOptional, false),
+  isNull(exerciseTable.pg.isOptional),
+);
 
 export type BasicChunk = {
   id: string;
@@ -176,11 +184,11 @@ const getCoreResourceAndRequiredExerciseIds = async (chunks: Chunk[]) => {
     .where(and(eq(unitResourceTable.pg.coreFurtherMaybe, 'Core'), inArray(unitResourceTable.pg.id, allResourceIds)));
   const coreResourceIds = coreResources.map((r) => r.id);
 
-  const activeExercises = await db.pg
-    .select({ id: exerciseTable.pg.id, isOptional: exerciseTable.pg.isOptional })
+  const requiredExercises = await db.pg
+    .select({ id: exerciseTable.pg.id })
     .from(exerciseTable.pg)
-    .where(and(eq(exerciseTable.pg.status, 'Active'), inArray(exerciseTable.pg.id, allExerciseIds)));
-  const requiredExerciseIds = activeExercises.filter((e) => !e.isOptional).map((e) => e.id);
+    .where(and(eq(exerciseTable.pg.status, 'Active'), exerciseIsRequired, inArray(exerciseTable.pg.id, allExerciseIds)));
+  const requiredExerciseIds = requiredExercises.map((e) => e.id);
 
   return { coreResourceIds, requiredExerciseIds };
 };
@@ -241,16 +249,15 @@ export const coursesRouter = router({
       const referencedExerciseIds = allChunks.flatMap((c) => c.chunkExercises ?? []);
       const requiredExerciseIds = new Set<string>();
       if (referencedExerciseIds.length > 0) {
-        const activeExercises = await db.pg
-          .select({ id: exerciseTable.pg.id, isOptional: exerciseTable.pg.isOptional })
+        const requiredExercises = await db.pg
+          .select({ id: exerciseTable.pg.id })
           .from(exerciseTable.pg)
           .where(and(
             eq(exerciseTable.pg.status, 'Active'),
+            exerciseIsRequired,
             inArray(exerciseTable.pg.id, referencedExerciseIds),
           ));
-        for (const e of activeExercises) {
-          if (!e.isOptional) requiredExerciseIds.add(e.id);
-        }
+        for (const e of requiredExercises) requiredExerciseIds.add(e.id);
       }
 
       // Calculate duration:

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -21,12 +21,6 @@ import db from '../../lib/api/db';
 import { removeInactiveChunkIdsFromUnits } from '../../lib/api/utils';
 import { protectedProcedure, publicProcedure, router } from '../trpc';
 
-// Non-optional exercises sync as isOptional = null (not false), so match both.
-const exerciseIsRequired = or(
-  eq(exerciseTable.pg.isOptional, false),
-  isNull(exerciseTable.pg.isOptional),
-);
-
 export type BasicChunk = {
   id: string;
   chunkTitle: string;
@@ -187,7 +181,11 @@ const getCoreResourceAndRequiredExerciseIds = async (chunks: Chunk[]) => {
   const requiredExercises = await db.pg
     .select({ id: exerciseTable.pg.id })
     .from(exerciseTable.pg)
-    .where(and(eq(exerciseTable.pg.status, 'Active'), exerciseIsRequired, inArray(exerciseTable.pg.id, allExerciseIds)));
+    .where(and(
+      eq(exerciseTable.pg.status, 'Active'),
+      or(eq(exerciseTable.pg.isOptional, false), isNull(exerciseTable.pg.isOptional)),
+      inArray(exerciseTable.pg.id, allExerciseIds),
+    ));
   const requiredExerciseIds = requiredExercises.map((e) => e.id);
 
   return { coreResourceIds, requiredExerciseIds };
@@ -254,7 +252,7 @@ export const coursesRouter = router({
           .from(exerciseTable.pg)
           .where(and(
             eq(exerciseTable.pg.status, 'Active'),
-            exerciseIsRequired,
+            or(eq(exerciseTable.pg.isOptional, false), isNull(exerciseTable.pg.isOptional)),
             inArray(exerciseTable.pg.id, referencedExerciseIds),
           ));
         for (const e of requiredExercises) requiredExerciseIds.add(e.id);

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -85,7 +85,7 @@ export const getAllActiveCourses = async () => {
   return courses;
 };
 
-const getUserCompletions = async (coreResourceIds: string[], activeExerciseIds: string[], email: string) => {
+const getUserCompletions = async (coreResourceIds: string[], requiredExerciseIds: string[], email: string) => {
   const [rawResourceCompletions, rawExerciseCompletions] = await Promise.all([
     db.pg
       .select()
@@ -105,7 +105,7 @@ const getUserCompletions = async (coreResourceIds: string[], activeExerciseIds: 
       .from(exerciseResponsePgTable)
       .where(and(
         eq(exerciseResponsePgTable.email, email),
-        inArray(exerciseResponsePgTable.exerciseId, activeExerciseIds),
+        inArray(exerciseResponsePgTable.exerciseId, requiredExerciseIds),
         isNotNull(exerciseResponsePgTable.completedAt), // Only fetch completed exercises
       ))
       .orderBy(desc(exerciseResponsePgTable.createdAt)),
@@ -146,12 +146,12 @@ const getUserCompletions = async (coreResourceIds: string[], activeExerciseIds: 
 const calculateChunkProgress = (
   chunk: Chunk,
   coreResourceIds: Set<string>,
-  activeExerciseIds: Set<string>,
+  requiredExerciseIds: Set<string>,
   completedResourceIds: Set<string>,
   completedExerciseIds: Set<string>,
 ) => {
   const chunkResourceIds = chunk.chunkResources?.filter((id) => coreResourceIds.has(id)) ?? [];
-  const chunkExerciseIds = chunk.chunkExercises?.filter((id) => activeExerciseIds.has(id)) ?? [];
+  const chunkExerciseIds = chunk.chunkExercises?.filter((id) => requiredExerciseIds.has(id)) ?? [];
 
   const chunkCompletedResources = chunkResourceIds.filter((id) => completedResourceIds.has(id));
   const chunkCompletedExercises = chunkExerciseIds.filter((id) => completedExerciseIds.has(id));
@@ -166,7 +166,7 @@ const calculateChunkProgress = (
   };
 };
 
-const getCoreResourceAndActiveExerciseIds = async (chunks: Chunk[]) => {
+const getCoreResourceAndRequiredExerciseIds = async (chunks: Chunk[]) => {
   const allResourceIds = chunks.flatMap((c) => c.chunkResources ?? []);
   const allExerciseIds = chunks.flatMap((c) => c.chunkExercises ?? []);
 
@@ -177,12 +177,12 @@ const getCoreResourceAndActiveExerciseIds = async (chunks: Chunk[]) => {
   const coreResourceIds = coreResources.map((r) => r.id);
 
   const activeExercises = await db.pg
-    .select({ id: exerciseTable.pg.id })
+    .select({ id: exerciseTable.pg.id, isOptional: exerciseTable.pg.isOptional })
     .from(exerciseTable.pg)
     .where(and(eq(exerciseTable.pg.status, 'Active'), inArray(exerciseTable.pg.id, allExerciseIds)));
-  const activeExerciseIds = activeExercises.map((e) => e.id);
+  const requiredExerciseIds = activeExercises.filter((e) => !e.isOptional).map((e) => e.id);
 
-  return { coreResourceIds, activeExerciseIds };
+  return { coreResourceIds, requiredExerciseIds };
 };
 
 export const coursesRouter = router({
@@ -239,16 +239,18 @@ export const coursesRouter = router({
         : [];
 
       const referencedExerciseIds = allChunks.flatMap((c) => c.chunkExercises ?? []);
-      const activeExerciseIds = new Set<string>();
+      const requiredExerciseIds = new Set<string>();
       if (referencedExerciseIds.length > 0) {
         const activeExercises = await db.pg
-          .select({ id: exerciseTable.pg.id })
+          .select({ id: exerciseTable.pg.id, isOptional: exerciseTable.pg.isOptional })
           .from(exerciseTable.pg)
           .where(and(
             eq(exerciseTable.pg.status, 'Active'),
             inArray(exerciseTable.pg.id, referencedExerciseIds),
           ));
-        for (const e of activeExercises) activeExerciseIds.add(e.id);
+        for (const e of activeExercises) {
+          if (!e.isOptional) requiredExerciseIds.add(e.id);
+        }
       }
 
       // Calculate duration:
@@ -271,7 +273,7 @@ export const coursesRouter = router({
         const totalDuration = regularTime + optionMaxTime;
 
         const exerciseCount = [...new Set(chunks.flatMap((c) => c.chunkExercises ?? []))]
-          .filter((id) => activeExerciseIds.has(id)).length;
+          .filter((id) => requiredExerciseIds.has(id)).length;
 
         return {
           unitId: unit.id,
@@ -295,17 +297,17 @@ export const coursesRouter = router({
         .from(chunkTable.pg)
         .where(and(eq(chunkTable.pg.status, 'Active'), inArray(chunkTable.pg.unitId, unitIds)));
 
-      const { coreResourceIds, activeExerciseIds } = await getCoreResourceAndActiveExerciseIds(allChunks);
+      const { coreResourceIds, requiredExerciseIds } = await getCoreResourceAndRequiredExerciseIds(allChunks);
 
       const { resourceCompletions, exerciseCompletions } = await getUserCompletions(
         coreResourceIds,
-        activeExerciseIds,
+        requiredExerciseIds,
         ctx.auth.email,
       );
 
       // Build Sets for faster lookup
       const coreResourceIdSet = new Set(coreResourceIds);
-      const activeExerciseIdSet = new Set(activeExerciseIds);
+      const requiredExerciseIdSet = new Set(requiredExerciseIds);
       const completedResourceIdSet = new Set(resourceCompletions.map((c) => c.unitResourceId).filter((id): id is string => id != null));
       const completedExerciseIdSet = new Set(exerciseCompletions.map((e) => e.exerciseId));
 
@@ -319,14 +321,14 @@ export const coursesRouter = router({
           return calculateChunkProgress(
             chunk,
             coreResourceIdSet,
-            activeExerciseIdSet,
+            requiredExerciseIdSet,
             completedResourceIdSet,
             completedExerciseIdSet,
           );
         });
       }
 
-      const courseTotalCount = coreResourceIds.length + activeExerciseIds.length;
+      const courseTotalCount = coreResourceIds.length + requiredExerciseIds.length;
       const courseCompletedCount = completedResourceIdSet.size + completedExerciseIdSet.size;
       const percentage = courseTotalCount > 0 ? Math.round((courseCompletedCount / courseTotalCount) * 100) : 0;
 


### PR DESCRIPTION
# Description

Currently, optional exercises count towards course completion, which means that users have to pretend they complete them in order to get their certificate. This PR stops them from counting towards course completion and adopts the schema level isOptional field (rather than just relying on the title of the exercise).

Optional-ness is displayed in the UI by adding "[Optional]" to the start of the title. It first checks for any existing "[Optional]"/"(Optional)" etc values in exercise titles with a helper `maybeApplyOptionalPrefix`.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2648

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
