### PR TITLE
[chore] isCompleted -> completedAt migration on resource completion: Deprecate and stop writing isCompleted

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -305,7 +305,6 @@ export const createMockResourceCompletion = (overrides: Partial<ResourceCompleti
   email: '',
   feedback: null,
   id: MOCK_RESOURCE_COMPLETION_ID,
-  isCompleted: false,
   resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
   unitResourceId: MOCK_RESOURCE_ID,
   resourceId: null,

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -146,7 +146,6 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
               unitResourceId,
               feedback: updatedFields.feedback ?? '',
               resourceFeedback: updatedFields.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
-              isCompleted: updatedFields.isCompleted ?? false,
               resourceId: null,
               createdByUserId: null,
               createdAt: new Date().toISOString(),

--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -28,7 +28,6 @@ describe('resources.saveResourceCompletion', () => {
 
     expect(result).toMatchObject({
       unitResourceId: 'ur-1',
-      isCompleted: true,
       resourceId: ['resource-1'],
       createdByUserId: ['cb-user-1'],
     });
@@ -50,7 +49,6 @@ describe('resources.saveResourceCompletion', () => {
       id: 'rc-1',
       email: CALLER_EMAIL,
       unitResourceId: 'ur-1',
-      isCompleted: false,
       resourceId: ['resource-original'],
       createdByUserId: ['cb-user-original'],
     });
@@ -62,7 +60,6 @@ describe('resources.saveResourceCompletion', () => {
 
     expect(result).toMatchObject({
       id: 'rc-1',
-      isCompleted: true,
       resourceId: ['resource-original'],
       createdByUserId: ['cb-user-original'],
     });
@@ -83,7 +80,6 @@ describe('resources.saveResourceCompletion', () => {
       id: 'rc-1',
       email: CALLER_EMAIL,
       unitResourceId: 'ur-1',
-      isCompleted: true,
       completedAt: '2026-01-01T00:00:00.000Z',
     });
 
@@ -100,7 +96,6 @@ describe('resources.saveResourceCompletion', () => {
       id: 'rc-1',
       email: CALLER_EMAIL,
       unitResourceId: 'ur-1',
-      isCompleted: true,
       completedAt: '2026-01-01T00:00:00.000Z',
     });
 

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -68,7 +68,7 @@ export const resourcesRouter = router({
       ]);
 
       let completedAt: string | null | undefined;
-      if (input.isCompleted === true && resourceCompletion?.isCompleted !== true) {
+      if (input.isCompleted === true && resourceCompletion?.completedAt == null) {
         completedAt = new Date().toISOString();
       } else if (input.isCompleted === false) {
         completedAt = null;
@@ -78,7 +78,6 @@ export const resourcesRouter = router({
         ? await db.pg
           .update(resourceCompletionPgTable.pg)
           .set({
-            isCompleted: input.isCompleted ?? resourceCompletion.isCompleted,
             completedAt: completedAt !== undefined ? completedAt : resourceCompletion.completedAt,
             feedback: input.feedback ?? resourceCompletion.feedback,
             resourceFeedback: input.resourceFeedback ?? resourceCompletion.resourceFeedback,
@@ -90,7 +89,6 @@ export const resourcesRouter = router({
           .values({
             email: ctx.auth.email,
             unitResourceId: input.unitResourceId,
-            isCompleted: input.isCompleted ?? false,
             completedAt: completedAt ?? null,
             feedback: input.feedback ?? '',
             resourceFeedback: input.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -571,7 +571,6 @@ describe('resource_completed', () => {
       email,
       unitResourceId,
       resourceId: resourceId ? [resourceId] : null,
-      isCompleted: completedAt != null,
       createdAt: '2026-06-01T00:00:00.000Z',
       completedAt,
     });

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1537,7 +1537,6 @@ export const resourceCompletionPgTable = deprecationSafePgTable('resource_comple
   columns: {
     id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
     unitResourceId: text(),
-    isCompleted: boolean(),
     email: text(),
     feedback: text(),
     resourceFeedback: numeric({ mode: 'number' }).$type<ResourceFeedbackValue>().default(RESOURCE_FEEDBACK.NO_RESPONSE),
@@ -1546,6 +1545,9 @@ export const resourceCompletionPgTable = deprecationSafePgTable('resource_comple
     createdByUserId: text().array(),
     createdAt: text(),
     completedAt: text(),
+  },
+  deprecatedColumns: {
+    isCompleted: boolean(),
   },
 });
 


### PR DESCRIPTION
# Description

The write path now sets completedAt exclusively (reads already moved off isCompleted in #2703). The isCompleted column will be deleted in a follow-up.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2700

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories