### PR TITLE
[feat] Re-enable career transition grantees showcase

### DIFF
--- a/apps/website/src/components/alumni/AlumniAvatar.tsx
+++ b/apps/website/src/components/alumni/AlumniAvatar.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useState } from 'react';
 import { getInitials } from '../../lib/utils';
 
 type Props = {
@@ -8,12 +9,17 @@ type Props = {
 };
 
 const AlumniAvatar = ({ name, imageSrc, className }: Props) => {
-  if (imageSrc) {
+  // Fall back to initials when the image is missing OR fails to load (e.g. a
+  // formula-generated headshot URL that 404s/500s for a person with no photo).
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+
+  if (imageSrc && imageSrc !== failedSrc) {
     return (
       <img
         src={imageSrc}
         alt={name}
         className={clsx('rounded-full object-cover shrink-0', className)}
+        onError={() => setFailedSrc(imageSrc)}
       />
     );
   }

--- a/apps/website/src/components/career-transition-grant/GranteesSection.stories.tsx
+++ b/apps/website/src/components/career-transition-grant/GranteesSection.stories.tsx
@@ -44,6 +44,29 @@ const mockGrantees: PublicCareerTransitionGrant[] = [
     grantPlan: 'Producing investigative pieces on frontier lab governance while exploring comms roles at AISIs.',
     profileUrl: 'https://www.linkedin.com/in/example-hana',
   },
+  // No imageUrl — renders the initials fallback avatar.
+  {
+    granteeName: 'Tomás Ferreira',
+    profileUrl: 'https://www.linkedin.com/in/example-tomas',
+  },
+  // No imageUrl and no profileUrl — initials avatar, non-linked card.
+  {
+    granteeName: 'Wei Chen',
+  },
+  {
+    granteeName: 'Amara Okafor',
+    imageUrl: 'https://picsum.photos/seed/amara/200/200',
+    profileUrl: 'https://www.linkedin.com/in/example-amara',
+  },
+  {
+    granteeName: 'Ravi Menon',
+    imageUrl: 'https://picsum.photos/seed/ravi/200/200',
+  },
+  {
+    granteeName: 'Elena Novak',
+    imageUrl: 'https://picsum.photos/seed/elena/200/200',
+    profileUrl: 'https://www.linkedin.com/in/example-elena',
+  },
 ];
 
 const meta: Meta<typeof GranteesSection> = {
@@ -58,7 +81,7 @@ const meta: Meta<typeof GranteesSection> = {
     },
     docs: {
       description: {
-        component: 'Grid of career transition grant recipients on /career-transition-grant. Cards link to a profile URL when present. Grantees without an image are filtered out.',
+        component: 'Grid of career transition grant recipients on /career-transition-grant. Cards link to a profile URL when present, and fall back to an initials avatar when a grantee has no headshot. Collapses to three rows with a "Show more" toggle once there are more than that.',
       },
     },
   },

--- a/apps/website/src/components/career-transition-grant/GranteesSection.tsx
+++ b/apps/website/src/components/career-transition-grant/GranteesSection.tsx
@@ -53,22 +53,24 @@ const GranteeCard = ({ name, bio, plan, imageUrl, profileUrl }: GranteeCardProps
   return <div className={cardClass}>{cardContent}</div>;
 };
 
+// Column count for the current viewport, matching the grid classes below
+// (bd-md = 680px, 3-col at 1120px). Defaults to desktop during SSR.
+const getGridColumns = (): number => {
+  if (typeof window === 'undefined') return 3;
+  if (window.matchMedia('(min-width: 1120px)').matches) return 3;
+  return window.matchMedia('(min-width: 680px)').matches ? 2 : 1;
+};
+
 // Tracks the grid's column count so the collapsed view shows exactly
-// COLLAPSED_ROWS rows at any width. Breakpoints mirror the grid classes below
-// (bd-md = 680px, 3-col at 1120px).
+// COLLAPSED_ROWS rows at any width. Initialised from the viewport so the
+// collapsed count is correct on first paint (no flash of the wrong row count).
 const useGridColumns = (): number => {
-  const [columns, setColumns] = useState(3);
+  const [columns, setColumns] = useState(getGridColumns);
 
   useEffect(() => {
     const tablet = window.matchMedia('(min-width: 680px)');
     const desktop = window.matchMedia('(min-width: 1120px)');
-    const update = () => {
-      if (desktop.matches) {
-        setColumns(3);
-      } else {
-        setColumns(tablet.matches ? 2 : 1);
-      }
-    };
+    const update = () => setColumns(getGridColumns());
 
     update();
     tablet.addEventListener('change', update);

--- a/apps/website/src/components/career-transition-grant/GranteesSection.tsx
+++ b/apps/website/src/components/career-transition-grant/GranteesSection.tsx
@@ -1,13 +1,17 @@
-import { P } from '@bluedot/ui';
-import { pageSectionHeadingClass } from '../PageListRow';
+import { CTALinkOrButton, P } from '@bluedot/ui';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { pageSectionHeadingClass } from '../PageListRow';
+import AlumniAvatar from '../alumni/AlumniAvatar';
 import { trpc } from '../../utils/trpc';
+
+const COLLAPSED_ROWS = 3;
 
 type GranteeCardProps = {
   name: string;
   bio: string;
   plan: string;
-  imageUrl: string;
+  imageUrl?: string;
   profileUrl?: string | null;
 };
 
@@ -17,12 +21,7 @@ const GranteeCard = ({ name, bio, plan, imageUrl, profileUrl }: GranteeCardProps
   const cardContent = (
     <>
       <div className="flex items-center gap-4">
-        <img
-          src={imageUrl}
-          alt=""
-          className="size-14 rounded-full object-cover"
-          loading="lazy"
-        />
+        <AlumniAvatar name={name} imageSrc={imageUrl} className="size-14 text-size-md" />
         <div className="flex min-w-0 flex-col">
           <h4 className="text-size-sm font-semibold leading-tight text-bluedot-navy">
             {name}
@@ -54,12 +53,47 @@ const GranteeCard = ({ name, bio, plan, imageUrl, profileUrl }: GranteeCardProps
   return <div className={cardClass}>{cardContent}</div>;
 };
 
+// Tracks the grid's column count so the collapsed view shows exactly
+// COLLAPSED_ROWS rows at any width. Breakpoints mirror the grid classes below
+// (bd-md = 680px, 3-col at 1120px).
+const useGridColumns = (): number => {
+  const [columns, setColumns] = useState(3);
+
+  useEffect(() => {
+    const tablet = window.matchMedia('(min-width: 680px)');
+    const desktop = window.matchMedia('(min-width: 1120px)');
+    const update = () => {
+      if (desktop.matches) {
+        setColumns(3);
+      } else {
+        setColumns(tablet.matches ? 2 : 1);
+      }
+    };
+
+    update();
+    tablet.addEventListener('change', update);
+    desktop.addEventListener('change', update);
+    return () => {
+      tablet.removeEventListener('change', update);
+      desktop.removeEventListener('change', update);
+    };
+  }, []);
+
+  return columns;
+};
+
 const GranteesSection = () => {
   const { data: grantees } = trpc.grants.getAllPublicCareerTransitionGrantees.useQuery();
+  const [expanded, setExpanded] = useState(false);
+  const columns = useGridColumns();
 
-  const visibleGrantees = grantees?.filter((g) => g.imageUrl) ?? [];
+  const allGrantees = grantees ?? [];
 
-  if (visibleGrantees.length === 0) return null;
+  if (allGrantees.length === 0) return null;
+
+  const collapsedCount = columns * COLLAPSED_ROWS;
+  const isCollapsible = allGrantees.length > collapsedCount;
+  const visibleGrantees = expanded ? allGrantees : allGrantees.slice(0, collapsedCount);
 
   return (
     <section className="section section-body career-transition-grant-grantees-section">
@@ -72,12 +106,22 @@ const GranteesSection = () => {
                 name={g.granteeName}
                 bio={g.bio ?? ''}
                 plan={g.grantPlan ?? ''}
-                imageUrl={g.imageUrl!}
+                imageUrl={g.imageUrl}
                 profileUrl={g.profileUrl}
               />
             </li>
           ))}
         </ul>
+        {isCollapsible && (
+          <div className="flex justify-center">
+            <CTALinkOrButton
+              variant="secondary"
+              onClick={() => setExpanded((prev) => !prev)}
+            >
+              {expanded ? 'Show fewer' : `Show ${allGrantees.length - collapsedCount} more`}
+            </CTALinkOrButton>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/website/src/pages/programs/career-transition-grant.tsx
+++ b/apps/website/src/pages/programs/career-transition-grant.tsx
@@ -9,6 +9,7 @@ import GrantCta from '../../components/grants/sections/GrantCta';
 import WhatThisIsForSection from '../../components/career-transition-grant/WhatThisIsForSection';
 import ExpectationsSection from '../../components/career-transition-grant/ExpectationsSection';
 import NextStepsSection from '../../components/career-transition-grant/NextStepsSection';
+import GranteesSection from '../../components/career-transition-grant/GranteesSection';
 import { ROUTES } from '../../lib/routes';
 import { formatAmountUsd } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
@@ -64,6 +65,7 @@ const CareerTransitionGrantPage = ({ programName, programDescription }: ProgramD
       <WhatThisIsForSection />
       <ExpectationsSection />
       <NextStepsSection />
+      <GranteesSection />
       <GrantFaqSection program="career-transition-grant" />
       <GrantCta program="career-transition-grant" />
     </div>


### PR DESCRIPTION
# Description

The "Some of our grantees" section on `/programs/career-transition-grant` was switched off in #2397 as dormant code ("re-enable later by re-adding one line") while we waited for enough grantees to consent to public listing. We now have 25 grantees who have explicitly opted into public sharing with their name, so this brings the section back.

Along the way it fixes a latent bug and adds a length guard. The grantee `imageUrl` is an Airtable formula that emits a permanent-headshot URL *even when no photo is attached*, so most grantees (24 of 25 currently) rendered as a broken image. Cards now fall back to an initials avatar when the headshot is missing or fails to load. The grid also collapses to three rows behind a "Show more" toggle so 25 cards don't dominate the page.

## What changed

1. **`apps/website/src/pages/programs/career-transition-grant.tsx`** — re-add the `GranteesSection` import and render (between "Next steps" and the FAQ), the exact inverse of the #2397 removal.
2. **`apps/website/src/components/career-transition-grant/GranteesSection.tsx`** — use the shared `AlumniAvatar` for the headshot (initials fallback), and collapse the grid to three rows (responsive: 3/6/9 cards) with a "Show more" / "Show fewer" toggle that mirrors the rapid-grants list pattern.
3. **`apps/website/src/components/alumni/AlumniAvatar.tsx`** — fall back to initials on image *load error*, not just an empty `imageSrc`. This also hardens the alumni pages against dead headshot URLs.
4. **`apps/website/src/components/career-transition-grant/GranteesSection.stories.tsx`** — mock data now includes photo-less grantees (to exercise the initials fallback) and enough entries to trigger "Show more"; description updated.

## Notes

- Order is alphabetical (unchanged).
- Bios / grant-description quotes are sparse today (only one grantee has them); they're being populated separately in Airtable and will appear via sync.

## Issue

N/A — re-enabling an existing section; no linked issue.

## Developer checklist

- [x] Front-end code follows the Component Accessibility Checklist — `AlumniAvatar` renders `role="img"` + `aria-label` for the initials fallback; the "Show more" control is a real button.
- [x] Considered snapshot/functional tests — the section is covered by its Storybook story (updated); no page-level test renders this route.
- [x] Considered Storybook stories — existing `GranteesSection` story updated to cover the new fallback + collapse behaviour.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8003` in the `anglilian/ctg-grantees` worktree):
- ✅ `/programs/career-transition-grant` — section renders 25 grantees; 24 show initials, 1 shows a real photo (no broken images); "Show more" expands/collapses correctly at mobile/tablet/desktop widths.
- ✅ tRPC `grants.getAllPublicCareerTransitionGrantees` returns all 25 consented grantees.

Type check + lint + full test suite all pass:
```
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 948 passed, 1 skipped (119 files) — run twice
```

## Screenshots

_To add: `/programs/career-transition-grant` grantees section (mobile + desktop, collapsed + expanded)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)