### PR TITLE
Update Digital Minds next steps

### DIFF
--- a/apps/website/src/components/courses/NextStepsChunk.stories.tsx
+++ b/apps/website/src/components/courses/NextStepsChunk.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import NextStepsChunk from './NextStepsChunk';
+
+const meta = {
+  title: 'website/courses/NextStepsChunk',
+  component: NextStepsChunk,
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-[900px] text-bluedot-navy">
+        <h1 className="text-size-xl font-bold leading-[130%] tracking-[-0.015em]">Next steps</h1>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    courseSlug: 'digital-minds',
+  },
+} satisfies Meta<typeof NextStepsChunk>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DigitalMinds: Story = {};

--- a/apps/website/src/components/courses/NextStepsChunk.test.tsx
+++ b/apps/website/src/components/courses/NextStepsChunk.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { getNextStepsChunkTitle } from '../../lib/constants';
+import NextStepsChunk from './NextStepsChunk';
+
+describe('NextStepsChunk', () => {
+  test.each([
+    'digital-minds',
+    'introduction-to-digital-minds',
+    'cambridge-digital-minds',
+  ])('uses the Digital Minds next-steps heading for the %s slug', (courseSlug) => {
+    expect(getNextStepsChunkTitle(courseSlug)).toBe('Next steps');
+  });
+
+  test('renders Cambridge Digital Minds next steps for the Digital Minds course', () => {
+    render(<NextStepsChunk courseSlug="digital-minds" />);
+
+    expect(screen.getByText(/Congratulations on finishing the Introduction to Digital Minds course!/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Cambridge Digital Minds Newsletter' })).toHaveAttribute('href', 'https://www.digitalminds.news/');
+    expect(screen.getByRole('link', { name: 'Cambridge Digital Minds Fellowship' })).toHaveAttribute('href', 'https://digitalminds.cam/fellowship/');
+    expect(screen.getByRole('link', { name: 'Beginner’s Guide to Digital Minds' })).toHaveAttribute('href', 'https://digitalminds.guide/events');
+    expect(screen.getByRole('link', { name: 'Future Impact Group' })).toHaveAttribute('href', 'https://futureimpact.group/ai-sentience');
+    expect(screen.getByRole('link', { name: 'MATS' })).toHaveAttribute('href', 'https://www.matsprogram.org/');
+    expect(screen.getByRole('link', { name: 'Sentient Futures' })).toHaveAttribute('href', 'https://www.sentientfutures.ai/projectincubator');
+    expect(screen.queryByText(/continue contributing to AI safety/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/website/src/components/courses/NextStepsChunk.tsx
+++ b/apps/website/src/components/courses/NextStepsChunk.tsx
@@ -1,12 +1,100 @@
 import { ErrorSection, P, ProgressDots } from '@bluedot/ui';
 import type React from 'react';
 import { PageListGroup, PageListRow } from '../PageListRow';
+import { isDigitalMindsCourseSlug } from '../../lib/constants';
 import { formatAmountUsd } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
 
 const pluralizeGrants = (count: number) => `${count} ${count === 1 ? 'grant' : 'grants'}`;
 
-const NextStepsChunk: React.FC = () => {
+type NextStepsChunkProps = {
+  courseSlug: string;
+};
+
+const externalLinkClassName = 'font-semibold text-bluedot-normal underline hover:text-bluedot-navy';
+
+const DigitalMindsNextStepsChunk: React.FC = () => (
+  <div className="next-steps-chunk flex flex-col gap-6 mt-8 md:mt-6">
+    <P className="text-size-sm leading-relaxed text-bluedot-navy">
+      Congratulations on finishing the Introduction to Digital Minds course! Here are some ways you can continue to learn about and contribute to the digital minds field.
+    </P>
+
+    <div className="flex flex-col gap-5 text-size-sm leading-relaxed text-bluedot-navy">
+      <div>
+        <a
+          href="https://www.digitalminds.news/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={externalLinkClassName}
+        >
+          Cambridge Digital Minds Newsletter
+        </a>
+        <p className="mt-1">
+          A quarterly round-up of the latest news and research on AI consciousness, moral status and digital minds
+        </p>
+      </div>
+
+      <div>
+        <a
+          href="https://digitalminds.cam/fellowship/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={externalLinkClassName}
+        >
+          Cambridge Digital Minds Fellowship
+        </a>
+        <p className="mt-1">
+          In person workshops and mentorship on projects. Sign up to the CDM Newsletter to hear when applications open.
+        </p>
+      </div>
+
+      <div>
+        <h2 className="font-semibold">Other fellowships and opportunities</h2>
+        <p className="mt-1">
+          The{' '}
+          <a
+            href="https://digitalminds.guide/events"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={externalLinkClassName}
+          >
+            Beginner’s Guide to Digital Minds
+          </a>
+          {' '}has a really helpful list. Also, keep an eye on programmes with organisations like{' '}
+          <a
+            href="https://futureimpact.group/ai-sentience"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={externalLinkClassName}
+          >
+            Future Impact Group
+          </a>
+          ,{' '}
+          <a
+            href="https://www.matsprogram.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={externalLinkClassName}
+          >
+            MATS
+          </a>
+          ,{' '}
+          <a
+            href="https://www.sentientfutures.ai/projectincubator"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={externalLinkClassName}
+          >
+            Sentient Futures
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  </div>
+);
+
+const BlueDotNextStepsChunk: React.FC = () => {
   const { data: programs, isLoading, error } = trpc.programs.getAll.useQuery();
   const { data: rapidStats } = trpc.grants.getRapidGrantStats.useQuery();
   const { data: ctStats } = trpc.grants.getCareerTransitionGrantStats.useQuery();
@@ -48,5 +136,11 @@ const NextStepsChunk: React.FC = () => {
     </div>
   );
 };
+
+const NextStepsChunk: React.FC<NextStepsChunkProps> = ({ courseSlug }) => (
+  isDigitalMindsCourseSlug(courseSlug)
+    ? <DigitalMindsNextStepsChunk />
+    : <BlueDotNextStepsChunk />
+);
 
 export default NextStepsChunk;

--- a/apps/website/src/components/courses/UnitLayout.tsx
+++ b/apps/website/src/components/courses/UnitLayout.tsx
@@ -206,7 +206,7 @@ const UnitLayout: React.FC<UnitLayoutProps> = ({
             )}
           </div>
           {chunk?.id === NEXT_STEPS_CHUNK_ID ? (
-            <NextStepsChunk />
+            <NextStepsChunk courseSlug={courseSlug} />
           ) : (
             <>
               {chunk?.chunkContent && (

--- a/apps/website/src/lib/constants.ts
+++ b/apps/website/src/lib/constants.ts
@@ -16,9 +16,26 @@ export const FOAI_COURSE_ID = 'rec0Zgize0c4liMl5';
 export const FOAI_COURSE_SLUG = 'future-of-ai';
 
 // Synthetic chunk appended to the last unit of every non-FoAI course so the
-// final view points learners at next-step programs (advising, grants, etc.).
+// final view points learners to relevant ways to continue after the course.
 export const NEXT_STEPS_CHUNK_ID = 'next-steps-synthetic';
 export const NEXT_STEPS_CHUNK_TITLE = 'Next steps: Programs';
+export const DIGITAL_MINDS_NEXT_STEPS_CHUNK_TITLE = 'Next steps';
+
+const DIGITAL_MINDS_COURSE_SLUGS = [
+  'digital-minds',
+  'introduction-to-digital-minds',
+  'cambridge-digital-minds',
+];
+
+export const isDigitalMindsCourseSlug = (courseSlug: string) => (
+  DIGITAL_MINDS_COURSE_SLUGS.includes(courseSlug)
+);
+
+export const getNextStepsChunkTitle = (courseSlug: string) => (
+  isDigitalMindsCourseSlug(courseSlug)
+    ? DIGITAL_MINDS_NEXT_STEPS_CHUNK_TITLE
+    : NEXT_STEPS_CHUNK_TITLE
+);
 
 export const BLUEDOT_LINKEDIN_ORG_ID = '86200389';
 

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -10,7 +10,7 @@ import { useEffect } from 'react';
 import UnitLayout, { type ChunkWithContent } from '../../../../components/courses/UnitLayout';
 import db from '../../../../lib/api/db';
 import {
-  FOAI_COURSE_ID, FOAI_COURSE_SLUG, NEXT_STEPS_CHUNK_ID, NEXT_STEPS_CHUNK_TITLE,
+  FOAI_COURSE_ID, FOAI_COURSE_SLUG, getNextStepsChunkTitle, NEXT_STEPS_CHUNK_ID,
 } from '../../../../lib/constants';
 import { getCourseOgImage } from '../../../../lib/courseOgImage';
 import { buildCourseUnitUrl } from '../../../../lib/utils';
@@ -178,18 +178,18 @@ export const getServerSideProps: GetServerSideProps<CourseUnitChunkPageProps> = 
   }
 };
 
-const buildNextStepsBasicChunk = (chunkOrder: string): BasicChunk => ({
+const buildNextStepsBasicChunk = (courseSlug: string, chunkOrder: string): BasicChunk => ({
   id: NEXT_STEPS_CHUNK_ID,
-  chunkTitle: NEXT_STEPS_CHUNK_TITLE,
+  chunkTitle: getNextStepsChunkTitle(courseSlug),
   chunkOrder,
   estimatedTime: null,
 });
 
-const buildNextStepsChunkWithContent = (unitId: string, chunkOrder: string): ChunkWithContent => ({
+const buildNextStepsChunkWithContent = (courseSlug: string, unitId: string, chunkOrder: string): ChunkWithContent => ({
   id: NEXT_STEPS_CHUNK_ID,
   chunkId: NEXT_STEPS_CHUNK_ID,
   unitId,
-  chunkTitle: NEXT_STEPS_CHUNK_TITLE,
+  chunkTitle: getNextStepsChunkTitle(courseSlug),
   chunkOrder,
   chunkType: 'next-steps',
   chunkContent: '',
@@ -214,14 +214,14 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
   const allUnitChunks = await getActiveChunksByUnit(units);
 
   // Append a synthetic "Next steps" chunk to the last unit of every non-FoAI
-  // course so learners see programs to continue with after finishing.
+  // course so learners see relevant ways to continue after finishing.
   const finalUnit = units[units.length - 1];
   const shouldShowNextSteps = courseSlug !== FOAI_COURSE_SLUG && finalUnit !== undefined;
   if (shouldShowNextSteps) {
     const finalUnitChunks = allUnitChunks[finalUnit.id] ?? [];
     const lastChunkOrder = finalUnitChunks[finalUnitChunks.length - 1]?.chunkOrder;
     const nextStepsOrder = String(Number(lastChunkOrder ?? '0') + 1);
-    allUnitChunks[finalUnit.id] = [...finalUnitChunks, buildNextStepsBasicChunk(nextStepsOrder)];
+    allUnitChunks[finalUnit.id] = [...finalUnitChunks, buildNextStepsBasicChunk(courseSlug, nextStepsOrder)];
   }
 
   // Get chunks for current unit (with full resources/exercises)
@@ -281,6 +281,7 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
     ? [
       ...chunksWithContent,
       buildNextStepsChunkWithContent(
+        courseSlug,
         unit.id,
         String(Number(chunksWithContent[chunksWithContent.length - 1]?.chunkOrder ?? '0') + 1),
       ),


### PR DESCRIPTION
## Summary

- replace the generic BlueDot programs list after the Digital Minds final unit with the Cambridge Digital Minds next-steps copy and links
- use the course-specific “Next steps” heading for all known Digital Minds slugs while leaving other courses unchanged
- add focused component coverage and a Storybook preview

## Why

The Digital Minds cohort is reaching Unit 8, and the generic BlueDot programs section would be misleading. This updates the final course view to the follow-on opportunities supplied by Cambridge Digital Minds.

## Validation

- `npm test --workspace @bluedot/website -- src/components/courses/NextStepsChunk.test.tsx src/components/courses/UnitLayout.test.tsx` (11 tests)
- targeted ESLint for all six changed files
- `npm run typecheck --workspace @bluedot/website`
- `git diff --check`
- manual review in Storybook