### PR TITLE
[chore] Drop vestigial autoNumberId columns from Postgres-only tables

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -302,7 +302,6 @@ export const createMockRound = (overrides: Partial<CourseRound> = {}): CourseRou
 };
 
 export const createMockResourceCompletion = (overrides: Partial<ResourceCompletion> = {}): ResourceCompletion => ({
-  autoNumberId: 1,
   email: '',
   feedback: null,
   id: MOCK_RESOURCE_COMPLETION_ID,

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -137,7 +137,6 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
             // If no existing item and isCompleted is true, add a new item
             newArray.push({
               id: unitResourceId,
-              autoNumberId: null,
               email: auth?.email ?? '',
               unitResourceId,
               feedback: updatedFields.feedback ?? '',

--- a/apps/website/src/components/courses/exercises/Exercise.stories.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.stories.tsx
@@ -45,7 +45,6 @@ const savedResponse = {
   completed: false,
   completedAt: null,
   createdAt: null,
-  autoNumberId: null,
   userId: null,
 };
 

--- a/apps/website/src/components/courses/exercises/Exercise.test.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.test.tsx
@@ -102,7 +102,6 @@ describe('Exercise', () => {
     server.use(trpcMsw.exercises.getExerciseResponse.query(() => ({
       id: 'resp-1',
       email: 'test@example.com',
-      autoNumberId: null,
       completedAt: null,
       createdAt: null,
       exerciseId: 'ex1',
@@ -121,7 +120,6 @@ describe('Exercise', () => {
     server.use(trpcMsw.exercises.getExerciseResponse.query(() => ({
       id: 'resp-2',
       email: 'test@example.com',
-      autoNumberId: null,
       completedAt: null,
       createdAt: null,
       exerciseId: 'ex1',
@@ -144,7 +142,6 @@ describe('Exercise', () => {
       trpcMsw.exercises.getExerciseResponse.query(() => ({
         id: 'resp-3',
         email: 'test@example.com',
-        autoNumberId: null,
         completedAt: null,
         createdAt: null,
         exerciseId: 'ex1',

--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -103,7 +103,6 @@ const Exercise: React.FC<ExerciseProps> = ({
         response: newData.response,
         completedAt: newCompletedAt,
         createdAt: previousResponse?.createdAt ?? null,
-        autoNumberId: previousResponse?.autoNumberId ?? null,
         userId: previousResponse?.userId ?? null,
       });
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -151,7 +151,6 @@ export const exerciseResponsePgTable = pgTable('exercise_response', {
   response: text().notNull(),
   createdAt: text(),
   completedAt: text(),
-  autoNumberId: numeric({ mode: 'number' }),
   userId: text().array(),
 });
 
@@ -1539,7 +1538,6 @@ export const resourceCompletionPgTable = pgTable('resource_completion', {
   email: text(),
   feedback: text(),
   resourceFeedback: numeric({ mode: 'number' }).$type<ResourceFeedbackValue>().default(RESOURCE_FEEDBACK.NO_RESPONSE),
-  autoNumberId: numeric({ mode: 'number' }),
   resourceId: text().array(),
   // Points at courseBuilderUserTable (the Course-builder-base sync of User)
   createdByUserId: text().array(),


### PR DESCRIPTION
# Description

Follow-up cleanup for #2639. After #2580 moved `exercise_response` and `resource_completion` into Postgres-only tables (`pgTable`, no longer synced from Airtable), their `autoNumberId` columns are vestigial: nothing writes them anymore (new rows leave them null) and nothing reads them for sorting. The two `getFirstFromPg` calls on `exercise_response` already pass an explicit `sortBy: createdAt`, and `resource_completion` is queried with explicit column lists ordered by `createdAt`.

This drops the column from both table definitions and removes the now-dead references in the optimistic-update literals, test fixtures, and the Storybook story.

## Issue

Fixes #2650

## Developer checklist

- [x] N/A Front-end code follows Component Accessibility Checklist (for Testing)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
