### PR TITLE
Decommission in-cluster airtable-sync-pg database

### DIFF
--- a/apps/infra/README.md
+++ b/apps/infra/README.md
@@ -112,7 +112,7 @@ Bump `version` in [vke.ts](./src/vultr/vke.ts) to the version offered in the Vul
 - Drive upgrades through Pulumi; don't let Vultr auto-upgrade. A forced upgrade leaves [vke.ts](./src/vultr/vke.ts) stale and drifts Pulumi state from reality (see PRs #1267 / #1268).
 - `pulumi preview` should show `update`, not `replace` — a replace destroys the prod cluster.
 - Don't blindly take Vultr's newest version. Check our operators support it first — especially CloudNativePG ([supported releases](https://cloudnative-pg.io/docs/current/supported_releases/)), which runs the in-cluster DBs and often lags the newest Kubernetes by a release. Target the newest version they all support, bumping charts (in separate prior PRs) as needed.
-- The cluster is single-node, so the upgrade briefly takes everything on-cluster down (apps + in-cluster `keycloak-pg`/`grafana-pg`/`airtable-sync-pg`; managed `appPg` is unaffected). Merge late at night and watch through — **there's no rollback**, Kubernetes can't downgrade a minor.
+- The cluster is single-node, so the upgrade briefly takes everything on-cluster down (apps + in-cluster `keycloak-pg`/`grafana-pg`; managed `appPg` is unaffected). Merge late at night and watch through — **there's no rollback**, Kubernetes can't downgrade a minor.
 
 **Clearing the upgrade preflight.** Vultr refuses the upgrade until the cluster can tolerate disruptions. Two blockers:
 

--- a/apps/infra/src/k8s/ingress.ts
+++ b/apps/infra/src/k8s/ingress.ts
@@ -30,10 +30,5 @@ export const ingressNginx = new k8s.helm.v3.Release('ingress-nginx', {
         default: 'true',
       },
     },
-    // This enables public connections to the airtable-sync-pg database
-    // For others, use `./tools/connectDb.sh` or `kubectl port-forward svc/postgres-cluster-rw 5433:5432`
-    tcp: {
-      5432: 'default/airtable-sync-pg-rw:5432',
-    },
   },
 }, { provider });

--- a/apps/infra/src/k8s/postgres.ts
+++ b/apps/infra/src/k8s/postgres.ts
@@ -50,22 +50,6 @@ export const grafanaPg = new k8s.apiextensions.CustomResource('grafana-pg', {
   },
 }, { provider, dependsOn: [cloudNativePg] });
 
-export const airtableSyncPg = new k8s.apiextensions.CustomResource('airtable-sync-pg', {
-  apiVersion: 'postgresql.cnpg.io/v1',
-  kind: 'Cluster',
-  metadata: {
-    name: 'airtable-sync-pg',
-  },
-  spec: {
-    instances: 1,
-    // Disabled deliberately. See keycloak-pg note above.
-    enablePDB: false,
-    storage: {
-      size: '10Gi',
-    },
-  },
-}, { provider, dependsOn: [cloudNativePg] });
-
 export type PgConnectionDetails = {
   /** @example 'some-pg-rw' */
   host: Input<string>;


### PR DESCRIPTION
# Description

Apps and pg-sync-service have been cut over to the managed appPg, so the in-cluster CNPG replica is no longer read or written. Remove the cluster and the public TCP 5432 ingress forward that exposed it.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2644

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
