### PR TITLE
[fix] Batch tRPC server-error Slack alerts (#2789)

### DIFF
--- a/apps/website/src/pages/api/trpc/[trpc].ts
+++ b/apps/website/src/pages/api/trpc/[trpc].ts
@@ -32,7 +32,7 @@ export default trpcNext.createNextApiHandler({
       `Error: Failed request on route ${path}, type ${type}: ${error.message}`,
       // Stack is sent as response to Slack thread
       `Stack:\n\`\`\`${error.stack}\`\`\``,
-    ]).catch((slackError: unknown) => {
+    ], { batchKey: 'trpc-server-errors' }).catch((slackError: unknown) => {
       logger.error('Failed to send Slack alert:', slackError);
     });
   },

--- a/libraries/utils/src/slackNotifications.test.ts
+++ b/libraries/utils/src/slackNotifications.test.ts
@@ -178,6 +178,28 @@ describe('slackNotifications', () => {
       expect(callBody.text).not.toContain('This error occurred');
     });
 
+    test('should batch messages without record IDs and omit the record clause', async () => {
+      const message = 'Error: Failed request on route users.getUser, type query: The service is temporarily unavailable. Please retry shortly.';
+
+      slackAlert(mockEnv, [message], { batchKey: 'trpc-server-errors', flushIntervalMs: DEFAULT_FLUSH_INTERVAL_MS });
+      slackAlert(mockEnv, [message], { batchKey: 'trpc-server-errors', flushIntervalMs: DEFAULT_FLUSH_INTERVAL_MS });
+      slackAlert(mockEnv, [message], { batchKey: 'trpc-server-errors', flushIntervalMs: DEFAULT_FLUSH_INTERVAL_MS });
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, ts: '1.0' }),
+      });
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_FLUSH_INTERVAL_MS);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      const callBody = JSON.parse(fetchMock.mock.calls[0]?.[1].body);
+      expect(callBody.text).toContain('This error occurred 3 times.');
+      expect(callBody.text).not.toContain('record(s)');
+      expect(callBody.text).not.toContain('affecting');
+    });
+
     test('should preserve first reply in batched messages', async () => {
       const message1 = ['Main error message rec1AbCdEfGhIjKl', 'Stack trace here'];
       const message2 = ['Main error message rec2MnOpQrStUvWx', 'Different stack trace'];

--- a/libraries/utils/src/slackNotifications.ts
+++ b/libraries/utils/src/slackNotifications.ts
@@ -227,12 +227,18 @@ const flushBatcher = async (batcher: BatcherState) => {
     if (batch.occurrences > 1) {
       const tableInfo = batch.tableId ? ` (Table: ${batch.tableId})` : '';
       const fieldInfo = batch.fieldId ? ` (Field: ${batch.fieldId})` : '';
-      const recordList = Array.from(batch.affectedRecords).slice(0, 10).join(', ');
-      const moreRecords = batch.affectedRecords.size > 10 ? ` and ${batch.affectedRecords.size - 10} more` : '';
+      const header = `${mainMessage}${tableInfo}${fieldInfo}\n\n⚠️ This error occurred ${batch.occurrences} times`;
 
-      messages.push(`${mainMessage}${tableInfo}${fieldInfo}\n\n`
-        + `⚠️ This error occurred ${batch.occurrences} times affecting ${batch.affectedRecords.size} record(s):\n`
-        + `${recordList}${moreRecords}`);
+      // Only Airtable-derived warnings carry record IDs; other batched errors
+      // (e.g. tRPC server errors) have none, so drop the record clause for them.
+      if (batch.affectedRecords.size > 0) {
+        const recordList = Array.from(batch.affectedRecords).slice(0, 10).join(', ');
+        const moreRecords = batch.affectedRecords.size > 10 ? ` and ${batch.affectedRecords.size - 10} more` : '';
+
+        messages.push(`${header} affecting ${batch.affectedRecords.size} record(s):\n${recordList}${moreRecords}`);
+      } else {
+        messages.push(`${header}.`);
+      }
     } else {
       messages.push(mainMessage!);
     }


### PR DESCRIPTION
## What

When a tRPC route hits a 5xx (commonly transient Airtable unavailability), `onError` in `apps/website/src/pages/api/trpc/[trpc].ts` fired an individual Slack alert per request, producing a barrage like:

```
website: Error: Failed request on route users.getUser, type query: The service is temporarily unavailable. Please retry shortly.
website: Error: Failed request on route users.getUser, type query: The service is temporarily unavailable. Please retry shortly.
... (x11)
```

Closes #2789.

## Changes

1. **Wire batching at the call site.** Pass `{ batchKey: 'trpc-server-errors' }` to the existing `slackAlert` call. Messages collapse into one Slack post per route+type per flush window (default 60s rolling, 5-min hard cap). `users.getUser` and `users.ensureExists` stay as separate messages, each with its own occurrence count, since the signature keeps the route path.

2. **Generalize the batcher summary.** `flushBatcher` in `libraries/utils/src/slackNotifications.ts` was hardwired to Airtable semantics ("affecting N record(s): rec..."). Route errors have no record IDs, so it now drops the record clause when `affectedRecords` is empty, emitting `This error occurred N times.` instead. The Airtable path is byte-for-byte unchanged when record IDs are present (guarded by the existing test at `slackNotifications.test.ts:154`).

## Deliberately out of scope

- **Multi-replica:** the batcher is in-memory per Node process. `apps/website` runs multiple K8s replicas, so this yields up to one message per pod that served a failing request, not a strict single message. Matches how the existing `pg-sync-service` validation batching works; cross-pod coordination (Redis/db) is overkill for a Slack-noise fix.
- **Spike escalation:** the batcher supports `spikeThreshold`/`escalationChannelId`, but per the issue's DoD this PR only quiets noise. Can be added later if a real outage should still page loudly.
- **Root cause:** this only reduces Slack spam. The underlying transient Airtable 503s on `users.getUser`/`ensureExists` still fail user requests; retry/caching is a separate issue.

## Testing

- `libraries/utils`: 21 tests pass, including a new case asserting a no-record-ID batch reads "occurred N times." with no record clause.
- `apps/website`: full suite, 999 tests pass.
- `tsc --noEmit` and eslint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
