### PR TITLE
[fix] infra: make app-pg-dump backup use libpq-compatible sslmode

### DIFF
--- a/apps/infra/src/k8s/backups.ts
+++ b/apps/infra/src/k8s/backups.ts
@@ -165,7 +165,9 @@ new k8s.apps.v1.Deployment('app-pg-dump', {
         labels: pgDumpLabels,
         annotations: {
           // sh -c so the shell expands $PG_URI (k8up shellword-splits the annotation).
-          'k8up.io/backupcommand': 'sh -c \'pg_dump "$PG_URI"\'',
+          // PG_URI carries sslmode=no-verify for node-postgres, but libpq/pg_dump rejects that
+          // value; rewrite it to the libpq equivalent `require` (encrypt, skip CA verification).
+          'k8up.io/backupcommand': 'sh -c \'pg_dump "$(echo "$PG_URI" | sed "s/sslmode=no-verify/sslmode=require/")"\'',
           'k8up.io/file-extension': '.sql',
         },
       },


### PR DESCRIPTION
## Problem

The GCS billing block is cleared and restic/volume backups are healthy again (`monitoring` ns green; every PVC in `default` backs up with `errors: 0`). But the `default`-ns daily Backup still reports **Failed** — a separate, pre-existing bug.

The `app-pg-dump` deployment (off-Vultr dump of managed appPg, #2576) runs its `backupcommand` as `pg_dump "$PG_URI"`. `PG_URI` carries `sslmode=no-verify`, which is a **node-postgres**-specific value. libpq (which `pg_dump` uses) rejects it:

```
pg_dump: error: invalid sslmode value: "no-verify"
```

So this dump has never succeeded (deployment is 22d old) — managed appPg has had **no working off-cluster backup**, only the in-cluster PVCs.

## Fix

Rewrite `sslmode=no-verify` → `sslmode=require` inside the `backupcommand` only. `require` is the libpq equivalent (encrypt, skip CA verification), matching the node-postgres intent. The shared node-postgres URI in `postgres.ts` is left untouched — apps still need `no-verify` for Vultr's cert chain.

## Verification

Ran against the live pod both ways:

- `pg_dump "$PG_URI"` → exit 1, `invalid sslmode value: "no-verify"`
- `pg_dump` with sslmode rewritten to `require` → exit 0, clean 375 MB dump

typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
