### PR TITLE
[fix] website: set initial UTM params on first login rather than on user creation

### DIFF
--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -276,6 +276,71 @@ describe('users.ensureExists', () => {
     expect(new Date(user.lastSeenAt!).getTime()).toBeGreaterThanOrEqual(before);
   });
 
+  test('writes initial UTM fields on first login for an applicant row (email exists, no keycloakIdentifier)', async () => {
+    // Row auto-created when the person applied (#2163): has an email but never logged in, so no
+    // keycloakIdentifier and no UTM. Their first login carries the UTM params in `input`.
+    await testDb.insert(userTable, {
+      id: 'u1',
+      email: 'test@example.com',
+      name: 'Test User',
+    });
+
+    const result = await createCaller(testAuthContextLoggedOut).users.ensureExists({
+      token: 'valid-token',
+      initialUtmSource: 'twitter',
+      initialUtmCampaign: 'launch',
+      initialUtmContent: 'thread',
+    });
+
+    expect(result).toEqual({ isNewUser: false });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.keycloakIdentifier).toBe('test-sub');
+    expect(user.utmSource).toBe('twitter');
+    expect(user.utmCampaign).toBe('launch');
+    expect(user.utmContent).toBe('thread');
+  });
+
+  test('does not write UTM fields on first login when no UTM params are supplied', async () => {
+    await testDb.insert(userTable, {
+      id: 'u1',
+      email: 'test@example.com',
+      name: 'Test User',
+    });
+
+    const result = await createCaller(testAuthContextLoggedOut).users.ensureExists({ token: 'valid-token' });
+
+    expect(result).toEqual({ isNewUser: false });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.keycloakIdentifier).toBe('test-sub');
+    expect(user.utmSource).toBeNull();
+    expect(user.utmCampaign).toBeNull();
+    expect(user.utmContent).toBeNull();
+  });
+
+  test('does not touch UTM fields for an email-matched user that already has a keycloakIdentifier (not their first login)', async () => {
+    await testDb.insert(userTable, {
+      id: 'u1',
+      email: 'test@example.com',
+      name: 'Test User',
+      keycloakIdentifier: 'other-sub',
+      utmSource: 'original-source',
+    });
+
+    const result = await createCaller(testAuthContextLoggedOut).users.ensureExists({
+      token: 'valid-token',
+      initialUtmSource: 'should-be-ignored',
+      initialUtmCampaign: 'should-be-ignored',
+    });
+
+    expect(result).toEqual({ isNewUser: false });
+
+    const user = await testDb.get(userTable, { email: 'test@example.com' });
+    expect(user.utmSource).toBe('original-source');
+    expect(user.utmCampaign).toBeNull();
+  });
+
   test('backfills keycloakIdentifier on login for a user that already existed without one (e.g. created by an Airtable automation), and does not report them as new', async () => {
     await testDb.insert(userTable, {
       id: 'u1',

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -75,6 +75,12 @@ export const usersRouter = router({
           : Promise.resolve(null),
       ]);
 
+      const getInitialUtmFields = (existingUser?: typeof existingUserByEmail) => ({
+        ...(input.initialUtmSource && !existingUser?.utmSource && { utmSource: input.initialUtmSource }),
+        ...(input.initialUtmCampaign && !existingUser?.utmCampaign && { utmCampaign: input.initialUtmCampaign }),
+        ...(input.initialUtmContent && !existingUser?.utmContent && { utmContent: input.initialUtmContent }),
+      });
+
       if (existingUserByKeycloakIdentifier) {
         // Update last seen timestamp if already exists
         await db.update(userTable, {
@@ -89,6 +95,7 @@ export const usersRouter = router({
         // Adopt the existing user row in this case (by setting `keycloakIdentifier` for next time).
         // Note: Until https://github.com/bluedotimpact/bluedot/issues/2710 is complete, this also covers
         // the case of legacy users who haven't yet been migrated from email -> keycloakIdentifier
+        const isFirstLogin = !existingUserByEmail.keycloakIdentifier;
         await db.update(userTable, {
           id: existingUserByEmail.id,
           ...(sub && { keycloakIdentifier: sub }),
@@ -96,6 +103,7 @@ export const usersRouter = router({
           ...(name && !existingUserByEmail.name && { name }),
           lastSeenAt: new Date().toISOString(),
           firstLoggedInAt: new Date().toISOString(),
+          ...(isFirstLogin && getInitialUtmFields(existingUserByEmail)),
         });
       } else {
         // Create user if doesn't exist
@@ -105,9 +113,7 @@ export const usersRouter = router({
           ...(name && { name }),
           lastSeenAt: new Date().toISOString(),
           firstLoggedInAt: new Date().toISOString(),
-          ...(input.initialUtmSource && { utmSource: input.initialUtmSource }),
-          ...(input.initialUtmCampaign && { utmCampaign: input.initialUtmCampaign }),
-          ...(input.initialUtmContent && { utmContent: input.initialUtmContent }),
+          ...getInitialUtmFields(),
         });
       }
 

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -93,8 +93,6 @@ export const usersRouter = router({
         // If `existingUserByEmail` exists but not `existingUserByKeycloakIdentifier`, that
         // means the user has been created by an Airtable automation, but hasn't logged in yet.
         // Adopt the existing user row in this case (by setting `keycloakIdentifier` for next time).
-        // Note: Until https://github.com/bluedotimpact/bluedot/issues/2710 is complete, this also covers
-        // the case of legacy users who haven't yet been migrated from email -> keycloakIdentifier
         const isFirstLogin = !existingUserByEmail.keycloakIdentifier;
         await db.update(userTable, {
           id: existingUserByEmail.id,


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

A user row is auto-created when a user applies, which led to a bug in how we track initialUtmParams on login: They were attached to completely new user rows, but not to these rows which had been auto-created. This PR fixes that by using whether they have ever logged in as the discriminating condition.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2741

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
