### PR TITLE
[fix] De-flake admin exercises course-filter test (#2716)

### DIFF
--- a/apps/website/src/__tests__/pages/admin/exercises.test.tsx
+++ b/apps/website/src/__tests__/pages/admin/exercises.test.tsx
@@ -124,10 +124,11 @@ describe('/admin/exercises', () => {
     const alignmentRadio = screen.getByRole('radio', { name: 'Alignment' });
     await user.click(alignmentRadio);
 
+    // This used to be flaky (#2716), fixed by moving the 'thinking about safety mechanisms' expect into the waitFor
     await waitFor(() => {
       expect(screen.queryByText(/policy considerations are important/)).not.toBeInTheDocument();
+      expect(screen.getByText(/thinking about safety mechanisms/)).toBeInTheDocument();
     });
-    expect(screen.getByText(/thinking about safety mechanisms/)).toBeInTheDocument();
 
     const allCoursesRadio = screen.getByRole('radio', { name: 'All courses' });
     await user.click(allCoursesRadio);


### PR DESCRIPTION
# Description

The 'thinking about safety mechanisms' assertion ran synchronously right after changing the course filter, which triggered a brief unmount and remount. This sometimes caused the test to fail. Fixed by moving the assertion inside the `waitFor`

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2716

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
