### PR TITLE
[refactor] Read resource completion status from completedAt, not isCompleted

### DIFF
--- a/apps/website/src/components/courses/ResourceListItem.test.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.test.tsx
@@ -271,7 +271,7 @@ describe('ResourceListItem - Optimistic Updates', () => {
       expect(screen.getByLabelText('Mark as incomplete')).toBeInTheDocument();
     });
 
-    resolveMutation({ ...mockResourceCompletion, isCompleted: true });
+    resolveMutation({ ...mockResourceCompletion, completedAt: '2024-01-01T00:00:00.000Z' });
 
     // UI stays in same state after mutation resolves
     await waitFor(() => {
@@ -283,7 +283,7 @@ describe('ResourceListItem - Optimistic Updates', () => {
     const user = userEvent.setup();
 
     // Start with a completed resource so we can see the feedback buttons
-    const completedMock = { ...mockResourceCompletion, isCompleted: true };
+    const completedMock = { ...mockResourceCompletion, completedAt: '2024-01-01T00:00:00.000Z' };
 
     let resolveMutation: (value: typeof completedMock) => void = () => {};
     const mutationPendingPromise = new Promise<typeof completedMock>((resolve) => {
@@ -332,7 +332,7 @@ describe('ResourceListItem - Optimistic Updates', () => {
 
     server.use(trpcMsw.resources.saveResourceCompletion.mutation(async () => {
       await mutationPendingPromise; // This line will throw when we call rejectMutation()
-      const result = { ...mockResourceCompletion, isCompleted: true };
+      const result = { ...mockResourceCompletion, completedAt: '2024-01-01T00:00:00.000Z' };
       return {
         ...result,
         feedback: result.feedback?.trimEnd(),

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -125,6 +125,10 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
 
           const { unitResourceId, ...updatedFields } = newData;
 
+          const completedAtUpdate = newData.isCompleted === undefined
+            ? {}
+            : { completedAt: newData.isCompleted ? new Date().toISOString() : null };
+
           const existingIndex = oldData.findIndex((item) => item.unitResourceId === resource.id);
 
           if (newArray[existingIndex]) {
@@ -132,6 +136,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
             newArray[existingIndex] = {
               ...newArray[existingIndex],
               ...updatedFields,
+              ...completedAtUpdate,
             };
           } else if (newData.isCompleted) {
             // If no existing item and isCompleted is true, add a new item
@@ -154,7 +159,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
       );
 
       // Optimistically update overall course progress
-      const isCompletionChange = newData.isCompleted !== undefined && newData.isCompleted !== (resourceCompletion?.isCompleted ?? false);
+      const isCompletionChange = newData.isCompleted !== undefined && newData.isCompleted !== (resourceCompletion?.completedAt != null);
       const previousCourseProgress = isCompletionChange ? await optimisticallyUpdateCourseProgress(utils, courseSlug, unitNumber, chunkIndex, newData.isCompleted ? 1 : -1) : undefined;
 
       return { previousQueriesData, previousCourseProgress };
@@ -171,7 +176,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
   // Only use mutation variables if mutation hasn't failed (to support rollback on error)
   const isCompleted = (!saveCompletionMutation.isError && saveCompletionMutation.variables?.isCompleted !== undefined)
     ? saveCompletionMutation.variables.isCompleted
-    : (resourceCompletion?.isCompleted ?? false);
+    : (resourceCompletion?.completedAt != null);
   const resourceFeedback = (!saveCompletionMutation.isError && saveCompletionMutation.variables?.resourceFeedback !== undefined)
     ? saveCompletionMutation.variables.resourceFeedback
     : (resourceCompletion?.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE);

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -95,7 +95,7 @@ const getUserCompletions = async (coreResourceIds: string[], requiredExerciseIds
       .where(and(
         eq(resourceCompletionPgTable.email, email),
         inArray(resourceCompletionPgTable.unitResourceId, coreResourceIds),
-        eq(resourceCompletionPgTable.isCompleted, true), // Only fetch completed resources
+        isNotNull(resourceCompletionPgTable.completedAt), // Only fetch completed resources
       ))
       .orderBy(desc(resourceCompletionPgTable.createdAt)),
 

--- a/libraries/computed-airtable-fields/src/definitions.test.ts
+++ b/libraries/computed-airtable-fields/src/definitions.test.ts
@@ -15,6 +15,8 @@ import {
 } from 'vitest';
 import { computedAirtableFieldDefinitions } from './definitions';
 
+const COMPLETED_AT = '2024-01-01T00:00:00.000Z';
+
 let db: PgAirtableDb;
 let testDb: TestPgAirtableDb;
 
@@ -81,14 +83,14 @@ describe('resource.computedNumCompletions', () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
     await testDb.insert(resourceTable, { id: 'res-2' });
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c1', email: 'a@x', isCompleted: true, resourceId: ['res-1'],
+      id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'],
     });
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c2', email: 'b@x', isCompleted: true, resourceId: ['res-1', 'res-2'],
+      id: 'c2', email: 'b@x', completedAt: COMPLETED_AT, resourceId: ['res-1', 'res-2'],
     });
-    // Not counted: isCompleted=false
+    // Not counted: not completed (completedAt null)
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c3', email: 'c@x', isCompleted: false, resourceId: ['res-1'],
+      id: 'c3', email: 'c@x', resourceId: ['res-1'],
     });
 
     const result = await compute()(db, ['res-1', 'res-2']);
@@ -108,21 +110,21 @@ describe('resource.computedAverageRating', () => {
   test('returns mean of resourceFeedback over completed rows, ignoring NO_RESPONSE and null', async () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c1', email: 'a@x', isCompleted: true, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
+      id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
     });
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c2', email: 'b@x', isCompleted: true, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
+      id: 'c2', email: 'b@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
     });
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c3', email: 'c@x', isCompleted: true, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
+      id: 'c3', email: 'c@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
     });
     // Ignored: NO_RESPONSE
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c4', email: 'd@x', isCompleted: true, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
+      id: 'c4', email: 'd@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
     });
-    // Ignored: rated but then un-completed (isCompleted=false), e.g. user rated then unticked the resource
+    // Ignored: rated but then un-completed (completedAt null), e.g. user rated then unticked the resource
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c5', email: 'e@x', isCompleted: false, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
+      id: 'c5', email: 'e@x', resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
     });
 
     const result = await compute()(db, ['res-1']);
@@ -133,7 +135,7 @@ describe('resource.computedAverageRating', () => {
   test('returns null when no ratings exist for a resource', async () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
     await testDb.pg.insert(resourceCompletionPgTable).values({
-      id: 'c1', email: 'a@x', isCompleted: true, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
+      id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
     });
     const result = await compute()(db, ['res-1']);
     expect(result['res-1']).toBeNull();

--- a/libraries/computed-airtable-fields/src/definitions.ts
+++ b/libraries/computed-airtable-fields/src/definitions.ts
@@ -2,7 +2,6 @@ import {
   and,
   arrayOverlaps,
   count,
-  eq,
   exerciseResponsePgTable,
   exerciseTable,
   inArray,
@@ -45,7 +44,7 @@ export const computedAirtableFieldDefinitions: ComputedAirtableFieldGroup[] = [
           .select({ rid, n: count() })
           .from(resourceCompletionPgTable)
           .where(and(
-            eq(resourceCompletionPgTable.isCompleted, true),
+            isNotNull(resourceCompletionPgTable.completedAt),
             arrayOverlaps(resourceCompletionPgTable.resourceId, ids),
           ))
           .groupBy(rid);
@@ -70,7 +69,7 @@ export const computedAirtableFieldDefinitions: ComputedAirtableFieldGroup[] = [
           .from(resourceCompletionPgTable)
           .where(and(
             // Ratings on uncompleted rows are ignored — same notion of "exists" as computedNumCompletions.
-            eq(resourceCompletionPgTable.isCompleted, true),
+            isNotNull(resourceCompletionPgTable.completedAt),
             arrayOverlaps(resourceCompletionPgTable.resourceId, ids),
             // != NO_RESPONSE also excludes NULL (NULL != 0 → UNKNOWN, filtered out).
             ne(resourceCompletionPgTable.resourceFeedback, RESOURCE_FEEDBACK.NO_RESPONSE),


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Switches all reads of resource_completion to derive completion from completedAt (IS NOT NULL) instead of the isCompleted boolean: the course-progress query, the computed Airtable fields (num completions / average rating), and the ResourceListItem display + optimistic cache. The write path still sets both columns.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2700

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories