### PR TITLE
Don't write empty name string to DB

### DIFF
--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -1,5 +1,6 @@
 import { userTable } from '@bluedot/db';
 import { loginPresets } from '@bluedot/ui';
+import db from '../../lib/api/db';
 import {
   beforeEach, describe, expect, test, vi,
 } from 'vitest';
@@ -149,6 +150,19 @@ describe('users.ensureExists', () => {
     expect(user.utmContent).toBe('thread');
     expect(user.keycloakIdentifier).toBe('test-sub');
     expect(user.lastSeenAt).toBeTruthy();
+  });
+
+  test('does not send an explicit name when creating the user', async () => {
+    // Writing name: '' puts the Airtable cell in an "explicitly empty" state, which makes
+    // lookups of the field return [null] instead of omitting it, breaking record mapping
+    // downstream (see #2763). The field must be left out of the insert payload entirely.
+    const insertSpy = vi.spyOn(db.airtableClient, 'insert');
+
+    await createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'valid-token' });
+
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    expect(insertSpy.mock.calls[0]?.[1]).not.toHaveProperty('name');
+    insertSpy.mockRestore();
   });
 
   test('is idempotent: a second call reports isNewUser false and creates no extra row', async () => {

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -96,7 +96,6 @@ export const usersRouter = router({
         // Create user if doesn't exist
         await db.insert(userTable, {
           email: auth.email,
-          name: '',
           ...(sub && { keycloakIdentifier: sub }),
           lastSeenAt: new Date().toISOString(),
           ...(input.initialUtmSource && { utmSource: input.initialUtmSource }),

--- a/libraries/db/src/lib/client.test.ts
+++ b/libraries/db/src/lib/client.test.ts
@@ -248,3 +248,23 @@ describe('pgConnectionConfig', () => {
     expect(config.ssl).toBeDefined();
   });
 });
+
+describe('db.insert (mock field defaults)', () => {
+  test('fills omitted fields with the defaults the real Airtable client produces', async () => {
+    const user = await db.insert(userTable, { email: 'a@x' });
+
+    // Non-nullable string falls back to '' (matches airtable-ts, and satisfies pg notNull)
+    expect(user.name).toBe('');
+    // Nullable fields fall back to null
+    expect(user.utmSource).toBeNull();
+    expect(user.isAdmin).toBeNull();
+    expect(user.allowedImpersonationTargets).toBeNull();
+  });
+
+  test('provided values are not overwritten by defaults', async () => {
+    const user = await db.insert(userTable, { email: 'a@x', name: 'Alice', isAdmin: true });
+
+    expect(user.name).toBe('Alice');
+    expect(user.isAdmin).toBe(true);
+  });
+});

--- a/libraries/db/src/lib/mock-airtable-ts.ts
+++ b/libraries/db/src/lib/mock-airtable-ts.ts
@@ -10,6 +10,16 @@ function generateRecordId(): string {
   return `rec${Math.random().toString(36).slice(2, 16).padEnd(14, 'a')}`;
 }
 
+function defaultForTsType(tsType: string): unknown {
+  if (tsType.includes('| null')) return null;
+  if (tsType.endsWith('[]')) return [];
+  if (tsType === 'string') return '';
+  if (tsType === 'boolean') return false;
+  // Matches airtable-ts, which throws when a missing value can't be coerced to
+  // the declared non-nullable type (e.g. 'number').
+  throw new Error(`MockAirtableTs: no value provided for non-nullable field of type '${tsType}'.`);
+}
+
 /**
  * Test mock of AirtableTs.
  *
@@ -66,10 +76,20 @@ export class MockAirtableTs extends AirtableTs {
     throw new Error('MockAirtableTs does not support scan(). PgAirtableDb.scan() reads from Postgres directly, so this method should not be called.');
   }
 
-  override async insert<T extends Item>(_table: Table<T>, data: Partial<Omit<T, 'id'>>): Promise<T> {
+  override async insert<T extends Item>(table: Table<T>, data: Partial<Omit<T, 'id'>>): Promise<T> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const id = (data as any).id ?? generateRecordId();
-    return { ...data, id } as T;
+    // Real Airtable omits unset fields in the created record, and airtable-ts maps
+    // them to type-appropriate defaults ('' / false / [] / null). Mirror that here so
+    // inserts that omit non-nullable fields behave the same as in production.
+    const defaults: Record<string, unknown> = {};
+    for (const [field, tsType] of Object.entries<string>(table.schema)) {
+      if (!(field in data)) {
+        defaults[field] = defaultForTsType(tsType);
+      }
+    }
+
+    return { ...defaults, ...data, id } as T;
   }
 
   override async update<T extends Item>(table: Table<T>, data: Partial<T> & { id: string }): Promise<T> {


### PR DESCRIPTION
# Description

`website/v2.32.3` (#2734) started writing `name: ''` when creating users. Airtable stores an explicitly-written `""` differently from a never-set field: reading the record looks identical, but lookups of the field return `[null]` instead of being omitted. `airtable-ts` can't coerce `[null]` to `string | null`, so every FoAI registration by a new user fired an Airtable validation warning from both `website` and `pg-sync-service` (see #2763 for the full diagnosis).

The `name: ''` was never needed — `db.insert` accepts partial data, and the real Airtable client maps the created record back with `''` for missing non-nullable string fields, satisfying the pg `notNull` constraint. This PR removes it, restoring the pre-#2734 behaviour.

It also fixes the divergence that likely prompted `name: ''` in the first place: `MockAirtableTs.insert` echoed input as-is instead of applying the type-appropriate defaults the real client produces, so omitting `name` failed in tests while working fine in production. The mock now fills omitted fields the same way airtable-ts does (`''` / `false` / `[]` / `null`).

Synced data is unaffected: nameless users produce `fullName = NULL` in Postgres on both the clean and the warning path. Users created between the `v2.32.3` deploy and this fix still carry the poisoned `""` in Airtable and need a one-off repair (tracked in #2763).

## Issue

Fixes #2763