### PR TITLE
[fix] Read linkToUser's trigger record from Airtable to avoid pg-sync race

### DIFF
--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -2,7 +2,7 @@ import {
   applicationsRoundTable, courseRegistrationTable, selfServeCourseRegistrationTable, userTable,
 } from '@bluedot/db';
 import {
-  beforeEach, describe, expect, test,
+  beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import {
   createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
@@ -158,9 +158,20 @@ describe('courseRegistrations.linkToUser input validation', () => {
 });
 
 describe('courseRegistrations.linkToUser by courseRegistrationId', () => {
-  test('throws for an unknown course registration', async () => {
+  test('throws NOT_FOUND for an unknown course registration', async () => {
     await expect(linkToUser({ courseRegistrationId: 'missing' }))
-      .rejects.toThrow('No records found');
+      .rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  test('reads the triggering registration from Airtable, not the Postgres replica', async () => {
+    await testDb.insert(courseRegistrationTable, { id: 'reg1', email: 'new@example.com', courseId: 'c1' });
+    const airtableGetSpy = vi.spyOn(testDb.airtableClient, 'get');
+
+    const result = await linkToUser({ courseRegistrationId: 'reg1' });
+
+    expect(result.action).toBe('created-user-and-linked');
+    expect(airtableGetSpy).toHaveBeenCalledWith(courseRegistrationTable.airtable, 'reg1');
+    airtableGetSpy.mockRestore();
   });
 
   test('leaves an already-linked registration untouched', async () => {
@@ -261,8 +272,32 @@ describe('courseRegistrations.linkToUser by courseRegistrationId', () => {
 });
 
 describe('courseRegistrations.linkToUser by userId', () => {
-  test('throws for an unknown user', async () => {
-    await expect(linkToUser({ userId: 'missing' })).rejects.toThrow('No records found');
+  test('throws NOT_FOUND for an unknown user', async () => {
+    await expect(linkToUser({ userId: 'missing' })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  test('reads the triggering user from Airtable, not the Postgres replica', async () => {
+    await testDb.insert(userTable, { id: 'user1', email: 'someone@example.com', name: 'Someone' });
+    await testDb.insert(courseRegistrationTable, { id: 'reg1', email: 'someone@example.com', courseId: 'c1' });
+    const airtableGetSpy = vi.spyOn(testDb.airtableClient, 'get');
+
+    const result = await linkToUser({ userId: 'user1' });
+
+    expect(result).toEqual({ action: 'linked-user-registrations', userId: 'user1', linkedCount: 1 });
+    expect(airtableGetSpy).toHaveBeenCalledWith(userTable.airtable, 'user1');
+    airtableGetSpy.mockRestore();
+  });
+
+  test('links registrations when the triggering user exists in Airtable but has not synced to Postgres yet', async () => {
+    const airtableGetSpy = vi.spyOn(testDb.airtableClient, 'get')
+      .mockResolvedValueOnce({ id: 'user-fresh', email: 'fresh@example.com', name: 'Fresh' } as never);
+    await testDb.insert(courseRegistrationTable, { id: 'reg1', email: 'fresh@example.com', courseId: 'c1' });
+
+    const result = await linkToUser({ userId: 'user-fresh' });
+
+    expect(result).toEqual({ action: 'linked-user-registrations', userId: 'user-fresh', linkedCount: 1 });
+    expect((await getRegistration('reg1'))?.userId).toBe('user-fresh');
+    airtableGetSpy.mockRestore();
   });
 
   test('links all unlinked registrations matching the user email case-insensitively', async () => {

--- a/apps/website/src/server/routers/course-registrations.ts
+++ b/apps/website/src/server/routers/course-registrations.ts
@@ -2,6 +2,7 @@ import {
   applicationsRoundTable, courseRegistrationTable, inArray,
   eq, and, or, ne, isNull, sql, userTable,
 } from '@bluedot/db';
+import { TRPCError } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
 import { normaliseEmail, verifyPublicToken } from '../../lib/api/utils';
@@ -64,13 +65,18 @@ export const courseRegistrationsRouter = router({
 
       // 1. Link-or-create the user if we are given a course registration
       if (input.courseRegistrationId !== undefined) {
-        const courseRegistration = await db.get(courseRegistrationTable, { id: input.courseRegistrationId });
+        // Read from Airtable, not Postgres: the webhook fires seconds after creation, before pg-sync replicates the record.
+        const courseRegistration = await db.airtableClient
+          .get(courseRegistrationTable.airtable, input.courseRegistrationId)
+          .catch((error: unknown) => {
+            throw new TRPCError({ code: 'NOT_FOUND', message: 'Course registration not found', cause: error });
+          });
 
         if (courseRegistration.userId) {
           return { action: 'already-linked', userId: courseRegistration.userId } as const;
         }
 
-        const email = normaliseEmail(courseRegistration.email);
+        const email = normaliseEmail(courseRegistration.email ?? '');
         if (!email) {
           return { action: 'skipped-no-email' } as const;
         }
@@ -91,9 +97,14 @@ export const courseRegistrationsRouter = router({
       }
 
       // 2. Link all matching course registrations if we are given a user
-      const user = await db.get(userTable, { id: input.userId! });
+      // Read from Airtable, not Postgres (same reason as above): the triggering user may be brand new.
+      const user = await db.airtableClient
+        .get(userTable.airtable, input.userId!)
+        .catch((error: unknown) => {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found', cause: error });
+        });
 
-      const email = normaliseEmail(user.email);
+      const email = normaliseEmail(user.email ?? '');
       if (!email) {
         return { action: 'skipped-no-email' } as const;
       }


### PR DESCRIPTION
# Description

courseRegistrations.linkToUser (added yesterday in #2777) is called by an Airtable automation within seconds of a record being created, before pg-sync has replicated it to the Postgres read-replica, so reading the trigger record via db.get failed with RESOURCE_NOT_FOUND and the registration never linked (~60% of the time).

This PR changes it to read the trigger record straight from Airtable instead. The downstream db.update/db.insert already write to Airtable then upsert to Postgres, so they were never an issue.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2774

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories