### PR TITLE
Add userId to meetPerson

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -245,6 +245,7 @@ export const createMockMeetPerson = (overrides: Partial<MeetPerson> = {}): MeetP
   id: MOCK_MEET_PERSON_ID,
   name: 'Test User',
   applicationsBaseRecordId: null,
+  userId: null,
   projectSubmission: [],
   role: 'Participant',
   humanOpinion: null,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -439,6 +439,11 @@ export const meetPersonTable = pgAirtable('meet_person', {
       pgColumn: text(),
       airtableId: 'fldoKAVy6QPWZmofb',
     },
+    // ID of the user in the Applications base
+    userId: {
+      pgColumn: text(),
+      airtableId: 'fldSJzQwhZn1aX1Lc',
+    },
     projectSubmission: {
       pgColumn: text().array(),
       airtableId: 'fldFjRSrXH8Z5sGaQ',


### PR DESCRIPTION
# Description

Added to enable looking meetPerson up via the user rather than by email. This is a newly added `RECORD_ID()` column in Airtable (pointing to the Applications base user table).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2709

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories