### PR TITLE
Add safePgTable wrapper for pgTable, to support deprecatedColumns

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,21 @@ reviews:
   suggested_reviewers: false
   in_progress_fortune: false
   poem: false
+  path_instructions:
+    - path: "libraries/db/src/schema.ts"
+      instructions: |
+        These tables are synced to Postgres by pg-sync-service, which pushes schema changes before
+        the website adopts the new code. Comment ONLY when a change appears to skip the migration
+        process below; stay silent on additive or unrelated edits.
+        - A column is deleted outright instead of first being moved into the table's
+          `deprecatedColumns`. Safe removal is two PRs: move to `deprecatedColumns` (nullable),
+          merge and deploy to prod, then delete.
+        - A column key is renamed in one step rather than add-new -> migrate-consumers ->
+          deprecate-old.
+        - For plain `pgTable`s, which don't support deprecatedColumns, still comment if a column
+          is deleted. Prompt the user to explain why it is safe to drop the column straight away,
+          rather than first migrating to `deprecationSafePgTable` (either approach may be acceptable).
+        See CLAUDE.md "Database / schema changes".
   auto_review:
     enabled: true
     ignore_title_keywords:

--- a/apps/pg-sync-service/src/lib/schema-sync.test.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
-  SafePgTable, isDeprecationSafeTable, isTable, sql,
+  DeprecationSafePgTable, isDeprecationSafeTable, isTable, sql,
 } from '@bluedot/db';
 // eslint-disable-next-line import/no-extraneous-dependencies -- drizzle-orm is transitive via @bluedot/db; only needed to build a table fixture below
 import { text } from 'drizzle-orm/pg-core';
@@ -158,8 +158,8 @@ describe('statementsRequireFullSync against real drizzle-kit push output', () =>
   });
 });
 
-describe('cleanupRemovedColumns and SafePgTable deprecated columns', () => {
-  // A SafePgTable keeps deprecated columns out of `.pg` (active) but present in
+describe('cleanupRemovedColumns and DeprecationSafePgTable deprecated columns', () => {
+  // A DeprecationSafePgTable keeps deprecated columns out of `.pg` (active) but present in
   // `.pgWithDeprecatedColumns`. runDrizzlePush feeds the with-deprecated variant to
   // cleanupRemovedColumns, so the deprecated column must survive — that's the whole
   // point of the wrapper. To isolate this from the shared schema, we create a
@@ -178,7 +178,7 @@ describe('cleanupRemovedColumns and SafePgTable deprecated columns', () => {
   };
 
   test('keeps the deprecated column when given the with-deprecated variant', async () => {
-    const table = new SafePgTable('safe_pg_cleanup_test', {
+    const table = new DeprecationSafePgTable('safe_pg_cleanup_test', {
       columns: { active: text() },
       deprecatedColumns: { legacy: text() },
     });
@@ -194,7 +194,7 @@ describe('cleanupRemovedColumns and SafePgTable deprecated columns', () => {
   });
 
   test('drops the deprecated column if only the active variant is passed (proving the variant matters)', async () => {
-    const table = new SafePgTable('safe_pg_cleanup_test', {
+    const table = new DeprecationSafePgTable('safe_pg_cleanup_test', {
       columns: { active: text() },
       deprecatedColumns: { legacy: text() },
     });

--- a/apps/pg-sync-service/src/lib/schema-sync.test.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from 'vitest';
-import { PgAirtableTable, isTable } from '@bluedot/db';
+import {
+  SafePgTable, isSchemaTable, isTable, sql,
+} from '@bluedot/db';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { text } from 'drizzle-orm/pg-core';
 import { pushSchema } from 'drizzle-kit/api';
 import * as schema from '@bluedot/db/src/schema';
-import { statementsRequireFullSync } from './schema-sync';
+import { statementsRequireFullSync, cleanupRemovedColumns } from './schema-sync';
 import { db } from './db';
 
 describe('statementsRequireFullSync', () => {
@@ -131,11 +135,10 @@ describe('statementsRequireFullSync against real drizzle-kit push output', () =>
   // against drift in drizzle's real output format, not just hand-written strings.
   test('re-pushing the unchanged schema produces only default churn and requires no full sync', async () => {
     const pgTables = Object.fromEntries(Object.entries(schema)
-      .filter(([, value]) => value instanceof PgAirtableTable || isTable(value))
+      .filter(([, value]) => isSchemaTable(value) || isTable(value))
       .map(([name, value]) => [
         name,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value instanceof PgAirtableTable ? ((value as any).pgWithDeprecatedColumns ?? value.pg) : value,
+        isSchemaTable(value) ? (value.pgWithDeprecatedColumns ?? value.pg) : value,
       ]));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -152,5 +155,57 @@ describe('statementsRequireFullSync against real drizzle-kit push output', () =>
     }
 
     expect(statementsRequireFullSync(result.statementsToExecute)).toBe(false);
+  });
+});
+
+describe('cleanupRemovedColumns and SafePgTable deprecated columns', () => {
+  // A SafePgTable keeps deprecated columns out of `.pg` (active) but present in
+  // `.pgWithDeprecatedColumns`. runDrizzlePush feeds the with-deprecated variant to
+  // cleanupRemovedColumns, so the deprecated column must survive — that's the whole
+  // point of the wrapper (a still-released consumer keeps SELECTing it). To isolate
+  // this from the shared schema, we create a throwaway physical table directly.
+  const createPhysicalTable = async (): Promise<void> => {
+    await db.pg.execute(sql`DROP TABLE IF EXISTS safe_pg_cleanup_test`);
+    await db.pg.execute(sql`CREATE TABLE safe_pg_cleanup_test ("active" text, "legacy" text)`);
+  };
+
+  const getColumns = async (): Promise<Set<string>> => {
+    const cols = await db.pg.execute(sql`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'safe_pg_cleanup_test' AND table_schema = 'public'
+    `);
+    return new Set(cols.rows.map((row: { column_name: string }) => row.column_name));
+  };
+
+  test('keeps the deprecated column when given the with-deprecated variant', async () => {
+    const table = new SafePgTable('safe_pg_cleanup_test', {
+      columns: { active: text() },
+      deprecatedColumns: { legacy: text() },
+    });
+    await createPhysicalTable();
+
+    await cleanupRemovedColumns({ table: table.pgWithDeprecatedColumns! });
+
+    const colNames = await getColumns();
+    expect(colNames.has('active')).toBe(true);
+    expect(colNames.has('legacy')).toBe(true);
+
+    await db.pg.execute(sql`DROP TABLE IF EXISTS safe_pg_cleanup_test`);
+  });
+
+  test('drops the deprecated column if only the active variant is passed (proving the variant matters)', async () => {
+    const table = new SafePgTable('safe_pg_cleanup_test', {
+      columns: { active: text() },
+      deprecatedColumns: { legacy: text() },
+    });
+    await createPhysicalTable();
+
+    await cleanupRemovedColumns({ table: table.pg });
+
+    const colNames = await getColumns();
+    expect(colNames.has('active')).toBe(true);
+    expect(colNames.has('legacy')).toBe(false);
+
+    await db.pg.execute(sql`DROP TABLE IF EXISTS safe_pg_cleanup_test`);
   });
 });

--- a/apps/pg-sync-service/src/lib/schema-sync.test.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import {
-  SafePgTable, isSchemaTable, isTable, sql,
+  SafePgTable, isDeprecationSafeTable, isTable, sql,
 } from '@bluedot/db';
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line import/no-extraneous-dependencies -- drizzle-orm is transitive via @bluedot/db; only needed to build a table fixture below
 import { text } from 'drizzle-orm/pg-core';
 import { pushSchema } from 'drizzle-kit/api';
 import * as schema from '@bluedot/db/src/schema';
@@ -135,10 +135,10 @@ describe('statementsRequireFullSync against real drizzle-kit push output', () =>
   // against drift in drizzle's real output format, not just hand-written strings.
   test('re-pushing the unchanged schema produces only default churn and requires no full sync', async () => {
     const pgTables = Object.fromEntries(Object.entries(schema)
-      .filter(([, value]) => isSchemaTable(value) || isTable(value))
+      .filter(([, value]) => isDeprecationSafeTable(value) || isTable(value))
       .map(([name, value]) => [
         name,
-        isSchemaTable(value) ? (value.pgWithDeprecatedColumns ?? value.pg) : value,
+        isDeprecationSafeTable(value) ? (value.pgWithDeprecatedColumns ?? value.pg) : value,
       ]));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -162,9 +162,9 @@ describe('cleanupRemovedColumns and SafePgTable deprecated columns', () => {
   // A SafePgTable keeps deprecated columns out of `.pg` (active) but present in
   // `.pgWithDeprecatedColumns`. runDrizzlePush feeds the with-deprecated variant to
   // cleanupRemovedColumns, so the deprecated column must survive — that's the whole
-  // point of the wrapper (a still-released consumer keeps SELECTing it). To isolate
-  // this from the shared schema, we create a throwaway physical table directly.
-  const createPhysicalTable = async (): Promise<void> => {
+  // point of the wrapper. To isolate this from the shared schema, we create a
+  // throwaway physical table directly.
+  const createTestTable = async (): Promise<void> => {
     await db.pg.execute(sql`DROP TABLE IF EXISTS safe_pg_cleanup_test`);
     await db.pg.execute(sql`CREATE TABLE safe_pg_cleanup_test ("active" text, "legacy" text)`);
   };
@@ -182,7 +182,7 @@ describe('cleanupRemovedColumns and SafePgTable deprecated columns', () => {
       columns: { active: text() },
       deprecatedColumns: { legacy: text() },
     });
-    await createPhysicalTable();
+    await createTestTable();
 
     await cleanupRemovedColumns({ table: table.pgWithDeprecatedColumns! });
 
@@ -198,7 +198,7 @@ describe('cleanupRemovedColumns and SafePgTable deprecated columns', () => {
       columns: { active: text() },
       deprecatedColumns: { legacy: text() },
     });
-    await createPhysicalTable();
+    await createTestTable();
 
     await cleanupRemovedColumns({ table: table.pg });
 

--- a/apps/pg-sync-service/src/lib/schema-sync.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.ts
@@ -2,9 +2,9 @@ import { logger } from '@bluedot/ui/src/api';
 import {
   getTableName, metaTable, sql, PgAirtableTable,
   isTable,
-  isSchemaTable,
+  isDeprecationSafeTable,
   getTableColumns,
-  type SchemaTable,
+  type DeprecationSafeTable,
 } from '@bluedot/db';
 import * as schema from '@bluedot/db/src/schema';
 import { pushSchema } from 'drizzle-kit/api';
@@ -16,7 +16,7 @@ import env from '../env';
  * Cleans up columns that exist in the database but are no longer in the schema definition.
  * This prevents migration hangs caused by simultaneous add/drop operations (e.g., column renames).
  */
-export async function cleanupRemovedColumns(pgTables: Record<string, SchemaTable['pg']>): Promise<void> {
+export async function cleanupRemovedColumns(pgTables: Record<string, DeprecationSafeTable['pg']>): Promise<void> {
   // Get current schema definition - what columns SHOULD exist
   const expectedColumns = new Map<string, Set<string>>();
 
@@ -68,7 +68,7 @@ export function statementsRequireFullSync(statements: string[]): boolean {
  * Wraps pushSchema with a timeout to prevent hanging migrations
  * Returns true if schema changes warranting a full data sync were applied, false otherwise
  */
-async function pushSchemaWithTimeout(pgTables: Record<string, SchemaTable['pg']>): Promise<boolean> {
+async function pushSchemaWithTimeout(pgTables: Record<string, DeprecationSafeTable['pg']>): Promise<boolean> {
   const timeoutPromise = new Promise<never>((_, reject) => {
     setTimeout(() => {
       reject(new Error('Schema push migration hung after 120 seconds. This is likely because you have made a change that breaks drizzle\'s pushSchema function. Also see https://github.com/drizzle-team/drizzle-orm/issues/4651.'));
@@ -97,17 +97,17 @@ async function pushSchemaWithTimeout(pgTables: Record<string, SchemaTable['pg']>
  */
 async function runDrizzlePush(): Promise<boolean> {
   const pgTables = Object.fromEntries(Object.entries(schema)
-    .filter(([, value]) => isTable(value) || isSchemaTable(value))
+    .filter(([, value]) => isTable(value) || isDeprecationSafeTable(value))
     .map(([name, value]) => {
       // PgAirtableTable and SafePgTable both expose `.pg` plus an optional
       // `.pgWithDeprecatedColumns`. Pushing the with-deprecated variant when
       // present keeps deprecated columns in the physical table so a still-released
       // consumer can keep SELECTing them during a deploy window.
-      if (isSchemaTable(value)) {
-        return [name, (value.pgWithDeprecatedColumns ?? value.pg) as unknown as SchemaTable['pg']];
+      if (isDeprecationSafeTable(value)) {
+        return [name, (value.pgWithDeprecatedColumns ?? value.pg) as unknown as DeprecationSafeTable['pg']];
       }
 
-      return [name, value as unknown as SchemaTable['pg']];
+      return [name, value as unknown as DeprecationSafeTable['pg']];
     }));
   logger.info(`[schema-sync] Running schema push with tables: ${Object.keys(pgTables).join(', ')}`);
 

--- a/apps/pg-sync-service/src/lib/schema-sync.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.ts
@@ -99,7 +99,7 @@ async function runDrizzlePush(): Promise<boolean> {
   const pgTables = Object.fromEntries(Object.entries(schema)
     .filter(([, value]) => isTable(value) || isDeprecationSafeTable(value))
     .map(([name, value]) => {
-      // PgAirtableTable and SafePgTable both expose `.pg` plus an optional
+      // PgAirtableTable and DeprecationSafePgTable both expose `.pg` plus an optional
       // `.pgWithDeprecatedColumns`. Pushing the with-deprecated variant when
       // present keeps deprecated columns in the physical table so a still-released
       // consumer can keep SELECTing them during a deploy window.

--- a/apps/pg-sync-service/src/lib/schema-sync.ts
+++ b/apps/pg-sync-service/src/lib/schema-sync.ts
@@ -2,7 +2,9 @@ import { logger } from '@bluedot/ui/src/api';
 import {
   getTableName, metaTable, sql, PgAirtableTable,
   isTable,
+  isSchemaTable,
   getTableColumns,
+  type SchemaTable,
 } from '@bluedot/db';
 import * as schema from '@bluedot/db/src/schema';
 import { pushSchema } from 'drizzle-kit/api';
@@ -14,7 +16,7 @@ import env from '../env';
  * Cleans up columns that exist in the database but are no longer in the schema definition.
  * This prevents migration hangs caused by simultaneous add/drop operations (e.g., column renames).
  */
-async function cleanupRemovedColumns(pgTables: Record<string, PgAirtableTable['pg']>): Promise<void> {
+export async function cleanupRemovedColumns(pgTables: Record<string, SchemaTable['pg']>): Promise<void> {
   // Get current schema definition - what columns SHOULD exist
   const expectedColumns = new Map<string, Set<string>>();
 
@@ -66,7 +68,7 @@ export function statementsRequireFullSync(statements: string[]): boolean {
  * Wraps pushSchema with a timeout to prevent hanging migrations
  * Returns true if schema changes warranting a full data sync were applied, false otherwise
  */
-async function pushSchemaWithTimeout(pgTables: Record<string, PgAirtableTable['pg']>): Promise<boolean> {
+async function pushSchemaWithTimeout(pgTables: Record<string, SchemaTable['pg']>): Promise<boolean> {
   const timeoutPromise = new Promise<never>((_, reject) => {
     setTimeout(() => {
       reject(new Error('Schema push migration hung after 120 seconds. This is likely because you have made a change that breaks drizzle\'s pushSchema function. Also see https://github.com/drizzle-team/drizzle-orm/issues/4651.'));
@@ -95,14 +97,17 @@ async function pushSchemaWithTimeout(pgTables: Record<string, PgAirtableTable['p
  */
 async function runDrizzlePush(): Promise<boolean> {
   const pgTables = Object.fromEntries(Object.entries(schema)
-    .filter(([, value]) => isTable(value) || 'pg' in value)
+    .filter(([, value]) => isTable(value) || isSchemaTable(value))
     .map(([name, value]) => {
-      if (value instanceof PgAirtableTable) {
-        // Use pgWithDeprecatedColumns when available to prevent Drizzle from dropping deprecated columns
-        return [name, (value.pgWithDeprecatedColumns ?? value.pg) as unknown as PgAirtableTable['pg']];
+      // PgAirtableTable and SafePgTable both expose `.pg` plus an optional
+      // `.pgWithDeprecatedColumns`. Pushing the with-deprecated variant when
+      // present keeps deprecated columns in the physical table so a still-released
+      // consumer can keep SELECTing them during a deploy window.
+      if (isSchemaTable(value)) {
+        return [name, (value.pgWithDeprecatedColumns ?? value.pg) as unknown as SchemaTable['pg']];
       }
 
-      return [name, value as unknown as PgAirtableTable['pg']];
+      return [name, value as unknown as SchemaTable['pg']];
     }));
   logger.info(`[schema-sync] Running schema push with tables: ${Object.keys(pgTables).join(', ')}`);
 

--- a/apps/website/src/__tests__/pages/admin/exercises.test.tsx
+++ b/apps/website/src/__tests__/pages/admin/exercises.test.tsx
@@ -61,13 +61,13 @@ async function seedTargetResponses() {
   await testDb.insert(exerciseTable, {
     id: 'ex-b1', courseId: 'course-b', unitId: 'unit-b', title: 'Governance prompt', exerciseNumber: '1.1', type: 'Free text',
   });
-  await testDb.pg.insert(exerciseResponsePgTable).values({
+  await testDb.pg.insert(exerciseResponsePgTable.pg).values({
     id: 'resp-a1', email: TARGET_EMAIL, exerciseId: 'ex-a1', response: 'thinking about safety mechanisms', createdAt: '2026-04-30T10:00:00Z', completedAt: '2026-05-01T10:00:00Z',
   });
-  await testDb.pg.insert(exerciseResponsePgTable).values({
+  await testDb.pg.insert(exerciseResponsePgTable.pg).values({
     id: 'resp-a2', email: TARGET_EMAIL, exerciseId: 'ex-a2', response: 'draft in progress', createdAt: '2026-05-03T10:00:00Z', completedAt: null,
   });
-  await testDb.pg.insert(exerciseResponsePgTable).values({
+  await testDb.pg.insert(exerciseResponsePgTable.pg).values({
     id: 'resp-b1', email: TARGET_EMAIL, exerciseId: 'ex-b1', response: 'policy considerations are important', createdAt: '2026-04-29T10:00:00Z', completedAt: '2026-05-02T10:00:00Z',
   });
 }

--- a/apps/website/src/server/routers/admin.ts
+++ b/apps/website/src/server/routers/admin.ts
@@ -145,10 +145,10 @@ export const adminRouter = router({
 
       const userCourses = await db.pg
         .selectDistinct({ courseId: exerciseTable.pg.courseId })
-        .from(exerciseResponsePgTable)
-        .innerJoin(exerciseTable.pg, eq(exerciseResponsePgTable.exerciseId, exerciseTable.pg.id))
+        .from(exerciseResponsePgTable.pg)
+        .innerJoin(exerciseTable.pg, eq(exerciseResponsePgTable.pg.exerciseId, exerciseTable.pg.id))
         .where(and(
-          eq(exerciseResponsePgTable.email, user.email),
+          eq(exerciseResponsePgTable.pg.email, user.email),
           isNotNull(exerciseTable.pg.courseId),
         ));
 
@@ -187,11 +187,11 @@ export const adminRouter = router({
 
       const trimmedSearch = input.search?.trim();
       const where = and(
-        eq(exerciseResponsePgTable.email, user.email),
+        eq(exerciseResponsePgTable.pg.email, user.email),
         input.courseId ? eq(exerciseTable.pg.courseId, input.courseId) : undefined,
-        input.includeInProgress ? undefined : isNotNull(exerciseResponsePgTable.completedAt),
+        input.includeInProgress ? undefined : isNotNull(exerciseResponsePgTable.pg.completedAt),
         trimmedSearch ? or(
-          ilike(exerciseResponsePgTable.response, `%${trimmedSearch}%`),
+          ilike(exerciseResponsePgTable.pg.response, `%${trimmedSearch}%`),
           ilike(exerciseTable.pg.title, `%${trimmedSearch}%`),
           ilike(exerciseTable.pg.description, `%${trimmedSearch}%`),
         ) : undefined,
@@ -200,20 +200,20 @@ export const adminRouter = router({
       const rows = await db.pg
         .select({
           response: {
-            id: exerciseResponsePgTable.id,
-            response: exerciseResponsePgTable.response,
-            completedAt: exerciseResponsePgTable.completedAt,
-            createdAt: exerciseResponsePgTable.createdAt,
+            id: exerciseResponsePgTable.pg.id,
+            response: exerciseResponsePgTable.pg.response,
+            completedAt: exerciseResponsePgTable.pg.completedAt,
+            createdAt: exerciseResponsePgTable.pg.createdAt,
           },
           exercise: exerciseTable.pg,
           unit: unitTable.pg,
         })
-        .from(exerciseResponsePgTable)
-        .leftJoin(exerciseTable.pg, eq(exerciseResponsePgTable.exerciseId, exerciseTable.pg.id))
+        .from(exerciseResponsePgTable.pg)
+        .leftJoin(exerciseTable.pg, eq(exerciseResponsePgTable.pg.exerciseId, exerciseTable.pg.id))
         .leftJoin(unitTable.pg, eq(exerciseTable.pg.unitId, unitTable.pg.id))
         .where(where)
         // Sort by "most recent activity": completedAt when set, else createdAt (when the draft was started).
-        .orderBy(sql`COALESCE(${exerciseResponsePgTable.completedAt}, ${exerciseResponsePgTable.createdAt}) DESC NULLS LAST`, desc(exerciseResponsePgTable.createdAt), desc(exerciseResponsePgTable.id))
+        .orderBy(sql`COALESCE(${exerciseResponsePgTable.pg.completedAt}, ${exerciseResponsePgTable.pg.createdAt}) DESC NULLS LAST`, desc(exerciseResponsePgTable.pg.createdAt), desc(exerciseResponsePgTable.pg.id))
         .limit(input.limit + 1)
         .offset(input.cursor);
 

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -334,7 +334,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     await testDb.insert(exerciseTable, {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Ex 1', exerciseNumber: '1',
     });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1', email, exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
   };
@@ -393,7 +393,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     await testDb.insert(exerciseTable, {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Required', exerciseNumber: '1',
     });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1', email: 'test@example.com', exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
     // Optional exercise with no completed response — must not block the certificate.

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -40,10 +40,10 @@ async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
   // submitted (across all courses) just to check FoAI completion.
   const exerciseResponses = await db.pg
     .select()
-    .from(exerciseResponsePgTable)
+    .from(exerciseResponsePgTable.pg)
     .where(and(
-      eq(exerciseResponsePgTable.email, email),
-      inArray(exerciseResponsePgTable.exerciseId, requiredExercises.map((e) => e.id)),
+      eq(exerciseResponsePgTable.pg.email, email),
+      inArray(exerciseResponsePgTable.pg.exerciseId, requiredExercises.map((e) => e.id)),
     ));
 
   const completedExerciseIds = new Set(exerciseResponses

--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -154,7 +154,7 @@ describe('courses.getCourseProgress', () => {
     await seedExercise('ex-opt', 'Active', true);
 
     // Complete the optional exercise; it must not move the progress numbers.
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'r-opt', email: 'test@example.com', exerciseId: 'ex-opt', response: 'x', completedAt: '2026-01-01',
     });
 

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -91,26 +91,26 @@ const getUserCompletions = async (coreResourceIds: string[], requiredExerciseIds
   const [rawResourceCompletions, rawExerciseCompletions] = await Promise.all([
     db.pg
       .select()
-      .from(resourceCompletionPgTable)
+      .from(resourceCompletionPgTable.pg)
       .where(and(
-        eq(resourceCompletionPgTable.email, email),
-        inArray(resourceCompletionPgTable.unitResourceId, coreResourceIds),
-        isNotNull(resourceCompletionPgTable.completedAt), // Only fetch completed resources
+        eq(resourceCompletionPgTable.pg.email, email),
+        inArray(resourceCompletionPgTable.pg.unitResourceId, coreResourceIds),
+        isNotNull(resourceCompletionPgTable.pg.completedAt), // Only fetch completed resources
       ))
-      .orderBy(desc(resourceCompletionPgTable.createdAt)),
+      .orderBy(desc(resourceCompletionPgTable.pg.createdAt)),
 
     db.pg
       .select({
-        exerciseId: exerciseResponsePgTable.exerciseId,
-        completedAt: exerciseResponsePgTable.completedAt,
+        exerciseId: exerciseResponsePgTable.pg.exerciseId,
+        completedAt: exerciseResponsePgTable.pg.completedAt,
       })
-      .from(exerciseResponsePgTable)
+      .from(exerciseResponsePgTable.pg)
       .where(and(
-        eq(exerciseResponsePgTable.email, email),
-        inArray(exerciseResponsePgTable.exerciseId, requiredExerciseIds),
-        isNotNull(exerciseResponsePgTable.completedAt), // Only fetch completed exercises
+        eq(exerciseResponsePgTable.pg.email, email),
+        inArray(exerciseResponsePgTable.pg.exerciseId, requiredExerciseIds),
+        isNotNull(exerciseResponsePgTable.pg.completedAt), // Only fetch completed exercises
       ))
-      .orderBy(desc(exerciseResponsePgTable.createdAt)),
+      .orderBy(desc(exerciseResponsePgTable.pg.createdAt)),
   ]);
 
   // Deduplicate by unitResourceId, keeping only the first occurrence.

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -197,7 +197,7 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
     await testDb.insert(exerciseTable, {
       id: 'foai-ex-2', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Action plan', exerciseNumber: '2',
     });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1', email: CALLER_EMAIL, exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
 
@@ -282,7 +282,7 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
     await testDb.insert(exerciseTable, {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Ex 1', exerciseNumber: '1',
     });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1', email: CALLER_EMAIL, exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
 
@@ -489,7 +489,7 @@ describe('exercises.getGroupExerciseResponses', () => {
 
   test('returns completed responses from group participants', async () => {
     await seedFacilitatorFlow();
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
       email: 'participant@example.com',
       exerciseId: 'ex-1',
@@ -511,7 +511,7 @@ describe('exercises.getGroupExerciseResponses', () => {
 
   test('excludes responses where completedAt is null', async () => {
     await seedFacilitatorFlow();
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
       email: 'participant@example.com',
       exerciseId: 'ex-1',
@@ -554,7 +554,7 @@ describe('exercises.getGroupExerciseResponses', () => {
       facilitator: ['meet-facilitator'],
       participants: ['meet-participant'],
     });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
       email: 'noname@example.com',
       exerciseId: 'ex-1',

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -34,7 +34,7 @@ export const exercisesRouter = router({
   getExerciseResponse: protectedProcedure
     .input(z.object({ exerciseId: z.string().min(1) }))
     .query(async ({ input, ctx }) => {
-      const exerciseResponse = await getFirstFromPg(db.pg, exerciseResponsePgTable, {
+      const exerciseResponse = await getFirstFromPg(db.pg, exerciseResponsePgTable.pg, {
         filter: { exerciseId: input.exerciseId, email: ctx.auth.email },
         sortBy: { field: 'createdAt', direction: 'desc' },
       });
@@ -57,7 +57,7 @@ export const exercisesRouter = router({
       } // else undefined = "don't change"
 
       const [existingResponse, exercise, user] = await Promise.all([
-        getFirstFromPg(db.pg, exerciseResponsePgTable, {
+        getFirstFromPg(db.pg, exerciseResponsePgTable.pg, {
           filter: { exerciseId: input.exerciseId, email: ctx.auth.email },
           sortBy: { field: 'createdAt', direction: 'desc' },
         }),
@@ -69,16 +69,16 @@ export const exercisesRouter = router({
 
       const [exerciseResponse] = existingResponse
         ? await db.pg
-          .update(exerciseResponsePgTable)
+          .update(exerciseResponsePgTable.pg)
           .set({
             exerciseId: input.exerciseId,
             response: input.response,
             completedAt: completedAt !== undefined ? completedAt : existingResponse.completedAt,
           })
-          .where(eq(exerciseResponsePgTable.id, existingResponse.id))
+          .where(eq(exerciseResponsePgTable.pg.id, existingResponse.id))
           .returning()
         : await db.pg
-          .insert(exerciseResponsePgTable)
+          .insert(exerciseResponsePgTable.pg)
           .values({
             email: ctx.auth.email,
             exerciseId: input.exerciseId,
@@ -180,14 +180,14 @@ export const exercisesRouter = router({
 
       const exerciseResponses = await db.pg
         .select({
-          email: exerciseResponsePgTable.email,
-          response: exerciseResponsePgTable.response,
+          email: exerciseResponsePgTable.pg.email,
+          response: exerciseResponsePgTable.pg.response,
         })
-        .from(exerciseResponsePgTable)
+        .from(exerciseResponsePgTable.pg)
         .where(and(
-          eq(exerciseResponsePgTable.exerciseId, input.exerciseId),
-          inArray(exerciseResponsePgTable.email, allEmails),
-          isNotNull(exerciseResponsePgTable.completedAt),
+          eq(exerciseResponsePgTable.pg.exerciseId, input.exerciseId),
+          inArray(exerciseResponsePgTable.pg.email, allEmails),
+          isNotNull(exerciseResponsePgTable.pg.completedAt),
         ));
 
       const responseByEmail = new Map(exerciseResponses.map((r) => [r.email, r.response]));

--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -46,7 +46,7 @@ describe('resources.saveResourceCompletion', () => {
   });
 
   test('updates an existing completion without touching the FK fields', async () => {
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'rc-1',
       email: CALLER_EMAIL,
       unitResourceId: 'ur-1',
@@ -79,7 +79,7 @@ describe('resources.saveResourceCompletion', () => {
   });
 
   test('clears completedAt when isCompleted is false', async () => {
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'rc-1',
       email: CALLER_EMAIL,
       unitResourceId: 'ur-1',
@@ -96,7 +96,7 @@ describe('resources.saveResourceCompletion', () => {
   });
 
   test('preserves completedAt when isCompleted is omitted', async () => {
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'rc-1',
       email: CALLER_EMAIL,
       unitResourceId: 'ur-1',

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -13,12 +13,12 @@ export const resourcesRouter = router({
     .query(async ({ input, ctx }) => {
       const resourceCompletions = await db.pg
         .select()
-        .from(resourceCompletionPgTable)
+        .from(resourceCompletionPgTable.pg)
         .where(and(
-          inArray(resourceCompletionPgTable.unitResourceId, input.unitResourceIds),
-          eq(resourceCompletionPgTable.email, ctx.auth.email),
+          inArray(resourceCompletionPgTable.pg.unitResourceId, input.unitResourceIds),
+          eq(resourceCompletionPgTable.pg.email, ctx.auth.email),
         ))
-        .orderBy(desc(resourceCompletionPgTable.createdAt));
+        .orderBy(desc(resourceCompletionPgTable.pg.createdAt));
 
       // Deduplicate by unitResourceId, keeping only the first occurrence.
       // Although we should only have one resource completion for a resource per user, it is possible to have multiple
@@ -56,7 +56,7 @@ export const resourcesRouter = router({
     }))
     .mutation(async ({ input, ctx }) => {
       const [resourceCompletion, unitResource, cbUser] = await Promise.all([
-        getFirstFromPg(db.pg, resourceCompletionPgTable, {
+        getFirstFromPg(db.pg, resourceCompletionPgTable.pg, {
           filter: {
             unitResourceId: input.unitResourceId,
             email: ctx.auth.email,
@@ -76,17 +76,17 @@ export const resourcesRouter = router({
 
       const [updatedResourceCompletion] = resourceCompletion
         ? await db.pg
-          .update(resourceCompletionPgTable)
+          .update(resourceCompletionPgTable.pg)
           .set({
             isCompleted: input.isCompleted ?? resourceCompletion.isCompleted,
             completedAt: completedAt !== undefined ? completedAt : resourceCompletion.completedAt,
             feedback: input.feedback ?? resourceCompletion.feedback,
             resourceFeedback: input.resourceFeedback ?? resourceCompletion.resourceFeedback,
           })
-          .where(eq(resourceCompletionPgTable.id, resourceCompletion.id))
+          .where(eq(resourceCompletionPgTable.pg.id, resourceCompletion.id))
           .returning()
         : await db.pg
-          .insert(resourceCompletionPgTable)
+          .insert(resourceCompletionPgTable.pg)
           .values({
             email: ctx.auth.email,
             unitResourceId: input.unitResourceId,

--- a/libraries/computed-airtable-fields/src/core.test.ts
+++ b/libraries/computed-airtable-fields/src/core.test.ts
@@ -34,10 +34,10 @@ describe('recomputeValues', () => {
   test('writes a fresh value to every row in a single chunk', async () => {
     await testDb.insert(exerciseTable, { id: 'ex-1' });
     await testDb.insert(exerciseTable, { id: 'ex-2' });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1', email: 'a@example.com', exerciseId: 'ex-1', response: 'done', completedAt: new Date().toISOString(),
     });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-2', email: 'b@example.com', exerciseId: 'ex-1', response: 'done', completedAt: new Date().toISOString(),
     });
 

--- a/libraries/computed-airtable-fields/src/definitions.test.ts
+++ b/libraries/computed-airtable-fields/src/definitions.test.ts
@@ -51,18 +51,18 @@ describe('exercise.computedNumResponses', () => {
     await testDb.insert(exerciseTable, { id: 'ex-2' });
     await testDb.insert(exerciseTable, { id: 'ex-other' });
     // ex-1: 2 completed, 1 in-progress → 2
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'r1', email: 'a@x', exerciseId: 'ex-1', response: '', completedAt: '2026-01-01',
     });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'r2', email: 'b@x', exerciseId: 'ex-1', response: '', completedAt: '2026-01-02',
     });
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'r3', email: 'c@x', exerciseId: 'ex-1', response: '', completedAt: null,
     });
     // ex-2: 0 completed → 0
     // ex-other not in input → not in output
-    await testDb.pg.insert(exerciseResponsePgTable).values({
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'r4', email: 'd@x', exerciseId: 'ex-other', response: '', completedAt: '2026-01-03',
     });
 
@@ -82,14 +82,14 @@ describe('resource.computedNumCompletions', () => {
   test('counts completed resource_completion rows per resource, multi-resource arrays counted once each', async () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
     await testDb.insert(resourceTable, { id: 'res-2' });
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'],
     });
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c2', email: 'b@x', completedAt: COMPLETED_AT, resourceId: ['res-1', 'res-2'],
     });
     // Not counted: not completed (completedAt null)
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c3', email: 'c@x', resourceId: ['res-1'],
     });
 
@@ -109,21 +109,21 @@ describe('resource.computedAverageRating', () => {
 
   test('returns mean of resourceFeedback over completed rows, ignoring NO_RESPONSE and null', async () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
     });
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c2', email: 'b@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
     });
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c3', email: 'c@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
     });
     // Ignored: NO_RESPONSE
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c4', email: 'd@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
     });
     // Ignored: rated but then un-completed (completedAt null), e.g. user rated then unticked the resource
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c5', email: 'e@x', resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
     });
 
@@ -134,7 +134,7 @@ describe('resource.computedAverageRating', () => {
 
   test('returns null when no ratings exist for a resource', async () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
-    await testDb.pg.insert(resourceCompletionPgTable).values({
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
     });
     const result = await compute()(db, ['res-1']);

--- a/libraries/computed-airtable-fields/src/definitions.ts
+++ b/libraries/computed-airtable-fields/src/definitions.ts
@@ -19,7 +19,7 @@ export const computedAirtableFieldDefinitions: ComputedAirtableFieldGroup[] = [
     table: exerciseTable,
     fields: {
       computedNumResponses: async (db, ids) => {
-        const response = exerciseResponsePgTable;
+        const response = exerciseResponsePgTable.pg;
         const rows = await db.pg
           .select({ exerciseId: response.exerciseId, n: count() })
           .from(response)
@@ -39,13 +39,13 @@ export const computedAirtableFieldDefinitions: ComputedAirtableFieldGroup[] = [
     fields: {
       computedNumCompletions: async (db, ids) => {
         // unnest expands the resourceId array so we can group/count per id.
-        const rid = sql<string>`unnest(${resourceCompletionPgTable.resourceId})`.as('rid');
+        const rid = sql<string>`unnest(${resourceCompletionPgTable.pg.resourceId})`.as('rid');
         const rows = await db.pg
           .select({ rid, n: count() })
-          .from(resourceCompletionPgTable)
+          .from(resourceCompletionPgTable.pg)
           .where(and(
-            isNotNull(resourceCompletionPgTable.completedAt),
-            arrayOverlaps(resourceCompletionPgTable.resourceId, ids),
+            isNotNull(resourceCompletionPgTable.pg.completedAt),
+            arrayOverlaps(resourceCompletionPgTable.pg.resourceId, ids),
           ))
           .groupBy(rid);
 
@@ -60,19 +60,19 @@ export const computedAirtableFieldDefinitions: ComputedAirtableFieldGroup[] = [
       },
 
       computedAverageRating: async (db, ids) => {
-        const rid = sql<string>`unnest(${resourceCompletionPgTable.resourceId})`.as('rid');
+        const rid = sql<string>`unnest(${resourceCompletionPgTable.pg.resourceId})`.as('rid');
         const rows = await db.pg
           .select({
             rid,
-            avg: sql<string>`avg(${resourceCompletionPgTable.resourceFeedback})`,
+            avg: sql<string>`avg(${resourceCompletionPgTable.pg.resourceFeedback})`,
           })
-          .from(resourceCompletionPgTable)
+          .from(resourceCompletionPgTable.pg)
           .where(and(
             // Ratings on uncompleted rows are ignored — same notion of "exists" as computedNumCompletions.
-            isNotNull(resourceCompletionPgTable.completedAt),
-            arrayOverlaps(resourceCompletionPgTable.resourceId, ids),
+            isNotNull(resourceCompletionPgTable.pg.completedAt),
+            arrayOverlaps(resourceCompletionPgTable.pg.resourceId, ids),
             // != NO_RESPONSE also excludes NULL (NULL != 0 → UNKNOWN, filtered out).
-            ne(resourceCompletionPgTable.resourceFeedback, RESOURCE_FEEDBACK.NO_RESPONSE),
+            ne(resourceCompletionPgTable.pg.resourceFeedback, RESOURCE_FEEDBACK.NO_RESPONSE),
           ))
           .groupBy(rid);
 

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -483,7 +483,7 @@ describe('exercise_completed', () => {
       id, courseId: opts.courseId, unitId: opts.unitId, title: opts.title, type: opts.type, status: 'Active',
     });
   const completeExercise = (id: string, email: string, exerciseId: string, completedAt: string | null) =>
-    db.pg.insert(exerciseResponsePgTable).values({
+    db.pg.insert(exerciseResponsePgTable.pg).values({
       id, email, exerciseId, response: 'an answer', createdAt: '2026-06-01T00:00:00.000Z', completedAt,
     });
 
@@ -566,7 +566,7 @@ describe('resource_completed', () => {
     id: string, email: string | null, unitResourceId: string | null, completedAt: string | null,
     resourceId?: string,
   ) =>
-    db.pg.insert(resourceCompletionPgTable).values({
+    db.pg.insert(resourceCompletionPgTable.pg).values({
       id,
       email,
       unitResourceId,

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -298,8 +298,8 @@ export const eventProjectionRules: EventProjectionRule[] = [
   {
     eventType: 'exercise_completed',
     async calculateEvents(db, { since }) {
-      const responses = await db.pg.select().from(exerciseResponsePgTable)
-        .where(filterGteOrNull(exerciseResponsePgTable.completedAt, since)); // completedAt is ISO text
+      const responses = await db.pg.select().from(exerciseResponsePgTable.pg)
+        .where(filterGteOrNull(exerciseResponsePgTable.pg.completedAt, since)); // completedAt is ISO text
       if (responses.length === 0) return [];
 
       const [courses, exercises] = await Promise.all([
@@ -336,8 +336,8 @@ export const eventProjectionRules: EventProjectionRule[] = [
   {
     eventType: 'resource_completed',
     async calculateEvents(db, { since }) {
-      const completions = await db.pg.select().from(resourceCompletionPgTable)
-        .where(filterGteOrNull(resourceCompletionPgTable.completedAt, since)); // completedAt is ISO text
+      const completions = await db.pg.select().from(resourceCompletionPgTable.pg)
+        .where(filterGteOrNull(resourceCompletionPgTable.pg.completedAt, since)); // completedAt is ISO text
       if (completions.length === 0) return [];
 
       const [unitResources, units] = await Promise.all([

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -113,9 +113,9 @@ export type {
 } from './schema';
 
 export {
-  getPgAirtableFromIds, PgAirtableTable, SafePgTable, safePgTable, isSchemaTable,
+  getPgAirtableFromIds, PgAirtableTable, SafePgTable, safePgTable, isDeprecationSafeTable,
 } from './lib/db-core';
-export type { SchemaTable } from './lib/db-core';
+export type { DeprecationSafeTable } from './lib/db-core';
 
 export { AirtableTsError, ErrorType } from 'airtable-ts/dist/AirtableTsError';
 

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -112,7 +112,10 @@ export type {
   VanityUrl,
 } from './schema';
 
-export { getPgAirtableFromIds, PgAirtableTable } from './lib/db-core';
+export {
+  getPgAirtableFromIds, PgAirtableTable, SafePgTable, safePgTable, isSchemaTable,
+} from './lib/db-core';
+export type { SchemaTable } from './lib/db-core';
 
 export { AirtableTsError, ErrorType } from 'airtable-ts/dist/AirtableTsError';
 

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -113,7 +113,7 @@ export type {
 } from './schema';
 
 export {
-  getPgAirtableFromIds, PgAirtableTable, SafePgTable, safePgTable, isDeprecationSafeTable,
+  getPgAirtableFromIds, PgAirtableTable, DeprecationSafePgTable, deprecationSafePgTable, isDeprecationSafeTable,
 } from './lib/db-core';
 export type { DeprecationSafeTable } from './lib/db-core';
 

--- a/libraries/db/src/lib/client.test.ts
+++ b/libraries/db/src/lib/client.test.ts
@@ -26,8 +26,7 @@ beforeAll(async () => {
   });
   testDb = db as unknown as TestPgAirtableDb;
   await pushTestSchema(db);
-  // Fix for intermittent timeout in CI
-}, 30_000);
+});
 
 beforeEach(async () => resetTestDb(db));
 

--- a/libraries/db/src/lib/client.test.ts
+++ b/libraries/db/src/lib/client.test.ts
@@ -26,8 +26,7 @@ beforeAll(async () => {
   });
   testDb = db as unknown as TestPgAirtableDb;
   await pushTestSchema(db);
-  // pushTestSchema runs drizzle-kit's schema diff against a fresh PGlite instance,
-  // which is ~1s locally but can exceed the 10s default under CI CPU contention.
+  // Fix for intermittent timeout in CI
 }, 30_000);
 
 beforeEach(async () => resetTestDb(db));

--- a/libraries/db/src/lib/client.test.ts
+++ b/libraries/db/src/lib/client.test.ts
@@ -26,7 +26,9 @@ beforeAll(async () => {
   });
   testDb = db as unknown as TestPgAirtableDb;
   await pushTestSchema(db);
-});
+  // pushTestSchema runs drizzle-kit's schema diff against a fresh PGlite instance,
+  // which is ~1s locally but can exceed the 10s default under CI CPU contention.
+}, 30_000);
 
 beforeEach(async () => resetTestDb(db));
 

--- a/libraries/db/src/lib/db-core.test.ts
+++ b/libraries/db/src/lib/db-core.test.ts
@@ -1,6 +1,6 @@
 import { text } from 'drizzle-orm/pg-core';
 import { describe, expect, test } from 'vitest';
-import { PgAirtableTable } from './db-core';
+import { PgAirtableTable, SafePgTable } from './db-core';
 
 describe('PgAirtableTable', () => {
   test('throws if deprecated column uses notNull', () => {
@@ -30,6 +30,38 @@ describe('PgAirtableTable', () => {
       tableId: 'table',
       columns: { duplicateCol: { pgColumn: text(), airtableId: 'fld1' } },
       deprecatedColumns: { duplicateCol: { pgColumn: text(), airtableId: 'fld2', deprecated: true } },
+    })).toThrow(/appears in both columns and deprecatedColumns/);
+  });
+});
+
+describe('SafePgTable', () => {
+  test('has no pgWithDeprecatedColumns when there are no deprecated columns', () => {
+    const table = new SafePgTable('test', {
+      columns: { active: text() },
+    });
+    expect(table.pg).toBeDefined();
+    expect(table.pgWithDeprecatedColumns).toBeUndefined();
+  });
+
+  test('throws if deprecated column uses notNull', () => {
+    expect(() => new SafePgTable('test', {
+      columns: { active: text() },
+      deprecatedColumns: { badCol: text().notNull() },
+    })).toThrow(/must be nullable/);
+  });
+
+  test('creates pgWithDeprecatedColumns when deprecated columns exist', () => {
+    const table = new SafePgTable('test', {
+      columns: { active: text() },
+      deprecatedColumns: { old: text() },
+    });
+    expect(table.pgWithDeprecatedColumns).toBeDefined();
+  });
+
+  test('throws if column appears in both columns and deprecatedColumns', () => {
+    expect(() => new SafePgTable('test', {
+      columns: { duplicateCol: text() },
+      deprecatedColumns: { duplicateCol: text() },
     })).toThrow(/appears in both columns and deprecatedColumns/);
   });
 });

--- a/libraries/db/src/lib/db-core.test.ts
+++ b/libraries/db/src/lib/db-core.test.ts
@@ -1,6 +1,6 @@
 import { text } from 'drizzle-orm/pg-core';
 import { describe, expect, test } from 'vitest';
-import { PgAirtableTable, SafePgTable } from './db-core';
+import { PgAirtableTable, DeprecationSafePgTable } from './db-core';
 
 describe('PgAirtableTable', () => {
   test('throws if deprecated column uses notNull', () => {
@@ -34,9 +34,9 @@ describe('PgAirtableTable', () => {
   });
 });
 
-describe('SafePgTable', () => {
+describe('DeprecationSafePgTable', () => {
   test('has no pgWithDeprecatedColumns when there are no deprecated columns', () => {
-    const table = new SafePgTable('test', {
+    const table = new DeprecationSafePgTable('test', {
       columns: { active: text() },
     });
     expect(table.pg).toBeDefined();
@@ -44,14 +44,14 @@ describe('SafePgTable', () => {
   });
 
   test('throws if deprecated column uses notNull', () => {
-    expect(() => new SafePgTable('test', {
+    expect(() => new DeprecationSafePgTable('test', {
       columns: { active: text() },
       deprecatedColumns: { badCol: text().notNull() },
     })).toThrow(/must be nullable/);
   });
 
   test('creates pgWithDeprecatedColumns when deprecated columns exist', () => {
-    const table = new SafePgTable('test', {
+    const table = new DeprecationSafePgTable('test', {
       columns: { active: text() },
       deprecatedColumns: { old: text() },
     });
@@ -59,7 +59,7 @@ describe('SafePgTable', () => {
   });
 
   test('throws if column appears in both columns and deprecatedColumns', () => {
-    expect(() => new SafePgTable('test', {
+    expect(() => new DeprecationSafePgTable('test', {
       columns: { duplicateCol: text() },
       deprecatedColumns: { duplicateCol: text() },
     })).toThrow(/appears in both columns and deprecatedColumns/);

--- a/libraries/db/src/lib/db-core.ts
+++ b/libraries/db/src/lib/db-core.ts
@@ -26,14 +26,12 @@ import {
  * satisfy this, letting pg-sync-service push `pgWithDeprecatedColumns ?? pg`
  * through a single code path.
  */
-export type SchemaTable = {
+export type DeprecationSafeTable = {
   pg: PgTable;
   pgWithDeprecatedColumns?: PgTable;
 };
 
-export function isSchemaTable(value: unknown): value is SchemaTable {
-  // instanceof rather than duck-typing on `'pg' in value`, so a plain pgTable
-  // that happens to have a column named `pg` can't be misclassified.
+export function isDeprecationSafeTable(value: unknown): value is DeprecationSafeTable {
   return value instanceof PgAirtableTable || value instanceof SafePgTable;
 }
 
@@ -67,10 +65,10 @@ export type SafePgTableConfig<
 export class SafePgTable<
   TTableName extends string = string,
   TColumnsMap extends SafePgColumnsMap = SafePgColumnsMap,
-> implements SchemaTable {
+> implements DeprecationSafeTable {
   public readonly pg: SafePgTablePg<TTableName, TColumnsMap>;
 
-  public readonly pgWithDeprecatedColumns?: SchemaTable['pg'];
+  public readonly pgWithDeprecatedColumns?: DeprecationSafeTable['pg'];
 
   constructor(name: TTableName, config: SafePgTableConfig<TColumnsMap>) {
     this.pg = pgTable(name, config.columns) as SafePgTablePg<TTableName, TColumnsMap>;
@@ -92,7 +90,7 @@ export class SafePgTable<
       this.pgWithDeprecatedColumns = pgTable(name, {
         ...config.columns,
         ...config.deprecatedColumns,
-      }) as unknown as SchemaTable['pg'];
+      }) as unknown as DeprecationSafeTable['pg'];
     }
   }
 }
@@ -110,7 +108,7 @@ export function safePgTable<
 export class PgAirtableTable<
   TTableName extends string = string,
   TColumnsMap extends Record<string, PgAirtableColumnInput> = Record<string, PgAirtableColumnInput>,
-> implements SchemaTable {
+> implements DeprecationSafeTable {
   public readonly pg: BasePgTableType<TTableName, TColumnsMap>;
 
   public readonly pgWithDeprecatedColumns?: PgAirtableTable['pg'];

--- a/libraries/db/src/lib/db-core.ts
+++ b/libraries/db/src/lib/db-core.ts
@@ -22,7 +22,7 @@ import {
  * Shared shape for tables that own a Postgres definition and may carry deprecated
  * columns that are still present in the physical table but no longer written to.
  *
- * Both `PgAirtableTable` (Airtable-synced) and `SafePgTable` (Postgres-only)
+ * Both `PgAirtableTable` (Airtable-synced) and `DeprecationSafePgTable` (Postgres-only)
  * satisfy this, letting pg-sync-service push `pgWithDeprecatedColumns ?? pg`
  * through a single code path.
  */
@@ -32,14 +32,14 @@ export type DeprecationSafeTable = {
 };
 
 export function isDeprecationSafeTable(value: unknown): value is DeprecationSafeTable {
-  return value instanceof PgAirtableTable || value instanceof SafePgTable;
+  return value instanceof PgAirtableTable || value instanceof DeprecationSafePgTable;
 }
 
-type SafePgColumnsMap = Record<string, PgColumnBuilderBase>;
+type DeprecationSafePgColumnsMap = Record<string, PgColumnBuilderBase>;
 
-type SafePgTablePg<
+type DeprecationSafePgTablePg<
   TTableName extends string,
-  TColumnsMap extends SafePgColumnsMap,
+  TColumnsMap extends DeprecationSafePgColumnsMap,
 > = PgTableWithColumns<{
   name: TTableName;
   schema: undefined;
@@ -47,11 +47,11 @@ type SafePgTablePg<
   dialect: 'pg';
 }>;
 
-export type SafePgTableConfig<
-  TColumnsMap extends SafePgColumnsMap,
+export type DeprecationSafePgTableConfig<
+  TColumnsMap extends DeprecationSafePgColumnsMap,
 > = {
   columns: TColumnsMap;
-  deprecatedColumns?: SafePgColumnsMap;
+  deprecatedColumns?: DeprecationSafePgColumnsMap;
 };
 
 /**
@@ -62,16 +62,16 @@ export type SafePgTableConfig<
  * consumer keep SELECTing a column for the deploy window after it's dropped from
  * the active schema, instead of pg-sync-service dropping it immediately.
  */
-export class SafePgTable<
+export class DeprecationSafePgTable<
   TTableName extends string = string,
-  TColumnsMap extends SafePgColumnsMap = SafePgColumnsMap,
+  TColumnsMap extends DeprecationSafePgColumnsMap = DeprecationSafePgColumnsMap,
 > implements DeprecationSafeTable {
-  public readonly pg: SafePgTablePg<TTableName, TColumnsMap>;
+  public readonly pg: DeprecationSafePgTablePg<TTableName, TColumnsMap>;
 
   public readonly pgWithDeprecatedColumns?: DeprecationSafeTable['pg'];
 
-  constructor(name: TTableName, config: SafePgTableConfig<TColumnsMap>) {
-    this.pg = pgTable(name, config.columns) as SafePgTablePg<TTableName, TColumnsMap>;
+  constructor(name: TTableName, config: DeprecationSafePgTableConfig<TColumnsMap>) {
+    this.pg = pgTable(name, config.columns) as DeprecationSafePgTablePg<TTableName, TColumnsMap>;
 
     if (config.deprecatedColumns && Object.keys(config.deprecatedColumns).length > 0) {
       for (const [columnName, columnBuilder] of Object.entries(config.deprecatedColumns)) {
@@ -95,14 +95,14 @@ export class SafePgTable<
   }
 }
 
-export function safePgTable<
+export function deprecationSafePgTable<
   TTableName extends string,
-  TColumnsMap extends SafePgColumnsMap,
+  TColumnsMap extends DeprecationSafePgColumnsMap,
 >(
   name: TTableName,
-  config: SafePgTableConfig<TColumnsMap>,
-): SafePgTable<TTableName, TColumnsMap> {
-  return new SafePgTable(name, config);
+  config: DeprecationSafePgTableConfig<TColumnsMap>,
+): DeprecationSafePgTable<TTableName, TColumnsMap> {
+  return new DeprecationSafePgTable(name, config);
 }
 
 export class PgAirtableTable<

--- a/libraries/db/src/lib/db-core.ts
+++ b/libraries/db/src/lib/db-core.ts
@@ -2,7 +2,11 @@ import { type Table } from 'airtable-ts';
 import {
   pgTable,
   text,
+  type PgColumnBuilderBase,
+  type PgTable,
+  type PgTableWithColumns,
 } from 'drizzle-orm/pg-core';
+import { type BuildColumns } from 'drizzle-orm/column-builder';
 import {
   drizzleColumnToTsTypeString,
   type TsTypeString,
@@ -14,10 +18,99 @@ import {
   type ExtractPgColumns,
 } from './typeUtils';
 
+/**
+ * Shared shape for tables that own a Postgres definition and may carry deprecated
+ * columns that are still present in the physical table but no longer written to.
+ *
+ * Both `PgAirtableTable` (Airtable-synced) and `SafePgTable` (Postgres-only)
+ * satisfy this, letting pg-sync-service push `pgWithDeprecatedColumns ?? pg`
+ * through a single code path.
+ */
+export type SchemaTable = {
+  pg: PgTable;
+  pgWithDeprecatedColumns?: PgTable;
+};
+
+export function isSchemaTable(value: unknown): value is SchemaTable {
+  // instanceof rather than duck-typing on `'pg' in value`, so a plain pgTable
+  // that happens to have a column named `pg` can't be misclassified.
+  return value instanceof PgAirtableTable || value instanceof SafePgTable;
+}
+
+type SafePgColumnsMap = Record<string, PgColumnBuilderBase>;
+
+type SafePgTablePg<
+  TTableName extends string,
+  TColumnsMap extends SafePgColumnsMap,
+> = PgTableWithColumns<{
+  name: TTableName;
+  schema: undefined;
+  columns: BuildColumns<TTableName, TColumnsMap, 'pg'>;
+  dialect: 'pg';
+}>;
+
+export type SafePgTableConfig<
+  TColumnsMap extends SafePgColumnsMap,
+> = {
+  columns: TColumnsMap;
+  deprecatedColumns?: SafePgColumnsMap;
+};
+
+/**
+ * A Postgres-only table (not synced from Airtable) that supports deprecating
+ * columns the same way `pgAirtable` does: deprecated columns stay physically
+ * present in the DB (via `pgWithDeprecatedColumns`) while application code reads
+ * and writes through `pg` (active columns only). This lets a still-released
+ * consumer keep SELECTing a column for the deploy window after it's dropped from
+ * the active schema, instead of pg-sync-service dropping it immediately.
+ */
+export class SafePgTable<
+  TTableName extends string = string,
+  TColumnsMap extends SafePgColumnsMap = SafePgColumnsMap,
+> implements SchemaTable {
+  public readonly pg: SafePgTablePg<TTableName, TColumnsMap>;
+
+  public readonly pgWithDeprecatedColumns?: SchemaTable['pg'];
+
+  constructor(name: TTableName, config: SafePgTableConfig<TColumnsMap>) {
+    this.pg = pgTable(name, config.columns) as SafePgTablePg<TTableName, TColumnsMap>;
+
+    if (config.deprecatedColumns && Object.keys(config.deprecatedColumns).length > 0) {
+      for (const [columnName, columnBuilder] of Object.entries(config.deprecatedColumns)) {
+        // @ts-expect-error accessing internal config
+        if (columnBuilder?.config?.notNull) {
+          throw new Error(`Deprecated column "${columnName}" in table "${name}" must be nullable. `
+            + 'Deprecated columns cannot use .notNull() because they stop receiving sync updates.');
+        }
+
+        if (columnName in config.columns) {
+          throw new Error(`Column "${columnName}" in table "${name}" appears in both columns and deprecatedColumns. `
+            + 'A column should only be in one or the other.');
+        }
+      }
+
+      this.pgWithDeprecatedColumns = pgTable(name, {
+        ...config.columns,
+        ...config.deprecatedColumns,
+      }) as unknown as SchemaTable['pg'];
+    }
+  }
+}
+
+export function safePgTable<
+  TTableName extends string,
+  TColumnsMap extends SafePgColumnsMap,
+>(
+  name: TTableName,
+  config: SafePgTableConfig<TColumnsMap>,
+): SafePgTable<TTableName, TColumnsMap> {
+  return new SafePgTable(name, config);
+}
+
 export class PgAirtableTable<
   TTableName extends string = string,
   TColumnsMap extends Record<string, PgAirtableColumnInput> = Record<string, PgAirtableColumnInput>,
-> {
+> implements SchemaTable {
   public readonly pg: BasePgTableType<TTableName, TColumnsMap>;
 
   public readonly pgWithDeprecatedColumns?: PgAirtableTable['pg'];

--- a/libraries/db/src/lib/test-db.ts
+++ b/libraries/db/src/lib/test-db.ts
@@ -8,7 +8,7 @@ import {
 import { pushSchema } from 'drizzle-kit/api';
 import { type PgAirtableDb, type PgDatabase } from './client';
 import { MockAirtableTs } from './mock-airtable-ts';
-import { isSchemaTable, type PgAirtableTable } from './db-core';
+import { isDeprecationSafeTable, type PgAirtableTable } from './db-core';
 import type { PgAirtableColumnInput, AirtableItemFromColumnsMap, BasePgTableType } from './typeUtils';
 import * as schema from '../schema';
 
@@ -37,9 +37,9 @@ export function createTestDbClients() {
 
 function collectPgTables() {
   return Object.fromEntries(Object.entries(schema)
-    .filter(([, value]) => isSchemaTable(value) || isTable(value))
+    .filter(([, value]) => isDeprecationSafeTable(value) || isTable(value))
     .map(([name, value]) => {
-      if (isSchemaTable(value)) {
+      if (isDeprecationSafeTable(value)) {
         return [name, value.pg];
       }
 

--- a/libraries/db/src/lib/test-db.ts
+++ b/libraries/db/src/lib/test-db.ts
@@ -8,7 +8,7 @@ import {
 import { pushSchema } from 'drizzle-kit/api';
 import { type PgAirtableDb, type PgDatabase } from './client';
 import { MockAirtableTs } from './mock-airtable-ts';
-import { PgAirtableTable } from './db-core';
+import { isSchemaTable, type PgAirtableTable } from './db-core';
 import type { PgAirtableColumnInput, AirtableItemFromColumnsMap, BasePgTableType } from './typeUtils';
 import * as schema from '../schema';
 
@@ -37,9 +37,9 @@ export function createTestDbClients() {
 
 function collectPgTables() {
   return Object.fromEntries(Object.entries(schema)
-    .filter(([, value]) => value instanceof PgAirtableTable || isTable(value))
+    .filter(([, value]) => isSchemaTable(value) || isTable(value))
     .map(([name, value]) => {
-      if (value instanceof PgAirtableTable) {
+      if (isSchemaTable(value)) {
         return [name, value.pg];
       }
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -4,7 +4,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import { type InferSelectModel, sql } from 'drizzle-orm';
 
-import { pgAirtable, safePgTable } from './lib/db-core';
+import { pgAirtable, deprecationSafePgTable } from './lib/db-core';
 
 const COURSE_BUILDER_BASE_ID = 'appbiNKDcn1sGPGOG';
 const APPLICATIONS_BASE_ID = 'appnJbsG1eWbAdEvf';
@@ -144,7 +144,7 @@ export const courseTable = pgAirtable('course', {
   },
 });
 
-export const exerciseResponsePgTable = safePgTable('exercise_response', {
+export const exerciseResponsePgTable = deprecationSafePgTable('exercise_response', {
   columns: {
     id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
     email: text().notNull(),
@@ -1533,7 +1533,7 @@ export const RESOURCE_FEEDBACK = {
 // Type for resourceFeedback field values
 export type ResourceFeedbackValue = typeof RESOURCE_FEEDBACK[keyof typeof RESOURCE_FEEDBACK];
 
-export const resourceCompletionPgTable = safePgTable('resource_completion', {
+export const resourceCompletionPgTable = deprecationSafePgTable('resource_completion', {
   columns: {
     id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
     unitResourceId: text(),

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -4,7 +4,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import { type InferSelectModel, sql } from 'drizzle-orm';
 
-import { pgAirtable } from './lib/db-core';
+import { pgAirtable, safePgTable } from './lib/db-core';
 
 const COURSE_BUILDER_BASE_ID = 'appbiNKDcn1sGPGOG';
 const APPLICATIONS_BASE_ID = 'appnJbsG1eWbAdEvf';
@@ -144,14 +144,16 @@ export const courseTable = pgAirtable('course', {
   },
 });
 
-export const exerciseResponsePgTable = pgTable('exercise_response', {
-  id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
-  email: text().notNull(),
-  exerciseId: text().notNull(),
-  response: text().notNull(),
-  createdAt: text(),
-  completedAt: text(),
-  userId: text().array(),
+export const exerciseResponsePgTable = safePgTable('exercise_response', {
+  columns: {
+    id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
+    email: text().notNull(),
+    exerciseId: text().notNull(),
+    response: text().notNull(),
+    createdAt: text(),
+    completedAt: text(),
+    userId: text().array(),
+  },
 });
 
 export const formConfigurationTable = pgAirtable('form_configuration', {
@@ -1531,18 +1533,20 @@ export const RESOURCE_FEEDBACK = {
 // Type for resourceFeedback field values
 export type ResourceFeedbackValue = typeof RESOURCE_FEEDBACK[keyof typeof RESOURCE_FEEDBACK];
 
-export const resourceCompletionPgTable = pgTable('resource_completion', {
-  id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
-  unitResourceId: text(),
-  isCompleted: boolean(),
-  email: text(),
-  feedback: text(),
-  resourceFeedback: numeric({ mode: 'number' }).$type<ResourceFeedbackValue>().default(RESOURCE_FEEDBACK.NO_RESPONSE),
-  resourceId: text().array(),
-  // Points at courseBuilderUserTable (the Course-builder-base sync of User)
-  createdByUserId: text().array(),
-  createdAt: text(),
-  completedAt: text(),
+export const resourceCompletionPgTable = safePgTable('resource_completion', {
+  columns: {
+    id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
+    unitResourceId: text(),
+    isCompleted: boolean(),
+    email: text(),
+    feedback: text(),
+    resourceFeedback: numeric({ mode: 'number' }).$type<ResourceFeedbackValue>().default(RESOURCE_FEEDBACK.NO_RESPONSE),
+    resourceId: text().array(),
+    // Points at courseBuilderUserTable (the Course-builder-base sync of User)
+    createdByUserId: text().array(),
+    createdAt: text(),
+    completedAt: text(),
+  },
 });
 
 export const teamMemberTable = pgAirtable('team_member', {
@@ -1729,7 +1733,7 @@ export type SyncMetadata = InferSelectModel<typeof syncMetadataTable>;
 export type SyncRequest = InferSelectModel<typeof syncRequestsTable>;
 export type PosthogEmittedEvent = InferSelectModel<typeof posthogEmittedEventsTable>;
 export type Course = InferSelectModel<typeof courseTable.pg>;
-export type ExerciseResponse = InferSelectModel<typeof exerciseResponsePgTable>;
+export type ExerciseResponse = InferSelectModel<typeof exerciseResponsePgTable.pg>;
 export type FormConfiguration = InferSelectModel<typeof formConfigurationTable.pg>;
 export type Person = InferSelectModel<typeof personTable.pg>;
 export type SharedDemoOutput = InferSelectModel<typeof sharedDemoOutputTable.pg>;
@@ -1763,7 +1767,7 @@ export type CourseRegistration = InferSelectModel<typeof courseRegistrationTable
 export type SelfServeCourseRegistration = InferSelectModel<typeof selfServeCourseRegistrationTable.pg>;
 export type User = InferSelectModel<typeof userTable.pg>;
 export type CourseBuilderUser = InferSelectModel<typeof courseBuilderUserTable.pg>;
-export type ResourceCompletion = InferSelectModel<typeof resourceCompletionPgTable>;
+export type ResourceCompletion = InferSelectModel<typeof resourceCompletionPgTable.pg>;
 export type FacilitatorSwitching = InferSelectModel<typeof facilitatorDiscussionSwitchingTable.pg>;
 export type Dropout = InferSelectModel<typeof dropoutTable.pg>;
 export type TeamMember = InferSelectModel<typeof teamMemberTable.pg>;

--- a/libraries/utils/src/default-config/vitest.mjs
+++ b/libraries/utils/src/default-config/vitest.mjs
@@ -15,6 +15,10 @@ export const withDefaultBlueDotVitestConfig = async (config) => defineConfig({
     env: dotenv.config({ path: '.env.test' }).parsed,
     // Sadly necessary for @testing-library/jest-dom
     globals: true,
+    // Generous timeouts: PGlite-backed suites run several-fold slower under CI CPU
+    // contention, blowing vitest's 5s/10s defaults.
+    testTimeout: 15_000,
+    hookTimeout: 30_000,
 
     ...config?.test,
 


### PR DESCRIPTION
# Description

Creates a `safePgTable` wrapper which implements the same (now named) interface as `pgAirtable`:
```typescript
export type DeprecationSafeTable = {
  pg: PgTable;
  pgWithDeprecatedColumns?: PgTable;
};
```

This allows deprecating columns with the same two-step process we use for `pgAirtable`, and exactly the same behaviour.

A side effect of this is adding the need to do `exerciseResponsePgTable.pg` to get at the table, rather than just `exerciseResponsePgTable`. This adds a bit of boilerplate but I think it's worth it to have exactly the same interface serving both versions. A lot of the diff is just line edits to make this change.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2706

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
