### PR TITLE
Migrate exercises to the same Core/Maybe/Optional system as resources: Support both old and new values

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -2,6 +2,7 @@ import type {
   Chunk,
   Course,
   CourseRegistration,
+  Exercise,
   Group,
   GroupDiscussion,
   MeetPerson,
@@ -64,6 +65,7 @@ const MOCK_GROUP_ID = 'group-id';
 const MOCK_MEET_PERSON_ID = 'meet-person-id';
 const MOCK_RESOURCE_ID = 'resource-id';
 const MOCK_RESOURCE_COMPLETION_ID = 'resource-completion-id';
+const MOCK_EXERCISE_ID = 'exercise-id';
 
 /** Default Programs router output for tests that render the Nav. */
 export const MOCK_NAV_PROGRAMS: Program[] = [
@@ -301,6 +303,22 @@ export const createMockRound = (overrides: Partial<CourseRound> = {}): CourseRou
     ...overrides,
   };
 };
+
+export const createMockExercise = (overrides: Partial<Exercise> = {}): Exercise => ({
+  id: MOCK_EXERCISE_ID,
+  answer: null,
+  courseId: 'course-id',
+  exerciseNumber: '1',
+  description: 'Exercise description',
+  options: null,
+  title: 'Exercise title',
+  type: 'Free text',
+  unitId: 'unit-1',
+  status: 'Active',
+  isOptional: false,
+  computedNumResponses: null,
+  ...overrides,
+});
 
 export const createMockResourceCompletion = (overrides: Partial<ResourceCompletion> = {}): ResourceCompletion => ({
   email: '',

--- a/apps/website/src/components/courses/ResourceDisplay.stories.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { loggedOutStory } from '@bluedot/ui/src/utils/storybook';
+import { createMockExercise, createMockResource } from '../../__tests__/testUtils';
+import { trpcStorybookMsw } from '../../__tests__/trpcMswSetup.browser';
+import { ResourceDisplay } from './ResourceDisplay';
+
+const coreResource = createMockResource({
+  id: 'resource-core-1',
+  resourceName: 'Introduction to AI Safety',
+  coreFurtherMaybe: 'Core',
+  timeFocusOnMins: 15,
+});
+
+const furtherResource = createMockResource({
+  id: 'resource-further-1',
+  resourceName: 'Deep dive: historical AI safety efforts',
+  coreFurtherMaybe: 'Further',
+  timeFocusOnMins: 20,
+});
+
+const coreExercise = createMockExercise({
+  id: 'exercise-core-1',
+  status: 'Core',
+  title: '1. What does a better future for yourself look like?',
+  description: 'Describe your ideal future in a few sentences.',
+});
+
+const activeRequiredExercise = createMockExercise({
+  id: 'exercise-active-1',
+  status: 'Active',
+  isOptional: false,
+  title: '2. What drove the shift from cod to shrimp fishing?',
+  description: 'Select the most accurate answer based on the reading.',
+});
+
+const furtherExercise = createMockExercise({
+  id: 'exercise-further-1',
+  status: 'Further',
+  title: '3. Go deeper: alternative fishing regulations',
+  description: 'An optional extension exercise for those who want to go further.',
+});
+
+const activeOptionalExercise = createMockExercise({
+  id: 'exercise-active-opt-1',
+  status: 'Active',
+  isOptional: true,
+  title: '4. Optional: reflect on your own community',
+  description: 'How do the dynamics from this unit show up in a community you are part of?',
+});
+
+const allExercises = [coreExercise, activeRequiredExercise, furtherExercise, activeOptionalExercise];
+
+const handlers = [
+  trpcStorybookMsw.exercises.getExercise.query(({ input }) => allExercises.find((e) => e.id === input.exerciseId)!),
+  trpcStorybookMsw.exercises.getExerciseResponse.query(() => null),
+  trpcStorybookMsw.exercises.getGroupExerciseResponses.query(() => null),
+];
+
+const meta: Meta<typeof ResourceDisplay> = {
+  title: 'website/courses/ResourceDisplay',
+  component: ResourceDisplay,
+  parameters: {
+    layout: 'padded',
+    nextjs: {
+      router: {
+        query: { courseSlug: 'test-course' },
+      },
+    },
+    msw: {
+      handlers,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 720, margin: '0 auto' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    unitTitle: 'Introduction to AI Safety',
+    unitNumber: '1',
+    courseSlug: 'test-course',
+    chunkIndex: 0,
+  },
+  ...loggedOutStory(),
+};
+
+export default meta;
+type Story = StoryObj<typeof ResourceDisplay>;
+
+export const Default: Story = {
+  args: {
+    resources: [coreResource],
+    exercises: [coreExercise, activeRequiredExercise],
+  },
+};
+
+export const WithOptionalContent: Story = {
+  args: {
+    resources: [coreResource, furtherResource],
+    exercises: allExercises,
+  },
+};

--- a/apps/website/src/components/courses/ResourceDisplay.test.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.test.tsx
@@ -1,5 +1,22 @@
-import { describe, expect, it } from 'vitest';
-import { formatResourceTime } from './ResourceDisplay';
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import {
+  describe, expect, it, test, vi,
+} from 'vitest';
+import { createMockExercise } from '../../__tests__/testUtils';
+import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
+import { TrpcProvider } from '../../__tests__/trpcProvider';
+import { formatResourceTime, ResourceDisplay } from './ResourceDisplay';
+
+// Mock next/router — exercises render FreeTextResponse, which calls useRouter()
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: { courseSlug: 'test-course' } }),
+}));
+
+// Mock MarkdownExtendedRenderer
+vi.mock('./MarkdownExtendedRenderer', () => ({
+  default: ({ children }: { children: string }) => <span>{children}</span>,
+}));
 
 describe('formatResourceTime', () => {
   it('should round up small times (< 60 mins) to nearest 5 minutes', () => {
@@ -43,5 +60,63 @@ describe('formatResourceTime', () => {
     expect(formatResourceTime(2.3)).toBe('5 mins');
     expect(formatResourceTime(60.1)).toBe('1 hr 10 mins');
     expect(formatResourceTime(125.7)).toBe('2 hrs 10 mins');
+  });
+});
+
+describe('ResourceDisplay - exercise status split', () => {
+  const registerExerciseHandlers = (exercises: ReturnType<typeof createMockExercise>[]) => {
+    server.use(
+      trpcMsw.exercises.getExercise.query(({ input }) => exercises.find((e) => e.id === input.exerciseId)!),
+      trpcMsw.exercises.getExerciseResponse.query(() => null),
+      trpcMsw.exercises.getGroupExerciseResponses.query(() => null),
+    );
+  };
+
+  test('required exercises render in the main Exercises section; Further/Active+isOptional render under Optional Exercises; Maybe/Inactive are absent', async () => {
+    const exercises = [
+      createMockExercise({ id: 'ex-core', status: 'Core', title: 'Core exercise' }),
+      createMockExercise({
+        id: 'ex-active-req', status: 'Active', isOptional: false, title: 'Active required exercise',
+      }),
+      createMockExercise({ id: 'ex-further', status: 'Further', title: 'Further exercise' }),
+      createMockExercise({
+        id: 'ex-active-opt', status: 'Active', isOptional: true, title: 'Active optional exercise',
+      }),
+      createMockExercise({ id: 'ex-maybe', status: 'Maybe', title: 'Maybe exercise' }),
+      createMockExercise({ id: 'ex-inactive', status: 'Inactive', title: 'Inactive exercise' }),
+    ];
+    registerExerciseHandlers(exercises);
+
+    render(<ResourceDisplay resources={[]} exercises={exercises} />, { wrapper: TrpcProvider });
+
+    expect(await screen.findByText('Core exercise')).toBeInTheDocument();
+    expect(await screen.findByText('Active required exercise')).toBeInTheDocument();
+    expect(await screen.findByText('Further exercise')).toBeInTheDocument();
+    expect(await screen.findByText('Active optional exercise')).toBeInTheDocument();
+    expect(screen.queryByText('Maybe exercise')).not.toBeInTheDocument();
+    expect(screen.queryByText('Inactive exercise')).not.toBeInTheDocument();
+
+    // Required exercises render inside the main "Exercises" section, not the collapsible
+    const exercisesSection = screen.getByText('Exercises').closest('section')!;
+    expect(within(exercisesSection).getByText('Core exercise')).toBeInTheDocument();
+    expect(within(exercisesSection).getByText('Active required exercise')).toBeInTheDocument();
+    expect(within(exercisesSection).queryByText('Further exercise')).not.toBeInTheDocument();
+    expect(within(exercisesSection).queryByText('Active optional exercise')).not.toBeInTheDocument();
+
+    // Further/Active+isOptional exercises render inside the "Optional Exercises" collapsible
+    expect(screen.getByText('Optional Exercises')).toBeInTheDocument();
+    const optionalExercisesSection = screen.getByText('Optional Exercises').closest('details')!;
+    expect(within(optionalExercisesSection).getByText('Further exercise')).toBeInTheDocument();
+    expect(within(optionalExercisesSection).getByText('Active optional exercise')).toBeInTheDocument();
+  });
+
+  test('does not render the Optional Exercises collapsible when there are no optional exercises', async () => {
+    const exercises = [createMockExercise({ id: 'ex-core', status: 'Core', title: 'Core exercise' })];
+    registerExerciseHandlers(exercises);
+
+    render(<ResourceDisplay resources={[]} exercises={exercises} />, { wrapper: TrpcProvider });
+
+    expect(await screen.findByText('Core exercise')).toBeInTheDocument();
+    expect(screen.queryByText('Optional Exercises')).not.toBeInTheDocument();
   });
 });

--- a/apps/website/src/components/courses/ResourceDisplay.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.tsx
@@ -129,7 +129,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
           >
             Exercises
           </h4>
-          <div className="resource-display__exercises flex flex-col gap-6" aria-labelledby={exercisesHeadingId}>
+          <div className="flex flex-col gap-6" aria-labelledby={exercisesHeadingId}>
             {requiredExercises.map((exercise) => (
               <Exercise
                 key={exercise.id}
@@ -145,7 +145,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
 
       {/* Optional Resources */}
       {optionalResources.length > 0 && (
-        <section className="resource-display__optional mt-8">
+        <section className="mt-8">
           <Collapsible title="Optional Resources" summaryClassName="justify-start gap-2">
             <ul className="flex flex-col gap-6" aria-label="Optional resources">
               {optionalResources.map((resource) => (
@@ -162,7 +162,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
 
       {/* Optional Exercises */}
       {optionalExercises.length > 0 && (
-        <section className="resource-display__optional-exercises mt-8">
+        <section className="mt-8">
           <Collapsible title="Optional Exercises" summaryClassName="justify-start gap-2">
             <div className="flex flex-col gap-6" aria-label="Optional exercises">
               {optionalExercises.map((exercise) => (

--- a/apps/website/src/components/courses/ResourceDisplay.tsx
+++ b/apps/website/src/components/courses/ResourceDisplay.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { type unitResourceTable, type exerciseTable, type InferSelectModel } from '@bluedot/db';
 import { Collapsible, ProgressDots, useAuthStore } from '@bluedot/ui';
 import { ErrorView } from '@bluedot/ui/src/ErrorView';
+import { isOptionalExercise, isRequiredExercise } from '../../lib/exerciseStatus';
 import { ResourceListItem } from './ResourceListItem';
 import Exercise from './exercises/Exercise';
 import { trpc } from '../../utils/trpc';
@@ -82,6 +83,8 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
   const coreResources = filterResourcesByType(resources, 'Core');
   const optionalResources = filterResourcesByType(resources, 'Further');
   const totalCoreResourceTime = calculateResourceTime(coreResources);
+  const requiredExercises = exercises.filter(isRequiredExercise);
+  const optionalExercises = exercises.filter(isOptionalExercise);
 
   // Generate unique IDs for ARIA labeling
   const unitContext = unitTitle && unitNumber ? `Unit ${unitNumber}: ${unitTitle}` : '';
@@ -118,7 +121,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
       )}
 
       {/* Exercises */}
-      {exercises.length > 0 && (
+      {requiredExercises.length > 0 && (
         <section className={`${coreResources.length > 0 ? 'mt-8' : ''}`}>
           <h4
             id={exercisesHeadingId}
@@ -127,7 +130,7 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
             Exercises
           </h4>
           <div className="resource-display__exercises flex flex-col gap-6" aria-labelledby={exercisesHeadingId}>
-            {exercises.map((exercise) => (
+            {requiredExercises.map((exercise) => (
               <Exercise
                 key={exercise.id}
                 exerciseId={exercise.id}
@@ -153,6 +156,25 @@ export const ResourceDisplay: React.FC<ResourceDisplayProps> = ({
                 />
               ))}
             </ul>
+          </Collapsible>
+        </section>
+      )}
+
+      {/* Optional Exercises */}
+      {optionalExercises.length > 0 && (
+        <section className="resource-display__optional-exercises mt-8">
+          <Collapsible title="Optional Exercises" summaryClassName="justify-start gap-2">
+            <div className="flex flex-col gap-6" aria-label="Optional exercises">
+              {optionalExercises.map((exercise) => (
+                <Exercise
+                  key={exercise.id}
+                  exerciseId={exercise.id}
+                  courseSlug={courseSlug}
+                  unitNumber={unitNumber}
+                  chunkIndex={chunkIndex}
+                />
+              ))}
+            </div>
           </Collapsible>
         </section>
       )}

--- a/apps/website/src/components/courses/exercises/Exercise.test.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.test.tsx
@@ -6,7 +6,7 @@ import {
 } from 'vitest';
 import { server, trpcMsw } from '../../../__tests__/trpcMswSetup';
 import { TrpcProvider } from '../../../__tests__/trpcProvider';
-import Exercise, { maybeApplyOptionalPrefix } from './Exercise';
+import Exercise from './Exercise';
 
 // Mock next/router
 vi.mock('next/router', () => ({
@@ -178,24 +178,5 @@ describe('Exercise', () => {
       expect(savedResponse).toContain('new draft');
       expect(savedResponse).not.toBe('Old saved text');
     });
-  });
-});
-
-describe('maybeApplyOptionalPrefix', () => {
-  test('leaves non-optional titles untouched', () => {
-    expect(maybeApplyOptionalPrefix({ title: 'Comprehension questions', isOptional: false })).toBe('Comprehension questions');
-    expect(maybeApplyOptionalPrefix({ title: 'Comprehension questions', isOptional: null })).toBe('Comprehension questions');
-  });
-
-  test('prepends [Optional] to optional titles without an existing marker', () => {
-    expect(maybeApplyOptionalPrefix({ title: 'Comprehension questions', isOptional: true })).toBe('[Optional] Comprehension questions');
-  });
-
-  test('does not double up when the title already starts with an optional marker', () => {
-    expect(maybeApplyOptionalPrefix({ title: '(Optional) Comprehension questions', isOptional: true })).toBe('(Optional) Comprehension questions');
-    expect(maybeApplyOptionalPrefix({ title: '[Optional] Reflection', isOptional: true })).toBe('[Optional] Reflection');
-    expect(maybeApplyOptionalPrefix({ title: '(Optional:) Additional prompts', isOptional: true })).toBe('(Optional:) Additional prompts');
-    expect(maybeApplyOptionalPrefix({ title: '(Optional, recommended) Historical efforts', isOptional: true })).toBe('(Optional, recommended) Historical efforts');
-    expect(maybeApplyOptionalPrefix({ title: 'Optional reading', isOptional: true })).toBe('Optional reading');
   });
 });

--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -11,6 +11,7 @@ import GroupResponses from './GroupResponses';
 import MarkdownExtendedRenderer from '../MarkdownExtendedRenderer';
 import { CheckmarkIcon } from '../../icons';
 import { FOAI_COURSE_SLUG } from '../../../lib/constants';
+import { isRequiredExercise } from '../../../lib/exerciseStatus';
 import { trpc } from '../../../utils/trpc';
 import { optimisticallyUpdateCourseProgress, rollbackCourseProgress } from '../../../utils/optimisticCourseProgress';
 
@@ -20,16 +21,6 @@ type ExerciseProps = {
   unitNumber?: string;
   chunkIndex?: number;
 };
-
-export function maybeApplyOptionalPrefix({ title, isOptional }: { title: string; isOptional: boolean | null | undefined }): string {
-  if (!isOptional) {
-    return title;
-  }
-
-  const [firstToken = ''] = title.trim().split(/\s+/);
-  const firstWord = firstToken.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '').toLowerCase();
-  return firstWord === 'optional' ? title : `[Optional] ${title}`;
-}
 
 const Exercise: React.FC<ExerciseProps> = ({
   exerciseId, courseSlug, unitNumber, chunkIndex,
@@ -106,7 +97,7 @@ const Exercise: React.FC<ExerciseProps> = ({
         userId: previousResponse?.userId ?? null,
       });
 
-      const previousCourseProgress = newData.completed !== undefined && !exerciseData?.isOptional ? await optimisticallyUpdateCourseProgress(utils, courseSlug, unitNumber, chunkIndex, newData.completed ? 1 : -1) : undefined;
+      const previousCourseProgress = newData.completed !== undefined && exerciseData && isRequiredExercise(exerciseData) ? await optimisticallyUpdateCourseProgress(utils, courseSlug, unitNumber, chunkIndex, newData.completed ? 1 : -1) : undefined;
       return { previousResponse, previousCourseProgress };
     },
     onError(_err, _variables, mutationResult) {
@@ -159,8 +150,6 @@ const Exercise: React.FC<ExerciseProps> = ({
   }
 
   const showGroupResponses = !!facilitatorGroupResponses && showGroupResponsesIfFacilitator;
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const displayTitle = maybeApplyOptionalPrefix({ title: exerciseData.title || '', isOptional: exerciseData.isOptional });
 
   // Free text completion checkbox (positioned outside the card)
   const hasResponse = editorHasText || !!(responseData?.response?.trim());
@@ -246,7 +235,7 @@ const Exercise: React.FC<ExerciseProps> = ({
         {/* Conditional padding: GroupResponses needs edge-to-edge for its blue background */}
         <div className={cn('container-lined bg-white flex flex-col gap-5', !showGroupResponses && 'p-8')}>
           <div className={cn('flex flex-col gap-2', showGroupResponses && 'px-8 pt-8')}>
-            <p className="bluedot-h4 not-prose">{displayTitle}</p>
+            <p className="bluedot-h4 not-prose">{exerciseData.title}</p>
             {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             <MarkdownExtendedRenderer>{exerciseData.description || ''}</MarkdownExtendedRenderer>
           </div>

--- a/apps/website/src/lib/exerciseStatus.ts
+++ b/apps/website/src/lib/exerciseStatus.ts
@@ -1,0 +1,14 @@
+import type { Exercise } from '@bluedot/db';
+
+// Transitional: status is migrating from Active/Inactive (+ isOptional) to Inactive/Core/Further/Maybe,
+// mirroring unitResource.coreFurtherMaybe. Both shapes are supported until the data migration lands.
+
+type ExerciseStatusFields = Pick<Exercise, 'status' | 'isOptional'>;
+
+export const isRequiredExercise = (exercise: ExerciseStatusFields): boolean => {
+  return exercise.status === 'Core' || (exercise.status === 'Active' && !exercise.isOptional);
+};
+
+export const isOptionalExercise = (exercise: ExerciseStatusFields): boolean => {
+  return exercise.status === 'Further' || (exercise.status === 'Active' && exercise.isOptional === true);
+};

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -246,7 +246,7 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
       ? db.pg
         .select()
         .from(exerciseTable.pg)
-        .where(and(eq(exerciseTable.pg.status, 'Active'), inArray(exerciseTable.pg.id, chunkExerciseIds)))
+        .where(and(inArray(exerciseTable.pg.status, ['Active', 'Core', 'Further']), inArray(exerciseTable.pg.id, chunkExerciseIds)))
       : [],
   ]);
 

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -407,4 +407,50 @@ describe('issueFoaiCertificateIfComplete', () => {
       .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
     expect(selfServe?.certificateId).toBe('ss-1');
   });
+
+  test('issues the certificate even when a Further or Maybe exercise is incomplete', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-1', email: 'test@example.com', courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Active', title: 'Required', exerciseNumber: '1',
+    });
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'resp-1', email: 'test@example.com', exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+    });
+    // Further/Maybe exercises with no completed response — must not block the certificate.
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-further', courseId: FOAI_COURSE_ID, status: 'Further', title: 'Further', exerciseNumber: '2',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-maybe', courseId: FOAI_COURSE_ID, status: 'Maybe', title: 'Maybe', exerciseNumber: '3',
+    });
+
+    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+
+    const [selfServe] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
+      .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
+    expect(selfServe?.certificateId).toBe('ss-1');
+  });
+
+  test('does not issue the certificate while a Core exercise is incomplete, and issues once it is completed', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-1', email: 'test@example.com', courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-core', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Core', exerciseNumber: '1',
+    });
+
+    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(false);
+
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'resp-core', email: 'test@example.com', exerciseId: 'foai-ex-core', response: 'done', completedAt: '2026-01-01',
+    });
+
+    expect(await issueFoaiCertificateIfComplete('test@example.com')).toBe(true);
+
+    const [selfServe] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
+      .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
+    expect(selfServe?.certificateId).toBe('ss-1');
+  });
 });

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -7,9 +7,7 @@ import {
   exerciseResponsePgTable,
   exerciseTable,
   inArray,
-  isNull,
   meetPersonTable,
-  or,
   roundTable,
   selfServeCourseRegistrationTable,
 } from '@bluedot/db';
@@ -22,6 +20,7 @@ import { FOAI_COURSE_ID, ONE_DAY_MS } from '../../lib/constants';
 import { protectedProcedure, publicProcedure, router } from '../trpc';
 import type { AppRouter } from './_app';
 import { hasUpcomingRoundsForCourseId } from './course-rounds';
+import { requiredExerciseCondition } from './courses';
 
 async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
   const requiredExercises = await db.pg
@@ -29,8 +28,7 @@ async function areAllFoaiExercisesComplete(email: string): Promise<boolean> {
     .from(exerciseTable.pg)
     .where(and(
       eq(exerciseTable.pg.courseId, FOAI_COURSE_ID),
-      eq(exerciseTable.pg.status, 'Active'),
-      or(eq(exerciseTable.pg.isOptional, false), isNull(exerciseTable.pg.isOptional)),
+      requiredExerciseCondition(),
     ));
   if (requiredExercises.length === 0) {
     return false;

--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -143,6 +143,36 @@ describe('courses.getCurriculumMetadata', () => {
       unitId: 'uo1', unitNumber: '1', duration: null, exerciseCount: 1,
     }]);
   });
+
+  test('Core status counts toward the exercise count like Active+required', async () => {
+    await seedCourse('core');
+    await seedUnit('uc1', 'core', '1');
+    await seedChunk('uc1-a', 'uc1', { title: 'Reading', exercises: ['ex-core'] });
+    await seedExercise('ex-core', 'Core');
+
+    const result = await caller.courses.getCurriculumMetadata({ courseSlug: 'core' });
+
+    expect(result).toEqual([{
+      unitId: 'uc1', unitNumber: '1', duration: null, exerciseCount: 1,
+    }]);
+  });
+
+  test('Further, Maybe, and Inactive statuses are excluded from the exercise count', async () => {
+    await seedCourse('nonreq');
+    await seedUnit('un1', 'nonreq', '1');
+    await seedChunk('un1-a', 'un1', {
+      title: 'Reading', exercises: ['ex-further', 'ex-maybe', 'ex-inactive'],
+    });
+    await seedExercise('ex-further', 'Further');
+    await seedExercise('ex-maybe', 'Maybe');
+    await seedExercise('ex-inactive', 'Inactive');
+
+    const result = await caller.courses.getCurriculumMetadata({ courseSlug: 'nonreq' });
+
+    expect(result).toEqual([{
+      unitId: 'un1', unitNumber: '1', duration: null, exerciseCount: 0,
+    }]);
+  });
 });
 
 describe('courses.getCourseProgress', () => {
@@ -159,6 +189,42 @@ describe('courses.getCourseProgress', () => {
     });
 
     const { courseProgress } = await caller.courses.getCourseProgress({ courseSlug: 'prog' });
+
+    expect(courseProgress).toEqual({ totalCount: 1, completedCount: 0, percentage: 0 });
+  });
+
+  test('Core-status exercises count toward progress like Active+required', async () => {
+    await seedCourse('core-prog');
+    await seedUnit('ucp', 'core-prog', '1');
+    await seedChunk('ucp-a', 'ucp', { exercises: ['ex-core'] });
+    await seedExercise('ex-core', 'Core');
+
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'r-core', email: 'test@example.com', exerciseId: 'ex-core', response: 'x', completedAt: '2026-01-01',
+    });
+
+    const { courseProgress } = await caller.courses.getCourseProgress({ courseSlug: 'core-prog' });
+
+    expect(courseProgress).toEqual({ totalCount: 1, completedCount: 1, percentage: 100 });
+  });
+
+  test('Further and Maybe statuses count towards neither the total nor completion', async () => {
+    await seedCourse('further-prog');
+    await seedUnit('ufp', 'further-prog', '1');
+    await seedChunk('ufp-a', 'ufp', { exercises: ['ex-req', 'ex-further', 'ex-maybe'] });
+    await seedExercise('ex-req');
+    await seedExercise('ex-further', 'Further');
+    await seedExercise('ex-maybe', 'Maybe');
+
+    // Complete the non-required exercises; they must not move the progress numbers.
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'r-further', email: 'test@example.com', exerciseId: 'ex-further', response: 'x', completedAt: '2026-01-01',
+    });
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'r-maybe', email: 'test@example.com', exerciseId: 'ex-maybe', response: 'x', completedAt: '2026-01-01',
+    });
+
+    const { courseProgress } = await caller.courses.getCourseProgress({ courseSlug: 'further-prog' });
 
     expect(courseProgress).toEqual({ totalCount: 1, completedCount: 0, percentage: 0 });
   });

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -21,6 +21,16 @@ import db from '../../lib/api/db';
 import { removeInactiveChunkIdsFromUnits } from '../../lib/api/utils';
 import { protectedProcedure, publicProcedure, router } from '../trpc';
 
+// SQL equivalent of isRequiredExercise (src/lib/exerciseStatus.ts), which can't build drizzle
+// conditions itself as it is imported by client components.
+export const requiredExerciseCondition = () => or(
+  eq(exerciseTable.pg.status, 'Core'),
+  and(
+    eq(exerciseTable.pg.status, 'Active'),
+    or(eq(exerciseTable.pg.isOptional, false), isNull(exerciseTable.pg.isOptional)),
+  ),
+);
+
 export type BasicChunk = {
   id: string;
   chunkTitle: string;
@@ -182,8 +192,7 @@ const getCoreResourceAndRequiredExerciseIds = async (chunks: Chunk[]) => {
     .select({ id: exerciseTable.pg.id })
     .from(exerciseTable.pg)
     .where(and(
-      eq(exerciseTable.pg.status, 'Active'),
-      or(eq(exerciseTable.pg.isOptional, false), isNull(exerciseTable.pg.isOptional)),
+      requiredExerciseCondition(),
       inArray(exerciseTable.pg.id, allExerciseIds),
     ));
   const requiredExerciseIds = requiredExercises.map((e) => e.id);
@@ -251,8 +260,7 @@ export const coursesRouter = router({
           .select({ id: exerciseTable.pg.id })
           .from(exerciseTable.pg)
           .where(and(
-            eq(exerciseTable.pg.status, 'Active'),
-            or(eq(exerciseTable.pg.isOptional, false), isNull(exerciseTable.pg.isOptional)),
+            requiredExerciseCondition(),
             inArray(exerciseTable.pg.id, referencedExerciseIds),
           ));
         for (const e of requiredExercises) requiredExerciseIds.add(e.id);


### PR DESCRIPTION
# Description

Before:
- Optional exercises show in the same place as regular exercises, but with "[Optional]" in the title
- The possible states of exercises were: Status == "Inactive" (hidden altogether, not counted), Status == "Active" && isOptional = false (regular exercise, required), Status == "Active" && isOptional = true (optional, not counted towards progress)

After:
- Optional exercises show at the bottom of a chunk under an "Optional exercises" heading, as we do with optional resources
- The new possible states are: Status == "Inactive" or "Maybe" (hidden altogether, not counted), Status == "Core" (regular exercise, required), Status == "Further" (optional, not counted towards progress)
- The old Active/Inactive/isOptional states are still supported in this PR, to allow migrating existing values, but will be removed in a cleanup PR after that

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2647

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="678" height="1498" alt="Screenshot 2026-07-03 at 14 25 01" src="https://github.com/user-attachments/assets/ce776356-4f24-4239-8823-938a32493447" /> | <img width="672" height="1476" alt="Screenshot 2026-07-03 at 14 26 48" src="https://github.com/user-attachments/assets/829d8ae4-11d7-48f2-98b7-b8a9d7c65287" /> |
| | | <img width="664" height="1472" alt="Screenshot 2026-07-03 at 14 23 55" src="https://github.com/user-attachments/assets/8c145a70-c589-425f-abd5-e7bbca681abe" /> |
| 🖥️ | <img width="3024" height="1656" alt="Screenshot 2026-07-03 at 14 24 42" src="https://github.com/user-attachments/assets/c1bece96-aaf9-4e94-a304-973471de1a21" /> | <img width="3020" height="1642" alt="Screenshot 2026-07-03 at 14 23 46" src="https://github.com/user-attachments/assets/1261fbfb-b2cb-4121-b72a-63af73083595" /> |
| | | <img width="3020" height="1642" alt="Screenshot 2026-07-03 at 14 23 28" src="https://github.com/user-attachments/assets/04e9e7e0-bbbc-4d9c-93f9-efcf1e2245da" /> |
