### PR TITLE
Look up users by `keycloakIdentifier` (`sub` auth property) rather than email

### DIFF
--- a/apps/website/src/__tests__/dbTestUtils.tsx
+++ b/apps/website/src/__tests__/dbTestUtils.tsx
@@ -47,8 +47,6 @@ export function setupTestDb() {
 }
 
 // Seeds the userTable row for `testAuthContextLoggedIn`, required by procedures that call getUserFromAuthOrThrow.
-// Test identifier convention: subs are `${id}-sub`, emails are `${id}@example.com`. keycloakIdentifier must
-// match testAuthContextLoggedIn.auth.sub so sub-only lookups resolve.
 export const seedLoggedInUser = () => testDb.insert(userTable, {
   id: 'test-user',
   email: 'test@example.com',

--- a/apps/website/src/__tests__/dbTestUtils.tsx
+++ b/apps/website/src/__tests__/dbTestUtils.tsx
@@ -46,11 +46,15 @@ export function setupTestDb() {
   });
 }
 
-// Seeds the userTable row for `testAuthContextLoggedIn`, required by procedures that call getUserOrThrow
+// Seeds the userTable row for `testAuthContextLoggedIn`, required by procedures that call getUserOrThrow.
+// keycloakIdentifier must match testAuthContextLoggedIn.auth.sub so sub-only lookups resolve.
 export const seedLoggedInUser = () => testDb.insert(userTable, {
   id: 'test-user',
   email: 'test@example.com',
   name: 'Test User',
+  // TODO convention (to be used across the board in tests): ${id}-sub for subs, ${id}@example.com for emails
+  // No need to fix historically, but should for any tests we touch
+  keycloakIdentifier: 'test-sub',
 });
 
 // Server-side caller, for router tests that don't render components

--- a/apps/website/src/__tests__/dbTestUtils.tsx
+++ b/apps/website/src/__tests__/dbTestUtils.tsx
@@ -46,14 +46,13 @@ export function setupTestDb() {
   });
 }
 
-// Seeds the userTable row for `testAuthContextLoggedIn`, required by procedures that call getUserOrThrow.
-// keycloakIdentifier must match testAuthContextLoggedIn.auth.sub so sub-only lookups resolve.
+// Seeds the userTable row for `testAuthContextLoggedIn`, required by procedures that call getUserFromAuthOrThrow.
+// Test identifier convention: subs are `${id}-sub`, emails are `${id}@example.com`. keycloakIdentifier must
+// match testAuthContextLoggedIn.auth.sub so sub-only lookups resolve.
 export const seedLoggedInUser = () => testDb.insert(userTable, {
   id: 'test-user',
   email: 'test@example.com',
   name: 'Test User',
-  // TODO convention (to be used across the board in tests): ${id}-sub for subs, ${id}@example.com for emails
-  // No need to fix historically, but should for any tests we touch
   keycloakIdentifier: 'test-sub',
 });
 

--- a/apps/website/src/__tests__/pages/admin/exercises.test.tsx
+++ b/apps/website/src/__tests__/pages/admin/exercises.test.tsx
@@ -28,17 +28,21 @@ vi.mock('next/head', () => ({
   default: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+// Permission checks resolve the caller by sub (keycloakIdentifier). Use the email as the sub too,
+// so seeding `keycloakIdentifier: <email>` makes the caller resolve.
 const ctxFor = (email: string) => ({
   ...testAuthContextLoggedIn,
-  auth: { ...testAuthContextLoggedIn.auth!, email },
+  auth: { ...testAuthContextLoggedIn.auth!, email, sub: email },
 });
 
+// TODO these are still written in quite a path-dependent way, we use email-first for everything. We should instead
+// use sub first, and derive emails from subs if needed (e.g. ${sub}@example.com)
 const ADMIN_EMAIL = 'admin@example.com';
 const TARGET_EMAIL = 'target@example.com';
 
 async function seedAdminAndTarget() {
   await testDb.insert(userTable, {
-    id: 'admin-id', email: ADMIN_EMAIL, name: 'Admin', isAdmin: true,
+    id: 'admin-id', email: ADMIN_EMAIL, name: 'Admin', isAdmin: true, keycloakIdentifier: ADMIN_EMAIL,
   });
   await testDb.insert(userTable, {
     id: 'target-id', email: TARGET_EMAIL, name: 'Target',
@@ -85,7 +89,9 @@ describe('/admin/exercises', () => {
   });
 
   test('non-admin is redirected to /404', async () => {
-    await testDb.insert(userTable, { id: 'regular-id', email: 'regular@example.com', name: 'Regular' });
+    await testDb.insert(userTable, {
+      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular@example.com',
+    });
 
     render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor('regular@example.com')) });
 

--- a/apps/website/src/__tests__/pages/admin/exercises.test.tsx
+++ b/apps/website/src/__tests__/pages/admin/exercises.test.tsx
@@ -28,21 +28,19 @@ vi.mock('next/head', () => ({
   default: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-// Permission checks resolve the caller by sub (keycloakIdentifier). Use the email as the sub too,
-// so seeding `keycloakIdentifier: <email>` makes the caller resolve.
-const ctxFor = (email: string) => ({
+// Permission checks resolve the caller by sub (keycloakIdentifier), so callers are keyed on sub.
+const ctxFor = (sub: string) => ({
   ...testAuthContextLoggedIn,
-  auth: { ...testAuthContextLoggedIn.auth!, email, sub: email },
+  auth: { ...testAuthContextLoggedIn.auth!, sub },
 });
 
-// TODO these are still written in quite a path-dependent way, we use email-first for everything. We should instead
-// use sub first, and derive emails from subs if needed (e.g. ${sub}@example.com)
+const ADMIN_SUB = 'admin-sub';
 const ADMIN_EMAIL = 'admin@example.com';
 const TARGET_EMAIL = 'target@example.com';
 
 async function seedAdminAndTarget() {
   await testDb.insert(userTable, {
-    id: 'admin-id', email: ADMIN_EMAIL, name: 'Admin', isAdmin: true, keycloakIdentifier: ADMIN_EMAIL,
+    id: 'admin-id', email: ADMIN_EMAIL, name: 'Admin', isAdmin: true, keycloakIdentifier: ADMIN_SUB,
   });
   await testDb.insert(userTable, {
     id: 'target-id', email: TARGET_EMAIL, name: 'Target',
@@ -90,10 +88,10 @@ describe('/admin/exercises', () => {
 
   test('non-admin is redirected to /404', async () => {
     await testDb.insert(userTable, {
-      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular@example.com',
+      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular-sub',
     });
 
-    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor('regular@example.com')) });
+    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor('regular-sub')) });
 
     await waitFor(() => {
       expect(routerReplace).toHaveBeenCalledWith('/404');
@@ -103,7 +101,7 @@ describe('/admin/exercises', () => {
   test('selecting a user via the modal navigates with their userId', async () => {
     await seedAdminAndTarget();
     const user = userEvent.setup();
-    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_EMAIL)) });
+    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_SUB)) });
 
     const selectButton = await screen.findByRole('button', { name: 'Select user' });
     await user.click(selectButton);
@@ -120,7 +118,7 @@ describe('/admin/exercises', () => {
     await seedTargetResponses();
     routerQuery = { userId: 'target-id' };
     const user = userEvent.setup();
-    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_EMAIL)) });
+    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_SUB)) });
 
     await waitFor(() => {
       expect(screen.getByText(/thinking about safety mechanisms/)).toBeInTheDocument();
@@ -149,7 +147,7 @@ describe('/admin/exercises', () => {
     await seedTargetResponses();
     routerQuery = { userId: 'target-id' };
     const user = userEvent.setup();
-    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_EMAIL)) });
+    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_SUB)) });
 
     const searchInput = await screen.findByPlaceholderText(/Search question or response/);
 
@@ -172,7 +170,7 @@ describe('/admin/exercises', () => {
   test('query errors render an ErrorSection rather than crashing', async () => {
     await seedAdminAndTarget();
     routerQuery = { userId: 'nonexistent-id' };
-    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_EMAIL)) });
+    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_SUB)) });
 
     // Both metaQuery and exerciseResponseQuery error with NOT_FOUND; each renders an ErrorSection.
     const headings = await screen.findAllByRole('heading', { name: /User not found/ });
@@ -184,7 +182,7 @@ describe('/admin/exercises', () => {
     await seedTargetResponses();
     routerQuery = { userId: 'target-id' };
     const user = userEvent.setup();
-    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_EMAIL)) });
+    render(<AdminExercisesPage />, { wrapper: createTrpcDbProvider(ctxFor(ADMIN_SUB)) });
 
     await waitFor(() => {
       expect(screen.getByText(/thinking about safety mechanisms/)).toBeInTheDocument();

--- a/apps/website/src/components/admin/ImpersonationBadge.test.tsx
+++ b/apps/website/src/components/admin/ImpersonationBadge.test.tsx
@@ -130,7 +130,9 @@ describe('ImpersonationBadge URL param handling', () => {
     await testDb.insert(userTable, {
       id: 'rec-admin', email: testAuthContextLoggedIn.auth!.email, name: 'Admin', isAdmin: true, keycloakIdentifier: testAuthContextLoggedIn.auth!.sub,
     });
-    await testDb.insert(userTable, { id: 'rec-foo', email: 'foo@bar.com', name: 'Foo' });
+    await testDb.insert(userTable, {
+      id: 'rec-foo', email: 'foo@bar.com', name: 'Foo', keycloakIdentifier: 'foo-sub',
+    });
 
     stubLocationSearch('?impersonate=foo@bar.com');
 
@@ -139,6 +141,26 @@ describe('ImpersonationBadge URL param handling', () => {
     await waitFor(() => {
       expect(mockSessionStorage.setItem).toHaveBeenCalledWith('bluedot_impersonating', 'rec-foo');
     });
+  });
+
+  test('?impersonate=<email> targeting a never-logged-in user does not start impersonating', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await testDb.insert(userTable, {
+      id: 'rec-admin', email: testAuthContextLoggedIn.auth!.email, name: 'Admin', isAdmin: true, keycloakIdentifier: testAuthContextLoggedIn.auth!.sub,
+    });
+    await testDb.insert(userTable, { id: 'rec-ghost', email: 'ghost@bar.com', name: 'Ghost' });
+
+    stubLocationSearch('?impersonate=ghost@bar.com');
+
+    render(<ImpersonationBadge />, { wrapper: createTrpcDbProvider(testAuthContextLoggedIn) });
+
+    // searchUsers filters out never-logged-in users, so the lookup finds no match
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('no user found with that email'));
+    });
+    expect(mockSessionStorage.setItem).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 
   test('?impersonate=clear removes any active impersonation', async () => {

--- a/apps/website/src/components/admin/ImpersonationBadge.test.tsx
+++ b/apps/website/src/components/admin/ImpersonationBadge.test.tsx
@@ -128,7 +128,7 @@ describe('ImpersonationBadge URL param handling', () => {
 
   test('?impersonate=<email> resolves via admin.searchUsers and writes sessionStorage', async () => {
     await testDb.insert(userTable, {
-      id: 'rec-admin', email: testAuthContextLoggedIn.auth!.email, name: 'Admin', isAdmin: true,
+      id: 'rec-admin', email: testAuthContextLoggedIn.auth!.email, name: 'Admin', isAdmin: true, keycloakIdentifier: testAuthContextLoggedIn.auth!.sub,
     });
     await testDb.insert(userTable, { id: 'rec-foo', email: 'foo@bar.com', name: 'Foo' });
 

--- a/apps/website/src/components/settings/ProfileNameEditor.test.tsx
+++ b/apps/website/src/components/settings/ProfileNameEditor.test.tsx
@@ -234,6 +234,7 @@ describe('ProfileNameEditor (with DB)', () => {
     await db.insert(userTable, {
       email: 'test@example.com',
       name: 'John Doe',
+      keycloakIdentifier: 'test-sub',
     });
 
     const { container } = render(

--- a/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
+++ b/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
@@ -6,11 +6,11 @@ import {
   groupDiscussionTable,
   meetPersonTable,
   unitTable,
-  userTable,
 } from '@bluedot/db';
 import db from '../../../../lib/api/db';
 import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
 import { createDiscussionCalendarIcs } from '../../../../lib/calendar';
+import { getUserBySub } from '../../../../server/trpc';
 
 function getDiscussionId(queryValue: string | string[] | undefined) {
   if (typeof queryValue === 'string' && queryValue.trim().length > 0) {
@@ -51,7 +51,7 @@ export default makeApiRoute({
 
   const [discussion, requestingUser] = await Promise.all([
     db.get(groupDiscussionTable, { id: discussionId }),
-    db.getFirst(userTable, { filter: { email: auth.email } }),
+    getUserBySub(auth.sub),
   ]);
   if (!discussion) {
     throw new createHttpError.NotFound('Discussion not found');

--- a/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
+++ b/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
@@ -10,7 +10,7 @@ import {
 import db from '../../../../lib/api/db';
 import { makeApiRoute } from '../../../../lib/api/makeApiRoute';
 import { createDiscussionCalendarIcs } from '../../../../lib/calendar';
-import { getUserBySub } from '../../../../server/trpc';
+import { getUserFromAuth } from '../../../../server/trpc';
 
 function getDiscussionId(queryValue: string | string[] | undefined) {
   if (typeof queryValue === 'string' && queryValue.trim().length > 0) {
@@ -51,7 +51,7 @@ export default makeApiRoute({
 
   const [discussion, requestingUser] = await Promise.all([
     db.get(groupDiscussionTable, { id: discussionId }),
-    getUserBySub(auth.sub),
+    getUserFromAuth(auth),
   ]);
   if (!discussion) {
     throw new createHttpError.NotFound('Discussion not found');

--- a/apps/website/src/server/context.test.ts
+++ b/apps/website/src/server/context.test.ts
@@ -98,7 +98,7 @@ describe('createContext: User impersonation', () => {
     });
 
     await expect(createContext({ req } as Parameters<typeof createContext>[0]))
-      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      .rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
   test('scoped user can impersonate allowed target', async () => {

--- a/apps/website/src/server/context.test.ts
+++ b/apps/website/src/server/context.test.ts
@@ -77,11 +77,12 @@ describe('createContext: User impersonation', () => {
     expect(result.auth?.sub).toBe('target-sub');
     expect(result.impersonation).toEqual({
       adminEmail: 'admin@example.com',
+      adminSub: 'admin-sub',
       targetEmail: 'target@example.com',
     });
   });
 
-  test('impersonating a not-yet-backfilled target yields an empty sub (falls back to email lookups downstream)', async () => {
+  test('impersonating a not-yet-backfilled target (no keycloakIdentifier) is blocked', async () => {
     const adminAuth = { ...mockAuth, email: 'admin@example.com', sub: 'admin-sub' };
     await testDb.insert(userTable, {
       id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
@@ -95,18 +96,19 @@ describe('createContext: User impersonation', () => {
       authorization: 'Bearer valid-token',
       'x-impersonate-user': 'target-id',
     });
-    const result = await createContext({ req } as Parameters<typeof createContext>[0]);
 
-    expect(result.auth?.email).toBe('target@example.com');
-    expect(result.auth?.sub).toBe('');
+    await expect(createContext({ req } as Parameters<typeof createContext>[0]))
+      .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
   test('scoped user can impersonate allowed target', async () => {
-    const scopedAuth = { ...mockAuth, email: 'scoped@example.com' };
+    const scopedAuth = { ...mockAuth, email: 'scoped@example.com', sub: 'scoped-sub' };
     await testDb.insert(userTable, {
-      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped User', allowedImpersonationTargets: ['allowed-id'],
+      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped User', keycloakIdentifier: 'scoped-sub', allowedImpersonationTargets: ['allowed-id'],
     });
-    await testDb.insert(userTable, { id: 'allowed-id', email: 'target@example.com', name: 'Target User' });
+    await testDb.insert(userTable, {
+      id: 'allowed-id', email: 'target@example.com', name: 'Target User', keycloakIdentifier: 'target-sub',
+    });
 
     vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(scopedAuth);
 
@@ -119,16 +121,19 @@ describe('createContext: User impersonation', () => {
     expect(result.auth?.email).toBe('target@example.com');
     expect(result.impersonation).toEqual({
       adminEmail: 'scoped@example.com',
+      adminSub: 'scoped-sub',
       targetEmail: 'target@example.com',
     });
   });
 
   test('scoped user cannot impersonate non-allowed target', async () => {
-    const scopedAuth = { ...mockAuth, email: 'scoped@example.com' };
+    const scopedAuth = { ...mockAuth, email: 'scoped@example.com', sub: 'scoped-sub' };
     await testDb.insert(userTable, {
-      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped User', allowedImpersonationTargets: ['allowed-id'],
+      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped User', keycloakIdentifier: 'scoped-sub', allowedImpersonationTargets: ['allowed-id'],
     });
-    await testDb.insert(userTable, { id: 'other-id', email: 'other@example.com', name: 'Other User' });
+    await testDb.insert(userTable, {
+      id: 'other-id', email: 'other@example.com', name: 'Other User', keycloakIdentifier: 'other-sub',
+    });
 
     vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(scopedAuth);
 
@@ -143,8 +148,13 @@ describe('createContext: User impersonation', () => {
   });
 
   test('user with no impersonation access is rejected', async () => {
-    await testDb.insert(userTable, { id: 'regular-id', email: 'user@example.com', name: 'Regular User' });
-    await testDb.insert(userTable, { id: 'some-target-id', email: 'target@example.com', name: 'Target User' });
+    // mockAuth.sub is 'user-sub-123'
+    await testDb.insert(userTable, {
+      id: 'regular-id', email: 'user@example.com', name: 'Regular User', keycloakIdentifier: 'user-sub-123',
+    });
+    await testDb.insert(userTable, {
+      id: 'some-target-id', email: 'target@example.com', name: 'Target User', keycloakIdentifier: 'target-sub',
+    });
 
     vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(mockAuth);
 
@@ -159,9 +169,9 @@ describe('createContext: User impersonation', () => {
   });
 
   test('impersonation falls back to normal user when target user not found', async () => {
-    const adminAuth = { ...mockAuth, email: 'admin@example.com' };
+    const adminAuth = { ...mockAuth, email: 'admin@example.com', sub: 'admin-sub' };
     await testDb.insert(userTable, {
-      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true,
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
     });
 
     vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(adminAuth);

--- a/apps/website/src/server/context.test.ts
+++ b/apps/website/src/server/context.test.ts
@@ -82,7 +82,7 @@ describe('createContext: User impersonation', () => {
     });
   });
 
-  test('impersonating a not-yet-backfilled target (no keycloakIdentifier) is blocked', async () => {
+  test('impersonating a never-logged-in target (no keycloakIdentifier) is blocked', async () => {
     const adminAuth = { ...mockAuth, email: 'admin@example.com', sub: 'admin-sub' };
     await testDb.insert(userTable, {
       id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',

--- a/apps/website/src/server/context.ts
+++ b/apps/website/src/server/context.ts
@@ -6,8 +6,6 @@ import type * as trpcNext from '@trpc/server/adapters/next';
 import db from '../lib/api/db';
 import { checkImpersonationAccess } from './trpc';
 
-// The server-verified caller identity, decoded from the Keycloak bearer token. Sourced directly from
-// the token verifier (not from `Context`) so permission helpers can reference it without a circular type.
 export type AuthContext = Awaited<ReturnType<typeof loginPresets.keycloak.verifyAndDecodeToken>>;
 
 export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) => {

--- a/apps/website/src/server/context.ts
+++ b/apps/website/src/server/context.ts
@@ -37,8 +37,7 @@ export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) 
         : null;
       if (targetUser) {
         // A target with no keycloakIdentifier has never logged in via Keycloak and so is not a
-        // legitimate user to act as. Block impersonation rather than downgrading to an empty sub
-        // (downstream reads resolve callers by sub only, so an empty sub can never resolve).
+        // legitimate user to act as.
         if (!targetUser.keycloakIdentifier) {
           throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Cannot impersonate a user who has never logged in' });
         }

--- a/apps/website/src/server/context.ts
+++ b/apps/website/src/server/context.ts
@@ -6,6 +6,10 @@ import type * as trpcNext from '@trpc/server/adapters/next';
 import db from '../lib/api/db';
 import { checkImpersonationAccess } from './trpc';
 
+// The server-verified caller identity, decoded from the Keycloak bearer token. Sourced directly from
+// the token verifier (not from `Context`) so permission helpers can reference it without a circular type.
+export type AuthContext = Awaited<ReturnType<typeof loginPresets.keycloak.verifyAndDecodeToken>>;
+
 export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) => {
   const authHeader = req.headers.authorization;
   const userAgent = req.headers['user-agent'];
@@ -27,7 +31,7 @@ export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) 
     // - Audit: impersonation events are logged with both admin and target emails so we can see when this is used in prod
     const impersonateUserId = req.headers['x-impersonate-user'] as string | undefined;
     if (impersonateUserId) {
-      const { access, allowedTargets } = await checkImpersonationAccess(auth.sub);
+      const { access, allowedTargets } = await checkImpersonationAccess(auth);
       const canImpersonate = access === 'admin' || (access === 'scoped' && allowedTargets.includes(impersonateUserId));
 
       const targetUser = canImpersonate

--- a/apps/website/src/server/context.ts
+++ b/apps/website/src/server/context.ts
@@ -39,7 +39,7 @@ export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) 
         // A target with no keycloakIdentifier has never logged in via Keycloak and so is not a
         // legitimate user to act as.
         if (!targetUser.keycloakIdentifier) {
-          throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Cannot impersonate a user who has never logged in' });
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot impersonate a user who has never logged in' });
         }
 
         logger.info(`${auth.email} impersonating user ${targetUser.email} (access: ${access})`);

--- a/apps/website/src/server/context.ts
+++ b/apps/website/src/server/context.ts
@@ -1,6 +1,7 @@
 import { userTable } from '@bluedot/db';
 import { loginPresets } from '@bluedot/ui/src/Login';
 import { logger } from '@bluedot/ui/src/api';
+import { TRPCError } from '@trpc/server';
 import type * as trpcNext from '@trpc/server/adapters/next';
 import db from '../lib/api/db';
 import { checkImpersonationAccess } from './trpc';
@@ -26,24 +27,36 @@ export const createContext = async ({ req }: trpcNext.CreateNextContextOptions) 
     // - Audit: impersonation events are logged with both admin and target emails so we can see when this is used in prod
     const impersonateUserId = req.headers['x-impersonate-user'] as string | undefined;
     if (impersonateUserId) {
-      const { access, allowedTargets } = await checkImpersonationAccess(auth.email);
+      const { access, allowedTargets } = await checkImpersonationAccess(auth.sub);
       const canImpersonate = access === 'admin' || (access === 'scoped' && allowedTargets.includes(impersonateUserId));
 
-      if (canImpersonate) {
-        const targetUser = await db.getFirst(userTable, { filter: { id: impersonateUserId } });
-        if (targetUser) {
-          logger.info(`${auth.email} impersonating user ${targetUser.email} (access: ${access})`);
-          return {
-            auth: { ...auth, email: targetUser.email, sub: targetUser.keycloakIdentifier ?? '' },
-            impersonation: { adminEmail: auth.email, targetEmail: targetUser.email },
-            userAgent,
-          };
+      const targetUser = canImpersonate
+        ? await db.getFirst(userTable, { filter: { id: impersonateUserId } })
+        : null;
+      if (targetUser) {
+        // A target with no keycloakIdentifier has never logged in via Keycloak and so is not a
+        // legitimate user to act as. Block impersonation rather than downgrading to an empty sub
+        // (downstream reads resolve callers by sub only, so an empty sub can never resolve).
+        if (!targetUser.keycloakIdentifier) {
+          throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Cannot impersonate a user who has never logged in' });
         }
+
+        logger.info(`${auth.email} impersonating user ${targetUser.email} (access: ${access})`);
+        return {
+          auth: { ...auth, email: targetUser.email, sub: targetUser.keycloakIdentifier },
+          impersonation: { adminEmail: auth.email, adminSub: auth.sub, targetEmail: targetUser.email },
+          userAgent,
+        };
       }
     }
 
     return { auth, impersonation: null, userAgent };
   } catch (error) {
+    // Deliberate rejections (e.g. impersonating an ineligible target) propagate as-is.
+    if (error instanceof TRPCError) {
+      throw error;
+    }
+
     // Token verification failed - return null and let protectedProcedure handle it
     logger.error('Error verifying token', error);
     return { auth: null, impersonation: null, userAgent };

--- a/apps/website/src/server/routers/admin.test.ts
+++ b/apps/website/src/server/routers/admin.test.ts
@@ -8,9 +8,12 @@ import {
 
 setupTestDb();
 
+// TODO similar comment elsewhere: Don't do this path-dependent mixing of email and sub, and cut the over-egged comment
+// Permission checks resolve the caller by sub (keycloakIdentifier). Use the email as the sub too,
+// so seeding `keycloakIdentifier: <email>` makes the caller resolve.
 const callerAs = (email: string) => createCaller({
   ...testAuthContextLoggedIn,
-  auth: { ...testAuthContextLoggedIn.auth!, email },
+  auth: { ...testAuthContextLoggedIn.auth!, email, sub: email },
 });
 
 describe('admin: privilege escalation prevention', () => {
@@ -18,15 +21,15 @@ describe('admin: privilege escalation prevention', () => {
   // the caller built for that impersonation. Every admin-gated procedure should refuse.
   async function callerForScopedImpersonatingAdmin() {
     await testDb.insert(userTable, {
-      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', allowedImpersonationTargets: ['admin-id'],
+      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped-sub', allowedImpersonationTargets: ['admin-id'],
     });
     await testDb.insert(userTable, {
-      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true,
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
     });
     return createCaller({
       ...testAuthContextLoggedIn,
-      auth: { ...testAuthContextLoggedIn.auth!, email: 'admin@example.com' },
-      impersonation: { adminEmail: 'scoped@example.com', targetEmail: 'admin@example.com' },
+      auth: { ...testAuthContextLoggedIn.auth!, email: 'admin@example.com', sub: 'admin-sub' },
+      impersonation: { adminEmail: 'scoped@example.com', adminSub: 'scoped-sub', targetEmail: 'admin@example.com' },
     });
   }
 
@@ -53,13 +56,15 @@ describe('admin.isUserAdmin', () => {
   });
 
   test('regular user → false', async () => {
-    await testDb.insert(userTable, { id: 'regular-id', email: 'regular@example.com', name: 'Regular' });
+    await testDb.insert(userTable, {
+      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular@example.com',
+    });
     expect(await callerAs('regular@example.com').admin.isUserAdmin()).toBe(false);
   });
 
   test('admin → true', async () => {
     await testDb.insert(userTable, {
-      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true,
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin@example.com',
     });
     expect(await callerAs('admin@example.com').admin.isUserAdmin()).toBe(true);
   });
@@ -68,7 +73,8 @@ describe('admin.isUserAdmin', () => {
 describe('admin.searchUsers', () => {
   test('scoped user only sees allowed targets', async () => {
     await testDb.insert(userTable, {
-      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', allowedImpersonationTargets: ['user-1'],
+      // TODO similar flag to elsewhere: don't use email as sub
+      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped@example.com', allowedImpersonationTargets: ['user-1'],
     });
     await testDb.insert(userTable, { id: 'user-1', email: 'alice@example.com', name: 'Alice' });
     await testDb.insert(userTable, { id: 'user-2', email: 'bob@example.com', name: 'Bob' });
@@ -79,14 +85,16 @@ describe('admin.searchUsers', () => {
   });
 
   test('regular user gets FORBIDDEN', async () => {
-    await testDb.insert(userTable, { id: 'regular-id', email: 'regular@example.com', name: 'Regular' });
+    await testDb.insert(userTable, {
+      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular@example.com',
+    });
 
     await expect(callerAs('regular@example.com').admin.searchUsers({})).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
   test('scope=all: non-admin gets FORBIDDEN even if they have scoped impersonation access', async () => {
     await testDb.insert(userTable, {
-      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', allowedImpersonationTargets: ['user-1'],
+      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped@example.com', allowedImpersonationTargets: ['user-1'],
     });
     await testDb.insert(userTable, { id: 'user-1', email: 'alice@example.com', name: 'Alice' });
 

--- a/apps/website/src/server/routers/admin.test.ts
+++ b/apps/website/src/server/routers/admin.test.ts
@@ -73,8 +73,12 @@ describe('admin.searchUsers', () => {
     await testDb.insert(userTable, {
       id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped-sub', allowedImpersonationTargets: ['user-1'],
     });
-    await testDb.insert(userTable, { id: 'user-1', email: 'alice@example.com', name: 'Alice' });
-    await testDb.insert(userTable, { id: 'user-2', email: 'bob@example.com', name: 'Bob' });
+    await testDb.insert(userTable, {
+      id: 'user-1', email: 'alice@example.com', name: 'Alice', keycloakIdentifier: 'alice-sub',
+    });
+    await testDb.insert(userTable, {
+      id: 'user-2', email: 'bob@example.com', name: 'Bob', keycloakIdentifier: 'bob-sub',
+    });
 
     const results = await callerAs('scoped-sub').admin.searchUsers({});
     expect(results).toHaveLength(1);
@@ -87,6 +91,33 @@ describe('admin.searchUsers', () => {
     });
 
     await expect(callerAs('regular-sub').admin.searchUsers({})).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  test('impersonate scope excludes never-logged-in users; all scope includes them', async () => {
+    await testDb.insert(userTable, {
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
+    });
+    await testDb.insert(userTable, {
+      id: 'user-1', email: 'alice@example.com', name: 'Alice', keycloakIdentifier: 'alice-sub',
+    });
+    await testDb.insert(userTable, { id: 'user-2', email: 'bob@example.com', name: 'Bob' });
+
+    const impersonateResults = await callerAs('admin-sub').admin.searchUsers({});
+    expect(impersonateResults.map((r) => r.email)).not.toContain('bob@example.com');
+    expect(impersonateResults.map((r) => r.email)).toContain('alice@example.com');
+
+    const allResults = await callerAs('admin-sub').admin.searchUsers({ scope: 'all' });
+    expect(allResults.map((r) => r.email)).toContain('bob@example.com');
+  });
+
+  test('scoped user cannot see a never-logged-in allowed target', async () => {
+    await testDb.insert(userTable, {
+      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped-sub', allowedImpersonationTargets: ['ghost-id'],
+    });
+    await testDb.insert(userTable, { id: 'ghost-id', email: 'ghost@example.com', name: 'Ghost' });
+
+    const results = await callerAs('scoped-sub').admin.searchUsers({});
+    expect(results).toHaveLength(0);
   });
 
   test('scope=all: non-admin gets FORBIDDEN even if they have scoped impersonation access', async () => {

--- a/apps/website/src/server/routers/admin.test.ts
+++ b/apps/website/src/server/routers/admin.test.ts
@@ -8,12 +8,10 @@ import {
 
 setupTestDb();
 
-// TODO similar comment elsewhere: Don't do this path-dependent mixing of email and sub, and cut the over-egged comment
-// Permission checks resolve the caller by sub (keycloakIdentifier). Use the email as the sub too,
-// so seeding `keycloakIdentifier: <email>` makes the caller resolve.
-const callerAs = (email: string) => createCaller({
+// Permission checks resolve the caller by sub (keycloakIdentifier), so callers are keyed on sub.
+const callerAs = (sub: string) => createCaller({
   ...testAuthContextLoggedIn,
-  auth: { ...testAuthContextLoggedIn.auth!, email, sub: email },
+  auth: { ...testAuthContextLoggedIn.auth!, sub },
 });
 
 describe('admin: privilege escalation prevention', () => {
@@ -57,48 +55,47 @@ describe('admin.isUserAdmin', () => {
 
   test('regular user → false', async () => {
     await testDb.insert(userTable, {
-      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular@example.com',
+      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular-sub',
     });
-    expect(await callerAs('regular@example.com').admin.isUserAdmin()).toBe(false);
+    expect(await callerAs('regular-sub').admin.isUserAdmin()).toBe(false);
   });
 
   test('admin → true', async () => {
     await testDb.insert(userTable, {
-      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin@example.com',
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
     });
-    expect(await callerAs('admin@example.com').admin.isUserAdmin()).toBe(true);
+    expect(await callerAs('admin-sub').admin.isUserAdmin()).toBe(true);
   });
 });
 
 describe('admin.searchUsers', () => {
   test('scoped user only sees allowed targets', async () => {
     await testDb.insert(userTable, {
-      // TODO similar flag to elsewhere: don't use email as sub
-      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped@example.com', allowedImpersonationTargets: ['user-1'],
+      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped-sub', allowedImpersonationTargets: ['user-1'],
     });
     await testDb.insert(userTable, { id: 'user-1', email: 'alice@example.com', name: 'Alice' });
     await testDb.insert(userTable, { id: 'user-2', email: 'bob@example.com', name: 'Bob' });
 
-    const results = await callerAs('scoped@example.com').admin.searchUsers({});
+    const results = await callerAs('scoped-sub').admin.searchUsers({});
     expect(results).toHaveLength(1);
     expect(results[0]!.email).toBe('alice@example.com');
   });
 
   test('regular user gets FORBIDDEN', async () => {
     await testDb.insert(userTable, {
-      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular@example.com',
+      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular-sub',
     });
 
-    await expect(callerAs('regular@example.com').admin.searchUsers({})).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    await expect(callerAs('regular-sub').admin.searchUsers({})).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
   test('scope=all: non-admin gets FORBIDDEN even if they have scoped impersonation access', async () => {
     await testDb.insert(userTable, {
-      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped@example.com', allowedImpersonationTargets: ['user-1'],
+      id: 'scoped-id', email: 'scoped@example.com', name: 'Scoped', keycloakIdentifier: 'scoped-sub', allowedImpersonationTargets: ['user-1'],
     });
     await testDb.insert(userTable, { id: 'user-1', email: 'alice@example.com', name: 'Alice' });
 
-    await expect(callerAs('scoped@example.com').admin.searchUsers({ scope: 'all' }))
+    await expect(callerAs('scoped-sub').admin.searchUsers({ scope: 'all' }))
       .rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 });

--- a/apps/website/src/server/routers/admin.ts
+++ b/apps/website/src/server/routers/admin.ts
@@ -21,7 +21,7 @@ import { TRPCError, type inferRouterOutputs } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';
 import {
-  adminProcedure, checkAdminAccess, checkImpersonationAccess, protectedProcedure, publicProcedure, router,
+  adminProcedure, checkAdminAccess, checkImpersonationAccess, protectedProcedure, publicProcedure, impersonationRealIdentity, router,
 } from '../trpc';
 
 type UserSearchResult = {
@@ -35,12 +35,10 @@ type UserSearchResult = {
 export const adminRouter = router({
   isUserAdmin: publicProcedure.query(async ({ ctx }) => {
     if (!ctx.auth) return false;
-    const realEmail = ctx.impersonation?.adminEmail ?? ctx.auth.email;
-    return checkAdminAccess(realEmail);
+    return checkAdminAccess(impersonationRealIdentity(ctx));
   }),
   canImpersonate: protectedProcedure.query(async ({ ctx }) => {
-    const realEmail = ctx.impersonation?.adminEmail ?? ctx.auth.email;
-    const { access } = await checkImpersonationAccess(realEmail);
+    const { access } = await checkImpersonationAccess(impersonationRealIdentity(ctx));
     return access;
   }),
 
@@ -51,17 +49,17 @@ export const adminRouter = router({
       scope: z.enum(['impersonate', 'all']).default('impersonate'),
     }))
     .query(async ({ ctx, input }) => {
-      const realEmail = ctx.impersonation?.adminEmail ?? ctx.auth.email;
+      const realSub = impersonationRealIdentity(ctx);
 
       let scopeClause;
       if (input.scope === 'all') {
-        if (!await checkAdminAccess(realEmail)) {
+        if (!await checkAdminAccess(realSub)) {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'Unauthorized' });
         }
 
         scopeClause = sql`TRUE`;
       } else {
-        const { access, allowedTargets } = await checkImpersonationAccess(realEmail);
+        const { access, allowedTargets } = await checkImpersonationAccess(realSub);
         if (access === 'none') {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'Unauthorized' });
         }

--- a/apps/website/src/server/routers/admin.ts
+++ b/apps/website/src/server/routers/admin.ts
@@ -65,8 +65,8 @@ export const adminRouter = router({
         }
 
         scopeClause = access === 'scoped'
-          ? sql`u.id IN (${sql.join(allowedTargets.map((id) => sql`${id}`), sql`, `)})`
-          : sql`TRUE`;
+          ? sql`u.id IN (${sql.join(allowedTargets.map((id) => sql`${id}`), sql`, `)}) AND u."keycloakIdentifier" IS NOT NULL`
+          : sql`u."keycloakIdentifier" IS NOT NULL`;
       }
 
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/apps/website/src/server/routers/admin.ts
+++ b/apps/website/src/server/routers/admin.ts
@@ -49,17 +49,17 @@ export const adminRouter = router({
       scope: z.enum(['impersonate', 'all']).default('impersonate'),
     }))
     .query(async ({ ctx, input }) => {
-      const realSub = impersonationRealIdentity(ctx);
+      const realAuth = impersonationRealIdentity(ctx);
 
       let scopeClause;
       if (input.scope === 'all') {
-        if (!await checkAdminAccess(realSub)) {
+        if (!await checkAdminAccess(realAuth)) {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'Unauthorized' });
         }
 
         scopeClause = sql`TRUE`;
       } else {
-        const { access, allowedTargets } = await checkImpersonationAccess(realSub);
+        const { access, allowedTargets } = await checkImpersonationAccess(realAuth);
         if (access === 'none') {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'Unauthorized' });
         }

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -18,7 +18,7 @@ import db from '../../lib/api/db';
 import { verifyPublicToken } from '../../lib/api/utils';
 import { FOAI_COURSE_ID, ONE_DAY_MS } from '../../lib/constants';
 import {
-  getUserOrThrow, protectedProcedure, publicProcedure, router,
+  getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
 } from '../trpc';
 import type { AppRouter } from './_app';
 import { hasUpcomingRoundsForCourseId } from './course-rounds';
@@ -147,7 +147,7 @@ export const certificatesRouter = router({
   verifyOwnership: protectedProcedure
     .input(z.object({ certificateId: z.string() }))
     .query(async ({ ctx, input: { certificateId } }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' });
       const facilitatedRegistration = await db.getFirst(courseRegistrationTable, { filter: { certificateId } });
@@ -164,7 +164,7 @@ export const certificatesRouter = router({
       return { status: 'not-authenticated', hasUpcomingRounds } as const;
     }
 
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     // Future of AI is self-serve: it lives in its own table and never has rounds.
     if (courseId === FOAI_COURSE_ID) {

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -147,7 +147,7 @@ export const certificatesRouter = router({
   verifyOwnership: protectedProcedure
     .input(z.object({ certificateId: z.string() }))
     .query(async ({ ctx, input: { certificateId } }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' });
       const facilitatedRegistration = await db.getFirst(courseRegistrationTable, { filter: { certificateId } });
@@ -164,7 +164,7 @@ export const certificatesRouter = router({
       return { status: 'not-authenticated', hasUpcomingRounds } as const;
     }
 
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     // Future of AI is self-serve: it lives in its own table and never has rounds.
     if (courseId === FOAI_COURSE_ID) {

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -7,7 +7,7 @@ import z from 'zod';
 import db from '../../lib/api/db';
 import { normaliseEmail, verifyPublicToken } from '../../lib/api/utils';
 import {
-  getUserOrThrow, protectedProcedure, publicProcedure, router,
+  getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
 } from '../trpc';
 import { ensureSelfServeRegistrationExistsProcedure } from './self-serve-course-registrations';
 
@@ -16,7 +16,7 @@ export const courseRegistrationsRouter = router({
     .input(z.object({ courseId: z.string() }))
     .query(async ({ ctx, input }) => {
       const { courseId } = input;
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       return db.getFirst(courseRegistrationTable, {
         filter: {
@@ -28,7 +28,7 @@ export const courseRegistrationsRouter = router({
     }),
 
   getAll: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     return db.pg.select()
       .from(courseRegistrationTable.pg)

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -16,7 +16,7 @@ export const courseRegistrationsRouter = router({
     .input(z.object({ courseId: z.string() }))
     .query(async ({ ctx, input }) => {
       const { courseId } = input;
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       return db.getFirst(courseRegistrationTable, {
         filter: {
@@ -28,7 +28,7 @@ export const courseRegistrationsRouter = router({
     }),
 
   getAll: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     return db.pg.select()
       .from(courseRegistrationTable.pg)

--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import db from '../../lib/api/db';
 import { ONE_DAY_MS } from '../../lib/constants';
 import { formatApplicationDeadlineUtcDetailed, formatDateRange, formatMonthAndDay } from '../../lib/utils';
-import { getUserBySub, publicProcedure, router } from '../trpc';
+import { getUserFromAuth, publicProcedure, router } from '../trpc';
 
 export function getDeadlineThresholdUtc(): Date {
   const now = new Date();
@@ -273,7 +273,7 @@ export const courseRoundsRouter = router({
       let hasApplied = false;
       if (ctx.auth?.sub) {
         // Optional-auth endpoint: resolve the user without throwing; no user means not applied.
-        const user = await getUserBySub(ctx.auth.sub);
+        const user = await getUserFromAuth(ctx.auth);
         if (user) {
           const result = await db.pg.execute<{ exists: boolean }>(sql`
             SELECT EXISTS (

--- a/apps/website/src/server/routers/course-rounds.ts
+++ b/apps/website/src/server/routers/course-rounds.ts
@@ -5,13 +5,12 @@ import {
   courseTable,
   eq,
   or, sql,
-  userTable,
 } from '@bluedot/db';
 import { z } from 'zod';
 import db from '../../lib/api/db';
 import { ONE_DAY_MS } from '../../lib/constants';
 import { formatApplicationDeadlineUtcDetailed, formatDateRange, formatMonthAndDay } from '../../lib/utils';
-import { publicProcedure, router } from '../trpc';
+import { getUserBySub, publicProcedure, router } from '../trpc';
 
 export function getDeadlineThresholdUtc(): Date {
   const now = new Date();
@@ -272,9 +271,9 @@ export const courseRoundsRouter = router({
 
       // Check if user has already applied (requires auth context)
       let hasApplied = false;
-      if (ctx.auth?.email) {
+      if (ctx.auth?.sub) {
         // Optional-auth endpoint: resolve the user without throwing; no user means not applied.
-        const user = await db.getFirst(userTable, { filter: { email: ctx.auth.email } });
+        const user = await getUserBySub(ctx.auth.sub);
         if (user) {
           const result = await db.pg.execute<{ exists: boolean }>(sql`
             SELECT EXISTS (

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -19,7 +19,7 @@ import z from 'zod';
 import db from '../../lib/api/db';
 import { removeInactiveChunkIdsFromUnits } from '../../lib/api/utils';
 import {
-  getUserOrThrow, protectedProcedure, publicProcedure, router,
+  getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
 } from '../trpc';
 
 export type BasicChunk = {
@@ -303,7 +303,7 @@ export const coursesRouter = router({
 
       const { coreResourceIds, requiredExerciseIds } = await getCoreResourceAndRequiredExerciseIds(allChunks);
 
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const { resourceCompletions, exerciseCompletions } = await getUserCompletions(
         coreResourceIds,

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -303,7 +303,7 @@ export const coursesRouter = router({
 
       const { coreResourceIds, requiredExerciseIds } = await getCoreResourceAndRequiredExerciseIds(allChunks);
 
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const { resourceCompletions, exerciseCompletions } = await getUserCompletions(
         coreResourceIds,

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -4,11 +4,11 @@ import {
 import { TRPCError } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
-import { getUserOrThrow, protectedProcedure, router } from '../trpc';
+import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 
 export const dropoutRouter = router({
   getStatusForUser: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     const regs = await db.pg
       .select({ id: courseRegistrationTable.pg.id })
@@ -58,7 +58,7 @@ export const dropoutRouter = router({
         applicantId, reason, type, newRoundId,
       } = input;
 
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const courseRegistration = await db.getFirst(courseRegistrationTable, {
         filter: {

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -8,7 +8,7 @@ import { getUserOrThrow, protectedProcedure, router } from '../trpc';
 
 export const dropoutRouter = router({
   getStatusForUser: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     const regs = await db.pg
       .select({ id: courseRegistrationTable.pg.id })
@@ -58,7 +58,7 @@ export const dropoutRouter = router({
         applicantId, reason, type, newRoundId,
       } = input;
 
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const courseRegistration = await db.getFirst(courseRegistrationTable, {
         filter: {

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -110,7 +110,7 @@ describe('exercises.saveExerciseResponse', () => {
   test('throws UNAUTHORIZED when the user row is missing', async () => {
     const noUserCaller = createCaller({
       ...testAuthContextLoggedIn,
-      auth: { ...testAuthContextLoggedIn.auth!, email: 'nouser@example.com' },
+      auth: { ...testAuthContextLoggedIn.auth!, email: 'nouser@example.com', sub: 'nouser-sub' },
     });
 
     await expect(noUserCaller.exercises.saveExerciseResponse({
@@ -317,7 +317,9 @@ describe('exercises.getExerciseResponse', () => {
   });
 
   test('returns response scoped to the current user', async () => {
-    await testDb.insert(userTable, { id: 'user-other', email: 'other@example.com', name: 'Other User' });
+    await testDb.insert(userTable, {
+      id: 'user-other', email: 'other@example.com', name: 'Other User', keycloakIdentifier: 'other-sub',
+    });
 
     await caller.exercises.saveExerciseResponse({
       exerciseId: 'exercise-1',
@@ -329,6 +331,7 @@ describe('exercises.getExerciseResponse', () => {
       auth: {
         ...testAuthContextLoggedIn.auth!,
         email: 'other@example.com',
+        sub: 'other-sub',
       },
     });
 

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -23,7 +23,7 @@ import { z } from 'zod';
 import db from '../../lib/api/db';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 import {
-  getUserOrThrow, protectedProcedure, publicProcedure, router,
+  getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
 } from '../trpc';
 import { issueFoaiCertificateIfComplete } from './certificates';
 
@@ -37,7 +37,7 @@ export const exercisesRouter = router({
   getExerciseResponse: protectedProcedure
     .input(z.object({ exerciseId: z.string().min(1) }))
     .query(async ({ input, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const [exerciseResponse] = await db.pg
         .select()
@@ -70,7 +70,7 @@ export const exercisesRouter = router({
         input.completed === true
           ? db.getFirst(exerciseTable, { filter: { id: input.exerciseId }, sortBy: 'id' })
           : Promise.resolve(undefined),
-        getUserOrThrow(ctx.auth.sub),
+        getUserFromAuthOrThrow(ctx.auth),
       ]);
 
       const [existingResponse] = await db.pg
@@ -130,7 +130,7 @@ export const exercisesRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${input.courseSlug}` });
       }
 
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       // 2. Find all of caller's active registrations for this course
       // roundStatus is 'Active' for live rounds, or null for self-paced courses with no round

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -37,7 +37,7 @@ export const exercisesRouter = router({
   getExerciseResponse: protectedProcedure
     .input(z.object({ exerciseId: z.string().min(1) }))
     .query(async ({ input, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const [exerciseResponse] = await db.pg
         .select()
@@ -70,7 +70,7 @@ export const exercisesRouter = router({
         input.completed === true
           ? db.getFirst(exerciseTable, { filter: { id: input.exerciseId }, sortBy: 'id' })
           : Promise.resolve(undefined),
-        getUserOrThrow(ctx.auth.email),
+        getUserOrThrow(ctx.auth.sub),
       ]);
 
       const [existingResponse] = await db.pg
@@ -130,7 +130,7 @@ export const exercisesRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${input.courseSlug}` });
       }
 
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       // 2. Find all of caller's active registrations for this course
       // roundStatus is 'Active' for live rounds, or null for self-paced courses with no round

--- a/apps/website/src/server/routers/facilitator-applications.ts
+++ b/apps/website/src/server/routers/facilitator-applications.ts
@@ -236,7 +236,7 @@ export type QuickApplyPrefillData = inferRouterOutputs<typeof facilitatorApplica
 
 export const facilitatorApplicationsRouter = router({
   list: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     const registrations = await db.pg
       .select()
@@ -295,7 +295,7 @@ export const facilitatorApplicationsRouter = router({
   // One card per course the facilitator is wrapping up that still has open upcoming rounds
   // they haven't applied to. Each card lists those rounds (earliest first).
   eligibleRounds: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     const eligibleCourseIds = await getQuickApplyEligibleCourseIds(user.id);
     if (eligibleCourseIds.length === 0) return [];
@@ -374,7 +374,7 @@ export const facilitatorApplicationsRouter = router({
   // Round + course context and prefill (from the facilitator's most recent prior application
   // for the same course) for the quick-apply form. Validates eligibility, openness, no duplicate.
   quickApplyPrefill: protectedProcedure.input(z.object({ roundId: z.string() })).query(async ({ ctx, input }) => {
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     const { round, courseId } = await getRoundContext(input.roundId);
     const priorRegs = await getEligiblePriorFacilitatorRegs(user.id, courseId, input.roundId);
@@ -397,7 +397,7 @@ export const facilitatorApplicationsRouter = router({
       { message: 'Invalid availability', path: ['availabilityIntervalsUTC'] },
     ))
     .mutation(async ({ ctx, input }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const { courseId } = await getOpenRound(input.roundId);
       await getEligiblePriorFacilitatorRegs(user.id, courseId, input.roundId);

--- a/apps/website/src/server/routers/facilitator-applications.ts
+++ b/apps/website/src/server/routers/facilitator-applications.ts
@@ -16,7 +16,7 @@ import { type inferRouterOutputs, TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';
 import { parseWeekFromRoundName, unique } from '../../lib/utils';
-import { getUserOrThrow, protectedProcedure, router } from '../trpc';
+import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 import { openRoundDeadlineCondition } from './course-rounds';
 
 type FacilitatorApplicationDecision = 'Accept' | 'Reject' | 'Withdrawn' | null;
@@ -236,7 +236,7 @@ export type QuickApplyPrefillData = inferRouterOutputs<typeof facilitatorApplica
 
 export const facilitatorApplicationsRouter = router({
   list: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     const registrations = await db.pg
       .select()
@@ -295,7 +295,7 @@ export const facilitatorApplicationsRouter = router({
   // One card per course the facilitator is wrapping up that still has open upcoming rounds
   // they haven't applied to. Each card lists those rounds (earliest first).
   eligibleRounds: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     const eligibleCourseIds = await getQuickApplyEligibleCourseIds(user.id);
     if (eligibleCourseIds.length === 0) return [];
@@ -374,7 +374,7 @@ export const facilitatorApplicationsRouter = router({
   // Round + course context and prefill (from the facilitator's most recent prior application
   // for the same course) for the quick-apply form. Validates eligibility, openness, no duplicate.
   quickApplyPrefill: protectedProcedure.input(z.object({ roundId: z.string() })).query(async ({ ctx, input }) => {
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     const { round, courseId } = await getRoundContext(input.roundId);
     const priorRegs = await getEligiblePriorFacilitatorRegs(user.id, courseId, input.roundId);
@@ -397,7 +397,7 @@ export const facilitatorApplicationsRouter = router({
       { message: 'Invalid availability', path: ['availabilityIntervalsUTC'] },
     ))
     .mutation(async ({ ctx, input }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const { courseId } = await getOpenRound(input.roundId);
       await getEligiblePriorFacilitatorRegs(user.id, courseId, input.roundId);

--- a/apps/website/src/server/routers/facilitators.ts
+++ b/apps/website/src/server/routers/facilitators.ts
@@ -20,7 +20,7 @@ import { TRPCError } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
 import {
-  checkAdminAccess, getUserOrThrow, impersonationRealIdentity, protectedProcedure, router,
+  checkAdminAccess, getUserFromAuthOrThrow, impersonationRealIdentity, protectedProcedure, router,
 } from '../trpc';
 import { getFieldOptions } from '../airtableFieldOptions';
 
@@ -63,7 +63,7 @@ const getFacilitator = async (roundId: string, userId: string) => {
 
 async function verifyFacilitatorById(meetPersonId: string, ctx: { auth: { sub: string }; impersonation?: { adminSub: string } | null }) {
   const [user, meetPerson] = await Promise.all([
-    getUserOrThrow(ctx.auth.sub),
+    getUserFromAuthOrThrow(ctx.auth),
     db.getFirst(meetPersonTable, {
       filter: { id: meetPersonId },
     }),
@@ -146,7 +146,7 @@ export const facilitatorRouter = router({
 
   getFacilitatorsForRound: protectedProcedure.input(z.object({ roundId: z.string() })).query(async ({ input, ctx }) => {
     const { roundId } = input;
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
     const currentFacilitator = await getFacilitator(roundId, user.id);
 
     const facilitators = await db.pg
@@ -162,7 +162,7 @@ export const facilitatorRouter = router({
   discussionsAvailable: protectedProcedure
     .input(z.object({ roundId: z.string() }))
     .query(async ({ input: { roundId }, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
       const facilitator = await getFacilitator(roundId, user.id);
 
       const groupDiscussions = await db.pg
@@ -209,7 +209,7 @@ export const facilitatorRouter = router({
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Requested time must be in the future' });
       }
 
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
       const facilitator = await getFacilitator(roundId, user.id);
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const allowedDiscussions = facilitator.expectedDiscussionsFacilitator || [];
@@ -262,7 +262,7 @@ export const facilitatorRouter = router({
     .mutation(async ({ input, ctx }) => {
       const { roundId, discussionId, groupId, newFacilitatorId } = input;
 
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
       const facilitator = await getFacilitator(roundId, user.id);
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const allowedDiscussions = facilitator.expectedDiscussionsFacilitator || [];

--- a/apps/website/src/server/routers/facilitators.ts
+++ b/apps/website/src/server/routers/facilitators.ts
@@ -20,7 +20,7 @@ import { TRPCError } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
 import {
-  checkAdminAccess, getUserOrThrow, protectedProcedure, router,
+  checkAdminAccess, getUserOrThrow, impersonationRealIdentity, protectedProcedure, router,
 } from '../trpc';
 import { getFieldOptions } from '../airtableFieldOptions';
 
@@ -61,9 +61,9 @@ const getFacilitator = async (roundId: string, userId: string) => {
   return facilitator;
 };
 
-async function verifyFacilitatorById(meetPersonId: string, ctx: { auth: { email: string }; impersonation?: { adminEmail: string } | null }) {
+async function verifyFacilitatorById(meetPersonId: string, ctx: { auth: { sub: string }; impersonation?: { adminSub: string } | null }) {
   const [user, meetPerson] = await Promise.all([
-    getUserOrThrow(ctx.auth.email),
+    getUserOrThrow(ctx.auth.sub),
     db.getFirst(meetPersonTable, {
       filter: { id: meetPersonId },
     }),
@@ -75,8 +75,7 @@ async function verifyFacilitatorById(meetPersonId: string, ctx: { auth: { email:
 
   if (meetPerson.userId !== user.id) {
     // During impersonation, check the real admin's permissions, not the impersonated user's.
-    const realEmail = ctx.impersonation?.adminEmail ?? ctx.auth.email;
-    const isAdmin = await checkAdminAccess(realEmail);
+    const isAdmin = await checkAdminAccess(impersonationRealIdentity(ctx));
     if (!isAdmin) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Not found' });
     }
@@ -147,7 +146,7 @@ export const facilitatorRouter = router({
 
   getFacilitatorsForRound: protectedProcedure.input(z.object({ roundId: z.string() })).query(async ({ input, ctx }) => {
     const { roundId } = input;
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
     const currentFacilitator = await getFacilitator(roundId, user.id);
 
     const facilitators = await db.pg
@@ -163,7 +162,7 @@ export const facilitatorRouter = router({
   discussionsAvailable: protectedProcedure
     .input(z.object({ roundId: z.string() }))
     .query(async ({ input: { roundId }, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
       const facilitator = await getFacilitator(roundId, user.id);
 
       const groupDiscussions = await db.pg
@@ -210,7 +209,7 @@ export const facilitatorRouter = router({
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Requested time must be in the future' });
       }
 
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
       const facilitator = await getFacilitator(roundId, user.id);
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const allowedDiscussions = facilitator.expectedDiscussionsFacilitator || [];
@@ -263,7 +262,7 @@ export const facilitatorRouter = router({
     .mutation(async ({ input, ctx }) => {
       const { roundId, discussionId, groupId, newFacilitatorId } = input;
 
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
       const facilitator = await getFacilitator(roundId, user.id);
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const allowedDiscussions = facilitator.expectedDiscussionsFacilitator || [];

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -21,7 +21,7 @@ import z from 'zod';
 import db from '../../lib/api/db';
 import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
 import {
-  getUserOrThrow, protectedProcedure, publicProcedure, router,
+  getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
 } from '../trpc';
 
 export type GroupDiscussionWithGroupAndUnit = inferRouterOutputs<
@@ -96,7 +96,7 @@ export const groupDiscussionsRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${courseSlug}` });
       }
 
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       // Get all accepted course registrations for this course (not just the first),
       // so facilitators with discussions across multiple rounds see the soonest one

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -96,7 +96,7 @@ export const groupDiscussionsRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${courseSlug}` });
       }
 
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       // Get all accepted course registrations for this course (not just the first),
       // so facilitators with discussions across multiple rounds see the soonest one

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -185,7 +185,7 @@ export const groupSwitchingRouter = router({
   discussionsAvailable: protectedProcedure
     .input(z.object({ roundId: z.string() }))
     .query(async ({ ctx, input: { roundId } }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const participant = await db.getFirst(meetPersonTable, { filter: { round: roundId, userId: user.id, role: COURSE_ROLE.PARTICIPANT } });
       if (!participant) {
@@ -268,7 +268,7 @@ export const groupSwitchingRouter = router({
         });
       }
 
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const participant = await db.getFirst(meetPersonTable, {
         filter: { round: roundId, userId: user.id, role: COURSE_ROLE.PARTICIPANT },

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -12,7 +12,7 @@ import { TRPCError, type inferRouterOutputs } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
 import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
-import { getUserOrThrow, protectedProcedure, router } from '../trpc';
+import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 
 export type DiscussionsAvailable = inferRouterOutputs<typeof groupSwitchingRouter>['discussionsAvailable'];
 
@@ -185,7 +185,7 @@ export const groupSwitchingRouter = router({
   discussionsAvailable: protectedProcedure
     .input(z.object({ roundId: z.string() }))
     .query(async ({ ctx, input: { roundId } }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const participant = await db.getFirst(meetPersonTable, { filter: { round: roundId, userId: user.id, role: COURSE_ROLE.PARTICIPANT } });
       if (!participant) {
@@ -268,7 +268,7 @@ export const groupSwitchingRouter = router({
         });
       }
 
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const participant = await db.getFirst(meetPersonTable, {
         filter: { round: roundId, userId: user.id, role: COURSE_ROLE.PARTICIPANT },

--- a/apps/website/src/server/routers/meet-person.ts
+++ b/apps/website/src/server/routers/meet-person.ts
@@ -19,7 +19,7 @@ export const meetPersonRouter = router({
   getByCourseRegistrationId: protectedProcedure
     .input(z.object({ courseRegistrationId: z.string() }))
     .query(async ({ input: { courseRegistrationId }, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       return db.getFirst(meetPersonTable, {
         filter: {
@@ -32,7 +32,7 @@ export const meetPersonRouter = router({
   getInactiveCourseRegistrations: protectedProcedure
     .input(z.object({ courseSlug: z.string().min(1).optional() }))
     .query(async ({ ctx, input }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const results = await db.pg
         .select({
@@ -69,7 +69,7 @@ export const meetPersonRouter = router({
   getGroupParticipants: protectedProcedure
     .input(z.object({ groupId: z.string().min(1) }))
     .query(async ({ input, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const groupRows = await db.pg.select().from(groupTable.pg).where(eq(groupTable.pg.id, input.groupId));
       const group = groupRows[0];

--- a/apps/website/src/server/routers/meet-person.ts
+++ b/apps/website/src/server/routers/meet-person.ts
@@ -13,13 +13,13 @@ import {
 import { TRPCError } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
-import { getUserOrThrow, protectedProcedure, router } from '../trpc';
+import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 
 export const meetPersonRouter = router({
   getByCourseRegistrationId: protectedProcedure
     .input(z.object({ courseRegistrationId: z.string() }))
     .query(async ({ input: { courseRegistrationId }, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       return db.getFirst(meetPersonTable, {
         filter: {
@@ -32,7 +32,7 @@ export const meetPersonRouter = router({
   getInactiveCourseRegistrations: protectedProcedure
     .input(z.object({ courseSlug: z.string().min(1).optional() }))
     .query(async ({ ctx, input }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const results = await db.pg
         .select({
@@ -69,7 +69,7 @@ export const meetPersonRouter = router({
   getGroupParticipants: protectedProcedure
     .input(z.object({ groupId: z.string().min(1) }))
     .query(async ({ input, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const groupRows = await db.pg.select().from(groupTable.pg).where(eq(groupTable.pg.id, input.groupId));
       const group = groupRows[0];

--- a/apps/website/src/server/routers/my-bluedot.ts
+++ b/apps/website/src/server/routers/my-bluedot.ts
@@ -26,7 +26,7 @@ import type { FacilitatorRowProps, ParticipantRowProps } from '../../components/
 import db from '../../lib/api/db';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 import { parseWeekFromRoundName, unique } from '../../lib/utils';
-import { getUserOrThrow, protectedProcedure, router } from '../trpc';
+import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 import { getAvailableGroupsAndDiscussions } from './group-switching';
 
 // Used for mapping self-serve registrations (where all these fields are empty) into the expected shape
@@ -107,7 +107,7 @@ export const myBluedotRouter = router({
     .input(z.object({ includeWithdrawn: z.boolean().optional() }).optional())
     .query(async ({ ctx, input }) => {
       const includeWithdrawn = input?.includeWithdrawn ?? false;
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const rows = await db.pg
         .select({ id: courseRegistrationTable.pg.id })
@@ -127,7 +127,7 @@ export const myBluedotRouter = router({
     }),
 
   myCoursesPage: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     // Step 1: Fetch data
     const [facilitatedRegistrations, selfServeRegistrations] = await Promise.all([
@@ -367,7 +367,7 @@ export const myBluedotRouter = router({
   }),
 
   facilitatedCoursesPage: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     // Step 1: Fetch data
     const courseRegistrations = await db.pg

--- a/apps/website/src/server/routers/my-bluedot.ts
+++ b/apps/website/src/server/routers/my-bluedot.ts
@@ -107,7 +107,7 @@ export const myBluedotRouter = router({
     .input(z.object({ includeWithdrawn: z.boolean().optional() }).optional())
     .query(async ({ ctx, input }) => {
       const includeWithdrawn = input?.includeWithdrawn ?? false;
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const rows = await db.pg
         .select({ id: courseRegistrationTable.pg.id })
@@ -127,7 +127,7 @@ export const myBluedotRouter = router({
     }),
 
   myCoursesPage: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     // Step 1: Fetch data
     const [facilitatedRegistrations, selfServeRegistrations] = await Promise.all([
@@ -367,7 +367,7 @@ export const myBluedotRouter = router({
   }),
 
   facilitatedCoursesPage: protectedProcedure.query(async ({ ctx }) => {
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     // Step 1: Fetch data
     const courseRegistrations = await db.pg

--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -53,7 +53,7 @@ describe('resources.saveResourceCompletion', () => {
   test('throws UNAUTHORIZED when the user row is missing', async () => {
     const noUserCaller = createCaller({
       ...testAuthContextLoggedIn,
-      auth: { ...testAuthContextLoggedIn.auth!, email: 'nouser@example.com' },
+      auth: { ...testAuthContextLoggedIn.auth!, email: 'nouser@example.com', sub: 'nouser-sub' },
     });
 
     await expect(noUserCaller.resources.saveResourceCompletion({

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -11,7 +11,7 @@ export const resourcesRouter = router({
   getResourceCompletions: protectedProcedure
     .input(z.object({ unitResourceIds: z.array(z.string().min(1)).max(100) }))
     .query(async ({ input, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
 
       const resourceCompletions = await db.pg
         .select()
@@ -59,7 +59,7 @@ export const resourcesRouter = router({
     .mutation(async ({ input, ctx }) => {
       const [unitResource, user] = await Promise.all([
         db.getFirst(unitResourceTable, { filter: { id: input.unitResourceId }, sortBy: 'id' }),
-        getUserOrThrow(ctx.auth.email),
+        getUserOrThrow(ctx.auth.sub),
       ]);
 
       const [resourceCompletion] = await db.pg

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -5,13 +5,13 @@ import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';
-import { getUserOrThrow, protectedProcedure, router } from '../trpc';
+import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 
 export const resourcesRouter = router({
   getResourceCompletions: protectedProcedure
     .input(z.object({ unitResourceIds: z.array(z.string().min(1)).max(100) }))
     .query(async ({ input, ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
 
       const resourceCompletions = await db.pg
         .select()
@@ -59,7 +59,7 @@ export const resourcesRouter = router({
     .mutation(async ({ input, ctx }) => {
       const [unitResource, user] = await Promise.all([
         db.getFirst(unitResourceTable, { filter: { id: input.unitResourceId }, sortBy: 'id' }),
-        getUserOrThrow(ctx.auth.sub),
+        getUserFromAuthOrThrow(ctx.auth),
       ]);
 
       const [resourceCompletion] = await db.pg

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -16,7 +16,7 @@ export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'Only the Future of AI course supports self-serve registration' });
     }
 
-    const user = await getUserOrThrow(ctx.auth.email);
+    const user = await getUserOrThrow(ctx.auth.sub);
 
     const existingRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
       filter: { userId: user.id, courseId },

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -4,7 +4,7 @@ import {
 import z from 'zod';
 import { TRPCError } from '@trpc/server';
 import db from '../../lib/api/db';
-import { getUserOrThrow, protectedProcedure, router } from '../trpc';
+import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 
 export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
@@ -16,7 +16,7 @@ export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'Only the Future of AI course supports self-serve registration' });
     }
 
-    const user = await getUserOrThrow(ctx.auth.sub);
+    const user = await getUserFromAuthOrThrow(ctx.auth);
 
     const existingRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
       filter: { userId: user.id, courseId },

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -58,6 +58,7 @@ describe('users.getUser', () => {
       id: 'u1',
       email: 'test@example.com',
       name: 'Test User',
+      keycloakIdentifier: 'test-sub',
       lastSeenAt: '2020-01-01T00:00:00.000Z',
     });
 
@@ -83,7 +84,7 @@ describe('users.changePassword', () => {
     const caller = createCaller({
       ...testAuthContextLoggedIn,
       auth: { ...testAuthContextLoggedIn.auth!, email: 'test@example.com' },
-      impersonation: { adminEmail: 'admin@example.com', targetEmail: 'test@example.com' },
+      impersonation: { adminEmail: 'admin@example.com', adminSub: 'admin-sub', targetEmail: 'test@example.com' },
     });
 
     await expect(caller.users.changePassword(validInput))
@@ -327,7 +328,7 @@ describe('users.updateName', () => {
 
   test('updates name on an existing user', async () => {
     await testDb.insert(userTable, {
-      id: 'u1', email: 'test@example.com', name: 'Old Name',
+      id: 'u1', email: 'test@example.com', name: 'Old Name', keycloakIdentifier: 'test-sub',
     });
 
     const result = await createCaller(testAuthContextLoggedIn).users.updateName({ name: 'New Name' });

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -7,13 +7,13 @@ import { updateKeycloakPassword, verifyKeycloakPassword } from '../../lib/api/ke
 import { changePasswordSchema } from '../../lib/schemas/user/changePassword.schema';
 import { updateNameSchema } from '../../lib/schemas/user/me.schema';
 import {
-  getUserOrThrow, protectedProcedure, publicProcedure, router,
+  getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
 } from '../trpc';
 
 export const usersRouter = router({
   getUser: protectedProcedure
     .query(async ({ ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
       // Update lastSeenAt timestamp
       return db.update(userTable, {
         id: user.id,
@@ -119,7 +119,7 @@ export const usersRouter = router({
   updateName: protectedProcedure
     .input(updateNameSchema)
     .mutation(async ({ ctx, input }) => {
-      const user = await getUserOrThrow(ctx.auth.sub);
+      const user = await getUserFromAuthOrThrow(ctx.auth);
       return db.update(userTable, {
         id: user.id,
         name: input.name,

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -13,7 +13,7 @@ import {
 export const usersRouter = router({
   getUser: protectedProcedure
     .query(async ({ ctx }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
       // Update lastSeenAt timestamp
       return db.update(userTable, {
         id: user.id,
@@ -119,7 +119,7 @@ export const usersRouter = router({
   updateName: protectedProcedure
     .input(updateNameSchema)
     .mutation(async ({ ctx, input }) => {
-      const user = await getUserOrThrow(ctx.auth.email);
+      const user = await getUserOrThrow(ctx.auth.sub);
       return db.update(userTable, {
         id: user.id,
         name: input.name,

--- a/apps/website/src/server/trpc.ts
+++ b/apps/website/src/server/trpc.ts
@@ -111,8 +111,15 @@ const openTelemetryMiddleware = t.middleware(async (opts) => {
   }
 });
 
-export const getUserOrThrow = async (email: string) => {
-  const user = await db.getFirst(userTable, { filter: { email } });
+// TODO rename to getUserFromAuth(auth: Pick<AuthType, 'sub'>)
+export const getUserBySub = async (sub: string) => {
+  if (!sub) return null;
+  return db.getFirst(userTable, { filter: { keycloakIdentifier: sub } });
+};
+
+// TODO rename to getUserFromAuthOrThrow
+export const getUserOrThrow = async (sub: string) => {
+  const user = await getUserBySub(sub);
   if (!user) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'No user record for this account. Please log in again.' });
   }
@@ -120,16 +127,26 @@ export const getUserOrThrow = async (email: string) => {
   return user;
 };
 
-export const checkAdminAccess = async (email: string): Promise<boolean> => {
-  const user = await db.getFirst(userTable, { filter: { email } });
+// TODO comment is over-egged, also: We should restructure to do this *first* as a standalone commit, *then* to the migration from email -> sub
+// The sub of the real actor behind the request: during impersonation this is the admin's
+// verified sub, otherwise the caller's own. Use this for permission checks so a scoped user
+// can't escalate by impersonating an admin.
+export const impersonationRealIdentity = (ctx: {
+  auth: { sub: string } | null;
+  impersonation?: { adminSub: string } | null;
+}): string => ctx.impersonation?.adminSub ?? ctx.auth?.sub ?? '';
+
+export const checkAdminAccess = async (sub: string): Promise<boolean> => {
+  const user = await getUserBySub(sub);
 
   return user?.isAdmin === true;
 };
 
 export type ImpersonationAccess = 'admin' | 'scoped' | 'none';
 
-export const checkImpersonationAccess = async (email: string): Promise<{ access: ImpersonationAccess; allowedTargets: string[] }> => {
-  const user = await db.getFirst(userTable, { filter: { email } });
+// TODO again pass auth: Pick<AuthType, 'sub'>, makes it more readable ('sub' is hard to remember as a standalone var)
+export const checkImpersonationAccess = async (sub: string): Promise<{ access: ImpersonationAccess; allowedTargets: string[] }> => {
+  const user = await getUserBySub(sub);
   if (user?.isAdmin) return { access: 'admin', allowedTargets: [] };
   if (user?.allowedImpersonationTargets?.length) return { access: 'scoped', allowedTargets: user.allowedImpersonationTargets };
   return { access: 'none', allowedTargets: [] };
@@ -161,8 +178,7 @@ export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
 export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
   // During impersonation, check the real user's permissions, not the impersonated user's.
   // This prevents privilege escalation when a scoped user impersonates an admin.
-  const realEmail = ctx.impersonation?.adminEmail ?? ctx.auth.email;
-  const hasAdminAccess = await checkAdminAccess(realEmail);
+  const hasAdminAccess = await checkAdminAccess(impersonationRealIdentity(ctx));
   if (!hasAdminAccess) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'Unauthorized' });
   }

--- a/apps/website/src/server/trpc.ts
+++ b/apps/website/src/server/trpc.ts
@@ -125,8 +125,7 @@ export const getUserFromAuthOrThrow = async (auth: Pick<AuthContext, 'sub'>) => 
   return user;
 };
 
-// The real actor behind the request — the admin during impersonation, otherwise the caller.
-// Permission checks use this so impersonating an admin can't escalate a scoped user.
+// The real actor behind the request: the admin during impersonation, otherwise the caller.
 export const impersonationRealIdentity = (ctx: {
   auth: { sub: string } | null;
   impersonation?: { adminSub: string } | null;

--- a/apps/website/src/server/trpc.ts
+++ b/apps/website/src/server/trpc.ts
@@ -9,7 +9,7 @@ import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import db from '../lib/api/db';
 import env from '../lib/api/env';
-import type { Context } from './context';
+import type { AuthContext, Context } from './context';
 
 // Avoid exporting the entire t-object since it's not very descriptive.
 // For instance, the use of a t variable is common in i18n libraries.
@@ -111,15 +111,13 @@ const openTelemetryMiddleware = t.middleware(async (opts) => {
   }
 });
 
-// TODO rename to getUserFromAuth(auth: Pick<AuthType, 'sub'>)
-export const getUserBySub = async (sub: string) => {
-  if (!sub) return null;
-  return db.getFirst(userTable, { filter: { keycloakIdentifier: sub } });
+export const getUserFromAuth = async (auth: Pick<AuthContext, 'sub'>) => {
+  if (!auth.sub) return null;
+  return db.getFirst(userTable, { filter: { keycloakIdentifier: auth.sub } });
 };
 
-// TODO rename to getUserFromAuthOrThrow
-export const getUserOrThrow = async (sub: string) => {
-  const user = await getUserBySub(sub);
+export const getUserFromAuthOrThrow = async (auth: Pick<AuthContext, 'sub'>) => {
+  const user = await getUserFromAuth(auth);
   if (!user) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'No user record for this account. Please log in again.' });
   }
@@ -127,26 +125,23 @@ export const getUserOrThrow = async (sub: string) => {
   return user;
 };
 
-// TODO comment is over-egged, also: We should restructure to do this *first* as a standalone commit, *then* to the migration from email -> sub
-// The sub of the real actor behind the request: during impersonation this is the admin's
-// verified sub, otherwise the caller's own. Use this for permission checks so a scoped user
-// can't escalate by impersonating an admin.
+// The real actor behind the request — the admin during impersonation, otherwise the caller.
+// Permission checks use this so impersonating an admin can't escalate a scoped user.
 export const impersonationRealIdentity = (ctx: {
   auth: { sub: string } | null;
   impersonation?: { adminSub: string } | null;
-}): string => ctx.impersonation?.adminSub ?? ctx.auth?.sub ?? '';
+}): Pick<AuthContext, 'sub'> => ({ sub: ctx.impersonation?.adminSub ?? ctx.auth?.sub ?? '' });
 
-export const checkAdminAccess = async (sub: string): Promise<boolean> => {
-  const user = await getUserBySub(sub);
+export const checkAdminAccess = async (auth: Pick<AuthContext, 'sub'>): Promise<boolean> => {
+  const user = await getUserFromAuth(auth);
 
   return user?.isAdmin === true;
 };
 
 export type ImpersonationAccess = 'admin' | 'scoped' | 'none';
 
-// TODO again pass auth: Pick<AuthType, 'sub'>, makes it more readable ('sub' is hard to remember as a standalone var)
-export const checkImpersonationAccess = async (sub: string): Promise<{ access: ImpersonationAccess; allowedTargets: string[] }> => {
-  const user = await getUserBySub(sub);
+export const checkImpersonationAccess = async (auth: Pick<AuthContext, 'sub'>): Promise<{ access: ImpersonationAccess; allowedTargets: string[] }> => {
+  const user = await getUserFromAuth(auth);
   if (user?.isAdmin) return { access: 'admin', allowedTargets: [] };
   if (user?.allowedImpersonationTargets?.length) return { access: 'scoped', allowedTargets: user.allowedImpersonationTargets };
   return { access: 'none', allowedTargets: [] };


### PR DESCRIPTION
# Description

Final step of issue #2710 to migrate to using Keycloak's `sub` property to lookup users rather than email. The property is now written to the user (#2742), and has been backfilled for legacy users (done locally). This will be unblocked once #2721 is merged, which removes all stray uses of `email` for things other than looking up the user.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2710

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
