### PR TITLE
[feat] posthog: alias the Keycloak sub onto the email person on login

### DIFF
--- a/libraries/ui/src/utils/auth.test.tsx
+++ b/libraries/ui/src/utils/auth.test.tsx
@@ -4,6 +4,7 @@ import {
 import { OidcClient } from 'oidc-client-ts';
 import { render } from '@testing-library/react';
 import type * as React from 'react';
+import posthog from 'posthog-js';
 import { type Auth, useAuthStore, withAuth } from './auth';
 import { createMockOidcResponse } from './testUtils';
 
@@ -25,6 +26,7 @@ vi.mock('posthog-js', () => ({
   default: {
     identify: vi.fn(),
     reset: vi.fn(),
+    alias: vi.fn(),
   },
 }));
 
@@ -84,6 +86,21 @@ describe('auth', () => {
 
       const state = useAuthStore.getState();
       expect(state.auth).toEqual(auth);
+    });
+
+    test('should identify by email and alias the sub onto the same person on login', () => {
+      const auth = createAuth({ sub: 'keycloak-sub-123', email: 'user@bluedot.org' });
+      useAuthStore.getState().setAuth(auth);
+
+      expect(posthog.identify).toHaveBeenCalledWith('user@bluedot.org', { email: 'user@bluedot.org' });
+      expect(posthog.alias).toHaveBeenCalledWith('keycloak-sub-123', 'user@bluedot.org');
+    });
+
+    test('should not alias when sub is absent', () => {
+      const auth = createAuth({ sub: undefined });
+      useAuthStore.getState().setAuth(auth);
+
+      expect(posthog.alias).not.toHaveBeenCalled();
     });
 
     test('should keep new token when replacing soon-to-expire token', () => {

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -117,6 +117,10 @@ export const useAuthStore = create<{
       email: auth.email,
     });
 
+    if (auth.sub) {
+      posthog.alias(auth.sub, auth.email);
+    }
+
     const now = Date.now();
     const expiresInMs = auth.expiresAt - now;
     const clearInMs = expiresInMs - FIVE_SEC_MS; // Clear/logout 5 seconds before expiry. This only happens if refresh fails


### PR DESCRIPTION
# Description

Step 2 of #2713:

More concrete migration plan (using [alias](https://posthog.com/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) rather than the `$anon_distinct_id` trick, which is the correct way to join up a user that might be `identify`-ed under two different ids):
> 1. PR 1: Resolve #2760, this unlocks flipping `email` -> `sub` in computed-posthog-events without breaking the funnel model
> 2. PR 2: In `libraries/ui/src/utils/auth.tsx`, add a `posthog.alias(auth.sub, auth.email)` immediately after the `posthog.identify(email, ...)`. Any user who hits this code will then be safe to identify as either `posthog.identity(auth.email)` or `posthog.identify(auth.sub)`
> 3. PR 3 (doesn't actually need to be a PR, can just be run locally): Run a script to backfill the `posthog.alias(auth.sub, auth.email)` call for all existing users. It will then be safe to identify all existing and newly created users as either `posthog.identity(auth.email)` or `posthog.identify(auth.sub)`
> 4. PR 4: Flip the 'identify_applicants' event definition from `distinctId: user.email` to `distinctId: user.keycloakIdentifier`. This submits identify events for both new users and new applications by existing users. It's safe to flip without any `alias` step because:
>   a. For new users: They will have already hit the `posthog.alias(auth.sub, auth.email)` in step 2
>   b. For new applications against existing users: They will have hit the `posthog.alias(auth.sub, auth.email)` from the backfill in step 3
> 5. PR 5: Flip `libraries/ui/src/utils/auth.tsx` to `posthog.identify(auth.sub)`, and cut the `posthog.alias` call added in step 2.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2713

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
