### PR TITLE
[chore] Deprecate resource_completion.createdByUserId

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -327,7 +327,6 @@ export const createMockResourceCompletion = (overrides: Partial<ResourceCompleti
   unitResourceId: MOCK_RESOURCE_ID,
   resourceId: null,
   userId: null,
-  createdByUserId: null,
   createdAt: null,
   completedAt: null,
   ...overrides,

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -148,7 +148,6 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
               resourceFeedback: updatedFields.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
               resourceId: null,
               userId: null,
-              createdByUserId: null,
               createdAt: new Date().toISOString(),
               completedAt: new Date().toISOString(),
             });

--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -1,5 +1,4 @@
 import {
-  courseBuilderUserTable,
   resourceCompletionPgTable,
   unitResourceTable,
   userTable,
@@ -25,8 +24,7 @@ beforeEach(async () => {
 });
 
 describe('resources.saveResourceCompletion', () => {
-  test('writes resourceId, userId, and createdByUserId on insert when both can be resolved', async () => {
-    await testDb.insert(courseBuilderUserTable, { id: 'cb-user-1', email: CALLER_EMAIL });
+  test('writes resourceId and userId on insert when they can be resolved', async () => {
     await testDb.insert(unitResourceTable, { id: 'ur-1', resourceId: ['resource-1'] });
 
     const result = await caller.resources.saveResourceCompletion({
@@ -38,12 +36,11 @@ describe('resources.saveResourceCompletion', () => {
       unitResourceId: 'ur-1',
       resourceId: ['resource-1'],
       userId: ['user-1'],
-      createdByUserId: ['cb-user-1'],
     });
     expect(result.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   });
 
-  test('leaves resourceId and createdByUserId null when those lookups miss', async () => {
+  test('leaves resourceId null when the resource lookup misses', async () => {
     const result = await caller.resources.saveResourceCompletion({
       unitResourceId: 'ur-missing',
       isCompleted: true,
@@ -51,7 +48,6 @@ describe('resources.saveResourceCompletion', () => {
 
     expect(result.resourceId).toBeNull();
     expect(result.userId).toEqual(['user-1']);
-    expect(result.createdByUserId).toBeNull();
   });
 
   test('throws UNAUTHORIZED when the user row is missing', async () => {
@@ -73,7 +69,6 @@ describe('resources.saveResourceCompletion', () => {
       unitResourceId: 'ur-1',
       resourceId: ['resource-original'],
       userId: ['user-1'],
-      createdByUserId: ['cb-user-original'],
     });
 
     const result = await caller.resources.saveResourceCompletion({
@@ -85,7 +80,6 @@ describe('resources.saveResourceCompletion', () => {
       id: 'rc-1',
       resourceId: ['resource-original'],
       userId: ['user-1'],
-      createdByUserId: ['cb-user-original'],
     });
   });
 

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -1,5 +1,5 @@
 import {
-  and, arrayContains, courseBuilderUserTable, userTable, desc, eq, inArray, resourceCompletionPgTable, unitResourceTable,
+  and, arrayContains, userTable, desc, eq, inArray, resourceCompletionPgTable, unitResourceTable,
 } from '@bluedot/db';
 import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
 import { TRPCError } from '@trpc/server';
@@ -61,9 +61,8 @@ export const resourcesRouter = router({
         .optional(),
     }))
     .mutation(async ({ input, ctx }) => {
-      const [unitResource, cbUser, user] = await Promise.all([
+      const [unitResource, user] = await Promise.all([
         db.getFirst(unitResourceTable, { filter: { id: input.unitResourceId }, sortBy: 'id' }),
-        db.getFirst(courseBuilderUserTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),
         db.getFirst(userTable, { filter: { email: ctx.auth.email }, sortBy: 'email' }),
       ]);
       if (!user) {
@@ -107,7 +106,6 @@ export const resourcesRouter = router({
             resourceFeedback: input.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,
             resourceId: unitResource?.resourceId ?? null,
             userId: [user.id],
-            createdByUserId: cbUser ? [cbUser.id] : null,
             createdAt: new Date().toISOString(),
           })
           .returning();

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1556,10 +1556,11 @@ export const resourceCompletionPgTable = deprecationSafePgTable('resource_comple
     resourceId: text().array(),
     // Points at userTable
     userId: text().array(),
-    // Points at courseBuilderUserTable (the Course-builder-base sync of User)
-    createdByUserId: text().array(),
     createdAt: text(),
     completedAt: text(),
+  },
+  deprecatedColumns: {
+    createdByUserId: text().array(),
   },
 });
 


### PR DESCRIPTION
# Description

This has been superseded by `userId` now.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

No issue

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories