### PR TITLE
Write `keycloakIdentifier` on user creation

### DIFF
--- a/apps/website/src/server/context.test.ts
+++ b/apps/website/src/server/context.test.ts
@@ -56,11 +56,37 @@ describe('createContext: User impersonation', () => {
     vi.clearAllMocks();
   });
 
-  test('admin can impersonate any user', async () => {
-    const adminAuth = { ...mockAuth, email: 'admin@example.com' };
+  test('admin can impersonate any user, and the context carries the target\'s sub not the admin\'s', async () => {
+    const adminAuth = { ...mockAuth, email: 'admin@example.com', sub: 'admin-sub' };
     await testDb.insert(userTable, {
-      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true,
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
     });
+    await testDb.insert(userTable, {
+      id: 'target-id', email: 'target@example.com', name: 'Target User', keycloakIdentifier: 'target-sub',
+    });
+
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(adminAuth);
+
+    const req = createMockReq({
+      authorization: 'Bearer valid-token',
+      'x-impersonate-user': 'target-id',
+    });
+    const result = await createContext({ req } as Parameters<typeof createContext>[0]);
+
+    expect(result.auth?.email).toBe('target@example.com');
+    expect(result.auth?.sub).toBe('target-sub');
+    expect(result.impersonation).toEqual({
+      adminEmail: 'admin@example.com',
+      targetEmail: 'target@example.com',
+    });
+  });
+
+  test('impersonating a not-yet-backfilled target yields an empty sub (falls back to email lookups downstream)', async () => {
+    const adminAuth = { ...mockAuth, email: 'admin@example.com', sub: 'admin-sub' };
+    await testDb.insert(userTable, {
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
+    });
+    // Target has no keycloakIdentifier yet (e.g. hasn't logged in since the backfill).
     await testDb.insert(userTable, { id: 'target-id', email: 'target@example.com', name: 'Target User' });
 
     vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(adminAuth);
@@ -72,10 +98,7 @@ describe('createContext: User impersonation', () => {
     const result = await createContext({ req } as Parameters<typeof createContext>[0]);
 
     expect(result.auth?.email).toBe('target@example.com');
-    expect(result.impersonation).toEqual({
-      adminEmail: 'admin@example.com',
-      targetEmail: 'target@example.com',
-    });
+    expect(result.auth?.sub).toBe('');
   });
 
   test('scoped user can impersonate allowed target', async () => {

--- a/apps/website/src/server/context.ts
+++ b/apps/website/src/server/context.ts
@@ -34,7 +34,7 @@ export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) 
         if (targetUser) {
           logger.info(`${auth.email} impersonating user ${targetUser.email} (access: ${access})`);
           return {
-            auth: { ...auth, email: targetUser.email },
+            auth: { ...auth, email: targetUser.email, sub: targetUser.keycloakIdentifier ?? '' },
             impersonation: { adminEmail: auth.email, targetEmail: targetUser.email },
             userAgent,
           };

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -160,6 +160,26 @@ describe('users.ensureExists', () => {
     const user = await testDb.get(userTable, { email: 'test@example.com' });
     expect(user.keycloakIdentifier).toBe('test-sub');
   });
+
+  test('does not write an empty keycloakIdentifier when sub is empty (e.g. impersonating a not-yet-backfilled target)', async () => {
+    await testDb.insert(userTable, {
+      id: 'u1',
+      email: 'test@example.com',
+      name: 'Test User',
+    });
+
+    const caller = createCaller({
+      ...testAuthContextLoggedIn,
+      auth: { ...testAuthContextLoggedIn.auth!, email: 'test@example.com', sub: '' },
+      impersonation: { adminEmail: 'admin@example.com', targetEmail: 'test@example.com' },
+    });
+    const result = await caller.users.ensureExists(undefined);
+
+    expect(result).toEqual({ isNewUser: false });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.keycloakIdentifier).toBeNull();
+  });
 });
 
 describe('users.updateName', () => {

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -145,6 +145,21 @@ describe('users.ensureExists', () => {
     expect(user.utmSource).toBe('original-source');
     expect(new Date(user.lastSeenAt!).getTime()).toBeGreaterThanOrEqual(before);
   });
+
+  test('backfills keycloakIdentifier on login for a user that already existed without one (e.g. created by an Airtable automation), and does not report them as new', async () => {
+    await testDb.insert(userTable, {
+      id: 'u1',
+      email: 'test@example.com',
+      name: 'Test User',
+    });
+
+    const result = await createCaller(testAuthContextLoggedIn).users.ensureExists(undefined);
+
+    expect(result).toEqual({ isNewUser: false });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.keycloakIdentifier).toBe('test-sub');
+  });
 });
 
 describe('users.updateName', () => {

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -122,6 +122,7 @@ describe('users.ensureExists', () => {
     expect(user.utmSource).toBe('twitter');
     expect(user.utmCampaign).toBe('launch');
     expect(user.utmContent).toBe('thread');
+    expect(user.keycloakIdentifier).toBe('test-sub');
   });
 
   test('updates lastSeenAt on an existing user without overwriting their UTM fields', async () => {

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -51,13 +51,16 @@ export const usersRouter = router({
   ensureExists: protectedProcedure
     .input(createUserSchema)
     .mutation(async ({ input, ctx }) => {
+      const { sub } = ctx.auth;
+
       const [existingUserByEmail, existingUserByKeycloakIdentifier] = await Promise.all([
         db.getFirst(userTable, {
           filter: { email: ctx.auth.email },
         }),
-        db.getFirst(userTable, {
-          filter: { keycloakIdentifier: ctx.auth.sub },
-        }),
+        // Skip the keycloakIdentifier lookup if `sub` is somehow empty so we never persist an empty identifier
+        sub
+          ? db.getFirst(userTable, { filter: { keycloakIdentifier: sub } })
+          : Promise.resolve(null),
       ]);
 
       if (existingUserByKeycloakIdentifier) {
@@ -74,14 +77,14 @@ export const usersRouter = router({
         // the case of legacy users who haven't yet been migrated from email -> keycloakIdentifier
         await db.update(userTable, {
           id: existingUserByEmail.id,
-          keycloakIdentifier: ctx.auth.sub,
+          ...(sub && { keycloakIdentifier: sub }),
           lastSeenAt: new Date().toISOString(),
         });
       } else {
         // Create user if doesn't exist
         await db.insert(userTable, {
           email: ctx.auth.email,
-          keycloakIdentifier: ctx.auth.sub,
+          ...(sub && { keycloakIdentifier: sub }),
           lastSeenAt: new Date().toISOString(),
           ...(input?.initialUtmSource && { utmSource: input.initialUtmSource }),
           ...(input?.initialUtmCampaign && { utmCampaign: input.initialUtmCampaign }),

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -51,14 +51,30 @@ export const usersRouter = router({
   ensureExists: protectedProcedure
     .input(createUserSchema)
     .mutation(async ({ input, ctx }) => {
-      const existingUser = await db.getFirst(userTable, {
-        filter: { email: ctx.auth.email },
-      });
+      const [existingUserByEmail, existingUserByKeycloakIdentifier] = await Promise.all([
+        db.getFirst(userTable, {
+          filter: { email: ctx.auth.email },
+        }),
+        db.getFirst(userTable, {
+          filter: { keycloakIdentifier: ctx.auth.sub },
+        }),
+      ]);
 
-      if (existingUser) {
+      if (existingUserByKeycloakIdentifier) {
         // Update last seen timestamp if already exists
         await db.update(userTable, {
-          id: existingUser.id,
+          id: existingUserByKeycloakIdentifier.id,
+          lastSeenAt: new Date().toISOString(),
+        });
+      } else if (existingUserByEmail) {
+        // If `existingUserByEmail` exists but not `existingUserByKeycloakIdentifier`, that
+        // means the user has been created by an Airtable automation, but hasn't logged in yet.
+        // Adopt the existing user row in this case (by setting `keycloakIdentifier` for next time).
+        // Note: Until https://github.com/bluedotimpact/bluedot/issues/2710 is complete, this also covers
+        // the case of legacy users who haven't yet been migrated from email -> keycloakIdentifier
+        await db.update(userTable, {
+          id: existingUserByEmail.id,
+          keycloakIdentifier: ctx.auth.sub,
           lastSeenAt: new Date().toISOString(),
         });
       } else {
@@ -74,7 +90,7 @@ export const usersRouter = router({
       }
 
       return {
-        isNewUser: !existingUser,
+        isNewUser: !existingUserByEmail && !existingUserByKeycloakIdentifier,
       };
     }),
 

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -65,6 +65,7 @@ export const usersRouter = router({
         // Create user if doesn't exist
         await db.insert(userTable, {
           email: ctx.auth.email,
+          keycloakIdentifier: ctx.auth.sub,
           lastSeenAt: new Date().toISOString(),
           ...(input?.initialUtmSource && { utmSource: input.initialUtmSource }),
           ...(input?.initialUtmCampaign && { utmCampaign: input.initialUtmCampaign }),


### PR DESCRIPTION
# Description

Start populating `userTable.keycloakIdentifier` (the Keycloak `sub` claim) when ensureExists creates a new user, so new signups no longer need backfilling. Lookups still rely on email.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2710

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
