### PR TITLE
Surface Keycloak `sub` on the client auth object

### DIFF
--- a/apps/website/src/__tests__/pages/login/clear.test.tsx
+++ b/apps/website/src/__tests__/pages/login/clear.test.tsx
@@ -37,6 +37,7 @@ describe('Logout Page - Redirect Logic', () => {
     token: 'mock-token-123',
     expiresAt: Date.now() + ONE_HOUR_MS,
     email: 'test@example.com',
+    sub: 'mock-sub-123',
   };
 
   const mockSetAuth = vi.fn();

--- a/apps/website/src/components/Nav/Nav.test.tsx
+++ b/apps/website/src/components/Nav/Nav.test.tsx
@@ -56,6 +56,7 @@ const withLoggedInUser = () => {
       email: 'test@example.com',
       token: 'mockToken',
       expiresAt: Date.now() + 86400_000,
+      sub: 'mock-sub',
     },
   });
 };

--- a/apps/website/src/utils/trpc.test.ts
+++ b/apps/website/src/utils/trpc.test.ts
@@ -22,6 +22,7 @@ const createAuth = (overrides?: Partial<Auth>): Auth => ({
     redirect_uri: 'http://localhost:3000/callback',
   },
   email: 'test+auth@bluedot.org',
+  sub: 'test-sub',
   ...overrides,
 });
 

--- a/libraries/ui/src/Login.test.tsx
+++ b/libraries/ui/src/Login.test.tsx
@@ -185,6 +185,7 @@ describe('LoginOauthCallbackPage', () => {
       refreshToken: mockSigninResponse.refresh_token,
       oidcSettings: mockLoginPreset.oidcSettings,
       email: mockSigninResponse.profile.email,
+      sub: mockSigninResponse.profile.sub,
     };
 
     await waitFor(() => {

--- a/libraries/ui/src/Login.tsx
+++ b/libraries/ui/src/Login.tsx
@@ -249,12 +249,17 @@ export const LoginOauthCallbackPage: React.FC<LoginOauthCallbackPageProps> = ({ 
           throw new Error('Bad login response: user.profile.email is missing or not a string');
         }
 
+        if (typeof user.profile.sub !== 'string') {
+          throw new Error('Bad login response: user.profile.sub is missing or not a string');
+        }
+
         const auth = {
           expiresAt: user.expires_at * 1000,
           token: user.id_token,
           refreshToken: user.refresh_token,
           oidcSettings: loginPreset.oidcSettings,
           email: user.profile.email,
+          sub: user.profile.sub,
         };
 
         setAuth(auth);

--- a/libraries/ui/src/utils/auth.test.tsx
+++ b/libraries/ui/src/utils/auth.test.tsx
@@ -39,6 +39,7 @@ const createAuth = (overrides?: Partial<Auth>): Auth => ({
     redirect_uri: 'http://localhost:3000/callback',
   },
   email: 'test+auth@bluedot.org',
+  sub: 'test-sub',
   ...overrides,
 });
 

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -44,6 +44,7 @@ const oidcRefreshWithRetries = async (auth: Auth): Promise<Auth> => {
         refreshToken: user.refresh_token ?? auth.refreshToken,
         oidcSettings: auth.oidcSettings,
         email: user.profile.email ?? auth.email,
+        sub: user.profile.sub ?? auth.sub,
       };
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
@@ -70,6 +71,7 @@ export type Auth = {
   refreshToken?: string;
   oidcSettings?: OidcClientSettings;
   email: string;
+  sub: string;
 };
 
 export const useAuthStore = create<{

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -71,7 +71,9 @@ export type Auth = {
   refreshToken?: string;
   oidcSettings?: OidcClientSettings;
   email: string;
-  sub: string;
+  // Always set for new logins, will be absent for users who logged inprior to
+  // https://github.com/bluedotimpact/bluedot/pull/2755 being deployed
+  sub?: string;
 };
 
 export const useAuthStore = create<{

--- a/libraries/ui/src/utils/storybook.ts
+++ b/libraries/ui/src/utils/storybook.ts
@@ -48,6 +48,7 @@ export const loggedInStory = () => ({
       token: 'mockToken',
       expiresAt: Date.now() + 3600000, // Expires in 1 hour
       email: 'test+storybook@bluedot.org',
+      sub: 'mock-sub-storybook',
     });
   },
 });


### PR DESCRIPTION
# Description

Part of the overall work (#2459) to deprecate the use of email as a user identifier, in favour of the `sub` property that Keycloak gives us (which is stable across email changes). The immediate reason for surfacing this on the client is to start using it as the `distinct_id` in PostHog (#2713).

Users who were already logged in at the time this goes out won't get the `sub` property until their auth token refreshes. This is something we'll need to factor in when doing the rest of the migration (Suggested approach: set things up so that for existing users either `email` or `sub` works as an identifier).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2713

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories