### PR TITLE
Bug report tracks page URL

### DIFF
--- a/apps/website/src/hooks/useBugReport.test.tsx
+++ b/apps/website/src/hooks/useBugReport.test.tsx
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  beforeEach, describe, expect, it,
+} from 'vitest';
+import { server, trpcMsw } from '../__tests__/trpcMswSetup';
+import { TrpcProvider } from '../__tests__/trpcProvider';
+import BugReportProvider, { useBugReport } from './useBugReport';
+
+const OpenButton = () => {
+  const { openBugReport } = useBugReport();
+  return <button type="button" onClick={openBugReport}>Open</button>;
+};
+
+const renderProvider = () => render(<TrpcProvider>
+  <BugReportProvider>
+    <OpenButton />
+  </BugReportProvider>
+</TrpcProvider>);
+
+const fillAndSubmit = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByLabelText('Description'), 'Something is broken');
+  await user.type(screen.getByPlaceholderText('Email'), 'user@example.com');
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
+};
+
+describe('BugReportProvider page URL capture', () => {
+  let capturedPageUrl: string | undefined;
+
+  beforeEach(() => {
+    capturedPageUrl = undefined;
+    // Birdie setup only runs on wide viewports; ensure the effect registers window.birdieSettings.
+    window.innerWidth = 1024;
+    server.use(trpcMsw.feedback.submitBugReport.mutation(({ input }) => {
+      capturedPageUrl = input.pageUrl;
+      return null;
+    }));
+  });
+
+  it('captures the page the report was opened from', async () => {
+    const user = userEvent.setup();
+    window.history.pushState({}, '', '/courses/agi-safety/2');
+    renderProvider();
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    await fillAndSubmit(user);
+
+    expect(capturedPageUrl).toBe(`${window.location.origin}/courses/agi-safety/2`);
+  });
+
+  it('captures the page recording stopped on, not the page the report was opened from', async () => {
+    const user = userEvent.setup();
+    window.history.pushState({}, '', '/page-a');
+    renderProvider();
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+
+    // User navigates while the modal is closed and they record their screen, then stops recording.
+    window.history.pushState({}, '', '/page-b');
+    act(() => {
+      window.birdieSettings?.onRecordingPosted?.('https://recording.example/xyz');
+    });
+
+    await fillAndSubmit(user);
+
+    expect(capturedPageUrl).toBe(`${window.location.origin}/page-b`);
+  });
+});

--- a/apps/website/src/hooks/useBugReport.tsx
+++ b/apps/website/src/hooks/useBugReport.tsx
@@ -15,6 +15,7 @@ const bugReportContext = createContext<BugReportContextType | null>(null);
 export default function BugReportProvider({ children }: { children: React.ReactNode }) {
   const [isBugReportOpen, setIsBugReportOpen] = useState(false);
   const [recordingUrl, setRecordingUrl] = useState<string | undefined>();
+  const [pageUrl, setPageUrl] = useState<string | undefined>();
 
   const submitBugMutation = trpc.feedback.submitBugReport.useMutation();
 
@@ -51,6 +52,7 @@ export default function BugReportProvider({ children }: { children: React.ReactN
       description: data.description,
       email: data.email,
       recordingUrl: data.recordingUrl,
+      pageUrl,
       attachments: await Promise.all(data.attachments?.map(async (file) => ({
         base64: (await toBase64(file)).split(',')[1] ?? '',
         filename: file.name,
@@ -64,6 +66,11 @@ export default function BugReportProvider({ children }: { children: React.ReactN
     if (!v) setRecordingUrl(undefined);
   };
 
+  const openBugReport = () => {
+    setPageUrl(window.location.origin + window.location.pathname);
+    setIsBugReportOpen(true);
+  };
+
   const handleRecordScreen = () => {
     if (!window.birdie) return;
     setIsBugReportOpen(false);
@@ -73,7 +80,7 @@ export default function BugReportProvider({ children }: { children: React.ReactN
   };
 
   return (
-    <bugReportContext.Provider value={{ openBugReport: () => setIsBugReportOpen(true) }}>
+    <bugReportContext.Provider value={{ openBugReport }}>
       {children}
       <BugReportModal
         isOpen={isBugReportOpen}

--- a/apps/website/src/hooks/useBugReport.tsx
+++ b/apps/website/src/hooks/useBugReport.tsx
@@ -42,10 +42,11 @@ export default function BugReportProvider({ children }: { children: React.ReactN
     };
   }, []);
 
-  // Auto-open bug report modal when recording completes and recording URL is available
+  // Auto-open bug report modal when recording completes and recording URL is available.
+  // Recapture the page here: the page they stopped recording on is the most relevant one.
   useEffect(() => {
     if (recordingUrl) {
-      setPageUrl((prev) => prev ?? getPageUrl());
+      setPageUrl(getPageUrl());
       setIsBugReportOpen(true);
     }
   }, [recordingUrl]);

--- a/apps/website/src/hooks/useBugReport.tsx
+++ b/apps/website/src/hooks/useBugReport.tsx
@@ -45,6 +45,7 @@ export default function BugReportProvider({ children }: { children: React.ReactN
   // Auto-open bug report modal when recording completes and recording URL is available
   useEffect(() => {
     if (recordingUrl) {
+      setPageUrl((prev) => prev ?? getPageUrl());
       setIsBugReportOpen(true);
     }
   }, [recordingUrl]);

--- a/apps/website/src/hooks/useBugReport.tsx
+++ b/apps/website/src/hooks/useBugReport.tsx
@@ -11,6 +11,8 @@ type BugReportContextType = {
 
 const bugReportContext = createContext<BugReportContextType | null>(null);
 
+const getPageUrl = () => window.location.origin + window.location.pathname;
+
 // eslint-disable-next-line react/function-component-definition
 export default function BugReportProvider({ children }: { children: React.ReactNode }) {
   const [isBugReportOpen, setIsBugReportOpen] = useState(false);
@@ -67,7 +69,7 @@ export default function BugReportProvider({ children }: { children: React.ReactN
   };
 
   const openBugReport = () => {
-    setPageUrl(window.location.origin + window.location.pathname);
+    setPageUrl(getPageUrl());
     setIsBugReportOpen(true);
   };
 

--- a/apps/website/src/server/routers/feedback.ts
+++ b/apps/website/src/server/routers/feedback.ts
@@ -11,6 +11,7 @@ export const feedbackRouter = router({
       description: z.string().min(1).max(5000),
       email: z.string().email(),
       recordingUrl: z.string().url().optional(),
+      pageUrl: z.string().url().optional(),
       attachments: z
         .array(z.object({
           base64: z.string().max(Math.ceil(10 * 1024 * 1024 / 3) * 4), // 10MB max file size; raw base64 is ceil(n/3)*4 chars
@@ -26,6 +27,7 @@ export const feedbackRouter = router({
         description: input.description,
         email: input.email,
         recordingUrl: input.recordingUrl ?? null,
+        pageUrl: input.pageUrl ?? null,
         createdAt: Math.floor(Date.now() / 1000),
       });
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1626,9 +1626,15 @@ export const bugReportsTable = pgAirtable('bug_reports', {
       pgColumn: text().array(),
       airtableId: 'fldwb2IJjBIpE4fJi',
     },
+    // Birdie URL for the recording of the bug report session, if any
     recordingUrl: {
       pgColumn: text(),
       airtableId: 'fldSd9pPXP44Sho8G',
+    },
+    // Page the bug was submitted from
+    pageUrl: {
+      pgColumn: text(),
+      airtableId: 'flduxQyQW2lFbi4S0',
     },
     email: {
       pgColumn: text(),


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

When users submit a bug report, we want to track the page that they submit from so it's easier to track down bugs. This is part 2, follows on from https://github.com/bluedotimpact/bluedot/pull/2785

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2674 

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

