### PR TITLE
[feat] db: add keycloakIdentifier column to user table

### DIFF
--- a/apps/website/src/__tests__/pages/facilitator-feedback/[meetPersonId].test.tsx
+++ b/apps/website/src/__tests__/pages/facilitator-feedback/[meetPersonId].test.tsx
@@ -37,6 +37,7 @@ const mockUser = {
   utmCampaign: null,
   utmContent: null,
   isAdmin: false,
+  keycloakIdentifier: null,
   allowedImpersonationTargets: null,
 };
 

--- a/apps/website/src/components/admin/ImpersonationBadge.test.tsx
+++ b/apps/website/src/components/admin/ImpersonationBadge.test.tsx
@@ -57,6 +57,7 @@ describe('ImpersonationBadge', () => {
       utmCampaign: null,
       utmContent: null,
       isAdmin: null,
+      keycloakIdentifier: null,
       allowedImpersonationTargets: [],
     })));
 
@@ -89,6 +90,7 @@ describe('ImpersonationBadge', () => {
       utmCampaign: null,
       utmContent: null,
       isAdmin: null,
+      keycloakIdentifier: null,
       allowedImpersonationTargets: [],
     })));
 

--- a/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.stories.tsx
@@ -45,6 +45,7 @@ const mockUser = {
   utmCampaign: null,
   utmContent: null,
   isAdmin: null,
+  keycloakIdentifier: null,
   allowedImpersonationTargets: [],
 };
 

--- a/apps/website/src/components/courses/GroupSwitchModal.test.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.test.tsx
@@ -47,6 +47,7 @@ const mockUser = {
   utmCampaign: null,
   utmContent: null,
   isAdmin: null,
+  keycloakIdentifier: null,
   allowedImpersonationTargets: [],
 };
 

--- a/apps/website/src/components/settings/ProfileNameEditor.test.tsx
+++ b/apps/website/src/components/settings/ProfileNameEditor.test.tsx
@@ -24,6 +24,7 @@ const mockUser = {
   utmContent: null,
   autoNumberId: null,
   isAdmin: null,
+  keycloakIdentifier: null,
   allowedImpersonationTargets: [],
 };
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1477,6 +1477,11 @@ export const userTable = pgAirtable('user', {
       pgColumn: text().notNull(),
       airtableId: 'fldLAGRfn7S6uEVRo',
     },
+    // The `sub` property returned from Keycloak
+    keycloakIdentifier: {
+      pgColumn: text(),
+      airtableId: 'fldCC20cAsdKtl4mX',
+    },
     createdAt: {
       pgColumn: text(),
       airtableId: 'fld2AGYp0VLOz3Pg6',


### PR DESCRIPTION
# Description

Schema-only PR adding the `Keycloak identifier` Airtable field (`fldCC20cAsdKtl4mX`, already created in the Applications base) to `userTable` as `keycloakIdentifier`. Nullable, since existing users won't have a value until the backfill.
## Issue

#2710

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories