### PR TITLE
Run user.ensureExists before auth token is stored, to remove the authenticated-but-no-user edge case

### DIFF
--- a/apps/website/src/__tests__/dbTestUtils.tsx
+++ b/apps/website/src/__tests__/dbTestUtils.tsx
@@ -3,7 +3,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { unstable_localLink } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
 import { useState } from 'react';
-import { pushTestSchema, resetTestDb, type TestPgAirtableDb } from '@bluedot/db';
+import {
+  pushTestSchema, resetTestDb, type TestPgAirtableDb, userTable,
+} from '@bluedot/db';
 import type { AppRouter } from '../server/routers/_app';
 import type { Context } from '../server/context';
 import { appRouter } from '../server/routers/_app';
@@ -43,6 +45,13 @@ export function setupTestDb() {
     await resetTestDb(db);
   });
 }
+
+// Seeds the userTable row for `testAuthContextLoggedIn`, required by protectedProcedure
+export const seedLoggedInUser = () => testDb.insert(userTable, {
+  id: 'test-user',
+  email: 'test@example.com',
+  name: 'Test User',
+});
 
 // Server-side caller, for router tests that don't render components
 export const createCaller = (ctx: Context = testAuthContextLoggedOut) => appRouter.createCaller(ctx);

--- a/apps/website/src/__tests__/dbTestUtils.tsx
+++ b/apps/website/src/__tests__/dbTestUtils.tsx
@@ -46,7 +46,7 @@ export function setupTestDb() {
   });
 }
 
-// Seeds the userTable row for `testAuthContextLoggedIn`, required by protectedProcedure
+// Seeds the userTable row for `testAuthContextLoggedIn`, required by procedures that call getUserOrThrow
 export const seedLoggedInUser = () => testDb.insert(userTable, {
   id: 'test-user',
   email: 'test@example.com',

--- a/apps/website/src/components/courses/AddParticipantModal.test.tsx
+++ b/apps/website/src/components/courses/AddParticipantModal.test.tsx
@@ -6,14 +6,15 @@ import {
   courseTable, groupTable, meetPersonTable, roundTable,
 } from '@bluedot/db';
 import {
-  describe, expect, test, vi,
+  beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import {
-  createTrpcDbProvider, setupTestDb, testAuthContextLoggedIn, testDb,
+  createTrpcDbProvider, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testDb,
 } from '../../__tests__/dbTestUtils';
 import AddParticipantModal from './AddParticipantModal';
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 const FACILITATOR = 'rec-facilitator';
 const GROUP = 'rec-group';

--- a/apps/website/src/components/courses/ParticipantFeedbackModal.test.tsx
+++ b/apps/website/src/components/courses/ParticipantFeedbackModal.test.tsx
@@ -6,10 +6,10 @@ import {
   courseTable, groupTable, meetPersonTable, peerFeedbackTable, roundTable,
 } from '@bluedot/db';
 import {
-  describe, expect, test, vi,
+  beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import {
-  createTrpcDbProvider, setupTestDb, testAuthContextLoggedIn, testDb,
+  createTrpcDbProvider, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testDb,
 } from '../../__tests__/dbTestUtils';
 import ParticipantFeedbackModal from './ParticipantFeedbackModal';
 
@@ -24,6 +24,7 @@ vi.mock('../../server/airtableFieldOptions', () => ({
 }));
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 const FACILITATOR = 'rec-facilitator';
 const GROUP = 'rec-group';

--- a/apps/website/src/lib/schemas/user/me.schema.ts
+++ b/apps/website/src/lib/schemas/user/me.schema.ts
@@ -1,11 +1,5 @@
 import z from 'zod';
 
-export const createUserSchema = z.object({
-  initialUtmSource: z.string().trim().max(255).nullish(),
-  initialUtmCampaign: z.string().trim().max(255).nullish(),
-  initialUtmContent: z.string().trim().max(255).nullish(),
-}).optional();
-
 export const updateNameSchema = z.object({
   name: z.string()
     .trim()

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -77,11 +77,7 @@ const CourseUnitChunkPage = ({
   }, [courseSlug, unitNumber]);
 
   const { latestUtmParams, isLoading: isUtmLoading } = useLatestUtmParams();
-  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.selfServeCourseRegistrations.ensureExists.useMutation({
-    // The User row can lag auth (created by oauth-callback's side-effect), so retry until it exists.
-    retry: (failureCount, error) => failureCount < 5 && error.data?.code === 'PRECONDITION_FAILED',
-    retryDelay: 5000,
-  });
+  const { mutate: createCourseRegistrationMutation, isPending: isEnsureExistsPending } = trpc.selfServeCourseRegistrations.ensureExists.useMutation();
 
   useEffect(() => {
     // FoAI course only: If we're logged in, ensures a course registration is recorded

--- a/apps/website/src/pages/login/oauth-callback.tsx
+++ b/apps/website/src/pages/login/oauth-callback.tsx
@@ -3,12 +3,15 @@ import posthog from 'posthog-js';
 import { trpc } from '../../utils/trpc';
 
 export default () => {
-  const ensureUserExistsMutation = trpc.users.ensureExists.useMutation();
+  const ensureUserExistsMutation = trpc.users.ensureExists.useMutation({
+    retry: 2,
+    retryDelay: (failureCount) => (failureCount + 1) * 1000,
+  });
 
   return (
     <LoginOauthCallbackPage
       loginPreset={loginPresets.keycloak}
-      onLoginComplete={async (auth, redirectTo) => {
+      onBeforeAuthPersist={async (auth, redirectTo) => {
         // Extract UTM params from the redirectTo URL and send them to `users.ensureExists` to track them in the database
         let initialUtmSource: string | null = null;
         let initialUtmCampaign: string | null = null;
@@ -28,12 +31,14 @@ export default () => {
           console.warn('Failed to parse UTM params from redirectTo:', error);
         }
 
+        const response = await ensureUserExistsMutation.mutateAsync({
+          token: auth.token,
+          initialUtmSource,
+          initialUtmCampaign,
+          initialUtmContent,
+        });
+
         try {
-          const response = await ensureUserExistsMutation.mutateAsync({
-            initialUtmSource,
-            initialUtmCampaign,
-            initialUtmContent,
-          });
           if (typeof window !== 'undefined' && window.dataLayer) {
             window.dataLayer.push({
               event: 'CompletedSignup',
@@ -71,7 +76,7 @@ export default () => {
           }
         } catch (error) {
           // eslint-disable-next-line no-console
-          console.error('Error ensuring user exists:', error);
+          console.error('Error recording signup analytics:', error);
         }
       }}
     />

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -3,10 +3,10 @@ import {
   meetPersonTable, roundTable, selfServeCourseRegistrationTable,
 } from '@bluedot/db';
 import {
-  describe, expect, test, vi,
+  beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import {
-  createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
+  createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 import { issueFoaiCertificateIfComplete } from './certificates';
@@ -29,6 +29,7 @@ vi.mock('../../lib/api/env', () => ({
 const TEST_CERT_TOKEN = 'test-token-secret';
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 describe('certificates.createFacilitatedCourseCertificate (Airtable-script callable, shared-secret auth)', () => {
   test('throws UNAUTHORIZED when token is the wrong length (length mismatch short-circuits before timingSafeEqual)', async () => {

--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -1,13 +1,16 @@
 import {
   applicationsRoundTable, courseRegistrationTable, selfServeCourseRegistrationTable,
 } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
 import {
-  createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
+  beforeEach, describe, expect, test,
+} from 'vitest';
+import {
+  createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 const otherCourseId = 'recOtherCourseId12345';
 

--- a/apps/website/src/server/routers/dropout.test.ts
+++ b/apps/website/src/server/routers/dropout.test.ts
@@ -1,10 +1,13 @@
 import { courseRegistrationTable, eq } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
 import {
-  createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
+  beforeEach, describe, expect, test,
+} from 'vitest';
+import {
+  createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 const getDecision = async (id: string) => {
   const [reg] = await testDb.pg

--- a/apps/website/src/server/routers/facilitator-applications.test.ts
+++ b/apps/website/src/server/routers/facilitator-applications.test.ts
@@ -6,9 +6,12 @@ import {
   meetPersonTable,
   userTable,
 } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
+import {
+  beforeEach, describe, expect, test,
+} from 'vitest';
 import {
   createCaller,
+  seedLoggedInUser,
   setupTestDb,
   testAuthContextLoggedIn,
   testAuthContextLoggedOut,
@@ -65,6 +68,8 @@ const seedMeetPerson = (id: string, applicationsBaseRecordId: string, expectedDi
   });
 
 describe('facilitatorApplications.list', () => {
+  beforeEach(seedLoggedInUser);
+
   test('returns empty array when caller has no facilitator registrations', async () => {
     const result = await caller.facilitatorApplications.list();
     expect(result).toEqual([]);
@@ -177,6 +182,8 @@ describe('facilitatorApplications.list', () => {
 });
 
 describe('facilitatorApplications.eligibleRounds', () => {
+  beforeEach(seedLoggedInUser);
+
   test('rejects unauthenticated callers', async () => {
     await expect(createCaller(testAuthContextLoggedOut).facilitatorApplications.eligibleRounds()).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
@@ -309,6 +316,8 @@ describe('facilitatorApplications.eligibleRounds', () => {
 });
 
 describe('facilitatorApplications.quickApplyPrefill', () => {
+  beforeEach(seedLoggedInUser);
+
   test('prefills from the most recent prior facilitator application for the same course', async () => {
     await seedCourse('course-1', 'tai', 'Technical AI Safety');
     await testDb.insert(courseRegistrationTable, {
@@ -391,6 +400,8 @@ describe('facilitatorApplications.quickApplyPrefill', () => {
 });
 
 describe('facilitatorApplications.quickApply', () => {
+  beforeEach(seedLoggedInUser);
+
   const validInput = {
     roundId: 'round-next',
     numGroupsToFacilitate: 2,

--- a/apps/website/src/server/routers/facilitators.test.ts
+++ b/apps/website/src/server/routers/facilitators.test.ts
@@ -8,10 +8,10 @@ import {
   roundTable,
 } from '@bluedot/db';
 import {
-  describe, expect, test, vi,
+  beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import {
-  createCaller, setupTestDb, testAuthContextLoggedIn, testDb,
+  createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testDb,
 } from '../../__tests__/dbTestUtils';
 
 vi.mock('../airtableFieldOptions', () => ({
@@ -25,6 +25,7 @@ vi.mock('../airtableFieldOptions', () => ({
 }));
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 const FACILITATOR_EMAIL = 'test@example.com';
 const FACILITATOR_ID = 'facilitator-1';

--- a/apps/website/src/server/routers/group-discussions.test.ts
+++ b/apps/website/src/server/routers/group-discussions.test.ts
@@ -4,15 +4,19 @@ import {
   groupDiscussionTable,
   meetPersonTable,
 } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
+import {
+  beforeEach, describe, expect, test,
+} from 'vitest';
 import {
   createCaller,
+  seedLoggedInUser,
   setupTestDb,
   testAuthContextLoggedIn,
   testDb,
 } from '../../__tests__/dbTestUtils';
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 const caller = createCaller(testAuthContextLoggedIn);
 const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;

--- a/apps/website/src/server/routers/group-switching.test.ts
+++ b/apps/website/src/server/routers/group-switching.test.ts
@@ -9,16 +9,17 @@ import {
   groupSwitchingTable,
 } from '@bluedot/db';
 import {
-  describe, expect, it, test,
+  beforeEach, describe, expect, it, test,
 } from 'vitest';
 import { createMockGroup, createMockGroupDiscussion } from '../../__tests__/testUtils';
 import {
-  setupTestDb, createCaller, testAuthContextLoggedIn, testDb,
+  setupTestDb, createCaller, seedLoggedInUser, testAuthContextLoggedIn, testDb,
 } from '../../__tests__/dbTestUtils';
 import { calculateGroupAvailability, getAvailableGroupsAndDiscussions } from './group-switching';
 import { ONE_DAY_SECONDS } from '../../lib/constants';
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 describe('calculateGroupAvailability', () => {
   const now = Math.floor(Date.now() / 1000);

--- a/apps/website/src/server/routers/meet-person.test.ts
+++ b/apps/website/src/server/routers/meet-person.test.ts
@@ -1,13 +1,17 @@
 import { groupTable, meetPersonTable } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
+import {
+  beforeEach, describe, expect, test,
+} from 'vitest';
 import {
   createCaller,
+  seedLoggedInUser,
   setupTestDb,
   testAuthContextLoggedIn,
   testDb,
 } from '../../__tests__/dbTestUtils';
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 const caller = createCaller(testAuthContextLoggedIn);
 const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;

--- a/apps/website/src/server/routers/my-bluedot.test.ts
+++ b/apps/website/src/server/routers/my-bluedot.test.ts
@@ -8,9 +8,12 @@ import {
   meetPersonTable,
   selfServeCourseRegistrationTable,
 } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
+import {
+  beforeEach, describe, expect, test,
+} from 'vitest';
 import {
   createCaller,
+  seedLoggedInUser,
   setupTestDb,
   testAuthContextLoggedIn,
   testDb,
@@ -18,6 +21,7 @@ import {
 import { FOAI_COURSE_ID } from '../../lib/constants';
 
 setupTestDb();
+beforeEach(seedLoggedInUser);
 
 const caller = createCaller(testAuthContextLoggedIn);
 const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;

--- a/apps/website/src/server/routers/self-serve-course-registrations.test.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.test.ts
@@ -1,7 +1,7 @@
-import { applicationsCourseTable, selfServeCourseRegistrationTable } from '@bluedot/db';
+import { selfServeCourseRegistrationTable } from '@bluedot/db';
 import { describe, expect, test } from 'vitest';
 import {
-  createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
+  createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 
@@ -16,12 +16,14 @@ describe('selfServeCourseRegistrations.ensureExists', () => {
   });
 
   test('throws BAD_REQUEST for non-FOAI courses', async () => {
+    await seedLoggedInUser();
     await expect(createCaller(testAuthContextLoggedIn)
       .selfServeCourseRegistrations.ensureExists({ courseId: otherCourseId }))
       .rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
   test('returns the existing self-serve registration', async () => {
+    await seedLoggedInUser();
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss-foai', email: 'test@example.com', courseId: FOAI_COURSE_ID,
     });
@@ -32,17 +34,10 @@ describe('selfServeCourseRegistrations.ensureExists', () => {
   });
 
   test('throws NOT_FOUND for FOAI when no applications_course config row exists', async () => {
+    await seedLoggedInUser();
     await expect(createCaller(testAuthContextLoggedIn)
       .selfServeCourseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))
       .rejects.toMatchObject({ code: 'NOT_FOUND' });
-  });
-
-  test('throws PRECONDITION_FAILED for FOAI when the User record does not exist yet (so the client retries)', async () => {
-    await testDb.insert(applicationsCourseTable, { id: 'foai-app-course', courseBuilderId: FOAI_COURSE_ID });
-
-    await expect(createCaller(testAuthContextLoggedIn)
-      .selfServeCourseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID }))
-      .rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
   });
 
   // The full "creates a new FOAI registration" path isn't unit-testable: the insert omits `courseId`

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -1,5 +1,5 @@
 import {
-  applicationsCourseTable, selfServeCourseRegistrationTable, userTable,
+  applicationsCourseTable, selfServeCourseRegistrationTable,
 } from '@bluedot/db';
 import z from 'zod';
 import { TRPCError } from '@trpc/server';
@@ -33,15 +33,8 @@ export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
       throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
     }
 
-    // The User row is created by a lagging login side-effect (oauth-callback). Fail before writing
-    // anything so the client retries
-    const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
-    if (!user) {
-      throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'User record not available yet' });
-    }
-
     return db.insert(selfServeCourseRegistrationTable, {
-      userId: user.id,
+      userId: ctx.user.id,
       courseApplicationsBaseId: applicationsCourse.id,
       source: source ?? null,
       createdAt: new Date().toISOString(),

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -4,7 +4,7 @@ import {
 import z from 'zod';
 import { TRPCError } from '@trpc/server';
 import db from '../../lib/api/db';
-import { protectedProcedure, router } from '../trpc';
+import { getUserOrThrow, protectedProcedure, router } from '../trpc';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 
 export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
@@ -33,8 +33,9 @@ export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
       throw new TRPCError({ code: 'NOT_FOUND', message: `Course configuration not found for course: ${courseId}` });
     }
 
+    const user = await getUserOrThrow(ctx.auth.email);
     return db.insert(selfServeCourseRegistrationTable, {
-      userId: ctx.user.id,
+      userId: user.id,
       courseApplicationsBaseId: applicationsCourse.id,
       source: source ?? null,
       createdAt: new Date().toISOString(),

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -1,10 +1,11 @@
 import { userTable } from '@bluedot/db';
+import { loginPresets } from '@bluedot/ui';
 import {
   beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import { updateKeycloakPassword, verifyKeycloakPassword } from '../../lib/api/keycloak';
 import {
-  createCaller, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
+  createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
 
 vi.mock('../../lib/api/keycloak', () => ({
@@ -12,11 +13,32 @@ vi.mock('../../lib/api/keycloak', () => ({
   updateKeycloakPassword: vi.fn(),
 }));
 
+vi.mock('@bluedot/ui', async () => {
+  const actual = await vi.importActual('@bluedot/ui');
+  return {
+    ...actual,
+    loginPresets: {
+      keycloak: {
+        verifyAndDecodeToken: vi.fn(),
+      },
+    },
+  };
+});
+
 setupTestDb();
 
 beforeEach(() => {
   vi.mocked(verifyKeycloakPassword).mockReset();
   vi.mocked(updateKeycloakPassword).mockReset();
+  vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockReset();
+  vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue({
+    sub: 'test-sub',
+    email: 'test@example.com',
+    iss: 'test-issuer',
+    aud: 'test-audience',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    email_verified: true,
+  });
 });
 
 describe('users.getUser', () => {
@@ -25,9 +47,9 @@ describe('users.getUser', () => {
       .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
-  test('throws NOT_FOUND when no user record exists for the authed email', async () => {
+  test('rejects with UNAUTHORIZED when the authed user has no row (ensureExists not run)', async () => {
     await expect(createCaller(testAuthContextLoggedIn).users.getUser())
-      .rejects.toMatchObject({ code: 'NOT_FOUND' });
+      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
   test('returns the user and bumps lastSeenAt', async () => {
@@ -56,6 +78,7 @@ describe('users.changePassword', () => {
   });
 
   test('blocks password change while impersonating another user', async () => {
+    await seedLoggedInUser();
     const caller = createCaller({
       ...testAuthContextLoggedIn,
       auth: { ...testAuthContextLoggedIn.auth!, email: 'test@example.com' },
@@ -70,6 +93,7 @@ describe('users.changePassword', () => {
   });
 
   test('throws UNAUTHORIZED when current password is wrong, and does not update', async () => {
+    await seedLoggedInUser();
     vi.mocked(verifyKeycloakPassword).mockResolvedValue(false);
 
     await expect(createCaller(testAuthContextLoggedIn).users.changePassword(validInput))
@@ -79,6 +103,7 @@ describe('users.changePassword', () => {
   });
 
   test('rejects new passwords shorter than 8 chars at the schema layer', async () => {
+    await seedLoggedInUser();
     await expect(createCaller(testAuthContextLoggedIn).users.changePassword({
       currentPassword: 'old-pw',
       newPassword: 'short',
@@ -88,6 +113,7 @@ describe('users.changePassword', () => {
   });
 
   test('updates Keycloak when current password verifies', async () => {
+    await seedLoggedInUser();
     vi.mocked(verifyKeycloakPassword).mockResolvedValue(true);
     vi.mocked(updateKeycloakPassword).mockResolvedValue(undefined);
 
@@ -100,17 +126,16 @@ describe('users.changePassword', () => {
 });
 
 describe('users.ensureExists', () => {
-  test('rejects unauthenticated callers', async () => {
-    await expect(createCaller(testAuthContextLoggedOut).users.ensureExists(undefined))
+  test('rejects invalid tokens with UNAUTHORIZED', async () => {
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockRejectedValue(new Error('bad token'));
+
+    await expect(createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'bad-token' }))
       .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
-  // Skipped: the "create new user" path in ensureExists asserts isNewUser: true after inserting a row,
-  // but the router's insert (users.ts L66-72) omits `name`, which is `notNull()` in the userTable schema.
-  // Test left in place as a tripwire so the gap stays visible until the router is fixed (e.g. derive a
-  // default name from auth, or accept name as part of createUserSchema).
-  test.skip('creates a new user and persists initial UTM fields', async () => {
-    const result = await createCaller(testAuthContextLoggedIn).users.ensureExists({
+  test('creates a new user and persists initial UTM fields', async () => {
+    const result = await createCaller(testAuthContextLoggedOut).users.ensureExists({
+      token: 'valid-token',
       initialUtmSource: 'twitter',
       initialUtmCampaign: 'launch',
       initialUtmContent: 'thread',
@@ -123,6 +148,19 @@ describe('users.ensureExists', () => {
     expect(user.utmCampaign).toBe('launch');
     expect(user.utmContent).toBe('thread');
     expect(user.keycloakIdentifier).toBe('test-sub');
+    expect(user.lastSeenAt).toBeTruthy();
+  });
+
+  test('is idempotent: a second call reports isNewUser false and creates no extra row', async () => {
+    const caller = createCaller(testAuthContextLoggedOut);
+
+    await caller.users.ensureExists({ token: 'valid-token' });
+    const second = await caller.users.ensureExists({ token: 'valid-token' });
+
+    expect(second).toEqual({ isNewUser: false });
+
+    const users = await testDb.scan(userTable);
+    expect(users).toHaveLength(1);
   });
 
   test('updates lastSeenAt on an existing user without overwriting their UTM fields', async () => {
@@ -135,7 +173,8 @@ describe('users.ensureExists', () => {
     });
 
     const before = Date.now();
-    const result = await createCaller(testAuthContextLoggedIn).users.ensureExists({
+    const result = await createCaller(testAuthContextLoggedOut).users.ensureExists({
+      token: 'valid-token',
       initialUtmSource: 'should-be-ignored',
     });
 
@@ -153,7 +192,7 @@ describe('users.ensureExists', () => {
       name: 'Test User',
     });
 
-    const result = await createCaller(testAuthContextLoggedIn).users.ensureExists(undefined);
+    const result = await createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'valid-token' });
 
     expect(result).toEqual({ isNewUser: false });
 
@@ -161,19 +200,22 @@ describe('users.ensureExists', () => {
     expect(user.keycloakIdentifier).toBe('test-sub');
   });
 
-  test('does not write an empty keycloakIdentifier when sub is empty (e.g. impersonating a not-yet-backfilled target)', async () => {
+  test('does not write an empty keycloakIdentifier when the token has an empty sub', async () => {
     await testDb.insert(userTable, {
       id: 'u1',
       email: 'test@example.com',
       name: 'Test User',
     });
 
-    const caller = createCaller({
-      ...testAuthContextLoggedIn,
-      auth: { ...testAuthContextLoggedIn.auth!, email: 'test@example.com', sub: '' },
-      impersonation: { adminEmail: 'admin@example.com', targetEmail: 'test@example.com' },
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue({
+      sub: '',
+      email: 'test@example.com',
+      iss: 'test-issuer',
+      aud: 'test-audience',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      email_verified: true,
     });
-    const result = await caller.users.ensureExists(undefined);
+    const result = await createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'valid-token' });
 
     expect(result).toEqual({ isNewUser: false });
 
@@ -188,9 +230,9 @@ describe('users.updateName', () => {
       .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
-  test('throws NOT_FOUND when the authed user has no record', async () => {
+  test('rejects with UNAUTHORIZED when the authed user has no row (ensureExists not run)', async () => {
     await expect(createCaller(testAuthContextLoggedIn).users.updateName({ name: 'New' }))
-      .rejects.toMatchObject({ code: 'NOT_FOUND' });
+      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
   test('updates name on an existing user', async () => {
@@ -203,11 +245,13 @@ describe('users.updateName', () => {
   });
 
   test('rejects empty names at the schema layer', async () => {
+    await seedLoggedInUser();
     await expect(createCaller(testAuthContextLoggedIn).users.updateName({ name: '   ' }))
       .rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
   test('rejects names longer than 50 characters at the schema layer', async () => {
+    await seedLoggedInUser();
     await expect(createCaller(testAuthContextLoggedIn).users.updateName({
       name: 'x'.repeat(51),
     })).rejects.toMatchObject({ code: 'BAD_REQUEST' });

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -1,24 +1,19 @@
 import { userTable } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
+import { loginPresets } from '@bluedot/ui';
+import z from 'zod';
 import db from '../../lib/api/db';
 import { updateKeycloakPassword, verifyKeycloakPassword } from '../../lib/api/keycloak';
 import { changePasswordSchema } from '../../lib/schemas/user/changePassword.schema';
-import { createUserSchema, updateNameSchema } from '../../lib/schemas/user/me.schema';
-import { protectedProcedure, router } from '../trpc';
+import { updateNameSchema } from '../../lib/schemas/user/me.schema';
+import { protectedProcedure, publicProcedure, router } from '../trpc';
 
 export const usersRouter = router({
   getUser: protectedProcedure
     .query(async ({ ctx }) => {
-      const existingUser = await db.getFirst(userTable, {
-        filter: { email: ctx.auth.email },
-      });
-      if (!existingUser) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
-      }
-
       // Update lastSeenAt timestamp
       return db.update(userTable, {
-        id: existingUser.id,
+        id: ctx.user.id,
         lastSeenAt: new Date().toISOString(),
       });
     }),
@@ -48,14 +43,28 @@ export const usersRouter = router({
       };
     }),
 
-  ensureExists: protectedProcedure
-    .input(createUserSchema)
-    .mutation(async ({ input, ctx }) => {
-      const { sub } = ctx.auth;
+  // publicProcedure because it runs before login completes, so the token isn't in the auth store yet
+  ensureExists: publicProcedure
+    .input(z.object({
+      token: z.string().min(1),
+      initialUtmSource: z.string().trim().max(255).nullish(),
+      initialUtmCampaign: z.string().trim().max(255).nullish(),
+      initialUtmContent: z.string().trim().max(255).nullish(),
+    }))
+    .mutation(async ({ input }) => {
+      let auth;
+      try {
+        // Must verify against the same login preset the oauth-callback page authenticates with
+        auth = await loginPresets.keycloak.verifyAndDecodeToken(input.token);
+      } catch {
+        throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Invalid login token' });
+      }
+
+      const { sub } = auth;
 
       const [existingUserByEmail, existingUserByKeycloakIdentifier] = await Promise.all([
         db.getFirst(userTable, {
-          filter: { email: ctx.auth.email },
+          filter: { email: auth.email },
         }),
         // Skip the keycloakIdentifier lookup if `sub` is somehow empty so we never persist an empty identifier
         sub
@@ -83,12 +92,13 @@ export const usersRouter = router({
       } else {
         // Create user if doesn't exist
         await db.insert(userTable, {
-          email: ctx.auth.email,
+          email: auth.email,
+          name: '',
           ...(sub && { keycloakIdentifier: sub }),
           lastSeenAt: new Date().toISOString(),
-          ...(input?.initialUtmSource && { utmSource: input.initialUtmSource }),
-          ...(input?.initialUtmCampaign && { utmCampaign: input.initialUtmCampaign }),
-          ...(input?.initialUtmContent && { utmContent: input.initialUtmContent }),
+          ...(input.initialUtmSource && { utmSource: input.initialUtmSource }),
+          ...(input.initialUtmCampaign && { utmCampaign: input.initialUtmCampaign }),
+          ...(input.initialUtmContent && { utmContent: input.initialUtmContent }),
         });
       }
 
@@ -100,16 +110,8 @@ export const usersRouter = router({
   updateName: protectedProcedure
     .input(updateNameSchema)
     .mutation(async ({ ctx, input }) => {
-      const existingUser = await db.getFirst(userTable, {
-        filter: { email: ctx.auth.email },
-      });
-
-      if (!existingUser) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
-      }
-
       return db.update(userTable, {
-        id: existingUser.id,
+        id: ctx.user.id,
         name: input.name,
       });
     }),

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -6,14 +6,17 @@ import db from '../../lib/api/db';
 import { updateKeycloakPassword, verifyKeycloakPassword } from '../../lib/api/keycloak';
 import { changePasswordSchema } from '../../lib/schemas/user/changePassword.schema';
 import { updateNameSchema } from '../../lib/schemas/user/me.schema';
-import { protectedProcedure, publicProcedure, router } from '../trpc';
+import {
+  getUserOrThrow, protectedProcedure, publicProcedure, router,
+} from '../trpc';
 
 export const usersRouter = router({
   getUser: protectedProcedure
     .query(async ({ ctx }) => {
+      const user = await getUserOrThrow(ctx.auth.email);
       // Update lastSeenAt timestamp
       return db.update(userTable, {
-        id: ctx.user.id,
+        id: user.id,
         lastSeenAt: new Date().toISOString(),
       });
     }),
@@ -110,8 +113,9 @@ export const usersRouter = router({
   updateName: protectedProcedure
     .input(updateNameSchema)
     .mutation(async ({ ctx, input }) => {
+      const user = await getUserOrThrow(ctx.auth.email);
       return db.update(userTable, {
-        id: ctx.user.id,
+        id: user.id,
         name: input.name,
       });
     }),

--- a/apps/website/src/server/trpc.ts
+++ b/apps/website/src/server/trpc.ts
@@ -111,6 +111,15 @@ const openTelemetryMiddleware = t.middleware(async (opts) => {
   }
 });
 
+export const getUserOrThrow = async (email: string) => {
+  const user = await db.getFirst(userTable, { filter: { email } });
+  if (!user) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'No user record for this account. Please log in again.' });
+  }
+
+  return user;
+};
+
 export const checkAdminAccess = async (email: string): Promise<boolean> => {
   const user = await db.getFirst(userTable, { filter: { email } });
 
@@ -141,26 +150,19 @@ const overrideUndefinedResponse = t.middleware(async (opts) => {
 // Base router and procedure helpers
 export const { router } = t;
 export const publicProcedure = t.procedure.use(openTelemetryMiddleware).use(overrideUndefinedResponse);
-export const protectedProcedure = publicProcedure.use(async ({ ctx, next }) => {
+export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
   if (!ctx.auth) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Authentication required' });
   }
 
-  const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
-  if (!user) {
-    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'No user record for this account. Please log in again.' });
-  }
-
-  // Patch the user into the context
-  return next({ ctx: { ...ctx, auth: ctx.auth, user } });
+  return next({ ctx });
 });
 
 export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
   // During impersonation, check the real user's permissions, not the impersonated user's.
   // This prevents privilege escalation when a scoped user impersonates an admin.
-  const hasAdminAccess = ctx.impersonation
-    ? await checkAdminAccess(ctx.impersonation.adminEmail)
-    : ctx.user.isAdmin === true;
+  const realEmail = ctx.impersonation?.adminEmail ?? ctx.auth.email;
+  const hasAdminAccess = await checkAdminAccess(realEmail);
   if (!hasAdminAccess) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'Unauthorized' });
   }

--- a/apps/website/src/server/trpc.ts
+++ b/apps/website/src/server/trpc.ts
@@ -141,19 +141,26 @@ const overrideUndefinedResponse = t.middleware(async (opts) => {
 // Base router and procedure helpers
 export const { router } = t;
 export const publicProcedure = t.procedure.use(openTelemetryMiddleware).use(overrideUndefinedResponse);
-export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
+export const protectedProcedure = publicProcedure.use(async ({ ctx, next }) => {
   if (!ctx.auth) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Authentication required' });
   }
 
-  return next({ ctx });
+  const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+  if (!user) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'No user record for this account. Please log in again.' });
+  }
+
+  // Patch the user into the context
+  return next({ ctx: { ...ctx, auth: ctx.auth, user } });
 });
 
 export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
   // During impersonation, check the real user's permissions, not the impersonated user's.
   // This prevents privilege escalation when a scoped user impersonates an admin.
-  const realEmail = ctx.impersonation?.adminEmail ?? ctx.auth.email;
-  const hasAdminAccess = await checkAdminAccess(realEmail);
+  const hasAdminAccess = ctx.impersonation
+    ? await checkAdminAccess(ctx.impersonation.adminEmail)
+    : ctx.user.isAdmin === true;
   if (!hasAdminAccess) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'Unauthorized' });
   }

--- a/libraries/ui/src/Login.test.tsx
+++ b/libraries/ui/src/Login.test.tsx
@@ -169,14 +169,14 @@ describe('LoginRedirectPage', () => {
 describe('LoginOauthCallbackPage', () => {
   const mockLoginPreset = loginPresets.keycloak;
 
-  test('should set auth and call `onLoginComplete` on success', async () => {
-    const mockOnLoginComplete = vi.fn();
+  test('should set auth and call `onBeforeAuthPersist` on success', async () => {
+    const mockOnBeforeAuthPersist = vi.fn();
     const mockSigninResponse = createMockOidcResponse({ userState: { redirectTo: CUSTOM_REDIRECT_PATH } });
     mockProcessSigninResponse.mockResolvedValue(mockSigninResponse);
 
     render(<LoginOauthCallbackPage
       loginPreset={mockLoginPreset}
-      onLoginComplete={mockOnLoginComplete}
+      onBeforeAuthPersist={mockOnBeforeAuthPersist}
     />);
 
     const expectedAuthObject = {
@@ -188,8 +188,8 @@ describe('LoginOauthCallbackPage', () => {
     };
 
     await waitFor(() => {
-      expect(mockOnLoginComplete).toHaveBeenCalledTimes(1);
-      expect(mockOnLoginComplete).toHaveBeenCalledWith(expectedAuthObject, CUSTOM_REDIRECT_PATH);
+      expect(mockOnBeforeAuthPersist).toHaveBeenCalledTimes(1);
+      expect(mockOnBeforeAuthPersist).toHaveBeenCalledWith(expectedAuthObject, CUSTOM_REDIRECT_PATH);
     });
 
     expect(OidcClient).toHaveBeenCalledTimes(1);
@@ -202,6 +202,46 @@ describe('LoginOauthCallbackPage', () => {
     expect(mockSetAuth).toHaveBeenCalledWith(expectedAuthObject);
     expect(mockPush).toHaveBeenCalledTimes(1);
     expect(mockPush).toHaveBeenCalledWith(CUSTOM_REDIRECT_PATH);
+  });
+
+  test('should run onBeforeAuthPersist before setting auth', async () => {
+    const callOrder: string[] = [];
+    const mockOnBeforeAuthPersist = vi.fn(async () => {
+      callOrder.push('onBeforeAuthPersist');
+    });
+    mockSetAuth.mockImplementationOnce(() => {
+      callOrder.push('setAuth');
+    });
+    mockProcessSigninResponse.mockResolvedValue(createMockOidcResponse({ userState: { redirectTo: CUSTOM_REDIRECT_PATH } }));
+
+    render(<LoginOauthCallbackPage
+      loginPreset={mockLoginPreset}
+      onBeforeAuthPersist={mockOnBeforeAuthPersist}
+    />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(CUSTOM_REDIRECT_PATH);
+    });
+
+    expect(callOrder).toEqual(['onBeforeAuthPersist', 'setAuth']);
+  });
+
+  test('should not set auth or redirect when onBeforeAuthPersist rejects', async () => {
+    mockProcessSigninResponse.mockResolvedValue(createMockOidcResponse({ userState: { redirectTo: CUSTOM_REDIRECT_PATH } }));
+
+    const { getByText } = render(<LoginOauthCallbackPage
+      loginPreset={mockLoginPreset}
+      onBeforeAuthPersist={async () => {
+        throw new Error('failed to create user row');
+      }}
+    />);
+
+    await waitFor(() => {
+      expect(getByText('failed to create user row')).toBeInTheDocument();
+    });
+
+    expect(mockSetAuth).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   test('should throw error if no user returned', async () => {

--- a/libraries/ui/src/Login.tsx
+++ b/libraries/ui/src/Login.tsx
@@ -15,7 +15,11 @@ export type LoginPageProps = {
 };
 
 export type LoginOauthCallbackPageProps = LoginPageProps & {
-  onLoginComplete?: (auth: Auth, redirectTo: string) => Promise<void>;
+  /**
+   * Runs after the OIDC response is validated but before auth is persisted to the store.
+   * Throwing aborts the login (shows the error page) and auth is never saved.
+   */
+  onBeforeAuthPersist?: (auth: Auth, redirectTo: string) => Promise<void>;
 };
 
 const verifyJwt = async (
@@ -222,7 +226,7 @@ export const LoginRedirectPage: React.FC<LoginPageProps> = ({ loginPreset }) => 
   return <ProgressDots />;
 };
 
-export const LoginOauthCallbackPage: React.FC<LoginOauthCallbackPageProps> = ({ loginPreset, onLoginComplete }) => {
+export const LoginOauthCallbackPage: React.FC<LoginOauthCallbackPageProps> = ({ loginPreset, onBeforeAuthPersist }) => {
   const [error, setError] = useState<undefined | React.ReactNode | Error>();
   const setAuth = useAuthStore((s) => s.setAuth);
   const router = useRouter();
@@ -257,14 +261,14 @@ export const LoginOauthCallbackPage: React.FC<LoginOauthCallbackPageProps> = ({ 
           email: user.profile.email,
         };
 
-        setAuth(auth);
-
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const redirectTo = (user.userState as { redirectTo?: string }).redirectTo || '/';
 
-        if (onLoginComplete) {
-          await onLoginComplete(auth, redirectTo);
+        if (onBeforeAuthPersist) {
+          await onBeforeAuthPersist(auth, redirectTo);
         }
+
+        setAuth(auth);
 
         router.push(redirectTo);
       } catch (err) {
@@ -276,7 +280,7 @@ export const LoginOauthCallbackPage: React.FC<LoginOauthCallbackPageProps> = ({ 
       hasEverMounted.current = true;
       signinUser();
     }
-  }, [loginPreset.oidcSettings, onLoginComplete, router, setAuth]);
+  }, [loginPreset.oidcSettings, onBeforeAuthPersist, router, setAuth]);
 
   if (error) {
     return <ErrorSection error={error} />;


### PR DESCRIPTION
# Description

Removes the window where a user can be authenticated but have no `userTable` row. Previously the row was created by a fire-and-forget `users.ensureExists` call after login completed, so authenticated requests could arrive before it. This was the cause of #2670, and a blocker for the email -> userId migration (#2709) which adds lots of places which assume the user exists.

The fix here is to keep `ensureExists` essentially as-is, but run it before the token is set rather than after (change `LoginOauthCallbackPage`'s  `onLoginComplete` to `onBeforeAuthPersist`).

Knock-on changes:
- `protectedProcedure` resolves the caller's user row and attaches it as `ctx.user`, this removes the need for consumers to look up the user
- A failed `ensureExists` now blocks the login with an error page instead of proceeding into a broken half-logged-in state
- `adminProcedure` reads `ctx.user.isAdmin` directly when not impersonating. `protectedProcedure` has already fetched the row, so keeping `checkAdminAccess` would repeat the same query
- Protected-route tests now seed the caller's user row (matching what production guarantees), via `seedLoggedInUser()` in dbTestUtils, which adds some boilerplate to tests

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2722

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
