### PR TITLE
Remove stray non-user email reads from website/ code

### DIFF
--- a/apps/website/src/components/my-courses/useCourseListRow.tsx
+++ b/apps/website/src/components/my-courses/useCourseListRow.tsx
@@ -325,7 +325,7 @@ const getParticipantActions = (
     },
     {
       id: 'availability',
-      isVisible: state === 'upcoming' && courseRegistration.decision !== 'Reject',
+      isVisible: state === 'upcoming' && courseRegistration.decision !== 'Reject' && !!courseRegistration.email,
       variant: 'inline',
       inline: (
         <CTALinkOrButton
@@ -451,7 +451,7 @@ const getFacilitatorActions = (
     },
     {
       id: 'availability-facilitator',
-      isVisible: isPending && courseRegistration.decision !== 'Reject',
+      isVisible: isPending && courseRegistration.decision !== 'Reject' && !!courseRegistration.email,
       variant: 'inline',
       inline: (
         <CTALinkOrButton

--- a/apps/website/src/server/routers/facilitators.test.ts
+++ b/apps/website/src/server/routers/facilitators.test.ts
@@ -6,6 +6,7 @@ import {
   meetPersonTable,
   peerFeedbackTable,
   roundTable,
+  userTable,
 } from '@bluedot/db';
 import {
   beforeEach, describe, expect, test, vi,
@@ -329,6 +330,7 @@ describe('facilitators.getFeedbackFormData', () => {
 
     const result = await caller.facilitators.getFeedbackFormData({ meetPersonId: FACILITATOR_ID });
 
+    expect(result.email).toBe('test@example.com');
     expect(result.groupIds).toEqual([GROUP_ID]);
     expect(result.participants.map((p) => p.id).sort()).toEqual([PARTICIPANT_1, PARTICIPANT_2].sort());
     expect(result.dropIns).toEqual([]);
@@ -359,6 +361,32 @@ describe('facilitators.getFeedbackFormData', () => {
 
     await expect(caller.facilitators.getFeedbackFormData({ meetPersonId: 'other-facilitator' }))
       .rejects.toThrow('Not found');
+  });
+
+  test('errors when the facilitator meetPerson has no linked user', async () => {
+    await seedFacilitatorGroup();
+    await testDb.insert(userTable, {
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
+    });
+    await testDb.insert(meetPersonTable, {
+      id: 'unlinked-facilitator',
+      round: ROUND_ID,
+      role: 'Facilitator',
+    });
+    await testDb.insert(groupTable, {
+      id: 'unlinked-group',
+      groupName: 'Unlinked Group',
+      round: ROUND_ID,
+      facilitator: ['unlinked-facilitator'],
+      participants: [PARTICIPANT_1],
+    });
+    const adminCaller = createCaller({
+      ...testAuthContextLoggedIn,
+      auth: { ...testAuthContextLoggedIn.auth!, sub: 'admin-sub' },
+    });
+
+    await expect(adminCaller.facilitators.getFeedbackFormData({ meetPersonId: 'unlinked-facilitator' }))
+      .rejects.toThrow('Facilitator has no linked user');
   });
 
   test('returns drop-ins (attendees not in group.participants)', async () => {

--- a/apps/website/src/server/routers/facilitators.ts
+++ b/apps/website/src/server/routers/facilitators.ts
@@ -328,6 +328,9 @@ export const facilitatorRouter = router({
       const facilitatorUser = meetPerson.userId
         ? await db.getFirst(userTable, { filter: { id: meetPerson.userId }, sortBy: 'id' })
         : null;
+      if (!facilitatorUser) {
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Facilitator has no linked user' });
+      }
 
       const existingCourseFeedback = (meetPerson.courseFeedback ?? []).length > 0
         ? await db.getFirst(courseFeedbackTable, { filter: { id: meetPerson.courseFeedback![0]! }, sortBy: 'id' })
@@ -356,7 +359,7 @@ export const facilitatorRouter = router({
         meetPersonId: meetPerson.id,
         firstName: meetPerson.firstName,
         lastName: meetPerson.lastName,
-        email: facilitatorUser?.email ?? null,
+        email: facilitatorUser.email,
         payForFacilitatedDiscussions: meetPerson.payForFacilitatedDiscussions,
         roundName: round?.title ?? '',
         roundStartDate: round?.startDate ?? null,

--- a/apps/website/src/server/routers/facilitators.ts
+++ b/apps/website/src/server/routers/facilitators.ts
@@ -15,6 +15,7 @@ import {
   peerFeedbackTable,
   roundTable,
   unitTable,
+  userTable,
 } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import z from 'zod';
@@ -324,6 +325,10 @@ export const facilitatorRouter = router({
         ? await db.getFirst(roundTable, { filter: { id: meetPerson.round }, sortBy: 'id' })
         : null;
 
+      const facilitatorUser = meetPerson.userId
+        ? await db.getFirst(userTable, { filter: { id: meetPerson.userId }, sortBy: 'id' })
+        : null;
+
       const existingCourseFeedback = (meetPerson.courseFeedback ?? []).length > 0
         ? await db.getFirst(courseFeedbackTable, { filter: { id: meetPerson.courseFeedback![0]! }, sortBy: 'id' })
         : null;
@@ -351,7 +356,7 @@ export const facilitatorRouter = router({
         meetPersonId: meetPerson.id,
         firstName: meetPerson.firstName,
         lastName: meetPerson.lastName,
-        email: meetPerson.email,
+        email: facilitatorUser?.email ?? null,
         payForFacilitatedDiscussions: meetPerson.payForFacilitatedDiscussions,
         roundName: round?.title ?? '',
         roundStartDate: round?.startDate ?? null,

--- a/apps/website/src/server/routers/my-bluedot.ts
+++ b/apps/website/src/server/routers/my-bluedot.ts
@@ -312,7 +312,7 @@ export const myBluedotRouter = router({
         courseRegistration: {
           id: reg.id,
           courseId: reg.courseId,
-          email: reg.email ?? '',
+          email: '',
           decision: null,
           certificateId: reg.certificateId,
           certificateCreatedAt: reg.certificateCreatedAt,


### PR DESCRIPTION
# Description

Removes the last two `apps/website` reads of `meetPersonTable.email` and `selfServeCourseRegistrationTable.email`, ahead of moving those columns to `deprecatedColumns` as part of the email-as-identifier deprecation. These were missed in #2721 because they aren't used to _look up_ the user.

- `facilitators.getFeedbackFormData` returned `meetPerson.email` to prefill the facilitator invoice form. It now resolves the email from the canonical `user` table via `meetPerson.userId`
- The my-bluedot self-serve (Future of AI) rows forwarded `reg.email` to the frontend. This can only be consumed by the availability-form CTA, which doesn't apply for self-serve registrations. I changed this to return `email: ''` (workaround, to avoid complicated type plumbing). I also left a [comment](https://github.com/bluedotimpact/bluedot/issues/2459#issuecomment-4993161152) on the overarching issue to review how the availability form interacts with the email -> sub change

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2709

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories