### PR TITLE
fix: completed course not visible under 'past courses'

### DIFF
--- a/apps/website/src/__tests__/pages/my-courses.test.tsx
+++ b/apps/website/src/__tests__/pages/my-courses.test.tsx
@@ -91,6 +91,12 @@ describe('bucketCoursesByTab', () => {
         rs: 'Past', d: 'Accept', drop: false, defer: false, cert: true, tab: 'pastCourses',
       },
       {
+        rs: 'Past', d: 'Accept', drop: false, defer: true, cert: true, tab: 'pastCourses', why: 'certificate outranks a stale deferral',
+      },
+      {
+        rs: 'Past', d: 'Accept', drop: false, defer: true, cert: false, tab: null, why: 'deferred away without cert stays hidden (superseded by successor)',
+      },
+      {
         rs: 'Past', d: 'Reject', drop: false, defer: false, cert: false, tab: null, why: 'rejection only visible while Future',
       },
 

--- a/apps/website/src/__tests__/pages/my-courses.test.tsx
+++ b/apps/website/src/__tests__/pages/my-courses.test.tsx
@@ -107,6 +107,12 @@ describe('bucketCoursesByTab', () => {
       {
         rs: null, d: 'Accept', drop: false, defer: false, cert: false, tab: null, why: 'no roundStatus + no cert is filtered out (FOAI bug — update when fixed)',
       },
+      {
+        rs: null, d: 'Accept', drop: false, defer: true, cert: true, tab: 'pastCourses', why: 'deferred + null roundStatus falls to the cert branch → certificate outranks the stale deferral',
+      },
+      {
+        rs: null, d: 'Accept', drop: false, defer: true, cert: false, tab: null, why: 'deferred + null roundStatus + no cert stays hidden',
+      },
     ])('rs=$rs, d=$d, drop=$drop, defer=$defer, cert=$cert → $tab', ({
       rs, d, drop, defer, cert, tab,
     }) => {

--- a/apps/website/src/components/my-courses/useCourseListRow.tsx
+++ b/apps/website/src/components/my-courses/useCourseListRow.tsx
@@ -100,10 +100,12 @@ const sortByPastDesc = (courses: CourseListRowProps[]): CourseListRowProps[] => 
 const assignTab = (row: CourseListRowProps): CourseTab | null => {
   const { courseRegistration: cr, isDroppedOut, isDeferred } = row;
   // Deferred rows keep a live track, so bucket them by round status; a drop wins over Future.
+  // A certificate outranks a stale deferral: the user completed the course, so surface it in Past
+  // rather than hiding it. Deferred-away rows without a certificate stay hidden.
   if (isDeferred) {
     if (cr.roundStatus === 'Active') return 'inProgress';
     if (cr.roundStatus === 'Future') return 'upcoming';
-    return null;
+    return cr.certificateCreatedAt ? 'pastCourses' : null;
   }
 
   if (isDroppedOut) return 'pastCourses';


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

When users navigate to 'my courses', `assignTab` checked `isDeferred` before the certificate and returned `null` for a Past round → the row was dropped from every tab, including Past Courses.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2736

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

