### PR TITLE
[chore] isCompleted -> completedAt migration on resource completion: Drop isCompleted

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1546,9 +1546,6 @@ export const resourceCompletionPgTable = deprecationSafePgTable('resource_comple
     createdAt: text(),
     completedAt: text(),
   },
-  deprecatedColumns: {
-    isCompleted: boolean(),
-  },
 });
 
 export const teamMemberTable = pgAirtable('team_member', {


### PR DESCRIPTION
# Description

Final step of the `isCompleted` removal. Removes `isCompleted` from the `deprecatedColumns` block on `resourceCompletionPgTable`, so `pg-sync-service` drops the physical column. Must be merged **after** #2704 is deployed.

## Issue

Fixes #2700

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories