### PR TITLE
Redact Axios authorisation token from logs

### DIFF
--- a/apps/pg-sync-service/src/lib/webhook.test.ts
+++ b/apps/pg-sync-service/src/lib/webhook.test.ts
@@ -1,0 +1,95 @@
+import {
+  AxiosError, AxiosHeaders, isAxiosError, type InternalAxiosRequestConfig,
+} from 'axios';
+import { describe, expect, test } from 'vitest';
+import env from '../env';
+import { createAirtableAxiosInstance, redactAxiosError } from './webhook';
+
+const SECRET = 'Bearer super-secret-pat';
+
+const buildAxiosError = () => {
+  const config = {
+    url: '/bases/app123/webhooks',
+    method: 'get',
+    headers: new AxiosHeaders({ Authorization: SECRET, 'Content-Type': 'application/json' }),
+  } as InternalAxiosRequestConfig;
+  const clientRequest = { _header: `GET /bases/app123/webhooks HTTP/1.1\r\nAuthorization: ${SECRET}` };
+  return new AxiosError('Request failed with status code 401', 'ERR_BAD_REQUEST', config, clientRequest, {
+    status: 401,
+    statusText: 'Unauthorized',
+    data: { error: { type: 'AUTHENTICATION_REQUIRED', message: 'Invalid authentication token' } },
+    headers: {},
+    config,
+    request: clientRequest,
+  });
+};
+
+describe('redactAxiosError', () => {
+  test('redacts the Authorization header and strips request objects', () => {
+    const result = redactAxiosError(buildAxiosError()) as AxiosError;
+
+    expect(result.config?.headers.Authorization).toBe('[REDACTED]');
+    expect(result.request).toBeUndefined();
+    expect(result.response?.request).toBeUndefined();
+
+    // Nothing serialisable on the error should contain the token
+    expect(JSON.stringify(result)).not.toContain(SECRET);
+    expect(JSON.stringify(result.toJSON())).not.toContain(SECRET);
+
+    // Diagnostic fields survive
+    expect(result.message).toBe('Request failed with status code 401');
+    expect(result.config?.url).toBe('/bases/app123/webhooks');
+    expect(result.response?.status).toBe(401);
+    expect(result.response?.data).toEqual({ error: { type: 'AUTHENTICATION_REQUIRED', message: 'Invalid authentication token' } });
+  });
+
+  test('redacts authorization headers regardless of key casing', () => {
+    const error = buildAxiosError();
+    error.config!.headers = new AxiosHeaders({ authorization: SECRET });
+
+    const result = redactAxiosError(error) as AxiosError;
+
+    expect(JSON.stringify(result)).not.toContain(SECRET);
+  });
+
+  test('passes non-axios errors through untouched', () => {
+    const error = new Error('boom');
+    expect(redactAxiosError(error)).toBe(error);
+  });
+});
+
+describe('createAirtableAxiosInstance', () => {
+  test('errors from failed requests never contain the Airtable token', async () => {
+    const token = env.AIRTABLE_PERSONAL_ACCESS_TOKEN;
+    const instance = createAirtableAxiosInstance();
+    // Stub the adapter to reject with a real AxiosError (merged config, request
+    // object) for a 401 without hitting the network, as axios' settle() would
+    instance.defaults.adapter = async (config) => {
+      const request = { _header: `GET /v0/bases/app123/webhooks HTTP/1.1\r\nAuthorization: Bearer ${token}` };
+      const response = {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: { error: { type: 'AUTHENTICATION_REQUIRED' } },
+        headers: {},
+        config,
+        request,
+      };
+      throw new AxiosError('Request failed with status code 401', AxiosError.ERR_BAD_REQUEST, config, request, response);
+    };
+
+    const caught: unknown = await instance.get('/bases/app123/webhooks').catch((error: unknown) => error);
+
+    if (!isAxiosError(caught)) {
+      throw new Error('expected an AxiosError');
+    }
+
+    expect(JSON.stringify(caught)).not.toContain(token);
+    expect(JSON.stringify(caught.toJSON())).not.toContain(token);
+    expect(caught.config?.headers.Authorization).toBe('[REDACTED]');
+    expect(caught.request).toBeUndefined();
+    expect(caught.response?.request).toBeUndefined();
+    // Diagnostic fields survive redaction
+    expect(caught.response?.status).toBe(401);
+    expect(caught.response?.data).toEqual({ error: { type: 'AUTHENTICATION_REQUIRED' } });
+  });
+});

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -75,13 +75,7 @@ export class AirtableWebhook {
     this.baseId = baseId;
     this.fieldIds = fieldIds;
     this.rateLimiter = rateLimiter;
-    this.axiosInstance = axios.create({
-      baseURL: 'https://api.airtable.com/v0',
-      headers: {
-        Authorization: `Bearer ${env.AIRTABLE_PERSONAL_ACCESS_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-    });
+    this.axiosInstance = createAirtableAxiosInstance();
   }
 
   public static async getOrCreate(baseId: string, fieldIds: string[], rateLimiter: RateLimiter): Promise<AirtableWebhook> {
@@ -510,6 +504,17 @@ export class AirtableWebhook {
     }
   }
 }
+
+export const createAirtableAxiosInstance = (): AxiosInstance => {
+  const instance = axios.create({
+    baseURL: 'https://api.airtable.com/v0',
+    headers: {
+      Authorization: `Bearer ${env.AIRTABLE_PERSONAL_ACCESS_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  return instance;
+};
 
 const getAirtableFeedbackMessage = (statusCode: number | undefined): string => {
   switch (statusCode) {

--- a/apps/pg-sync-service/src/lib/webhook.ts
+++ b/apps/pg-sync-service/src/lib/webhook.ts
@@ -513,7 +513,37 @@ export const createAirtableAxiosInstance = (): AxiosInstance => {
       'Content-Type': 'application/json',
     },
   });
+  instance.interceptors.response.use(undefined, async (error: unknown) => {
+    throw redactAxiosError(error);
+  });
   return instance;
+};
+
+/**
+ * Axios errors embed the full request config and raw ClientRequest, both of which
+ * contain the Authorization header. Strip these before the error can reach a logger
+ * or Slack alert. The request objects carry no diagnostic value beyond what config
+ * (url, method) and response (status, data) already provide.
+ */
+export const redactAxiosError = (error: unknown): unknown => {
+  if (isAxiosError(error)) {
+    const { headers } = error.config ?? {};
+    if (headers) {
+      for (const key of Object.keys(headers)) {
+        if (key.toLowerCase() === 'authorization') {
+          headers[key] = '[REDACTED]';
+        }
+      }
+    }
+
+    delete error.request;
+
+    if (error.response) {
+      delete error.response.request;
+    }
+  }
+
+  return error;
 };
 
 const getAirtableFeedbackMessage = (statusCode: number | undefined): string => {


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Sanitise Axios logs by integrating a new interceptor that strips authorisation header.

An alternative approach could be to strip sensitive keys within Winston itself by inspecting each value being logged. I opted for the interceptor for simplicity.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2759

