### PR TITLE
Airtable liveness check on pg sync startup

### DIFF
--- a/apps/pg-sync-service/src/index.ts
+++ b/apps/pg-sync-service/src/index.ts
@@ -38,7 +38,14 @@ const start = async () => {
       await assertAirtableLiveness(db.airtableClient);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      await slackAlert(env, [`pg-sync-service: Airtable liveness check failed on startup: ${message}`]);
+      // Best-effort alert, but never let a stalled Slack request block the process
+      // from failing fast: cap the wait so we always fall through to `throw` → exit.
+      await Promise.race([
+        slackAlert(env, [`pg-sync-service: Airtable liveness check failed on startup: ${message}`]),
+        new Promise((resolve) => {
+          setTimeout(resolve, 5000);
+        }),
+      ]).catch(() => {});
       throw error;
     }
 

--- a/apps/pg-sync-service/src/index.ts
+++ b/apps/pg-sync-service/src/index.ts
@@ -1,6 +1,9 @@
 import { logger } from '@bluedot/ui/src/api';
+import { slackAlert } from '@bluedot/utils';
 import { getInstance } from './app';
 import env from './env';
+import { db } from './lib/db';
+import { assertAirtableLiveness } from './lib/airtable-liveness';
 import { startWebhooksAndProcessingUpdates, startAdminSyncCron } from './lib/cron';
 import { performFullSync } from './lib/scan';
 import { addToQueue, waitForQueueToEmpty } from './lib/pg-sync';
@@ -30,6 +33,14 @@ const getInitialSyncTableNames = (args: string[]) => {
 const start = async () => {
   try {
     logger.info('Server starting...');
+
+    try {
+      await assertAirtableLiveness(db.airtableClient);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await slackAlert(env, [`pg-sync-service: Airtable liveness check failed on startup: ${message}`]);
+      throw error;
+    }
 
     const hasInitialSyncFlag = process.argv.includes('--initial-sync');
     const hasInitialSyncTablesFlag = process.argv.includes('--initial-sync-tables');

--- a/apps/pg-sync-service/src/lib/airtable-liveness.test.ts
+++ b/apps/pg-sync-service/src/lib/airtable-liveness.test.ts
@@ -1,0 +1,41 @@
+import {
+  describe, expect, it, vi, beforeEach,
+} from 'vitest';
+import { assertAirtableLiveness } from './airtable-liveness';
+
+vi.mock('@bluedot/ui/src/api', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@bluedot/db', () => ({
+  courseTable: { airtable: { baseId: 'base', tableId: 'table', schema: {} } },
+}));
+
+// Minimal stand-in for the AirtableTs client; only scan() is exercised.
+const makeClient = (scan: ReturnType<typeof vi.fn>) => ({ scan }) as unknown as Parameters<typeof assertAirtableLiveness>[0];
+
+describe('assertAirtableLiveness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves when the first scan succeeds', async () => {
+    const scan = vi.fn().mockResolvedValue([]);
+    await expect(assertAirtableLiveness(makeClient(scan), 0)).resolves.toBeUndefined();
+    expect(scan).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws after 3 failed attempts', async () => {
+    const scan = vi.fn().mockRejectedValue(new Error('airtable down'));
+    await expect(assertAirtableLiveness(makeClient(scan), 0)).rejects.toThrow('Airtable liveness check failed after 3 attempts: airtable down');
+    expect(scan).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries and resolves when a later attempt succeeds', async () => {
+    const scan = vi.fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce([]);
+    await expect(assertAirtableLiveness(makeClient(scan), 0)).resolves.toBeUndefined();
+    expect(scan).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/pg-sync-service/src/lib/airtable-liveness.test.ts
+++ b/apps/pg-sync-service/src/lib/airtable-liveness.test.ts
@@ -7,10 +7,6 @@ vi.mock('@bluedot/ui/src/api', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock('@bluedot/db', () => ({
-  courseTable: { airtable: { baseId: 'base', tableId: 'table', schema: {} } },
-}));
-
 // Minimal stand-in for the AirtableTs client; only scan() is exercised.
 const makeClient = (scan: ReturnType<typeof vi.fn>) => ({ scan }) as unknown as Parameters<typeof assertAirtableLiveness>[0];
 

--- a/apps/pg-sync-service/src/lib/airtable-liveness.ts
+++ b/apps/pg-sync-service/src/lib/airtable-liveness.ts
@@ -1,0 +1,39 @@
+import { courseTable, type PgAirtableDb } from '@bluedot/db';
+import { logger } from '@bluedot/ui/src/api';
+
+type AirtableClient = PgAirtableDb['airtableClient'];
+
+const MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
+/**
+ * Verifies the airtable package can actually reach Airtable before the service
+ * starts processing rows. A broken airtable-ts errors on every request, so a
+ * single cheap round-trip surfaces the outage at startup rather than silently
+ * failing later once rows are being synced.
+ */
+export const assertAirtableLiveness = async (
+  airtableClient: AirtableClient,
+  retryDelayMs: number = DEFAULT_RETRY_DELAY_MS,
+): Promise<void> => {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await airtableClient.scan(courseTable.airtable, { maxRecords: 1 });
+      return;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt < MAX_ATTEMPTS) {
+        logger.warn(`[airtable-liveness] Check failed (attempt ${attempt}/${MAX_ATTEMPTS}), retrying...`, error);
+        // eslint-disable-next-line no-await-in-loop -- Intentional retry delay
+        await new Promise((resolve) => {
+          setTimeout(resolve, retryDelayMs);
+        });
+      }
+    }
+  }
+
+  throw new Error(`Airtable liveness check failed after ${MAX_ATTEMPTS} attempts: ${lastError?.message}`);
+};


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Scans course table at startup (with backoff retries) to as a liveness check for airtable-ts library functioning correctly. If check fails an error is thrown and process will exit.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2686

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

