### PR TITLE
Add userId (pointing to Applications base) to resource completions

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -308,6 +308,7 @@ export const createMockResourceCompletion = (overrides: Partial<ResourceCompleti
   resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
   unitResourceId: MOCK_RESOURCE_ID,
   resourceId: null,
+  userId: null,
   createdByUserId: null,
   createdAt: null,
   completedAt: null,

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -147,6 +147,7 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
               feedback: updatedFields.feedback ?? '',
               resourceFeedback: updatedFields.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
               resourceId: null,
+              userId: null,
               createdByUserId: null,
               createdAt: new Date().toISOString(),
               completedAt: new Date().toISOString(),

--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -2,6 +2,7 @@ import {
   courseBuilderUserTable,
   resourceCompletionPgTable,
   unitResourceTable,
+  userTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
@@ -17,7 +18,8 @@ const caller = createCaller(testAuthContextLoggedIn);
 const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;
 
 describe('resources.saveResourceCompletion', () => {
-  test('writes resourceId and createdByUserId on insert when both can be resolved', async () => {
+  test('writes resourceId, userId, and createdByUserId on insert when both can be resolved', async () => {
+    await testDb.insert(userTable, { id: 'user-1', name: 'user-1-name', email: CALLER_EMAIL });
     await testDb.insert(courseBuilderUserTable, { id: 'cb-user-1', email: CALLER_EMAIL });
     await testDb.insert(unitResourceTable, { id: 'ur-1', resourceId: ['resource-1'] });
 
@@ -29,6 +31,7 @@ describe('resources.saveResourceCompletion', () => {
     expect(result).toMatchObject({
       unitResourceId: 'ur-1',
       resourceId: ['resource-1'],
+      userId: ['user-1'],
       createdByUserId: ['cb-user-1'],
     });
     expect(result.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
@@ -41,6 +44,7 @@ describe('resources.saveResourceCompletion', () => {
     });
 
     expect(result.resourceId).toBeNull();
+    expect(result.userId).toBeNull();
     expect(result.createdByUserId).toBeNull();
   });
 
@@ -50,6 +54,7 @@ describe('resources.saveResourceCompletion', () => {
       email: CALLER_EMAIL,
       unitResourceId: 'ur-1',
       resourceId: ['resource-original'],
+      userId: ['user-original'],
       createdByUserId: ['cb-user-original'],
     });
 
@@ -61,6 +66,7 @@ describe('resources.saveResourceCompletion', () => {
     expect(result).toMatchObject({
       id: 'rc-1',
       resourceId: ['resource-original'],
+      userId: ['user-original'],
       createdByUserId: ['cb-user-original'],
     });
   });

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -1,7 +1,7 @@
 import {
-  and, courseBuilderUserTable, desc, eq, getFirstFromPg, inArray, resourceCompletionPgTable, unitResourceTable,
+  and, courseBuilderUserTable, userTable, desc, eq, getFirstFromPg, inArray, resourceCompletionPgTable, unitResourceTable,
 } from '@bluedot/db';
-import { RESOURCE_FEEDBACK, userTable } from '@bluedot/db/src/schema';
+import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -1,7 +1,7 @@
 import {
   and, courseBuilderUserTable, desc, eq, getFirstFromPg, inArray, resourceCompletionPgTable, unitResourceTable,
 } from '@bluedot/db';
-import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
+import { RESOURCE_FEEDBACK, userTable } from '@bluedot/db/src/schema';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';
@@ -55,7 +55,7 @@ export const resourcesRouter = router({
         .optional(),
     }))
     .mutation(async ({ input, ctx }) => {
-      const [resourceCompletion, unitResource, cbUser] = await Promise.all([
+      const [resourceCompletion, unitResource, cbUser, user] = await Promise.all([
         getFirstFromPg(db.pg, resourceCompletionPgTable.pg, {
           filter: {
             unitResourceId: input.unitResourceId,
@@ -65,6 +65,7 @@ export const resourcesRouter = router({
         }),
         db.getFirst(unitResourceTable, { filter: { id: input.unitResourceId }, sortBy: 'id' }),
         db.getFirst(courseBuilderUserTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),
+        db.getFirst(userTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),
       ]);
 
       let completedAt: string | null | undefined;
@@ -93,6 +94,7 @@ export const resourcesRouter = router({
             feedback: input.feedback ?? '',
             resourceFeedback: input.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
             resourceId: unitResource?.resourceId ?? null,
+            userId: user ? [user.id] : null,
             createdByUserId: cbUser ? [cbUser.id] : null,
             createdAt: new Date().toISOString(),
           })

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1541,6 +1541,8 @@ export const resourceCompletionPgTable = deprecationSafePgTable('resource_comple
     feedback: text(),
     resourceFeedback: numeric({ mode: 'number' }).$type<ResourceFeedbackValue>().default(RESOURCE_FEEDBACK.NO_RESPONSE),
     resourceId: text().array(),
+    // Points at userTable
+    userId: text().array(),
     // Points at courseBuilderUserTable (the Course-builder-base sync of User)
     createdByUserId: text().array(),
     createdAt: text(),


### PR DESCRIPTION
# Description

Previously this used the Course builder user id. Now this table doesn't live in Airtable, there is no need for this indirection, so we can point it at the regular `userTable`.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2709

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories