### PR TITLE
[feat] website: backfill facilitator quick-apply name by email

### DIFF
--- a/apps/website/src/server/routers/facilitator-applications.test.ts
+++ b/apps/website/src/server/routers/facilitator-applications.test.ts
@@ -538,6 +538,11 @@ describe('resolveApplicantName', () => {
     expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: 'Cher', lastName: null });
   });
 
+  test('treats a whitespace-only user account name as missing', async () => {
+    await seedUser(CALLER_EMAIL, '   ');
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: null, lastName: null });
+  });
+
   test('does not read another user\'s name from either source', async () => {
     await seedUser('other@example.com', 'Someone Else');
     await testDb.insert(courseRegistrationTable, {

--- a/apps/website/src/server/routers/facilitator-applications.test.ts
+++ b/apps/website/src/server/routers/facilitator-applications.test.ts
@@ -4,6 +4,7 @@ import {
   courseTable,
   groupDiscussionTable,
   meetPersonTable,
+  userTable,
 } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
@@ -13,6 +14,7 @@ import {
   testAuthContextLoggedOut,
   testDb,
 } from '../../__tests__/dbTestUtils';
+import { resolveApplicantName } from './facilitator-applications';
 
 setupTestDb();
 
@@ -446,5 +448,107 @@ describe('facilitatorApplications.quickApply', () => {
     });
     await seedRound('round-next', 'course-1', null);
     await expect(caller.facilitatorApplications.quickApply(validInput)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+describe('resolveApplicantName', () => {
+  const seedUser = (email: string, name: string) => testDb.insert(userTable, { id: `user-${email}`, email, name });
+
+  test('returns null names when neither a prior application nor a user account has a name', async () => {
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: null, lastName: null });
+  });
+
+  test('prefers a prior application\'s split name over the user account', async () => {
+    await seedUser(CALLER_EMAIL, 'Account Name');
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-1',
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      role: 'Participant',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      autoNumberId: 1,
+    });
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: 'Ada', lastName: 'Lovelace' });
+  });
+
+  test('prefers the most recent prior application that has a name', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-old',
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      role: 'Participant',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      autoNumberId: 1,
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-new',
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      role: 'Facilitator',
+      firstName: 'Grace',
+      lastName: 'Hopper',
+      autoNumberId: 2,
+    });
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: 'Grace', lastName: 'Hopper' });
+  });
+
+  test('trims surrounding whitespace on a prior application name', async () => {
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-1',
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      role: 'Participant',
+      firstName: 'Caroline ',
+      lastName: ' Chitongo',
+      autoNumberId: 1,
+    });
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: 'Caroline', lastName: 'Chitongo' });
+  });
+
+  test('ignores a prior application whose name is only whitespace and falls back to the user account', async () => {
+    await seedUser(CALLER_EMAIL, 'Grace Hopper');
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-ws',
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      role: 'Facilitator',
+      firstName: '   ',
+      lastName: '',
+      autoNumberId: 5,
+    });
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: 'Grace', lastName: 'Hopper' });
+  });
+
+  test('falls back to the user account name (split on first space) when no prior application has a name', async () => {
+    await seedUser(CALLER_EMAIL, 'Caroline Shamiso Chitongo');
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-blank',
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      role: 'Facilitator',
+      autoNumberId: 2,
+    });
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: 'Caroline', lastName: 'Shamiso Chitongo' });
+  });
+
+  test('splits a single-word user account name into a null last name', async () => {
+    await seedUser(CALLER_EMAIL, 'Cher');
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: 'Cher', lastName: null });
+  });
+
+  test('does not read another user\'s name from either source', async () => {
+    await seedUser('other@example.com', 'Someone Else');
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-other',
+      email: 'other@example.com',
+      courseId: 'course-1',
+      role: 'Participant',
+      firstName: 'Someone',
+      lastName: 'Else',
+      autoNumberId: 1,
+    });
+    expect(await resolveApplicantName(CALLER_EMAIL)).toEqual({ firstName: null, lastName: null });
   });
 });

--- a/apps/website/src/server/routers/facilitator-applications.ts
+++ b/apps/website/src/server/routers/facilitator-applications.ts
@@ -208,7 +208,8 @@ export const resolveApplicantName = async (email: string): Promise<{ firstName: 
     .from(userTable.pg)
     .where(eq(userTable.pg.email, email))
     .limit(1);
-  if (user?.name) return splitName(user.name);
+  const accountName = cleanNamePart(user?.name);
+  if (accountName) return splitName(accountName);
 
   return { firstName: null, lastName: null };
 };

--- a/apps/website/src/server/routers/facilitator-applications.ts
+++ b/apps/website/src/server/routers/facilitator-applications.ts
@@ -9,6 +9,7 @@ import {
   groupDiscussionTable,
   inArray,
   meetPersonTable,
+  userTable,
 } from '@bluedot/db';
 import { type inferRouterOutputs, TRPCError } from '@trpc/server';
 import { z } from 'zod';
@@ -163,6 +164,53 @@ const getEligiblePriorFacilitatorRegs = async (email: string, courseId: string, 
   }
 
   return priorRegs;
+};
+
+// Trims a name part, treating null/undefined/blank/whitespace-only as "no value".
+const cleanNamePart = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return trimmed;
+};
+
+// Best-effort split of a single full-name string on the first space. The last name captures
+// everything after the first word, which is imperfect for multi-word given names but keeps the
+// first name (used in greetings) correct.
+const splitName = (name: string): { firstName: string; lastName: string | null } => {
+  const normalised = name.trim().replace(/\s+/g, ' ');
+  const spaceIndex = normalised.indexOf(' ');
+  if (spaceIndex === -1) return { firstName: normalised, lastName: null };
+  return { firstName: normalised.slice(0, spaceIndex), lastName: normalised.slice(spaceIndex + 1) };
+};
+
+// The quick-apply form doesn't capture the applicant's name. Prefer the split first/last from
+// their most recent prior application (any course/role) that recorded one — human-entered, so the
+// most accurate split. Otherwise fall back to the user account's single name field (always present
+// for a logged-in user), split on the first space. Leaves both null only if neither has a name.
+export const resolveApplicantName = async (email: string): Promise<{ firstName: string | null; lastName: string | null }> => {
+  const regs = await db.pg
+    .select({
+      firstName: courseRegistrationTable.pg.firstName,
+      lastName: courseRegistrationTable.pg.lastName,
+      autoNumberId: courseRegistrationTable.pg.autoNumberId,
+    })
+    .from(courseRegistrationTable.pg)
+    .where(eq(courseRegistrationTable.pg.email, email));
+
+  const named = [...regs]
+    .sort((a, b) => (b.autoNumberId ?? 0) - (a.autoNumberId ?? 0))
+    .map((r) => ({ firstName: cleanNamePart(r.firstName), lastName: cleanNamePart(r.lastName) }))
+    .find((r) => r.firstName !== null || r.lastName !== null);
+  if (named) return named;
+
+  const [user] = await db.pg
+    .select({ name: userTable.pg.name })
+    .from(userTable.pg)
+    .where(eq(userTable.pg.email, email))
+    .limit(1);
+  if (user?.name) return splitName(user.name);
+
+  return { firstName: null, lastName: null };
 };
 
 // The resolved form of a prior application's answers: every field present (optional strings
@@ -345,8 +393,12 @@ export const facilitatorApplicationsRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
       }
 
+      const { firstName, lastName } = await resolveApplicantName(ctx.auth.email);
+
       return db.insert(courseRegistrationTable, {
         email: ctx.auth.email,
+        firstName,
+        lastName,
         courseApplicationsBaseId: applicationsCourse.id,
         roundId: input.roundId,
         role: COURSE_ROLE.FACILITATOR,


### PR DESCRIPTION
# Description

When a facilitator uses the quick-apply flow (`/facilitator-applications/quick-apply?round=…`), the form collects their answers but never their name. As a result the new `course_registration` records were created with blank `firstName`/`lastName`. The name still *displayed* because the `fullName` formula field falls back to a lookup on the linked `user` record — but the discrete name columns themselves were empty.

This change backfills those columns at insert time. `resolveApplicantName(email)` prefers the human-entered split from the applicant's most recent prior application that recorded a name (any course/role — typically their original participant application, so the first/last split is accurate). When no prior application has a name, it falls back to the applicant's `user` account name (looked up by email, split on the first space) so the fields are populated regardless. Names are trimmed, and blank / whitespace-only values are treated as "no name".

## What changed

1. **`apps/website/src/server/routers/facilitator-applications.ts`** — new `resolveApplicantName` helper (with `cleanNamePart` and `splitName` sub-helpers), called in the `quickApply` mutation to set `firstName`/`lastName` on the inserted `course_registration`.
2. **`apps/website/src/server/routers/facilitator-applications.test.ts`** — unit tests for `resolveApplicantName`: prefers a prior application over the account, most-recent prior application wins, trims surrounding whitespace, ignores whitespace-only names, falls back to the account name split on first space, single-word name → null last name, and email isolation across both sources.

## Notes on the name source

No available source has a reliably clean first/last split: prior quick-apply records are blank, `meet_person` splits the same person's name inconsistently across records, and the `user` account stores only a single combined `name`. The hybrid here uses the most accurate split available (a human-entered prior application) and only falls back to splitting a combined name when nothing better exists. Splitting on the first space keeps `firstName` correct (the part used in greetings) at the cost of an approximate `lastName` for multi-word names.

## Issue

N/A — follow-up to the facilitator quick-apply feature; no linked issue.

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist — N/A, backend-only change (tRPC router).
- [x] Considered having snapshot tests / functional tests — added 8 unit tests for the new helper.
- [x] Considered adding Storybook stories — N/A, no component change.

No DB schema changes.

## Verification

Backend-only change (no UI surface). The `quickApply` mutation's insert can't run under the PGlite test harness because `courseId` is Airtable-computed and `notNull` in Postgres (same documented limitation as the existing `quickApply` test), so the name-resolution logic is verified directly via `resolveApplicantName` unit tests.

Type check + lint + full test suite all pass:
```
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npm test            # 928 passed, 1 skipped (119 files) — run twice, stable
```

## Screenshots

N/A — invisible diff (backend logic only, no visual change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
