### PR TITLE
[chore] Deep-import @bluedot/ui in the server router graph to cut test collect time

### DIFF
--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { addQueryParam } from '@bluedot/ui';
+import { addQueryParam } from '@bluedot/ui/src/utils/addQueryParam';
 import { type AxiosError } from 'axios';
 import posthog from 'posthog-js';
 

--- a/apps/website/src/server/context.test.ts
+++ b/apps/website/src/server/context.test.ts
@@ -2,13 +2,13 @@ import {
   beforeEach, describe, expect, test, vi,
 } from 'vitest';
 import { userTable } from '@bluedot/db';
-import { loginPresets } from '@bluedot/ui';
+import { loginPresets } from '@bluedot/ui/src/Login';
 import { createContext } from './context';
 import { setupTestDb, testDb } from '../__tests__/dbTestUtils';
 import { ONE_HOUR_SECONDS } from '../lib/constants';
 
-vi.mock('@bluedot/ui', async () => {
-  const actual = await vi.importActual('@bluedot/ui');
+vi.mock('@bluedot/ui/src/Login', async () => {
+  const actual = await vi.importActual('@bluedot/ui/src/Login');
   return {
     ...actual,
     loginPresets: {

--- a/apps/website/src/server/context.ts
+++ b/apps/website/src/server/context.ts
@@ -1,5 +1,5 @@
 import { userTable } from '@bluedot/db';
-import { loginPresets } from '@bluedot/ui';
+import { loginPresets } from '@bluedot/ui/src/Login';
 import { logger } from '@bluedot/ui/src/api';
 import type * as trpcNext from '@trpc/server/adapters/next';
 import db from '../lib/api/db';

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -1,5 +1,5 @@
 import { userTable } from '@bluedot/db';
-import { loginPresets } from '@bluedot/ui';
+import { loginPresets } from '@bluedot/ui/src/Login';
 import db from '../../lib/api/db';
 import {
   beforeEach, describe, expect, test, vi,
@@ -14,8 +14,8 @@ vi.mock('../../lib/api/keycloak', () => ({
   updateKeycloakPassword: vi.fn(),
 }));
 
-vi.mock('@bluedot/ui', async () => {
-  const actual = await vi.importActual('@bluedot/ui');
+vi.mock('@bluedot/ui/src/Login', async () => {
+  const actual = await vi.importActual('@bluedot/ui/src/Login');
   return {
     ...actual,
     loginPresets: {

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -1,6 +1,6 @@
 import { userTable } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
-import { loginPresets } from '@bluedot/ui';
+import { loginPresets } from '@bluedot/ui/src/Login';
 import z from 'zod';
 import db from '../../lib/api/db';
 import { updateKeycloakPassword, verifyKeycloakPassword } from '../../lib/api/keycloak';


### PR DESCRIPTION
# Description

Claude measured this as speeding up the website/ tests by about 10% by avoiding barrel imports. I'm somewhat skeptical, but it's harmless anyway.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->