### PR TITLE
Update Incubator Week track record

### DIFF
--- a/apps/website/src/components/incubator-week/TrackRecordSection.tsx
+++ b/apps/website/src/components/incubator-week/TrackRecordSection.tsx
@@ -28,15 +28,23 @@ const TrackRecordSection = () => {
               </li>
               <li>
                 <a href="https://www.linkedin.com/in/jacob-arbeid/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Jacob Arbeid</a>
-                : quit AISI; raised from Manifund for an automated evals lab (stealth)
+                : quit AISI; raised from ACX/Manifund to build an automated cyber evals lab (stealth)
               </li>
               <li>
                 <a href="https://www.linkedin.com/in/shay-yahal/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Shay Yahal</a>
                 : enterprise AI safety (stealth); paying customers, Redwood Research partnership
               </li>
               <li>
-                <a href="https://www.linkedin.com/in/z-saber/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Zac Saber</a>
-                : dropped out of EF; building long-horizon evals (stealth)
+                <a href="https://www.linkedin.com/in/cecilia-elena-tilli-8a6890a4/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Cecilia Tilli</a>
+                : raised $480k from Coefficient Giving after pitching on the Friday of Incubator Week; building an organisation working on desirable propensities and character traits for safe deployment in multi-agent settings
+              </li>
+              <li>
+                <a href="https://www.linkedin.com/in/alexcsaky/" target="_blank" rel="noreferrer" className="underline hover:no-underline">Alex Csaky</a>
+                : offered an Entrepreneur in Residence role at Forethought after Incubator Week; now growing the field around AI for epistemics and coordination technology
+              </li>
+              <li>
+                <a href="https://safely.bio/" target="_blank" rel="noreferrer" className="underline hover:no-underline">safely.bio</a>
+                : runs know-your-customer checks on researchers placing synthetic DNA orders, records the evidence, and returns a clear recommendation so labs can distinguish legitimate researchers from bad actors before shipping
               </li>
             </ul>
           </div>

--- a/apps/website/src/components/incubator-week/WhatThisIsForSection.tsx
+++ b/apps/website/src/components/incubator-week/WhatThisIsForSection.tsx
@@ -50,7 +50,6 @@ const WhatThisIsForSection = () => {
             <ul className="list-disc pl-6 flex flex-col gap-1">
               <li>Exona Lab: Founders met during the week; Pre-seed raised, 7-figure round in progress</li>
               <li>Jacob Arbeid: Quit AISI to found; Funding secured; $2.4M ARR pending</li>
-              <li>Zac Saber: Dropped out of EF; now on long-horizon AI evals; met his co-founder Jacob Arbeid during Incubator Week</li>
               <li>Shay Yahal: Enterprise AI safety; Already has paying customers and partnership with Redwood Research</li>
               <li>Lysander Mawby: Mechanistic interpretability; Just wrapped up the FR8 incubator ($100k at $5M val)</li>
             </ul>


### PR DESCRIPTION
## Summary

- add the latest outcomes for Cecilia Tilli, Alex Csaky, and safely.bio
- update Jacob Arbeid’s automated cyber evaluations lab description
- remove Zac Saber from current and legacy Incubator Week alumni content
- keep supporting-document links out while retaining alumni and organisation links

## Why

The August Incubator Week landing page should reflect the latest alumni outcomes and current founding status.

## Impact

Visitors will see a more accurate and up-to-date track record for the program.

## Validation

- `npm run lint --workspace @bluedot/website -- --quiet`
- `npm run typecheck --workspace @bluedot/website`
- `git diff --check`