### PR TITLE
Facilitator quick apply - make availability non optional

### DIFF
--- a/apps/website/src/pages/facilitator-applications/quick-apply/index.tsx
+++ b/apps/website/src/pages/facilitator-applications/quick-apply/index.tsx
@@ -252,11 +252,6 @@ const QuickApplyForm = ({ roundId, round, prefill }: { roundId: string } & Quick
   const quickApply = trpc.facilitatorApplications.quickApply.useMutation();
 
   const onSubmit = (values: FormValues) => {
-    const hasAvailability = Object.values(values.timeAv).some(Boolean);
-    const availabilityIntervalsUTC = hasAvailability
-      ? gridToUtcIntervalString(values.timeAv, values.timezone)
-      : undefined;
-
     quickApply.mutate(
       {
         roundId,
@@ -267,8 +262,8 @@ const QuickApplyForm = ({ roundId, round, prefill }: { roundId: string } & Quick
         impressiveProject: emptyToUndefined(values.impressiveProject),
         motivationToFacilitate: emptyToUndefined(values.motivationToFacilitate),
         prevFacilitationExperience: emptyToUndefined(values.prevFacilitationExperience),
-        availabilityIntervalsUTC,
-        availabilityTimezone: hasAvailability ? values.timezone : undefined,
+        availabilityIntervalsUTC: gridToUtcIntervalString(values.timeAv, values.timezone),
+        availabilityTimezone: values.timezone,
         availabilityComments: emptyToUndefined(values.availabilityComments),
       },
       {

--- a/apps/website/src/pages/facilitator-applications/quick-apply/index.tsx
+++ b/apps/website/src/pages/facilitator-applications/quick-apply/index.tsx
@@ -390,11 +390,15 @@ const QuickApplyForm = ({ roundId, round, prefill }: { roundId: string } & Quick
           </button>
         </div>
 
-        <Controller
-          control={control}
-          name="timeAv"
-          render={({ field }) => <TimeAvailabilityGrid value={field.value} onChange={field.onChange} />}
-        />
+        <div className="flex flex-col gap-2">
+          <Controller
+            control={control}
+            name="timeAv"
+            rules={{ validate: (v) => Object.values(v).some(Boolean) || 'Select at least one time slot.' }}
+            render={({ field }) => <TimeAvailabilityGrid value={field.value} onChange={field.onChange} />}
+          />
+          {errors.timeAv && <p className="text-size-xs text-red-600">{errors.timeAv.message}</p>}
+        </div>
 
         <div className="flex flex-col gap-3">
           <label htmlFor="availabilityComments" className="text-size-xs text-bluedot-navy font-semibold">

--- a/apps/website/src/pages/facilitator-applications/quick-apply/index.tsx
+++ b/apps/website/src/pages/facilitator-applications/quick-apply/index.tsx
@@ -155,7 +155,7 @@ const Section = ({
   children,
 }: {
   label: string;
-  title: string;
+  title: React.ReactNode;
   description?: string;
   children: React.ReactNode;
 }) => (
@@ -360,7 +360,11 @@ const QuickApplyForm = ({ roundId, round, prefill }: { roundId: string } & Quick
 
       <Section
         label="Your availability"
-        title="Share your availability"
+        title={(
+          <>
+            Share your availability <span className="text-red-600">*</span>
+          </>
+        )}
         description="Provide your availability so we can schedule your discussions at times that suit you. It'll be saved as a default for your next application."
       >
         <div className="flex items-end justify-between gap-4">

--- a/apps/website/src/server/routers/facilitator-applications.test.ts
+++ b/apps/website/src/server/routers/facilitator-applications.test.ts
@@ -391,14 +391,24 @@ describe('facilitatorApplications.quickApplyPrefill', () => {
 });
 
 describe('facilitatorApplications.quickApply', () => {
-  const validInput = { roundId: 'round-next', numGroupsToFacilitate: 2 };
+  const validInput = {
+    roundId: 'round-next',
+    numGroupsToFacilitate: 2,
+    availabilityIntervalsUTC: 'M16:00 M18:00',
+    availabilityTimezone: 'UTC+00:00',
+  };
 
   test('rejects unauthenticated callers', async () => {
     await expect(createCaller(testAuthContextLoggedOut).facilitatorApplications.quickApply(validInput)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
   test('rejects numGroupsToFacilitate below 1', async () => {
-    await expect(caller.facilitatorApplications.quickApply({ roundId: 'round-next', numGroupsToFacilitate: 0 })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    await expect(caller.facilitatorApplications.quickApply({ ...validInput, numGroupsToFacilitate: 0 })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  test('rejects missing availability', async () => {
+    // @ts-expect-error intentionally omit required availability fields to exercise server-side validation
+    await expect(caller.facilitatorApplications.quickApply({ roundId: 'round-next', numGroupsToFacilitate: 2 })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
   test('throws FORBIDDEN when the caller has not facilitated the course', async () => {
@@ -430,7 +440,7 @@ describe('facilitatorApplications.quickApply', () => {
       roundId: 'round-a',
     });
     await seedRound('round-closed', 'course-1', '2000-01-01');
-    await expect(caller.facilitatorApplications.quickApply({ roundId: 'round-closed', numGroupsToFacilitate: 2 })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    await expect(caller.facilitatorApplications.quickApply({ ...validInput, roundId: 'round-closed' })).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   // Validations pass (prior facilitator app exists, round open, not a duplicate), so the mutation

--- a/apps/website/src/server/routers/facilitator-applications.test.ts
+++ b/apps/website/src/server/routers/facilitator-applications.test.ts
@@ -411,6 +411,11 @@ describe('facilitatorApplications.quickApply', () => {
     await expect(caller.facilitatorApplications.quickApply({ roundId: 'round-next', numGroupsToFacilitate: 2 })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
+  test('rejects malformed availability strings', async () => {
+    await expect(caller.facilitatorApplications.quickApply({ ...validInput, availabilityTimezone: 'bad' })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    await expect(caller.facilitatorApplications.quickApply({ ...validInput, availabilityIntervalsUTC: '   ' })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
   test('throws FORBIDDEN when the caller has not facilitated the course', async () => {
     await seedCourse('course-1', 'tai', 'Technical AI Safety');
     await seedRound('round-next', 'course-1', null);

--- a/apps/website/src/server/routers/facilitator-applications.ts
+++ b/apps/website/src/server/routers/facilitator-applications.ts
@@ -11,6 +11,7 @@ import {
   meetPersonTable,
   userTable,
 } from '@bluedot/db';
+import { utcIntervalStringToGrid } from '@bluedot/utils';
 import { type inferRouterOutputs, TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';
@@ -379,7 +380,16 @@ export const facilitatorApplicationsRouter = router({
   }),
 
   quickApply: protectedProcedure
-    .input(facilitatorApplicationAnswersSchema.extend({ roundId: z.string() }))
+    .input(facilitatorApplicationAnswersSchema.extend({ roundId: z.string() }).refine(
+      (v) => {
+        try {
+          return Object.values(utcIntervalStringToGrid(v.availabilityIntervalsUTC, v.availabilityTimezone)).some(Boolean);
+        } catch {
+          return false;
+        }
+      },
+      { message: 'Invalid availability', path: ['availabilityIntervalsUTC'] },
+    ))
     .mutation(async ({ ctx, input }) => {
       const { courseId } = await getOpenRound(input.roundId);
       await getEligiblePriorFacilitatorRegs(ctx.auth.email, courseId, input.roundId);

--- a/apps/website/src/server/routers/facilitator-applications.ts
+++ b/apps/website/src/server/routers/facilitator-applications.ts
@@ -91,8 +91,8 @@ const facilitatorApplicationAnswersSchema = z.object({
   impressiveProject: z.string().optional(),
   motivationToFacilitate: z.string().optional(),
   prevFacilitationExperience: z.string().optional(),
-  availabilityIntervalsUTC: z.string().optional(),
-  availabilityTimezone: z.string().optional(),
+  availabilityIntervalsUTC: z.string().min(1),
+  availabilityTimezone: z.string().min(1),
   availabilityComments: z.string().optional(),
 });
 
@@ -412,8 +412,8 @@ export const facilitatorApplicationsRouter = router({
         impressiveProject: input.impressiveProject ?? null,
         motivationToFacilitate: input.motivationToFacilitate ?? null,
         prevFacilitationExperience: input.prevFacilitationExperience ?? null,
-        availabilityIntervalsUTC: input.availabilityIntervalsUTC ?? null,
-        availabilityTimezone: input.availabilityTimezone ?? null,
+        availabilityIntervalsUTC: input.availabilityIntervalsUTC,
+        availabilityTimezone: input.availabilityTimezone,
         availabilityComments: input.availabilityComments ?? null,
       });
     }),


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Make availability intervals on quick apply non-optional on both client and server.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->
