### PR TITLE
[chore] Provision PG_SYNC_SLACK_CHANNEL_ID for pg-sync-service

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -13,6 +13,7 @@ import { config } from '../config';
 const ALERTS_SLACK_CHANNEL_ID = 'C04SAGM4FN1'; // #update_tech-prod
 const INFO_SLACK_CHANNEL_ID = 'C04SFUECECU'; // #updates_tech-dev
 const CLIENT_ERRORS_SLACK_CHANNEL_ID = 'C0AL75QQ0SC'; // #update_client-errors
+const PG_SYNC_SLACK_CHANNEL_ID = 'C0BFEG755PG'; // #update_pg-sync
 
 // Public PostHog project key, same value the website ships as NEXT_PUBLIC_POSTHOG_KEY
 // (apps/website/.env.production.template). Not a secret: it's exposed in the browser bundle.
@@ -339,6 +340,7 @@ export const services: ServiceDefinition[] = [
           { name: 'PG_URL', valueFrom: appPgConnectionDetails.uri },
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
           { name: 'INFO_SLACK_CHANNEL_ID', value: INFO_SLACK_CHANNEL_ID },
+          { name: 'PG_SYNC_SLACK_CHANNEL_ID', value: PG_SYNC_SLACK_CHANNEL_ID },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
           { name: 'PROD_ONLY_WEBHOOK_DELETION', valueFrom: envVarSources.prodOnlyWebhookDeletion },
           { name: 'POSTHOG_PROJECT_API_KEY', value: POSTHOG_PROJECT_API_KEY },


### PR DESCRIPTION
Infra-only PR: adds the (non-secret) `PG_SYNC_SLACK_CHANNEL_ID` env var (channel `#update_pg-sync`, `C0BFEG755PG`) to the `bluedot-pg-sync-service` deployment.

Split out from the code change per `apps/infra/ADDING_ENV_GUIDE.md`: the variable must exist on the deployment **before** the code marks it required, otherwise the pod crashloops on "Missing required environment variable".

**Merge + deploy this first**, then the code PR (#2738) that consumes it.

After merge, `pulumi up` runs but does not auto-restart pods for infra-only changes; a rollout may be needed so the new pod picks up the var (the code PR's deploy will also restart it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
