### PR TITLE
Show exercise responses for all rounds to facilitators (in course content pages)

### DIFF
--- a/apps/website/src/components/courses/exercises/Exercise.stories.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.stories.tsx
@@ -55,6 +55,8 @@ const groupResponsesData = {
     {
       id: '1',
       name: 'Group 01 - Alice Thompson',
+      roundName: null,
+      groupNumber: null,
       totalParticipants: 5,
       responses: [
         { name: 'Alice Thompson', response: longResponse },
@@ -63,7 +65,7 @@ const groupResponsesData = {
       ],
     },
     {
-      id: '2', name: 'Group 02 - Carlos Mendez', totalParticipants: 4, responses: [],
+      id: '2', name: 'Group 02 - Carlos Mendez', roundName: null, groupNumber: null, totalParticipants: 4, responses: [],
     },
   ],
 };

--- a/apps/website/src/components/courses/exercises/Exercise.test.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.test.tsx
@@ -84,7 +84,7 @@ describe('Exercise', () => {
   test('shows facilitator view when group data is returned', async () => {
     server.use(trpcMsw.exercises.getGroupExerciseResponses.query(() => ({
       groups: [{
-        id: 'g1', name: 'Group 1', totalParticipants: 2, responses: [{ name: 'Alice', response: 'My answer' }],
+        id: 'g1', name: 'Group 1', roundName: null, groupNumber: null, totalParticipants: 2, responses: [{ name: 'Alice', response: 'My answer' }],
       }],
     })));
 

--- a/apps/website/src/components/courses/exercises/GroupResponses.stories.tsx
+++ b/apps/website/src/components/courses/exercises/GroupResponses.stories.tsx
@@ -60,3 +60,20 @@ export const EmptyResponses: Story = {
     }],
   },
 };
+
+// Dropdown labels render as "Week 28 Part-time Group 6" etc., matching the Facilitated Courses page
+export const MultipleRounds: Story = {
+  args: {
+    groups: [
+      {
+        id: '1', name: 'Group 06 - Bartek Zielinski', roundName: 'AGI Strategy (2026 Jul W28) - Part-time', groupNumber: 6, totalParticipants: 5, responses: [{ name: 'Alice Thompson', response: shortResponse }],
+      },
+      {
+        id: '2', name: 'Group 07 - Priya Sharma', roundName: 'AGI Strategy (2026 Jul W28) - Part-time', groupNumber: 7, totalParticipants: 4, responses: [],
+      },
+      {
+        id: '3', name: 'Group 02 - Carlos Mendez', roundName: 'AGI Strategy (2026 Jun W23) - Intensive', groupNumber: 2, totalParticipants: 3, responses: [{ name: 'Fatima Al-Rashid', response: longResponse }],
+      },
+    ],
+  },
+};

--- a/apps/website/src/components/courses/exercises/GroupResponses.test.tsx
+++ b/apps/website/src/components/courses/exercises/GroupResponses.test.tsx
@@ -59,6 +59,30 @@ describe('GroupResponses', () => {
     expect(screen.queryByText('Select your group:')).not.toBeInTheDocument();
   });
 
+  test('dropdown labels use week/intensity/group number format when derivable', () => {
+    render(<GroupResponses groups={[
+      ...makeGroups({ roundName: 'Course (2026 Jul W28) - Part-time', groupNumber: 9 }),
+      {
+        id: 'g2', name: 'Group B', roundName: 'Course (2026 Jun W23) - Intensive', groupNumber: 12, totalParticipants: 3, responses: [],
+      },
+    ]}
+    />);
+    expect(screen.getAllByText('Week 28 Part-time Group 9').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Week 23 Intensive Group 12').length).toBeGreaterThan(0);
+  });
+
+  test('dropdown labels fall back to group name when round or group number is missing', () => {
+    render(<GroupResponses groups={[
+      ...makeGroups({ roundName: null, groupNumber: 1 }),
+      {
+        id: 'g2', name: 'Group B', roundName: 'Course (2026 Jul W28) - Part-time', groupNumber: null, totalParticipants: 3, responses: [],
+      },
+    ]}
+    />);
+    expect(screen.getAllByText('Group A').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Group B').length).toBeGreaterThan(0);
+  });
+
   test('short responses do not show "Show more"', () => {
     render(<GroupResponses groups={makeGroups()} />);
     expect(screen.queryByText('Show more')).not.toBeInTheDocument();

--- a/apps/website/src/components/courses/exercises/GroupResponses.tsx
+++ b/apps/website/src/components/courses/exercises/GroupResponses.tsx
@@ -18,8 +18,7 @@ export type GroupData = {
   responses: { name: string; response: string }[];
 };
 
-// "Week 28 Part-time Group 12" — same format as the Facilitated Courses page, so facilitators
-// with groups in multiple rounds can tell which is which
+// "Week 28 Part-time Group 12"
 const getGroupLabel = (group: GroupData): string => {
   const week = parseWeekFromRoundName(group.roundName);
   if (week === null || group.groupNumber == null) {

--- a/apps/website/src/components/courses/exercises/GroupResponses.tsx
+++ b/apps/website/src/components/courses/exercises/GroupResponses.tsx
@@ -4,6 +4,7 @@ import { Select } from '@bluedot/ui';
 import { FaUser } from 'react-icons/fa6';
 // TODO remove this import cycle
 
+import { parseIntensityFromRoundName, parseWeekFromRoundName } from '../../../lib/utils';
 import MarkdownExtendedRenderer from '../MarkdownExtendedRenderer';
 
 const TRUNCATION_LINES = 8;
@@ -11,8 +12,22 @@ const TRUNCATION_LINES = 8;
 export type GroupData = {
   id: string;
   name: string;
+  roundName?: string | null;
+  groupNumber?: number | null;
   totalParticipants: number;
   responses: { name: string; response: string }[];
+};
+
+// "Week 28 Part-time Group 12" — same format as the Facilitated Courses page, so facilitators
+// with groups in multiple rounds can tell which is which
+const getGroupLabel = (group: GroupData): string => {
+  const week = parseWeekFromRoundName(group.roundName);
+  if (week === null || group.groupNumber == null) {
+    return group.name;
+  }
+
+  const intensity = parseIntensityFromRoundName(group.roundName);
+  return [`Week ${week}`, intensity, `Group ${group.groupNumber}`].filter(Boolean).join(' ');
 };
 
 export type GroupResponsesProps = {
@@ -39,7 +54,7 @@ const GroupResponses: React.FC<GroupResponsesProps> = ({
         <div className="flex flex-col gap-2">
           <span className="text-size-xs font-semibold text-bluedot-navy">Select your group:</span>
           <Select
-            options={groups.map((g) => ({ value: g.id, label: g.name }))}
+            options={groups.map((g) => ({ value: g.id, label: getGroupLabel(g) }))}
             value={selectedGroup.id}
             onChange={setSelectedGroupId}
             ariaLabel="Select your group"

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -152,6 +152,12 @@ export const parseWeekFromRoundName = (roundName: string | null | undefined): nu
   return match ? Number(match[1]) : null;
 };
 
+// "AGI Strategy (2026 May W19) - Part-time" → "Part-time"
+export const parseIntensityFromRoundName = (roundName: string | null | undefined): string | null => {
+  if (!roundName) return null;
+  return /- (Part-time|Intensive)$/.exec(roundName)?.[1] ?? null;
+};
+
 export const getActionPlanUrl = (meetPersonId: string) => `https://web.miniextensions.com/7WZKkZiusMiAO1RMznFv?prefill_Participant=${meetPersonId}`;
 
 export const getGMTOffsetWithCity = () => {

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -6,6 +6,7 @@ import {
   exerciseTable,
   groupTable,
   meetPersonTable,
+  roundTable,
   selfServeCourseRegistrationTable,
   userTable,
 } from '@bluedot/db';
@@ -568,5 +569,126 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
 
     expect(result!.groups[0]!.responses[0]!.name).toBe('Anonymous');
+  });
+
+  // Registration + facilitator meetPerson + a one-participant group, suffixed so multiple rounds can coexist
+  async function seedFacilitatorRound(suffix: string, {
+    roundStatus = 'Active', roundTitle, roundStartDate, groupNumber = 1,
+  }: { roundStatus?: string; roundTitle?: string; roundStartDate?: string; groupNumber?: number } = {}) {
+    await testDb.insert(courseRegistrationTable, {
+      id: `reg-${suffix}`,
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      decision: 'Accept',
+      roundStatus,
+    });
+    await testDb.insert(roundTable, {
+      id: `round-${suffix}`,
+      title: roundTitle,
+      startDate: roundStartDate,
+    });
+    await testDb.insert(meetPersonTable, {
+      id: `meet-facilitator-${suffix}`,
+      email: CALLER_EMAIL,
+      applicationsBaseRecordId: `reg-${suffix}`,
+      role: 'Facilitator',
+      round: `round-${suffix}`,
+    });
+    await testDb.insert(meetPersonTable, {
+      id: `meet-participant-${suffix}`, email: `${suffix}@example.com`, name: `Participant ${suffix}`,
+    });
+    await testDb.insert(groupTable, {
+      id: `group-${suffix}`,
+      groupName: `Group ${suffix}`,
+      round: `round-${suffix}`,
+      groupNumber,
+      facilitator: [`meet-facilitator-${suffix}`],
+      participants: [`meet-participant-${suffix}`],
+    });
+  }
+
+  test('returns groups from all active rounds, newest round first by start date', async () => {
+    await seedCourse();
+    await seedFacilitatorRound('old', { roundTitle: 'Course (2026 Jun W23) - Part-time', roundStartDate: '2026-06-01T00:00:00.000Z' });
+    await seedFacilitatorRound('new', { roundTitle: 'Course (2026 Jul W28) - Part-time', roundStartDate: '2026-07-06T00:00:00.000Z' });
+
+    const result = await caller.exercises.getGroupExerciseResponses({
+      courseSlug: 'test-course',
+      exerciseId: 'ex-1',
+    });
+
+    expect(result!.groups.map((g) => g.id)).toEqual(['group-new', 'group-old']);
+    expect(result!.groups.map((g) => g.roundName)).toEqual(['Course (2026 Jul W28) - Part-time', 'Course (2026 Jun W23) - Part-time']);
+    expect(result!.groups.map((g) => g.groupNumber)).toEqual([1, 1]);
+  });
+
+  test('keeps each round\'s groups contiguous when rounds share a start date', async () => {
+    await seedCourse();
+    await seedFacilitatorRound('a', { roundStartDate: '2026-07-06T00:00:00.000Z', groupNumber: 2 });
+    await seedFacilitatorRound('b', { roundStartDate: '2026-07-06T00:00:00.000Z', groupNumber: 1 });
+
+    const result = await caller.exercises.getGroupExerciseResponses({
+      courseSlug: 'test-course',
+      exerciseId: 'ex-1',
+    });
+
+    // Sorted by round id on the start-date tie, not interleaved by groupNumber
+    expect(result!.groups.map((g) => g.id)).toEqual(['group-a', 'group-b']);
+  });
+
+  test('orders groups within a round by groupNumber', async () => {
+    await seedCourse();
+    await seedFacilitatorRound('r1', { groupNumber: 2 });
+    await testDb.insert(groupTable, {
+      id: 'group-b', round: 'round-r1', groupNumber: 10, facilitator: ['meet-facilitator-r1'], participants: ['meet-participant-r1'],
+    });
+    await testDb.insert(groupTable, {
+      id: 'group-a', round: 'round-r1', groupNumber: 1, facilitator: ['meet-facilitator-r1'], participants: ['meet-participant-r1'],
+    });
+
+    const result = await caller.exercises.getGroupExerciseResponses({
+      courseSlug: 'test-course',
+      exerciseId: 'ex-1',
+    });
+
+    expect(result!.groups.map((g) => g.id)).toEqual(['group-a', 'group-r1', 'group-b']);
+  });
+
+  test('still returns facilitator groups when a newer registration is not a facilitator', async () => {
+    await seedCourse();
+    await seedFacilitatorRound('old');
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-new',
+      email: CALLER_EMAIL,
+      courseId: 'course-1',
+      decision: 'Accept',
+      roundStatus: 'Active',
+    });
+    await testDb.insert(meetPersonTable, {
+      id: 'meet-self-as-participant',
+      email: CALLER_EMAIL,
+      applicationsBaseRecordId: 'reg-new',
+      role: 'Participant',
+    });
+
+    const result = await caller.exercises.getGroupExerciseResponses({
+      courseSlug: 'test-course',
+      exerciseId: 'ex-1',
+    });
+
+    expect(result!.groups.map((g) => g.id)).toEqual(['group-old']);
+  });
+
+  test('excludes groups from non-active rounds', async () => {
+    await seedCourse();
+    await seedFacilitatorRound('active');
+    await seedFacilitatorRound('past', { roundStatus: 'Past' });
+
+    const result = await caller.exercises.getGroupExerciseResponses({
+      courseSlug: 'test-course',
+      exerciseId: 'ex-1',
+    });
+
+    expect(result!.groups.map((g) => g.id)).toEqual(['group-active']);
   });
 });

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -22,7 +22,6 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';
 import { FOAI_COURSE_ID } from '../../lib/constants';
-import { unique } from '../../lib/utils';
 import { protectedProcedure, publicProcedure, router } from '../trpc';
 import { issueFoaiCertificateIfComplete } from './certificates';
 
@@ -171,7 +170,7 @@ export const exercisesRouter = router({
         return null;
       }
 
-      const roundIds = unique(groups.map((g) => g.round));
+      const roundIds = [...new Set(groups.map((g) => g.round).filter((r): r is string => r != null))];
       const rounds = roundIds.length > 0
         ? await db.pg
           .select({ id: roundTable.pg.id, title: roundTable.pg.title, startDate: roundTable.pg.startDate })

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -1,10 +1,10 @@
 import {
   and,
-  arrayContains,
+  arrayOverlaps,
+  asc,
   COURSE_ROLE,
   courseRegistrationTable,
   courseTable,
-  desc,
   eq,
   exerciseResponsePgTable,
   exerciseTable,
@@ -15,12 +15,14 @@ import {
   isNull,
   meetPersonTable,
   or,
+  roundTable,
   userTable,
 } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';
 import { FOAI_COURSE_ID } from '../../lib/constants';
+import { unique } from '../../lib/utils';
 import { protectedProcedure, publicProcedure, router } from '../trpc';
 import { issueFoaiCertificateIfComplete } from './certificates';
 
@@ -114,9 +116,9 @@ export const exercisesRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${input.courseSlug}` });
       }
 
-      // 2. Find caller's registration
+      // 2. Find all of caller's active registrations for this course
       // roundStatus is 'Active' for live rounds, or null for self-paced courses with no round
-      const courseRegistrationRows = await db.pg
+      const courseRegistrations = await db.pg
         .select()
         .from(courseRegistrationTable.pg)
         .where(and(
@@ -131,36 +133,64 @@ export const exercisesRouter = router({
             eq(courseRegistrationTable.pg.roundStatus, 'Active'),
             isNull(courseRegistrationTable.pg.roundStatus),
           ),
-        ))
-        .orderBy(desc(courseRegistrationTable.pg.autoNumberId))
-        .limit(1);
-      const courseRegistration = courseRegistrationRows[0] ?? null;
-      if (!courseRegistration) {
+        ));
+      if (courseRegistrations.length === 0) {
         return null;
       }
 
-      // 3. Find meetPerson record and verify facilitator role
-      const meetPerson = await db.getFirst(meetPersonTable, {
-        filter: { applicationsBaseRecordId: courseRegistration.id },
-      });
-      if (!meetPerson || meetPerson.role !== COURSE_ROLE.FACILITATOR) {
+      // 3. Find facilitator meetPerson records for all registrations
+      const facilitatorMeetPersons = await db.pg
+        .select({ id: meetPersonTable.pg.id })
+        .from(meetPersonTable.pg)
+        .where(and(
+          inArray(meetPersonTable.pg.applicationsBaseRecordId, courseRegistrations.map((r) => r.id)),
+          eq(meetPersonTable.pg.role, COURSE_ROLE.FACILITATOR),
+        ));
+      if (facilitatorMeetPersons.length === 0) {
         // Return null rather than throwing — no groups/responses is a valid empty state, and throwing would trigger
         // retries unnecessarily.
         return null;
       }
 
-      // 4. Find groups this person facilitates
+      const facilitatorMeetPersonIds = facilitatorMeetPersons.map((mp) => mp.id);
+
+      // 4. Find groups facilitated by any of these meetPersons
       const groups = await db.pg
-        .select({ id: groupTable.pg.id, groupName: groupTable.pg.groupName, participants: groupTable.pg.participants })
+        .select({
+          id: groupTable.pg.id,
+          groupName: groupTable.pg.groupName,
+          participants: groupTable.pg.participants,
+          round: groupTable.pg.round,
+          groupNumber: groupTable.pg.groupNumber,
+        })
         .from(groupTable.pg)
-        .where(arrayContains(groupTable.pg.facilitator, [meetPerson.id]));
+        .where(arrayOverlaps(groupTable.pg.facilitator, facilitatorMeetPersonIds))
+        .orderBy(asc(groupTable.pg.groupNumber), asc(groupTable.pg.id));
 
       if (groups.length === 0) {
         return null;
       }
 
+      const roundIds = unique(groups.map((g) => g.round));
+      const rounds = roundIds.length > 0
+        ? await db.pg
+          .select({ id: roundTable.pg.id, title: roundTable.pg.title, startDate: roundTable.pg.startDate })
+          .from(roundTable.pg)
+          .where(inArray(roundTable.pg.id, roundIds))
+        : [];
+      const roundById = new Map(rounds.map((r) => [r.id, r]));
+
+      // Newest round first (groups of the same round contiguous, even if two rounds share a start
+      // date); the SQL groupNumber ordering is the stable within-round tiebreak
+      const startDateOf = (round: string | null) => (round ? roundById.get(round)?.startDate ?? '' : '');
+      const sortedGroups = [...groups].sort((a, b) => {
+        const byStartDate = startDateOf(b.round).localeCompare(startDateOf(a.round));
+        if (byStartDate !== 0) return byStartDate;
+        return (a.round ?? '').localeCompare(b.round ?? '');
+      });
+
       // 5. Get all participant IDs across all groups
-      const allParticipantIds = [...new Set(groups.flatMap((g) => g.participants ?? []))];
+      const allParticipantIds = [...new Set(sortedGroups.flatMap((g) => g.participants ?? []))];
       if (allParticipantIds.length === 0) {
         return null;
       }
@@ -193,7 +223,7 @@ export const exercisesRouter = router({
       const responseByEmail = new Map(exerciseResponses.map((r) => [r.email, r.response]));
 
       // 7. Build per-group response data
-      const groupData = groups.map((g) => {
+      const groupData = sortedGroups.map((g) => {
         const groupParticipantIds = g.participants ?? [];
         const responses: { name: string; response: string }[] = [];
         for (const pid of groupParticipantIds) {
@@ -213,6 +243,8 @@ export const exercisesRouter = router({
           id: g.id,
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           name: g.groupName || 'Unnamed group',
+          roundName: g.round ? roundById.get(g.round)?.title ?? null : null,
+          groupNumber: g.groupNumber,
           totalParticipants: groupParticipantIds.length,
           responses,
         };


### PR DESCRIPTION
# Description

Previously, facilitators could only see exercise responses for the most recent round they had signed up for, which led to several users getting "0 responses, 0 pending", due to e.g. having applied for a new round (thus creating a new course registration) while still facilitating their existing round.

This changes it so they can see all groups they have ever facilitated. I also changed the dropdown labels from e.g. "Group 07 - Priya Sharma" to "Week 28 Part-time Group 6", matching what is on the Facilitated Courses page.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2229

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

_Screenshots illustrating the label change_

| 📸 | Before | After |
|---------|---|---|
| 📱  | <img width="666" height="870" alt="Screenshot 2026-07-06 at 12 35 50" src="https://github.com/user-attachments/assets/1dc8aee5-5eaf-49be-9e12-19e4c86bdc90" /> | <img width="672" height="796" alt="Screenshot 2026-07-06 at 12 38 17" src="https://github.com/user-attachments/assets/4273df51-6622-49c2-9bc6-c95641b04422" /> |
| 🖥️ | <img width="930" height="546" alt="Screenshot 2026-07-06 at 12 36 10" src="https://github.com/user-attachments/assets/5171b5a1-0949-4c85-86fb-2a46e9521fb3" /> | <img width="1330" height="796" alt="Screenshot 2026-07-06 at 12 37 51" src="https://github.com/user-attachments/assets/f88bb89a-e96a-4f5a-a407-c37a47b591e7" /> |
