### PR TITLE
Use Google login user's name

### DIFF
--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -165,6 +165,63 @@ describe('users.ensureExists', () => {
     insertSpy.mockRestore();
   });
 
+  test('writes the name from the token when creating a new user', async () => {
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue({
+      sub: 'test-sub',
+      email: 'test@example.com',
+      name: 'John Doe',
+      iss: 'test-issuer',
+      aud: 'test-audience',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      email_verified: true,
+    });
+
+    await createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'valid-token' });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.name).toBe('John Doe');
+  });
+
+  test('backfills an empty name from the token on an existing user', async () => {
+    await testDb.insert(userTable, { id: 'u1', email: 'test@example.com' });
+
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue({
+      sub: 'test-sub',
+      email: 'test@example.com',
+      name: 'John Doe',
+      iss: 'test-issuer',
+      aud: 'test-audience',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      email_verified: true,
+    });
+
+    await createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'valid-token' });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.name).toBe('John Doe');
+  });
+
+  test('does not overwrite a name the user already has', async () => {
+    await testDb.insert(userTable, {
+      id: 'u1', email: 'test@example.com', name: 'Manual Name', keycloakIdentifier: 'test-sub',
+    });
+
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue({
+      sub: 'test-sub',
+      email: 'test@example.com',
+      name: 'Google Name',
+      iss: 'test-issuer',
+      aud: 'test-audience',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      email_verified: true,
+    });
+
+    await createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'valid-token' });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.name).toBe('Manual Name');
+  });
+
   test('is idempotent: a second call reports isNewUser false and creates no extra row', async () => {
     const caller = createCaller(testAuthContextLoggedOut);
 

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -182,8 +182,27 @@ describe('users.ensureExists', () => {
     expect(user.name).toBe('John Doe');
   });
 
-  test('backfills an empty name from the token on an existing user', async () => {
+  test('backfills an empty name from the token on a user matched by email (no keycloakIdentifier yet)', async () => {
     await testDb.insert(userTable, { id: 'u1', email: 'test@example.com' });
+
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue({
+      sub: 'test-sub',
+      email: 'test@example.com',
+      name: 'John Doe',
+      iss: 'test-issuer',
+      aud: 'test-audience',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      email_verified: true,
+    });
+
+    await createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'valid-token' });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.name).toBe('John Doe');
+  });
+
+  test('backfills an empty name from the token on a returning user matched by keycloakIdentifier', async () => {
+    await testDb.insert(userTable, { id: 'u1', email: 'test@example.com', keycloakIdentifier: 'test-sub' });
 
     vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue({
       sub: 'test-sub',

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -63,7 +63,7 @@ export const usersRouter = router({
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Invalid login token' });
       }
 
-      const { sub } = auth;
+      const { sub, name } = auth;
 
       const [existingUserByEmail, existingUserByKeycloakIdentifier] = await Promise.all([
         db.getFirst(userTable, {
@@ -79,6 +79,8 @@ export const usersRouter = router({
         // Update last seen timestamp if already exists
         await db.update(userTable, {
           id: existingUserByKeycloakIdentifier.id,
+          // Don't clobber a name the user set themselves; only backfill an empty one
+          ...(name && !existingUserByKeycloakIdentifier.name && { name }),
           lastSeenAt: new Date().toISOString(),
         });
       } else if (existingUserByEmail) {
@@ -90,6 +92,8 @@ export const usersRouter = router({
         await db.update(userTable, {
           id: existingUserByEmail.id,
           ...(sub && { keycloakIdentifier: sub }),
+          // Don't clobber a name the user set themselves; only backfill an empty one
+          ...(name && !existingUserByEmail.name && { name }),
           lastSeenAt: new Date().toISOString(),
           firstLoggedInAt: new Date().toISOString(),
         });
@@ -98,6 +102,7 @@ export const usersRouter = router({
         await db.insert(userTable, {
           email: auth.email,
           ...(sub && { keycloakIdentifier: sub }),
+          ...(name && { name }),
           lastSeenAt: new Date().toISOString(),
           firstLoggedInAt: new Date().toISOString(),
           ...(input.initialUtmSource && { utmSource: input.initialUtmSource }),

--- a/libraries/ui/src/Login.tsx
+++ b/libraries/ui/src/Login.tsx
@@ -115,11 +115,13 @@ export const loginPresets = {
       scope: 'openid email profile offline_access',
     },
     async verifyAndDecodeToken(token: string) {
-      return verifyJwt(token, {
+      const payload = await verifyJwt(token, {
         aud: 'bluedot-web-apps',
         iss: 'https://login.bluedot.org/realms/customers',
         jwksUrl: 'https://login.bluedot.org/realms/customers/protocol/openid-connect/certs',
       });
+      const name = typeof payload.name === 'string' ? payload.name.trim() : undefined;
+      return { ...payload, ...(name && { name }) };
     },
     getRegistrationUrl(authUrl: string) {
       const url = new URL(authUrl);

--- a/libraries/ui/src/Login.tsx
+++ b/libraries/ui/src/Login.tsx
@@ -112,7 +112,7 @@ export const loginPresets = {
       authority: 'https://login.bluedot.org/realms/customers/',
       client_id: 'bluedot-web-apps',
       redirect_uri: `${typeof window === 'undefined' ? '' : window.location.origin}/login/oauth-callback`,
-      scope: 'openid email offline_access',
+      scope: 'openid email profile offline_access',
     },
     async verifyAndDecodeToken(token: string) {
       return verifyJwt(token, {


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Populate a user's name from their Google login.

Previously, signing in with Google only stored email, Keycloak ID, and timestamps. The name had to be set manually via the profile settings editor. Now the name from the Google/OIDC token is written automatically on login.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2723

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

