### PR TITLE
[feat] Sort career transition grantees by card completeness

### DIFF
--- a/apps/website/src/server/routers/grants.test.ts
+++ b/apps/website/src/server/routers/grants.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
-  careerTransitionGrantApplicationTable, oneOnOneAdvisingApplicationTable, rapidGrantApplicationTable, rapidGrantTable,
+  careerTransitionGrantApplicationTable, careerTransitionGrantTable, oneOnOneAdvisingApplicationTable, rapidGrantApplicationTable, rapidGrantTable,
 } from '@bluedot/db';
 import { createCaller, setupTestDb, testDb } from '../../__tests__/dbTestUtils';
 
@@ -125,6 +125,55 @@ describe('grants.getAllPublicRapidGrantees', () => {
         monthLabel: undefined,
       },
     ]);
+  });
+});
+
+describe('grants.getAllPublicCareerTransitionGrantees', () => {
+  test('drops nameless rows, trims and sanitizes fields, and surfaces complete cards (photo + bio + description) first, each group alphabetical', async () => {
+    // Complete cards (photo, bio and grant plan) — should lead, alphabetised between themselves.
+    await testDb.insert(careerTransitionGrantTable, {
+      firstName: 'Zoe', lastName: 'Adams', imageUrl: 'https://example.com/zoe.png', bio: 'Engineer', grantPlan: 'Skilling up on evals', profileUrl: 'https://example.com/zoe',
+    });
+    await testDb.insert(careerTransitionGrantTable, {
+      firstName: '  Amy  ', lastName: '  Baker  ', imageUrl: '  https://example.com/amy.png  ', bio: '  Researcher  ', grantPlan: '  Studying interpretability  ', profileUrl: ' https://example.com/amy ',
+    });
+    // Incomplete — each missing exactly one of photo / bio / description — should fall below, alphabetised.
+    await testDb.insert(careerTransitionGrantTable, {
+      firstName: 'Ann', lastName: 'Davis', imageUrl: 'https://example.com/ann.png', bio: 'Has a bio but no plan', grantPlan: '   ',
+    });
+    await testDb.insert(careerTransitionGrantTable, {
+      firstName: 'Bob', lastName: 'Carter', imageUrl: 'https://example.com/bob.png', bio: '   ', grantPlan: 'Has a plan but no bio',
+    });
+    await testDb.insert(careerTransitionGrantTable, {
+      firstName: 'Cara', lastName: 'Evans',
+    });
+    await testDb.insert(careerTransitionGrantTable, {
+      firstName: 'Kai', lastName: 'Foster', bio: 'Has a bio and plan but no photo', grantPlan: 'Doing safety work',
+    });
+    // Dropped — missing last name.
+    await testDb.insert(careerTransitionGrantTable, {
+      firstName: 'NoLast', lastName: '   ', imageUrl: 'https://example.com/x.png', bio: 'x', grantPlan: 'y',
+    });
+
+    const caller = createCaller();
+    const result = await caller.grants.getAllPublicCareerTransitionGrantees();
+
+    expect(result.map((grantee) => grantee.granteeName)).toEqual([
+      'Amy Baker',
+      'Zoe Adams',
+      'Ann Davis',
+      'Bob Carter',
+      'Cara Evans',
+      'Kai Foster',
+    ]);
+    // Leading complete card has its fields trimmed and URLs sanitized.
+    expect(result[0]).toEqual({
+      granteeName: 'Amy Baker',
+      imageUrl: 'https://example.com/amy.png',
+      bio: 'Researcher',
+      grantPlan: 'Studying interpretability',
+      profileUrl: 'https://example.com/amy',
+    });
   });
 });
 

--- a/apps/website/src/server/routers/grants.ts
+++ b/apps/website/src/server/routers/grants.ts
@@ -142,7 +142,14 @@ const mapPublicCareerTransitionGrants = (all: CareerTransitionGrant[]): PublicCa
         profileUrl: sanitizeUrl(grant.profileUrl),
       };
     })
-    .sort((a, b) => a.granteeName.localeCompare(b.granteeName));
+    .sort((a, b) => {
+      // Grantees with a photo, a bio and a grant description render as full
+      // cards, so surface those first; the rest follow, each group alphabetical.
+      const aComplete = Boolean(a.imageUrl) && Boolean(a.bio) && Boolean(a.grantPlan);
+      const bComplete = Boolean(b.imageUrl) && Boolean(b.bio) && Boolean(b.grantPlan);
+      if (aComplete !== bComplete) return aComplete ? -1 : 1;
+      return a.granteeName.localeCompare(b.granteeName);
+    });
 };
 
 export const grantsRouter = router({


### PR DESCRIPTION
# Description

On `/programs/career-transition-grant`, the grantees showcase was ordered purely alphabetically, so sparse cards (name + initials, no bio) were interleaved with full ones. This surfaces the complete cards first — those with a photo, a bio and a grant description — with everyone else following. Each group stays alphabetical.

Photo presence is now readable server-side: the Airtable "Permanent headshot URL" formula was updated to return empty when no photo is attached, so a non-empty `imageUrl` reliably means the grantee has a headshot (previously the formula emitted a URL for everyone, which is why some cards rendered broken before the initials fallback landed).

## What changed

1. **`apps/website/src/server/routers/grants.ts`** — `getAllPublicCareerTransitionGrantees` now sorts by completeness (`imageUrl` && `bio` && `grantPlan`) first, then alphabetically within each group.
2. **`apps/website/src/server/routers/grants.test.ts`** — new test covering the completeness ordering (including a grantee with bio+description but no photo sorting into the incomplete group), plus field trimming and URL sanitisation.

## Issue

N/A — ordering refinement on an existing section, no linked issue.

## Developer checklist

- [x] Front-end code follows the Component Accessibility Checklist — no UI markup changed; this is server-side ordering only.
- [x] Considered snapshot/functional tests — added a router test for the new ordering.
- [x] Considered Storybook stories — N/A; the `GranteesSection` story already covers the card rendering.

No DB schema changes.

## Verification

Local dev (`npx next dev -p 8004` in the `anglilian/ctg-sort` worktree):
- ✅ `/programs/career-transition-grant` — 14 complete cards (photo + bio + description) lead; the 11 still-incomplete grantees follow, each group alphabetical. Order adapts automatically as more bios are added in Airtable.

Type check + lint + full test suite all pass:
```
npm run typecheck   # clean
npm run lint        # clean (--max-warnings=0)
npx vitest run      # 949 passed, 1 skipped (119 files) — run twice
```

## Screenshots

Invisible diff — server-side ordering only, no markup change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)