### PR TITLE
Use userId instead of email for all lookups of exercise responses and resource completions

### DIFF
--- a/apps/website/src/__tests__/pages/admin/exercises.test.tsx
+++ b/apps/website/src/__tests__/pages/admin/exercises.test.tsx
@@ -62,13 +62,13 @@ async function seedTargetResponses() {
     id: 'ex-b1', courseId: 'course-b', unitId: 'unit-b', title: 'Governance prompt', exerciseNumber: '1.1', type: 'Free text',
   });
   await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-    id: 'resp-a1', email: TARGET_EMAIL, exerciseId: 'ex-a1', response: 'thinking about safety mechanisms', createdAt: '2026-04-30T10:00:00Z', completedAt: '2026-05-01T10:00:00Z',
+    id: 'resp-a1', email: TARGET_EMAIL, userId: ['target-id'], exerciseId: 'ex-a1', response: 'thinking about safety mechanisms', createdAt: '2026-04-30T10:00:00Z', completedAt: '2026-05-01T10:00:00Z',
   });
   await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-    id: 'resp-a2', email: TARGET_EMAIL, exerciseId: 'ex-a2', response: 'draft in progress', createdAt: '2026-05-03T10:00:00Z', completedAt: null,
+    id: 'resp-a2', email: TARGET_EMAIL, userId: ['target-id'], exerciseId: 'ex-a2', response: 'draft in progress', createdAt: '2026-05-03T10:00:00Z', completedAt: null,
   });
   await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-    id: 'resp-b1', email: TARGET_EMAIL, exerciseId: 'ex-b1', response: 'policy considerations are important', createdAt: '2026-04-29T10:00:00Z', completedAt: '2026-05-02T10:00:00Z',
+    id: 'resp-b1', email: TARGET_EMAIL, userId: ['target-id'], exerciseId: 'ex-b1', response: 'policy considerations are important', createdAt: '2026-04-29T10:00:00Z', completedAt: '2026-05-02T10:00:00Z',
   });
 }
 

--- a/apps/website/src/server/routers/admin.ts
+++ b/apps/website/src/server/routers/admin.ts
@@ -1,5 +1,6 @@
 import {
   and,
+  arrayContains,
   chunkTable,
   courseRegistrationTable,
   desc,
@@ -148,7 +149,7 @@ export const adminRouter = router({
         .from(exerciseResponsePgTable.pg)
         .innerJoin(exerciseTable.pg, eq(exerciseResponsePgTable.pg.exerciseId, exerciseTable.pg.id))
         .where(and(
-          eq(exerciseResponsePgTable.pg.email, user.email),
+          arrayContains(exerciseResponsePgTable.pg.userId, [user.id]),
           isNotNull(exerciseTable.pg.courseId),
         ));
 
@@ -187,7 +188,7 @@ export const adminRouter = router({
 
       const trimmedSearch = input.search?.trim();
       const where = and(
-        eq(exerciseResponsePgTable.pg.email, user.email),
+        arrayContains(exerciseResponsePgTable.pg.userId, [user.id]),
         input.courseId ? eq(exerciseTable.pg.courseId, input.courseId) : undefined,
         input.includeInProgress ? undefined : isNotNull(exerciseResponsePgTable.pg.completedAt),
         trimmedSearch ? or(

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -330,12 +330,14 @@ describe('certificates.getStatus', () => {
 });
 
 describe('issueFoaiCertificateIfComplete', () => {
+  const FOAI_USER_ID = 'user-foai';
+
   const setupCompletedFoaiExercises = async (email: string) => {
     await testDb.insert(exerciseTable, {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email, exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1', email, userId: [FOAI_USER_ID], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
   };
 
@@ -348,7 +350,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     });
     await setupCompletedFoaiExercises('test@example.com');
 
-    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+    expect(await issueFoaiCertificateIfComplete('test@example.com', FOAI_USER_ID)).toBe(true);
 
     const [selfServe] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
       .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
@@ -365,7 +367,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     });
     await setupCompletedFoaiExercises('test@example.com');
 
-    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(false);
+    expect(await issueFoaiCertificateIfComplete('test@example.com', FOAI_USER_ID)).toBe(false);
 
     const legacy = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
     expect(legacy.certificateId).toBeNull();
@@ -379,7 +381,7 @@ describe('issueFoaiCertificateIfComplete', () => {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
     });
 
-    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(false);
+    expect(await issueFoaiCertificateIfComplete('test@example.com', FOAI_USER_ID)).toBe(false);
 
     const legacy = await testDb.get(courseRegistrationTable, { id: 'reg-foai' });
     expect(legacy.certificateId).toBeNull();
@@ -394,7 +396,7 @@ describe('issueFoaiCertificateIfComplete', () => {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Required', exerciseNumber: '1',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email: 'test@example.com', exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1', email: 'test@example.com', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
     // Further/Maybe exercises with no completed response — must not block the certificate.
     await testDb.insert(exerciseTable, {
@@ -404,7 +406,7 @@ describe('issueFoaiCertificateIfComplete', () => {
       id: 'foai-ex-maybe', courseId: FOAI_COURSE_ID, status: 'Maybe', title: 'Maybe', exerciseNumber: '3',
     });
 
-    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+    expect(await issueFoaiCertificateIfComplete('test@example.com', FOAI_USER_ID)).toBe(true);
 
     const [selfServe] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
       .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
@@ -419,13 +421,13 @@ describe('issueFoaiCertificateIfComplete', () => {
       id: 'foai-ex-core', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Core', exerciseNumber: '1',
     });
 
-    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(false);
+    expect(await issueFoaiCertificateIfComplete('test@example.com', FOAI_USER_ID)).toBe(false);
 
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-core', email: 'test@example.com', exerciseId: 'foai-ex-core', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-core', email: 'test@example.com', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-core', response: 'done', completedAt: '2026-01-01',
     });
 
-    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+    expect(await issueFoaiCertificateIfComplete('test@example.com', FOAI_USER_ID)).toBe(true);
 
     const [selfServe] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
       .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -1,5 +1,6 @@
 import {
   and,
+  arrayContains,
   COURSE_ROLE,
   courseRegistrationTable,
   courseTable,
@@ -21,7 +22,7 @@ import { protectedProcedure, publicProcedure, router } from '../trpc';
 import type { AppRouter } from './_app';
 import { hasUpcomingRoundsForCourseId } from './course-rounds';
 
-async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
+async function areAllFoaiExercisesComplete(userId: string): Promise<boolean> {
   const requiredExercises = await db.pg
     .select({ id: exerciseTable.pg.id })
     .from(exerciseTable.pg)
@@ -39,7 +40,7 @@ async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
     .select()
     .from(exerciseResponsePgTable.pg)
     .where(and(
-      eq(exerciseResponsePgTable.pg.email, email),
+      arrayContains(exerciseResponsePgTable.pg.userId, [userId]),
       inArray(exerciseResponsePgTable.pg.exerciseId, requiredExercises.map((e) => e.id)),
     ));
 
@@ -49,7 +50,8 @@ async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
   return requiredExercises.every((exercise) => completedExerciseIds.has(exercise.id));
 }
 
-export async function issueFoaiCertificateIfComplete(email: string): Promise<boolean> {
+export async function issueFoaiCertificateIfComplete(email: string, userId: string): Promise<boolean> {
+  // TODO we should use userId here even
   const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
     filter: { email, courseId: FOAI_COURSE_ID },
     sortBy: 'createdAt',
@@ -59,7 +61,7 @@ export async function issueFoaiCertificateIfComplete(email: string): Promise<boo
     return false;
   }
 
-  if (!(await areAllFoaiExercisesComplete(email))) {
+  if (!(await areAllFoaiExercisesComplete(userId))) {
     return false;
   }
 

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -51,7 +51,6 @@ async function areAllFoaiExercisesComplete(userId: string): Promise<boolean> {
 }
 
 export async function issueFoaiCertificateIfComplete(email: string, userId: string): Promise<boolean> {
-  // TODO we should use userId here even
   const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
     filter: { email, courseId: FOAI_COURSE_ID },
     sortBy: 'createdAt',

--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -4,6 +4,7 @@ import {
   exerciseResponsePgTable,
   exerciseTable,
   unitTable,
+  userTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
@@ -163,13 +164,14 @@ describe('courses.getCurriculumMetadata', () => {
 
 describe('courses.getCourseProgress', () => {
   test('Core-status exercises count toward progress', async () => {
+    await testDb.insert(userTable, { id: 'user-1', email: 'test@example.com', name: 'Test User' });
     await seedCourse('core-prog');
     await seedUnit('ucp', 'core-prog', '1');
     await seedChunk('ucp-a', 'ucp', { exercises: ['ex-core'] });
     await seedExercise('ex-core');
 
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r-core', email: 'test@example.com', exerciseId: 'ex-core', response: 'x', completedAt: '2026-01-01',
+      id: 'r-core', email: 'test@example.com', userId: ['user-1'], exerciseId: 'ex-core', response: 'x', completedAt: '2026-01-01',
     });
 
     const { courseProgress } = await caller.courses.getCourseProgress({ courseSlug: 'core-prog' });
@@ -178,6 +180,7 @@ describe('courses.getCourseProgress', () => {
   });
 
   test('Further and Maybe statuses count towards neither the total nor completion', async () => {
+    await testDb.insert(userTable, { id: 'user-1', email: 'test@example.com', name: 'Test User' });
     await seedCourse('further-prog');
     await seedUnit('ufp', 'further-prog', '1');
     await seedChunk('ufp-a', 'ufp', { exercises: ['ex-req', 'ex-further', 'ex-maybe'] });
@@ -187,10 +190,10 @@ describe('courses.getCourseProgress', () => {
 
     // Complete the non-required exercises; they must not move the progress numbers.
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r-further', email: 'test@example.com', exerciseId: 'ex-further', response: 'x', completedAt: '2026-01-01',
+      id: 'r-further', email: 'test@example.com', userId: ['user-1'], exerciseId: 'ex-further', response: 'x', completedAt: '2026-01-01',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r-maybe', email: 'test@example.com', exerciseId: 'ex-maybe', response: 'x', completedAt: '2026-01-01',
+      id: 'r-maybe', email: 'test@example.com', userId: ['user-1'], exerciseId: 'ex-maybe', response: 'x', completedAt: '2026-01-01',
     });
 
     const { courseProgress } = await caller.courses.getCourseProgress({ courseSlug: 'further-prog' });

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -1,5 +1,6 @@
 import {
   and,
+  arrayContains,
   chunkTable,
   courseTable,
   desc,
@@ -11,6 +12,7 @@ import {
   resourceCompletionPgTable,
   unitResourceTable,
   unitTable,
+  userTable,
   type Chunk,
 } from '@bluedot/db';
 import { TRPCError, type inferRouterOutputs } from '@trpc/server';
@@ -85,13 +87,13 @@ export const getAllActiveCourses = async () => {
   return courses;
 };
 
-const getUserCompletions = async (coreResourceIds: string[], requiredExerciseIds: string[], email: string) => {
+const getUserCompletions = async (coreResourceIds: string[], requiredExerciseIds: string[], userId: string) => {
   const [rawResourceCompletions, rawExerciseCompletions] = await Promise.all([
     db.pg
       .select()
       .from(resourceCompletionPgTable.pg)
       .where(and(
-        eq(resourceCompletionPgTable.pg.email, email),
+        arrayContains(resourceCompletionPgTable.pg.userId, [userId]),
         inArray(resourceCompletionPgTable.pg.unitResourceId, coreResourceIds),
         isNotNull(resourceCompletionPgTable.pg.completedAt), // Only fetch completed resources
       ))
@@ -104,7 +106,7 @@ const getUserCompletions = async (coreResourceIds: string[], requiredExerciseIds
       })
       .from(exerciseResponsePgTable.pg)
       .where(and(
-        eq(exerciseResponsePgTable.pg.email, email),
+        arrayContains(exerciseResponsePgTable.pg.userId, [userId]),
         inArray(exerciseResponsePgTable.pg.exerciseId, requiredExerciseIds),
         isNotNull(exerciseResponsePgTable.pg.completedAt), // Only fetch completed exercises
       ))
@@ -300,10 +302,15 @@ export const coursesRouter = router({
 
       const { coreResourceIds, requiredExerciseIds } = await getCoreResourceAndRequiredExerciseIds(allChunks);
 
+      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+      if (!user) {
+        throw new TRPCError({ code: 'UNAUTHORIZED', message: 'user not found' });
+      }
+
       const { resourceCompletions, exerciseCompletions } = await getUserCompletions(
         coreResourceIds,
         requiredExerciseIds,
-        ctx.auth.email,
+        user.id,
       );
 
       // Build Sets for faster lookup

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -111,6 +111,8 @@ describe('exercises.saveExerciseResponse', () => {
   });
 
   test('updates an existing response', async () => {
+    await testDb.insert(userTable, { id: 'user-1', email: CALLER_EMAIL, name: 'Test User' });
+
     await caller.exercises.saveExerciseResponse({
       exerciseId: 'exercise-1',
       response: 'Draft answer',
@@ -301,11 +303,16 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
 
 describe('exercises.getExerciseResponse', () => {
   test('returns null when no response exists', async () => {
+    await testDb.insert(userTable, { id: 'user-1', email: CALLER_EMAIL, name: 'Test User' });
+
     const result = await caller.exercises.getExerciseResponse({ exerciseId: 'exercise-1' });
     expect(result).toBeNull();
   });
 
   test('returns response scoped to the current user', async () => {
+    await testDb.insert(userTable, { id: 'user-1', email: CALLER_EMAIL, name: 'Test User' });
+    await testDb.insert(userTable, { id: 'user-other', email: 'other@example.com', name: 'Other User' });
+
     await caller.exercises.saveExerciseResponse({
       exerciseId: 'exercise-1',
       response: 'My answer',

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -65,6 +65,7 @@ async function seedFacilitatorFlow() {
   await testDb.insert(meetPersonTable, {
     id: 'meet-participant',
     email: 'participant@example.com',
+    userId: 'up-user',
     name: 'Alice',
     role: 'Participant',
   });
@@ -446,7 +447,9 @@ describe('exercises.getGroupExerciseResponses', () => {
       applicationsBaseRecordId: 'reg-1',
       role: 'Facilitator',
     });
-    await testDb.insert(meetPersonTable, { id: 'meet-participant', email: 'participant@example.com', name: 'Alice' });
+    await testDb.insert(meetPersonTable, {
+      id: 'meet-participant', email: 'participant@example.com', userId: 'up-user', name: 'Alice',
+    });
     await testDb.insert(groupTable, {
       id: 'group-1',
       facilitator: ['meet-facilitator'],
@@ -510,6 +513,7 @@ describe('exercises.getGroupExerciseResponses', () => {
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
       email: 'participant@example.com',
+      userId: ['up-user'],
       exerciseId: 'ex-1',
       response: 'My answer',
       completedAt: new Date().toISOString(),
@@ -532,6 +536,7 @@ describe('exercises.getGroupExerciseResponses', () => {
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
       email: 'participant@example.com',
+      userId: ['up-user'],
       exerciseId: 'ex-1',
       response: 'Work in progress',
       completedAt: null,
@@ -563,6 +568,7 @@ describe('exercises.getGroupExerciseResponses', () => {
     await testDb.insert(meetPersonTable, {
       id: 'meet-participant',
       email: 'noname@example.com',
+      userId: 'noname-user',
       name: null,
       role: 'Participant',
     });
@@ -575,6 +581,7 @@ describe('exercises.getGroupExerciseResponses', () => {
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
       email: 'noname@example.com',
+      userId: ['noname-user'],
       exerciseId: 'ex-1',
       response: 'An answer',
       completedAt: new Date().toISOString(),
@@ -612,7 +619,7 @@ describe('exercises.getGroupExerciseResponses', () => {
       round: `round-${suffix}`,
     });
     await testDb.insert(meetPersonTable, {
-      id: `meet-participant-${suffix}`, email: `${suffix}@example.com`, name: `Participant ${suffix}`,
+      id: `meet-participant-${suffix}`, email: `${suffix}@example.com`, userId: `user-${suffix}`, name: `Participant ${suffix}`,
     });
     await testDb.insert(groupTable, {
       id: `group-${suffix}`,

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -97,10 +97,6 @@ describe('exercises.saveExerciseResponse', () => {
   });
 
   test('writes userId on insert when the user exists', async () => {
-    await testDb.insert(userTable, {
-      id: 'user-1', email: CALLER_EMAIL, name: 'Test User',
-    });
-
     const result = await caller.exercises.saveExerciseResponse({
       exerciseId: 'exercise-1',
       response: 'My answer',
@@ -122,8 +118,6 @@ describe('exercises.saveExerciseResponse', () => {
   });
 
   test('updates an existing response', async () => {
-    await testDb.insert(userTable, { id: 'user-1', email: CALLER_EMAIL, name: 'Test User' });
-
     await caller.exercises.saveExerciseResponse({
       exerciseId: 'exercise-1',
       response: 'Draft answer',
@@ -314,14 +308,11 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
 
 describe('exercises.getExerciseResponse', () => {
   test('returns null when no response exists', async () => {
-    await testDb.insert(userTable, { id: 'user-1', email: CALLER_EMAIL, name: 'Test User' });
-
     const result = await caller.exercises.getExerciseResponse({ exerciseId: 'exercise-1' });
     expect(result).toBeNull();
   });
 
   test('returns response scoped to the current user', async () => {
-    await testDb.insert(userTable, { id: 'user-1', email: CALLER_EMAIL, name: 'Test User' });
     await testDb.insert(userTable, { id: 'user-other', email: 'other@example.com', name: 'Other User' });
 
     await caller.exercises.saveExerciseResponse({

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -10,7 +10,9 @@ import {
   selfServeCourseRegistrationTable,
   userTable,
 } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
+import {
+  beforeEach, describe, expect, test,
+} from 'vitest';
 import {
   createCaller,
   setupTestDb,
@@ -22,6 +24,11 @@ setupTestDb();
 
 const caller = createCaller(testAuthContextLoggedIn);
 const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;
+
+// The authenticated user's row is assumed to exist by the userId-scoped routes.
+beforeEach(async () => {
+  await testDb.insert(userTable, { id: 'user-1', email: CALLER_EMAIL, name: 'Test User' });
+});
 
 async function seedCourse() {
   return testDb.insert(courseTable, {
@@ -101,13 +108,16 @@ describe('exercises.saveExerciseResponse', () => {
     expect(result.userId).toEqual(['user-1']);
   });
 
-  test('leaves userId null on insert when the user row is missing', async () => {
-    const result = await caller.exercises.saveExerciseResponse({
-      exerciseId: 'exercise-1',
-      response: 'My answer',
+  test('throws UNAUTHORIZED when the user row is missing', async () => {
+    const noUserCaller = createCaller({
+      ...testAuthContextLoggedIn,
+      auth: { ...testAuthContextLoggedIn.auth!, email: 'nouser@example.com' },
     });
 
-    expect(result.userId).toBeNull();
+    await expect(noUserCaller.exercises.saveExerciseResponse({
+      exerciseId: 'exercise-1',
+      response: 'My answer',
+    })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
   test('updates an existing response', async () => {
@@ -201,7 +211,7 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
       id: 'foai-ex-2', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Action plan', exerciseNumber: '2',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email: CALLER_EMAIL, exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1', email: CALLER_EMAIL, userId: ['user-1'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
 
     const before = Math.floor(Date.now() / 1000);
@@ -286,7 +296,7 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email: CALLER_EMAIL, exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1', email: CALLER_EMAIL, userId: ['user-1'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
 
     const result = await caller.exercises.saveExerciseResponse({

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -5,10 +5,10 @@ import {
   COURSE_ROLE,
   courseRegistrationTable,
   courseTable,
+  desc,
   eq,
   exerciseResponsePgTable,
   exerciseTable,
-  getFirstFromPg,
   groupTable,
   inArray,
   isNotNull,
@@ -68,16 +68,25 @@ export const exercisesRouter = router({
         completedAt = null;
       } // else undefined = "don't change"
 
-      const [existingResponse, exercise, user] = await Promise.all([
-        getFirstFromPg(db.pg, exerciseResponsePgTable.pg, {
-          filter: { exerciseId: input.exerciseId, email: ctx.auth.email },
-          sortBy: { field: 'createdAt', direction: 'desc' },
-        }),
+      const [exercise, user] = await Promise.all([
         input.completed === true
           ? db.getFirst(exerciseTable, { filter: { id: input.exerciseId }, sortBy: 'id' })
           : Promise.resolve(undefined),
         db.getFirst(userTable, { filter: { email: ctx.auth.email } }),
       ]);
+      if (!user) {
+        throw new TRPCError({ code: 'UNAUTHORIZED', message: 'user not found' });
+      }
+
+      const [existingResponse] = await db.pg
+        .select()
+        .from(exerciseResponsePgTable.pg)
+        .where(and(
+          eq(exerciseResponsePgTable.pg.exerciseId, input.exerciseId),
+          arrayContains(exerciseResponsePgTable.pg.userId, [user.id]),
+        ))
+        .orderBy(desc(exerciseResponsePgTable.pg.createdAt))
+        .limit(1);
 
       const [exerciseResponse] = existingResponse
         ? await db.pg
@@ -98,14 +107,14 @@ export const exercisesRouter = router({
             // Airtable defaulted this field to now(); without Airtable it must be set in code
             createdAt: new Date().toISOString(),
             completedAt: completedAt ?? null,
-            userId: user ? [user.id] : null,
+            userId: [user.id],
           })
           .returning();
 
       if (!exerciseResponse) throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to save exercise response' });
 
       const certificateIssued = exercise?.courseId === FOAI_COURSE_ID
-        ? await issueFoaiCertificateIfComplete(ctx.auth.email)
+        ? await issueFoaiCertificateIfComplete(ctx.auth.email, user.id)
         : false;
 
       return { ...exerciseResponse, certificateIssued };

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -35,10 +35,21 @@ export const exercisesRouter = router({
   getExerciseResponse: protectedProcedure
     .input(z.object({ exerciseId: z.string().min(1) }))
     .query(async ({ input, ctx }) => {
-      const exerciseResponse = await getFirstFromPg(db.pg, exerciseResponsePgTable.pg, {
-        filter: { exerciseId: input.exerciseId, email: ctx.auth.email },
-        sortBy: { field: 'createdAt', direction: 'desc' },
-      });
+      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+
+      if (!user) {
+        throw new TRPCError({ code: 'UNAUTHORIZED', message: 'user not found' });
+      }
+
+      const [exerciseResponse] = await db.pg
+        .select()
+        .from(exerciseResponsePgTable.pg)
+        .where(and(
+          eq(exerciseResponsePgTable.pg.exerciseId, input.exerciseId),
+          arrayContains(exerciseResponsePgTable.pg.userId, [user.id]),
+        ))
+        .orderBy(desc(exerciseResponsePgTable.pg.createdAt))
+        .limit(1);
 
       return exerciseResponse ?? null;
     }),

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -1,5 +1,6 @@
 import {
   and,
+  arrayContains,
   arrayOverlaps,
   asc,
   COURSE_ROLE,
@@ -215,31 +216,33 @@ export const exercisesRouter = router({
       }
 
       const participants = await db.pg
-        .select({ id: meetPersonTable.pg.id, name: meetPersonTable.pg.name, email: meetPersonTable.pg.email })
+        .select({ id: meetPersonTable.pg.id, name: meetPersonTable.pg.name, userId: meetPersonTable.pg.userId })
         .from(meetPersonTable.pg)
         .where(inArray(meetPersonTable.pg.id, allParticipantIds));
 
       const participantById = new Map(participants.map((p) => [p.id, p]));
 
       // 6. Get completed responses for this exercise from all participants
-      const allEmails = participants.map((p) => p.email).filter(Boolean) as string[];
-      if (allEmails.length === 0) {
+      const participantUserIds = participants.map((p) => p.userId).filter(Boolean) as string[];
+      if (participantUserIds.length === 0) {
         return null;
       }
 
       const exerciseResponses = await db.pg
         .select({
-          email: exerciseResponsePgTable.pg.email,
+          userId: exerciseResponsePgTable.pg.userId,
           response: exerciseResponsePgTable.pg.response,
         })
         .from(exerciseResponsePgTable.pg)
         .where(and(
           eq(exerciseResponsePgTable.pg.exerciseId, input.exerciseId),
-          inArray(exerciseResponsePgTable.pg.email, allEmails),
+          arrayOverlaps(exerciseResponsePgTable.pg.userId, participantUserIds),
           isNotNull(exerciseResponsePgTable.pg.completedAt),
         ));
 
-      const responseByEmail = new Map(exerciseResponses.map((r) => [r.email, r.response]));
+      const responseByUserId = new Map(exerciseResponses
+        .map((r) => [r.userId?.[0], r.response] as const)
+        .filter((entry): entry is readonly [string, string] => entry[0] != null));
 
       // 7. Build per-group response data
       const groupData = sortedGroups.map((g) => {
@@ -247,11 +250,11 @@ export const exercisesRouter = router({
         const responses: { name: string; response: string }[] = [];
         for (const pid of groupParticipantIds) {
           const p = participantById.get(pid);
-          if (!p?.email) {
+          if (!p?.userId) {
             continue;
           }
 
-          const response = responseByEmail.get(p.email);
+          const response = responseByUserId.get(p.userId);
           if (response !== undefined) {
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             responses.push({ name: p.name || 'Anonymous', response });

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -242,7 +242,7 @@ export const exercisesRouter = router({
 
       const responseByUserId = new Map(exerciseResponses
         .map((r) => [r.userId?.[0], r.response] as const)
-        .filter((entry): entry is readonly [string, string] => entry[0] != null));
+        .filter((entry): entry is readonly [string, string] => entry[0] !== undefined && entry[0] !== null));
 
       // 7. Build per-group response data
       const groupData = sortedGroups.map((g) => {

--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -4,7 +4,9 @@ import {
   unitResourceTable,
   userTable,
 } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
+import {
+  beforeEach, describe, expect, test,
+} from 'vitest';
 import {
   createCaller,
   setupTestDb,
@@ -17,9 +19,13 @@ setupTestDb();
 const caller = createCaller(testAuthContextLoggedIn);
 const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;
 
+// The authenticated user's row is assumed to exist by the userId-scoped routes.
+beforeEach(async () => {
+  await testDb.insert(userTable, { id: 'user-1', email: CALLER_EMAIL, name: 'Test User' });
+});
+
 describe('resources.saveResourceCompletion', () => {
   test('writes resourceId, userId, and createdByUserId on insert when both can be resolved', async () => {
-    await testDb.insert(userTable, { id: 'user-1', name: 'user-1-name', email: CALLER_EMAIL });
     await testDb.insert(courseBuilderUserTable, { id: 'cb-user-1', email: CALLER_EMAIL });
     await testDb.insert(unitResourceTable, { id: 'ur-1', resourceId: ['resource-1'] });
 
@@ -37,15 +43,27 @@ describe('resources.saveResourceCompletion', () => {
     expect(result.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   });
 
-  test('leaves the FK fields null on insert when the lookups miss', async () => {
+  test('leaves resourceId and createdByUserId null when those lookups miss', async () => {
     const result = await caller.resources.saveResourceCompletion({
       unitResourceId: 'ur-missing',
       isCompleted: true,
     });
 
     expect(result.resourceId).toBeNull();
-    expect(result.userId).toBeNull();
+    expect(result.userId).toEqual(['user-1']);
     expect(result.createdByUserId).toBeNull();
+  });
+
+  test('throws UNAUTHORIZED when the user row is missing', async () => {
+    const noUserCaller = createCaller({
+      ...testAuthContextLoggedIn,
+      auth: { ...testAuthContextLoggedIn.auth!, email: 'nouser@example.com' },
+    });
+
+    await expect(noUserCaller.resources.saveResourceCompletion({
+      unitResourceId: 'ur-1',
+      isCompleted: true,
+    })).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
   test('updates an existing completion without touching the FK fields', async () => {
@@ -54,7 +72,7 @@ describe('resources.saveResourceCompletion', () => {
       email: CALLER_EMAIL,
       unitResourceId: 'ur-1',
       resourceId: ['resource-original'],
-      userId: ['user-original'],
+      userId: ['user-1'],
       createdByUserId: ['cb-user-original'],
     });
 
@@ -66,7 +84,7 @@ describe('resources.saveResourceCompletion', () => {
     expect(result).toMatchObject({
       id: 'rc-1',
       resourceId: ['resource-original'],
-      userId: ['user-original'],
+      userId: ['user-1'],
       createdByUserId: ['cb-user-original'],
     });
   });
@@ -85,6 +103,7 @@ describe('resources.saveResourceCompletion', () => {
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'rc-1',
       email: CALLER_EMAIL,
+      userId: ['user-1'],
       unitResourceId: 'ur-1',
       completedAt: '2026-01-01T00:00:00.000Z',
     });
@@ -101,6 +120,7 @@ describe('resources.saveResourceCompletion', () => {
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'rc-1',
       email: CALLER_EMAIL,
+      userId: ['user-1'],
       unitResourceId: 'ur-1',
       completedAt: '2026-01-01T00:00:00.000Z',
     });

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -1,5 +1,5 @@
 import {
-  and, courseBuilderUserTable, userTable, desc, eq, getFirstFromPg, inArray, resourceCompletionPgTable, unitResourceTable,
+  and, arrayContains, courseBuilderUserTable, userTable, desc, eq, getFirstFromPg, inArray, resourceCompletionPgTable, unitResourceTable,
 } from '@bluedot/db';
 import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
 import { TRPCError } from '@trpc/server';
@@ -11,12 +11,18 @@ export const resourcesRouter = router({
   getResourceCompletions: protectedProcedure
     .input(z.object({ unitResourceIds: z.array(z.string().min(1)).max(100) }))
     .query(async ({ input, ctx }) => {
+      const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+
+      if (!user) {
+        throw new TRPCError({ code: 'UNAUTHORIZED', message: 'user not found' });
+      }
+
       const resourceCompletions = await db.pg
         .select()
         .from(resourceCompletionPgTable.pg)
         .where(and(
           inArray(resourceCompletionPgTable.pg.unitResourceId, input.unitResourceIds),
-          eq(resourceCompletionPgTable.pg.email, ctx.auth.email),
+          arrayContains(resourceCompletionPgTable.pg.userId, [user.id]),
         ))
         .orderBy(desc(resourceCompletionPgTable.pg.createdAt));
 

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -1,5 +1,5 @@
 import {
-  and, arrayContains, courseBuilderUserTable, userTable, desc, eq, getFirstFromPg, inArray, resourceCompletionPgTable, unitResourceTable,
+  and, arrayContains, courseBuilderUserTable, userTable, desc, eq, inArray, resourceCompletionPgTable, unitResourceTable,
 } from '@bluedot/db';
 import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
 import { TRPCError } from '@trpc/server';
@@ -61,18 +61,24 @@ export const resourcesRouter = router({
         .optional(),
     }))
     .mutation(async ({ input, ctx }) => {
-      const [resourceCompletion, unitResource, cbUser, user] = await Promise.all([
-        getFirstFromPg(db.pg, resourceCompletionPgTable.pg, {
-          filter: {
-            unitResourceId: input.unitResourceId,
-            email: ctx.auth.email,
-          },
-          sortBy: { field: 'createdAt', direction: 'desc' },
-        }),
+      const [unitResource, cbUser, user] = await Promise.all([
         db.getFirst(unitResourceTable, { filter: { id: input.unitResourceId }, sortBy: 'id' }),
         db.getFirst(courseBuilderUserTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),
         db.getFirst(userTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),
       ]);
+      if (!user) {
+        throw new TRPCError({ code: 'UNAUTHORIZED', message: 'user not found' });
+      }
+
+      const [resourceCompletion] = await db.pg
+        .select()
+        .from(resourceCompletionPgTable.pg)
+        .where(and(
+          eq(resourceCompletionPgTable.pg.unitResourceId, input.unitResourceId),
+          arrayContains(resourceCompletionPgTable.pg.userId, [user.id]),
+        ))
+        .orderBy(desc(resourceCompletionPgTable.pg.createdAt))
+        .limit(1);
 
       let completedAt: string | null | undefined;
       if (input.isCompleted === true && resourceCompletion?.completedAt == null) {
@@ -100,7 +106,7 @@ export const resourcesRouter = router({
             feedback: input.feedback ?? '',
             resourceFeedback: input.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
             resourceId: unitResource?.resourceId ?? null,
-            userId: user ? [user.id] : null,
+            userId: [user.id],
             createdByUserId: cbUser ? [cbUser.id] : null,
             createdAt: new Date().toISOString(),
           })


### PR DESCRIPTION
# Description

Part of the work to deprecate the use of `email` as an identifier (#2709). This replaces all lookups of exercise responses and resource completions that used `email` with `userId` instead.

Before raising this I cleaned up the data to make sure a `userId` is populated for all rows where we can find one. Here are some queries you can run to verify this:
```sql
SELECT
  count(*) AS total,
  count(*) FILTER (WHERE "userId" IS NOT NULL AND cardinality("userId") > 0) AS has_userid,
  count(*) FILTER (WHERE ("userId" IS NULL OR cardinality("userId") = 0)
                    AND coalesce(trim(email), '') <> '') AS missing_userid_but_has_email
FROM resource_completion;
```
```sql
SELECT
  count(*) AS total,
  count(*) FILTER (WHERE "userId" IS NOT NULL AND cardinality("userId") > 0) AS has_userid,
  count(*) FILTER (WHERE ("userId" IS NULL OR cardinality("userId") = 0)
                    AND coalesce(trim(email), '') <> '') AS missing_userid_but_has_email
FROM exercise_response;
```

I tried to keep the scope limited to exercise responses and resource completions (to cover other tables in a later PR). There was one route `getGroupExerciseResponses` which mixed together exercise responses and `meetPerson`s a lot, so I did migrate `meetPerson` lookups from `email` to `userId` there too. Here's a query for verifying that all the `meetPerson`s are backfilled correctly:

```
WITH distinct_users AS (
    SELECT DISTINCT ON (lower(trim(email))) id, lower(trim(email)) AS email_norm
    FROM "user"
    ORDER BY lower(trim(email)), id
  )
  SELECT
    count(*) AS total,
    count(*) FILTER (WHERE coalesce(trim(mp."userId"), '') <> '') AS has_userid,
    count(*) FILTER (WHERE coalesce(trim(mp."userId"), '') = ''
                      AND coalesce(trim(mp.email), '') <> ''
                      AND du.id IS NULL) AS no_userid_no_user,
    count(*) FILTER (WHERE coalesce(trim(mp."userId"), '') = ''
                      AND coalesce(trim(mp.email), '') <> ''
                      AND du.id IS NOT NULL) AS no_userid_yes_user
  FROM meet_person mp
  LEFT JOIN distinct_users du ON du.email_norm = lower(trim(mp.email));
```

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2709

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories