### PR TITLE
Redact keycloak secret from logs

### DIFF
--- a/apps/website/src/lib/api/keycloak.test.ts
+++ b/apps/website/src/lib/api/keycloak.test.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
-import {
-  describe, it, expect, vi, beforeEach,
-} from 'vitest';
+import { isHttpError } from 'http-errors';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { registerPreviewRedirectUri } from './keycloak';
 
 vi.mock('axios');
@@ -126,7 +125,40 @@ describe('registerPreviewRedirectUri', () => {
     mockedAxios.post.mockResolvedValueOnce(FAKE_TOKEN_RESPONSE);
     mockedAxios.get.mockResolvedValueOnce({ data: [] });
 
-    await expect(registerPreviewRedirectUri('https://bluedot-website-pr-42.onrender.com/*'))
-      .rejects.toThrow('Client \'bluedot-web-apps\' not found');
+    await expect(registerPreviewRedirectUri('https://bluedot-website-pr-42.onrender.com/*')).rejects.toThrow(
+      "Client 'bluedot-web-apps' not found",
+    );
+  });
+
+  it('does not leak client_secret or admin token when Keycloak errors', async () => {
+    const CLIENT_SECRET = 'preview-secret';
+    const ADMIN_TOKEN = 'super-secret-admin-token';
+
+    // A realistic axios error embeds the request body (with client_secret) in
+    // config.data and the bearer token in config.headers.Authorization.
+    const axiosError = Object.assign(new Error('Request failed with status code 401'), {
+      isAxiosError: true,
+      config: {
+        data: `grant_type=client_credentials&client_id=preview-client&client_secret=${CLIENT_SECRET}`,
+        headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+      },
+      response: { status: 401, data: { error: 'invalid_client' } },
+    });
+    mockedAxios.post.mockRejectedValueOnce(axiosError);
+    mockedAxios.isAxiosError.mockReturnValue(true);
+
+    const caught: unknown = await registerPreviewRedirectUri('https://bluedot-website-pr-42.onrender.com/*').catch(
+      (error: unknown) => error,
+    );
+
+    if (!isHttpError(caught)) {
+      throw new Error('expected an HttpError');
+    }
+
+    expect(caught.statusCode).toBe(503);
+
+    const serialised = JSON.stringify(caught) + caught.message + (caught.stack ?? '');
+    expect(serialised).not.toContain(CLIENT_SECRET);
+    expect(serialised).not.toContain(ADMIN_TOKEN);
   });
 });

--- a/apps/website/src/lib/api/keycloak.test.ts
+++ b/apps/website/src/lib/api/keycloak.test.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 import { logger } from '@bluedot/ui/src/api';
 import { isHttpError } from 'http-errors';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
 import { registerPreviewRedirectUri } from './keycloak';
 
 vi.mock('axios');
@@ -129,9 +131,7 @@ describe('registerPreviewRedirectUri', () => {
     mockedAxios.post.mockResolvedValueOnce(FAKE_TOKEN_RESPONSE);
     mockedAxios.get.mockResolvedValueOnce({ data: [] });
 
-    await expect(registerPreviewRedirectUri('https://bluedot-website-pr-42.onrender.com/*')).rejects.toThrow(
-      "Client 'bluedot-web-apps' not found",
-    );
+    await expect(registerPreviewRedirectUri('https://bluedot-website-pr-42.onrender.com/*')).rejects.toThrow('Client \'bluedot-web-apps\' not found');
   });
 
   it('does not leak client_secret or admin token when Keycloak errors', async () => {
@@ -152,9 +152,7 @@ describe('registerPreviewRedirectUri', () => {
     mockedAxios.post.mockRejectedValueOnce(axiosError);
     mockedAxios.isAxiosError.mockReturnValue(true);
 
-    const caught: unknown = await registerPreviewRedirectUri('https://bluedot-website-pr-42.onrender.com/*').catch(
-      (error: unknown) => error,
-    );
+    const caught: unknown = await registerPreviewRedirectUri('https://bluedot-website-pr-42.onrender.com/*').catch((error: unknown) => error);
 
     if (!isHttpError(caught)) {
       throw new Error('expected an HttpError');

--- a/apps/website/src/lib/api/keycloak.test.ts
+++ b/apps/website/src/lib/api/keycloak.test.ts
@@ -1,9 +1,13 @@
 import axios from 'axios';
+import { logger } from '@bluedot/ui/src/api';
 import { isHttpError } from 'http-errors';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { registerPreviewRedirectUri } from './keycloak';
 
 vi.mock('axios');
+vi.mock('@bluedot/ui/src/api', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
 vi.mock('./env', () => ({
   default: {
     KEYCLOAK_CLIENT_ID: 'fake',
@@ -138,6 +142,7 @@ describe('registerPreviewRedirectUri', () => {
     // config.data and the bearer token in config.headers.Authorization.
     const axiosError = Object.assign(new Error('Request failed with status code 401'), {
       isAxiosError: true,
+      code: 'ERR_BAD_REQUEST',
       config: {
         data: `grant_type=client_credentials&client_id=preview-client&client_secret=${CLIENT_SECRET}`,
         headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
@@ -160,5 +165,14 @@ describe('registerPreviewRedirectUri', () => {
     const serialised = JSON.stringify(caught) + caught.message + (caught.stack ?? '');
     expect(serialised).not.toContain(CLIENT_SECRET);
     expect(serialised).not.toContain(ADMIN_TOKEN);
+
+    // Safe diagnostics are logged; secrets are not.
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Keycloak request failed'), {
+      status: 401,
+      code: 'ERR_BAD_REQUEST',
+    });
+    const loggedArgs = JSON.stringify(vi.mocked(logger.error).mock.calls);
+    expect(loggedArgs).not.toContain(CLIENT_SECRET);
+    expect(loggedArgs).not.toContain(ADMIN_TOKEN);
   });
 });

--- a/apps/website/src/lib/api/keycloak.ts
+++ b/apps/website/src/lib/api/keycloak.ts
@@ -191,61 +191,75 @@ export async function registerPreviewRedirectUri(redirectUri: string): Promise<{
     throw createHttpError.InternalServerError('KEYCLOAK_PREVIEW_CLIENT_ID and KEYCLOAK_PREVIEW_CLIENT_SECRET must be set');
   }
 
-  const tokenResponse = await axios.post(
-    `${KEYCLOAK_BASE_URL}/realms/customers/protocol/openid-connect/token`,
-    new URLSearchParams({
-      grant_type: 'client_credentials',
-      client_id: env.KEYCLOAK_PREVIEW_CLIENT_ID,
-      client_secret: env.KEYCLOAK_PREVIEW_CLIENT_SECRET,
-    }),
-    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
-  );
-  const token = (tokenResponse.data as { access_token: string }).access_token;
+  // Axios errors embed config.data (the token request body, which carries
+  // client_secret) and config.headers (the admin bearer token). Drop so neither can reach any logging path.
+  try {
+    const tokenResponse = await axios.post(
+      `${KEYCLOAK_BASE_URL}/realms/customers/protocol/openid-connect/token`,
+      new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: env.KEYCLOAK_PREVIEW_CLIENT_ID,
+        client_secret: env.KEYCLOAK_PREVIEW_CLIENT_SECRET,
+      }),
+      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+    );
+    const token = (tokenResponse.data as { access_token: string }).access_token;
 
-  // Get current client config
-  const clientsResponse = await axios.get(
-    `${KEYCLOAK_BASE_URL}/admin/realms/customers/clients?clientId=${PUBLIC_LOGIN_CLIENT_ID}`,
-    { headers: { Authorization: `Bearer ${token}` } },
-  );
+    // Get current client config
+    const clientsResponse = await axios.get(
+      `${KEYCLOAK_BASE_URL}/admin/realms/customers/clients?clientId=${PUBLIC_LOGIN_CLIENT_ID}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
 
-  const clients = clientsResponse.data as Record<string, unknown>[];
-  if (clients.length === 0) {
-    throw createHttpError.InternalServerError(`Client '${PUBLIC_LOGIN_CLIENT_ID}' not found`);
-  }
-
-  const client = clients[0]!;
-  const existingUris = client.redirectUris as string[];
-  let uris = [...existingUris];
-
-  const added = !uris.includes(redirectUri);
-  if (added) {
-    uris.push(redirectUri);
-  }
-
-  // Clean up URIs for closed PRs
-  const previewUris = existingUris.filter((uri) => uri !== redirectUri && !PERMANENT_URIS.has(uri) && extractPrNumber(uri) !== null);
-  const openStatuses = await Promise.all(previewUris.map((uri) => isPrOpen(extractPrNumber(uri)!)));
-  const staleUris = new Set(previewUris.filter((_, i) => !openStatuses[i]));
-  uris = uris.filter((uri) => !staleUris.has(uri));
-  const cleaned = staleUris.size;
-
-  if (uris.length === existingUris.length && uris.every((u) => existingUris.includes(u))) {
-    return { added, cleaned };
-  }
-
-  // Safety check: never remove permanent URIs
-  for (const permanent of PERMANENT_URIS) {
-    if (!uris.includes(permanent) && existingUris.includes(permanent)) {
-      throw createHttpError.InternalServerError(`Bug: would have removed permanent URI ${permanent}`);
+    const clients = clientsResponse.data as Record<string, unknown>[];
+    if (clients.length === 0) {
+      throw createHttpError.InternalServerError(`Client '${PUBLIC_LOGIN_CLIENT_ID}' not found`);
     }
+
+    const client = clients[0]!;
+    const existingUris = client.redirectUris as string[];
+    let uris = [...existingUris];
+
+    const added = !uris.includes(redirectUri);
+    if (added) {
+      uris.push(redirectUri);
+    }
+
+    // Clean up URIs for closed PRs
+    const previewUris = existingUris.filter(
+      (uri) => uri !== redirectUri && !PERMANENT_URIS.has(uri) && extractPrNumber(uri) !== null,
+    );
+    const openStatuses = await Promise.all(previewUris.map((uri) => isPrOpen(extractPrNumber(uri)!)));
+    const staleUris = new Set(previewUris.filter((_, i) => !openStatuses[i]));
+    uris = uris.filter((uri) => !staleUris.has(uri));
+    const cleaned = staleUris.size;
+
+    if (uris.length === existingUris.length && uris.every((u) => existingUris.includes(u))) {
+      return { added, cleaned };
+    }
+
+    // Safety check: never remove permanent URIs
+    for (const permanent of PERMANENT_URIS) {
+      if (!uris.includes(permanent) && existingUris.includes(permanent)) {
+        throw createHttpError.InternalServerError(`Bug: would have removed permanent URI ${permanent}`);
+      }
+    }
+
+    // Update client with full representation
+    await axios.put(
+      `${KEYCLOAK_BASE_URL}/admin/realms/customers/clients/${client.id as string}`,
+      { ...client, redirectUris: uris },
+      { headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' } },
+    );
+
+    return { added, cleaned };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      throw createHttpError.ServiceUnavailable(
+        'Authentication service is currently unavailable. Please try again later.',
+      );
+    }
+
+    throw error;
   }
-
-  // Update client with full representation
-  await axios.put(
-    `${KEYCLOAK_BASE_URL}/admin/realms/customers/clients/${client.id as string}`,
-    { ...client, redirectUris: uris },
-    { headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' } },
-  );
-
-  return { added, cleaned };
 }

--- a/apps/website/src/lib/api/keycloak.ts
+++ b/apps/website/src/lib/api/keycloak.ts
@@ -227,9 +227,7 @@ export async function registerPreviewRedirectUri(redirectUri: string): Promise<{
     }
 
     // Clean up URIs for closed PRs
-    const previewUris = existingUris.filter(
-      (uri) => uri !== redirectUri && !PERMANENT_URIS.has(uri) && extractPrNumber(uri) !== null,
-    );
+    const previewUris = existingUris.filter((uri) => uri !== redirectUri && !PERMANENT_URIS.has(uri) && extractPrNumber(uri) !== null);
     const openStatuses = await Promise.all(previewUris.map((uri) => isPrOpen(extractPrNumber(uri)!)));
     const staleUris = new Set(previewUris.filter((_, i) => !openStatuses[i]));
     uris = uris.filter((uri) => !staleUris.has(uri));

--- a/apps/website/src/lib/api/keycloak.ts
+++ b/apps/website/src/lib/api/keycloak.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { logger } from '@bluedot/ui/src/api';
 import createHttpError from 'http-errors';
 import env from './env';
 import { ONE_MINUTE_SECONDS } from '../constants';
@@ -255,9 +256,11 @@ export async function registerPreviewRedirectUri(redirectUri: string): Promise<{
     return { added, cleaned };
   } catch (error) {
     if (axios.isAxiosError(error)) {
-      throw createHttpError.ServiceUnavailable(
-        'Authentication service is currently unavailable. Please try again later.',
-      );
+      logger.error('registerPreviewRedirectUri: Keycloak request failed', {
+        status: error.response?.status,
+        code: error.code,
+      });
+      throw createHttpError.ServiceUnavailable('Authentication service is currently unavailable. Please try again later.');
     }
 
     throw error;

--- a/apps/website/src/pages/api/keycloak-register-preview-redirect-uri.test.ts
+++ b/apps/website/src/pages/api/keycloak-register-preview-redirect-uri.test.ts
@@ -1,6 +1,8 @@
 import createHttpError from 'http-errors';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
 import { registerPreviewRedirectUri } from '../../lib/api/keycloak';
 import handler from './keycloak-register-preview-redirect-uri';
 
@@ -76,9 +78,7 @@ describe('keycloak-register-preview-redirect-uri', () => {
   });
 
   it('maps an HttpError from the lib to its status code', async () => {
-    mockedRegister.mockRejectedValueOnce(
-      createHttpError.ServiceUnavailable('Authentication service is currently unavailable. Please try again later.'),
-    );
+    mockedRegister.mockRejectedValueOnce(createHttpError.ServiceUnavailable('Authentication service is currently unavailable. Please try again later.'));
     const { req, res } = createMockReqRes();
     await handler(req, res);
     expect(res.status).toHaveBeenCalledWith(503);

--- a/apps/website/src/pages/api/keycloak-register-preview-redirect-uri.test.ts
+++ b/apps/website/src/pages/api/keycloak-register-preview-redirect-uri.test.ts
@@ -1,12 +1,14 @@
+import createHttpError from 'http-errors';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import {
-  describe, it, expect, vi, beforeEach,
-} from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { registerPreviewRedirectUri } from '../../lib/api/keycloak';
 import handler from './keycloak-register-preview-redirect-uri';
 
 vi.mock('../../lib/api/keycloak', () => ({
   registerPreviewRedirectUri: vi.fn().mockResolvedValue({ added: true, cleaned: 0 }),
 }));
+
+const mockedRegister = vi.mocked(registerPreviewRedirectUri);
 
 vi.mock('../../lib/api/env', () => ({
   default: {
@@ -71,5 +73,25 @@ describe('keycloak-register-preview-redirect-uri', () => {
     await handler(req, res);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ added: true, cleaned: 0 });
+  });
+
+  it('maps an HttpError from the lib to its status code', async () => {
+    mockedRegister.mockRejectedValueOnce(
+      createHttpError.ServiceUnavailable('Authentication service is currently unavailable. Please try again later.'),
+    );
+    const { req, res } = createMockReqRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Authentication service is currently unavailable. Please try again later.',
+    });
+  });
+
+  it('returns a generic 500 for non-HttpError failures', async () => {
+    mockedRegister.mockRejectedValueOnce(new Error('unexpected'));
+    const { req, res } = createMockReqRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
   });
 });

--- a/apps/website/src/pages/api/keycloak-register-preview-redirect-uri.ts
+++ b/apps/website/src/pages/api/keycloak-register-preview-redirect-uri.ts
@@ -1,4 +1,5 @@
 import { timingSafeEqual } from 'crypto';
+import { isHttpError } from 'http-errors';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import env from '../../lib/api/env';
 import { registerPreviewRedirectUri } from '../../lib/api/keycloak';
@@ -28,6 +29,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(401).json({ error: 'Invalid token' });
   }
 
-  const result = await registerPreviewRedirectUri(redirectUri);
-  return res.status(200).json(result);
+  try {
+    const result = await registerPreviewRedirectUri(redirectUri);
+    return res.status(200).json(result);
+  } catch (error) {
+    if (isHttpError(error)) {
+      return res.status(error.statusCode).json({ error: error.message });
+    }
+
+    return res.status(500).json({ error: 'Internal server error' });
+  }
 }


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Don't expose `KEYCLOAK_PREVIEW_CLIENT_SECRET` or authorisation token in logs via raw axios calls in `registerPreviewRedirectUri`.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Closes #2762. 

I checked grafana ({service_name="bluedot-website-production"} with |= "client_secret" and |= "Bearer ") across the exposure window 2026-02-19→2026-07-10 - no hits. Secret not exposed; no rotation needed.

