### PR TITLE
Resolve PostHog event emails via the user link instead of per-table email columns

### DIFF
--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -38,9 +38,13 @@ describe('certificate_issued (two source tables)', () => {
     await testDb.insert(courseRegistrationTable, {
       id: 'cr3', courseId: 'c1', email: 'd@x.com', certificateCreatedAt: 1_700_000_500,
     }); // cert timestamp but no certificateId -> loaded, but emits nothing
+    await testDb.insert(userTable, { id: 'u-ss', email: 'c@x.com', name: 'c' });
     await testDb.insert(selfServeCourseRegistrationTable, {
-      id: 'ss1', courseId: 'c2', email: 'c@x.com', certificateId: 'sc1', certificateCreatedAt: 1_700_000_001,
+      id: 'ss1', courseId: 'c2', userId: 'u-ss', certificateId: 'sc1', certificateCreatedAt: 1_700_000_001,
     });
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss2', courseId: 'c2', certificateId: 'sc2', certificateCreatedAt: 1_700_000_002,
+    }); // no linked user -> nothing to attribute to
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog();
@@ -51,8 +55,10 @@ describe('certificate_issued (two source tables)', () => {
     expect(courseReg.distinct_id).toBe('a@x.com');
     expect(courseReg.timestamp).toBe(new Date(1_700_000_000 * 1000).toISOString());
     expect(courseReg.properties).toMatchObject({ course_id: 'c1', round_id: 'rd1' });
-    // self-serve has no round
-    expect(certs.find((e) => e.properties.certificate_id === 'sc1')!.properties).not.toHaveProperty('round_id');
+    // self-serve emails come from the linked user, and self-serve has no round
+    const selfServeCert = certs.find((e) => e.properties.certificate_id === 'sc1')!;
+    expect(selfServeCert.distinct_id).toBe('c@x.com');
+    expect(selfServeCert.properties).not.toHaveProperty('round_id');
   });
 });
 
@@ -294,11 +300,13 @@ describe('discussion_attended / discussion_absent', () => {
     await testDb.insert(unitTable, {
       id: 'u1', courseId: 'c1', courseTitle: 'AGI Strategy', courseSlug: 'agi-strategy', title: 'Intro to AGI', unitNumber: '1', unitStatus: 'Active',
     });
+    await testDb.insert(userTable, { id: 'u-att', email: 'attendee@x.com', name: 'attendee' });
+    await testDb.insert(userTable, { id: 'u-abs', email: 'absentee@x.com', name: 'absentee' });
     await testDb.insert(meetPersonTable, {
-      id: 'mp1', email: 'attendee@x.com', round: 'rd1', numUnits: 8,
+      id: 'mp1', email: 'row@x.com', userId: 'u-att', round: 'rd1', numUnits: 8,
     });
     await testDb.insert(meetPersonTable, {
-      id: 'mp2', email: 'absentee@x.com', round: 'rd1', numUnits: 8,
+      id: 'mp2', userId: 'u-abs', round: 'rd1', numUnits: 8,
     });
   };
 
@@ -368,10 +376,11 @@ describe('discussion_attended / discussion_absent', () => {
   });
 
   test('skips expected participants we cannot resolve an email for', async () => {
-    await testDb.insert(meetPersonTable, { id: 'mp1', email: 'attendee@x.com', round: 'rd1' });
-    await testDb.insert(meetPersonTable, { id: 'noEmail' }); // no email -> skipped
+    await testDb.insert(userTable, { id: 'u-att', email: 'attendee@x.com', name: 'attendee' });
+    await testDb.insert(meetPersonTable, { id: 'mp1', userId: 'u-att', round: 'rd1' });
+    await testDb.insert(meetPersonTable, { id: 'noUser', email: 'unused@x.com' }); // no linked user -> skipped
     await insertDiscussion({
-      id: 'd1', participantsExpected: ['mp1', 'noEmail'], attendees: ['mp1'], startSec: nowSec - 7200, endSec: nowSec - 3600,
+      id: 'd1', participantsExpected: ['mp1', 'noUser'], attendees: ['mp1'], startSec: nowSec - 7200, endSec: nowSec - 3600,
     });
 
     const ph = mockPostHogBackend();
@@ -420,23 +429,27 @@ describe('exercise_completed', () => {
     testDb.insert(exerciseTable, {
       id, courseId: opts.courseId, unitId: opts.unitId, title: opts.title, type: opts.type, status: 'Core',
     });
-  const completeExercise = (id: string, email: string, exerciseId: string, completedAt: string | null) =>
+  const seedUser = (id: string, email: string) => testDb.insert(userTable, { id, email, name: email });
+  const completeExercise = (id: string, userId: string | null, exerciseId: string, completedAt: string | null) =>
     db.pg.insert(exerciseResponsePgTable.pg).values({
-      id, email, exerciseId, response: 'an answer', createdAt: '2026-06-01T00:00:00.000Z', completedAt,
+      id, email: 'row@x.com', exerciseId, response: 'an answer', createdAt: '2026-06-01T00:00:00.000Z', completedAt, userId: userId ? [userId] : null,
     });
 
-  test('emits one event per completed response, enriched with the exercise and course', async () => {
+  test('emits one event per completed response with the linked user\'s email, enriched with the exercise and course', async () => {
     await seedCourse('c1', 'AGI Strategy');
     await seedExercise('ex2', {
       courseId: 'c1', unitId: 'u1', title: 'Quiz', type: 'Multiple choice',
     });
-    await completeExercise('r1', 'a@x.com', 'ex2', '2026-06-10T10:00:00.000Z');
+    await seedUser('u1', 'a@x.com');
+    await completeExercise('r1', 'u1', 'ex2', '2026-06-10T10:00:00.000Z');
+    await completeExercise('r2', null, 'ex2', '2026-06-10T10:00:00.000Z'); // no linked user -> nothing to attribute to
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog();
 
     const events = ph.events.filter((e) => e.event === 'exercise_completed');
     expect(events).toHaveLength(1);
+    // the user's email, not the response row's own email column
     expect(events[0]!.distinct_id).toBe('a@x.com');
     expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
     expect(events[0]!.properties).toMatchObject({
@@ -452,7 +465,8 @@ describe('exercise_completed', () => {
   test('skips responses without a completedAt', async () => {
     await seedCourse('c1', 'AGI Strategy');
     await seedExercise('ex1', { courseId: 'c1' });
-    await completeExercise('r1', 'a@x.com', 'ex1', null);
+    await seedUser('u1', 'a@x.com');
+    await completeExercise('r1', 'u1', 'ex1', null);
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog();
@@ -462,8 +476,10 @@ describe('exercise_completed', () => {
   test('since scans only responses completed on/after it', async () => {
     await seedCourse('c1', 'AGI Strategy');
     await seedExercise('ex1', { courseId: 'c1' });
-    await completeExercise('old', 'old@x.com', 'ex1', '2026-01-01T00:00:00.000Z');
-    await completeExercise('new', 'new@x.com', 'ex1', '2026-06-01T00:00:00.000Z');
+    await seedUser('u-old', 'old@x.com');
+    await seedUser('u-new', 'new@x.com');
+    await completeExercise('old', 'u-old', 'ex1', '2026-01-01T00:00:00.000Z');
+    await completeExercise('new', 'u-new', 'ex1', '2026-06-01T00:00:00.000Z');
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
@@ -474,7 +490,8 @@ describe('exercise_completed', () => {
   test('send-once across runs: a second run re-sends nothing', async () => {
     await seedCourse('c1', 'AGI Strategy');
     await seedExercise('ex1', { courseId: 'c1' });
-    await completeExercise('r1', 'a@x.com', 'ex1', '2026-06-10T10:00:00.000Z');
+    await seedUser('u1', 'a@x.com');
+    await completeExercise('r1', 'u1', 'ex1', '2026-06-10T10:00:00.000Z');
 
     mockPostHogBackend();
     await forwardAllEventsToPostHog();
@@ -500,29 +517,33 @@ describe('resource_completed', () => {
     testDb.insert(unitResourceTable, {
       id, unitId: opts.unitId, resourceName: opts.resourceName, coreFurtherMaybe: opts.coreFurtherMaybe,
     });
+  const seedUser = (id: string, email: string) => testDb.insert(userTable, { id, email, name: email });
   const completeResource = (
-    id: string, email: string | null, unitResourceId: string | null, completedAt: string | null,
+    id: string, userId: string | null, unitResourceId: string | null, completedAt: string | null,
     resourceId?: string,
   ) =>
     db.pg.insert(resourceCompletionPgTable.pg).values({
       id,
-      email,
+      email: 'row@x.com',
+      userId: userId ? [userId] : null,
       unitResourceId,
       resourceId: resourceId ? [resourceId] : null,
       createdAt: '2026-06-01T00:00:00.000Z',
       completedAt,
     });
 
-  test('emits one event per completed resource, enriched with the unit_resource and unit', async () => {
+  test('emits one event per completed resource with the linked user\'s email, enriched with the unit_resource and unit', async () => {
     await seedUnit('u1', { unitNumber: '2', title: 'What is AGI?' });
     await seedUnitResource('ur1', { unitId: 'u1', resourceName: 'The Bitter Lesson', coreFurtherMaybe: 'Core' });
-    await completeResource('rc1', 'a@x.com', 'ur1', '2026-06-10T10:00:00.000Z', 'res1');
+    await seedUser('user1', 'a@x.com');
+    await completeResource('rc1', 'user1', 'ur1', '2026-06-10T10:00:00.000Z', 'res1');
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog();
 
     const events = ph.events.filter((e) => e.event === 'resource_completed');
     expect(events).toHaveLength(1);
+    // the user's email, not the completion row's own email column
     expect(events[0]!.distinct_id).toBe('a@x.com');
     expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
     expect(events[0]!.properties).toMatchObject({
@@ -541,14 +562,15 @@ describe('resource_completed', () => {
 
   test('skips completions without a completedAt', async () => {
     await seedUnitResource('ur1', { unitId: 'u1' });
-    await completeResource('rc1', 'a@x.com', 'ur1', null);
+    await seedUser('user1', 'a@x.com');
+    await completeResource('rc1', 'user1', 'ur1', null);
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog();
     expect(ph.events.filter((e) => e.event === 'resource_completed')).toHaveLength(0);
   });
 
-  test('skips completions without an email (no distinct id to attribute)', async () => {
+  test('skips completions without a linked user (nothing to attribute to)', async () => {
     await seedUnitResource('ur1', { unitId: 'u1' });
     await completeResource('rc1', null, 'ur1', '2026-06-10T10:00:00.000Z');
 
@@ -559,8 +581,10 @@ describe('resource_completed', () => {
 
   test('since scans only completions on/after it', async () => {
     await seedUnitResource('ur1', { unitId: 'u1' });
-    await completeResource('old', 'old@x.com', 'ur1', '2026-01-01T00:00:00.000Z');
-    await completeResource('new', 'new@x.com', 'ur1', '2026-06-01T00:00:00.000Z');
+    await seedUser('u-old', 'old@x.com');
+    await seedUser('u-new', 'new@x.com');
+    await completeResource('old', 'u-old', 'ur1', '2026-01-01T00:00:00.000Z');
+    await completeResource('new', 'u-new', 'ur1', '2026-06-01T00:00:00.000Z');
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
@@ -570,7 +594,8 @@ describe('resource_completed', () => {
 
   test('send-once across runs: a second run re-sends nothing', async () => {
     await seedUnitResource('ur1', { unitId: 'u1' });
-    await completeResource('rc1', 'a@x.com', 'ur1', '2026-06-10T10:00:00.000Z');
+    await seedUser('user1', 'a@x.com');
+    await completeResource('rc1', 'user1', 'ur1', '2026-06-10T10:00:00.000Z');
 
     mockPostHogBackend();
     await forwardAllEventsToPostHog();
@@ -583,7 +608,7 @@ describe('resource_completed', () => {
 
 describe('project_submitted', () => {
   // distinct id (email) and course/round are all resolved via the participant link, not stored on the row:
-  // submission.participant -> meetPerson.email, and meetPerson.applicationsBaseRecordId -> course_registration.
+  // submission.participant -> meetPerson.userId -> user, and meetPerson.applicationsBaseRecordId -> course_registration.
   const seedRegisteredParticipant = async () => {
     await testDb.insert(courseTable, {
       id: 'c1', slug: 'agi-strategy', shortDescription: 'x', title: 'AGI Strategy', units: [], status: 'Active',
@@ -591,7 +616,10 @@ describe('project_submitted', () => {
     await testDb.insert(courseRegistrationTable, {
       id: 'cr1', courseId: 'c1', email: 'a@x.com', roundId: 'rd1', roundName: 'AGI Strategy (2026 Mar W14) - Intensive',
     });
-    await testDb.insert(meetPersonTable, { id: 'mp1', email: 'a@x.com', applicationsBaseRecordId: 'cr1' });
+    await testDb.insert(userTable, { id: 'u1', email: 'a@x.com', name: 'a' });
+    await testDb.insert(meetPersonTable, {
+      id: 'mp1', email: 'row@x.com', userId: 'u1', applicationsBaseRecordId: 'cr1',
+    });
   };
 
   test('emits one event per submission at its createdAt, enriched with course/round via the participant link', async () => {
@@ -622,7 +650,8 @@ describe('project_submitted', () => {
   });
 
   test('emits with email but no course/round when the participant has no registration', async () => {
-    await testDb.insert(meetPersonTable, { id: 'mp2', email: 'solo@x.com' }); // no applicationsBaseRecordId
+    await testDb.insert(userTable, { id: 'u2', email: 'solo@x.com', name: 'solo' });
+    await testDb.insert(meetPersonTable, { id: 'mp2', userId: 'u2' }); // no applicationsBaseRecordId
     await testDb.insert(projectSubmissionTable, {
       id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', link: 'https://example.com/p', participant: ['mp2'],
     });
@@ -639,7 +668,8 @@ describe('project_submitted', () => {
 
   test('group projects fan out: one event per participant, each keyed and attributed separately', async () => {
     await seedRegisteredParticipant(); // mp1 -> a@x.com (course c1, round rd1)
-    await testDb.insert(meetPersonTable, { id: 'mp2', email: 'b@x.com', applicationsBaseRecordId: 'cr1' });
+    await testDb.insert(userTable, { id: 'u2', email: 'b@x.com', name: 'b' });
+    await testDb.insert(meetPersonTable, { id: 'mp2', userId: 'u2', applicationsBaseRecordId: 'cr1' });
     await testDb.insert(projectSubmissionTable, {
       id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', projectTitle: 'Group plan', participant: ['mp1', 'mp2'],
     });
@@ -675,7 +705,8 @@ describe('project_submitted', () => {
     await testDb.insert(projectSubmissionTable, {
       id: 'old', createdAt: '2026-01-01T00:00:00.000Z', participant: ['mp1'],
     });
-    await testDb.insert(meetPersonTable, { id: 'mp2', email: 'new@x.com' });
+    await testDb.insert(userTable, { id: 'u-new', email: 'new@x.com', name: 'new' });
+    await testDb.insert(meetPersonTable, { id: 'mp2', userId: 'u-new' });
     await testDb.insert(projectSubmissionTable, {
       id: 'new', createdAt: '2026-06-01T00:00:00.000Z', participant: ['mp2'],
     });
@@ -845,9 +876,9 @@ describe('identify_applicants', () => {
     db, posthogCredentials: POSTHOG_CREDS, eventProjectionRule: identifyApplicants, since: opts.since, now: '2026-07-01T00:00:00.000Z',
   });
 
-  const seedRegistration = (id: string, email: string, opts: { createdAt?: string; posthogDistinctId?: string } = {}) => (
+  const seedRegistration = (id: string, email: string, opts: { createdAt?: string; posthogDistinctId?: string; userId?: string } = {}) => (
     testDb.insert(courseRegistrationTable, {
-      id, courseId: 'c1', email, createdAt: opts.createdAt ?? '2026-05-01T00:00:00.000Z', posthogDistinctId: opts.posthogDistinctId,
+      id, courseId: 'c1', email, createdAt: opts.createdAt ?? '2026-05-01T00:00:00.000Z', posthogDistinctId: opts.posthogDistinctId, userId: opts.userId,
     })
   );
 
@@ -856,7 +887,7 @@ describe('identify_applicants', () => {
   });
 
   test('a new login joins an application created before `since`', async () => {
-    await seedRegistration('cr1', 'a@x.com', { createdAt: '2026-01-01T00:00:00.000Z', posthogDistinctId: 'anon-1' });
+    await seedRegistration('cr1', 'a@x.com', { createdAt: '2026-01-01T00:00:00.000Z', posthogDistinctId: 'anon-1', userId: 'u1' });
     await seedLoggedInUser('u1', 'a@x.com', { firstLoggedInAt: '2026-06-01T00:00:00.000Z' });
 
     const ph = mockPostHogBackend();
@@ -869,7 +900,7 @@ describe('identify_applicants', () => {
 
   test('a new application joins a user who logged in before `since`', async () => {
     await seedLoggedInUser('u1', 'a@x.com', { firstLoggedInAt: '2026-01-01T00:00:00.000Z' });
-    await seedRegistration('cr1', 'a@x.com', { createdAt: '2026-06-01T00:00:00.000Z', posthogDistinctId: 'anon-1' });
+    await seedRegistration('cr1', 'a@x.com', { createdAt: '2026-06-01T00:00:00.000Z', posthogDistinctId: 'anon-1', userId: 'u1' });
 
     const ph = mockPostHogBackend();
     await runIdentifyApplicants({ since: '2026-03-01T00:00:00.000Z' });
@@ -880,7 +911,7 @@ describe('identify_applicants', () => {
   });
 
   test('anchors on the registration record id when no posthogDistinctId was captured', async () => {
-    await seedRegistration('cr-norec', 'b@x.com');
+    await seedRegistration('cr-norec', 'b@x.com', { userId: 'u1' });
     await seedLoggedInUser('u1', 'b@x.com');
 
     const ph = mockPostHogBackend();
@@ -889,8 +920,9 @@ describe('identify_applicants', () => {
     expect(ph.events.find((e) => e.event === '$identify')!.properties).toMatchObject({ $anon_distinct_id: 'cr-norec' });
   });
 
-  test('no-op when no user has the application email', async () => {
+  test('no-op when the application is not linked to a user', async () => {
     await seedRegistration('cr1', 'orphan@x.com', { posthogDistinctId: 'anon-1' });
+    await seedLoggedInUser('u1', 'orphan@x.com');
 
     const ph = mockPostHogBackend();
     await runIdentifyApplicants();
@@ -898,9 +930,9 @@ describe('identify_applicants', () => {
     expect(ph.events).toHaveLength(0);
   });
 
-  test('no-op when the matching user has never logged in', async () => {
+  test('no-op when the linked user has never logged in', async () => {
     // user rows are created at apply time, before any login — that alone must not trigger a join
-    await seedRegistration('cr1', 'a@x.com', { posthogDistinctId: 'anon-1' });
+    await seedRegistration('cr1', 'a@x.com', { posthogDistinctId: 'anon-1', userId: 'u1' });
     await seedLoggedInUser('u1', 'a@x.com', { firstLoggedInAt: null });
 
     const ph = mockPostHogBackend();
@@ -910,7 +942,7 @@ describe('identify_applicants', () => {
   });
 
   test('each application is joined at most once across runs', async () => {
-    await seedRegistration('cr1', 'a@x.com', { posthogDistinctId: 'anon-1' });
+    await seedRegistration('cr1', 'a@x.com', { posthogDistinctId: 'anon-1', userId: 'u1' });
     await seedLoggedInUser('u1', 'a@x.com');
 
     mockPostHogBackend();
@@ -921,16 +953,16 @@ describe('identify_applicants', () => {
     expect(ph2.events).toHaveLength(0);
   });
 
-  test('earliest login wins when multiple users share an email', async () => {
-    await seedRegistration('cr1', 'shared@x.com', { posthogDistinctId: 'anon-1' });
-    await seedLoggedInUser('u-late', 'shared@x.com', { firstLoggedInAt: '2026-06-01T00:00:00.000Z' });
-    await seedLoggedInUser('u-early', 'shared@x.com', { firstLoggedInAt: '2026-04-01T00:00:00.000Z' });
+  test('joins via userId, not email', async () => {
+    await seedRegistration('cr1', 'old@x.com', { posthogDistinctId: 'anon-1', userId: 'u-linked' });
+    await seedLoggedInUser('u-linked', 'new@x.com');
+    await seedLoggedInUser('u-same-email', 'old@x.com');
 
     const ph = mockPostHogBackend();
     await runIdentifyApplicants();
 
     const identifies = ph.events.filter((e) => e.event === '$identify');
     expect(identifies).toHaveLength(1);
-    expect(identifies[0]!.timestamp).toBe('2026-04-01T00:00:00.000Z'); // the earliest login's timestamp
+    expect(identifies[0]!.distinct_id).toBe('new@x.com');
   });
 });

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -20,6 +20,14 @@ const courseRegistrationAnonDistinctId = (r: Pick<CourseRegistration, 'id' | 'po
   r.posthogDistinctId || r.id
 );
 
+const getEmailByUserId = async (db: PgAirtableDb, userIds: (string | null | undefined)[]): Promise<Map<string, string>> => {
+  const ids = [...new Set(userIds.filter((id): id is string => !!id))];
+  if (ids.length === 0) return new Map();
+  const users = await db.pg.select({ id: userTable.pg.id, email: userTable.pg.email })
+    .from(userTable.pg).where(inArray(userTable.pg.id, ids));
+  return new Map(users.map((u) => [u.id, u.email]));
+};
+
 // Mirrors the my-courses UI (deriveStatus in useDiscussionActions.tsx): a participant is `attended` when
 // their meet_person id is in the discussion's attendees, and `absent` once the discussion has ended without it.
 const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
@@ -38,6 +46,7 @@ const calculateDiscussionAttendanceEvents = async (
   if (meetPersonIds.length === 0) return [];
   const meetPersons = await db.pg.select().from(meetPersonTable.pg).where(inArray(meetPersonTable.pg.id, meetPersonIds));
   const meetPersonById = new Map(meetPersons.map((mp) => [mp.id, mp] as const));
+  const emailByUserId = await getEmailByUserId(db, meetPersons.map((mp) => mp.userId));
 
   const roundIds = [...new Set(meetPersons.map((mp) => mp.round).filter((r): r is string => !!r))];
   const rounds = roundIds.length
@@ -67,12 +76,13 @@ const calculateDiscussionAttendanceEvents = async (
       if (kind === 'attended' ? !isAttended : isAttended) continue;
 
       const meetPerson = meetPersonById.get(meetPersonId);
-      if (!meetPerson?.email) continue;
+      const email = meetPerson?.userId ? emailByUserId.get(meetPerson.userId) : undefined;
+      if (!meetPerson || !email) continue;
       const roundName = meetPerson.round ? roundTitleById.get(meetPerson.round) : undefined;
 
       events.push({
         internalUniqueKey: `${meetPersonId}:${d.id}`,
-        distinctId: meetPerson.email,
+        distinctId: email,
         timestampMs: d.startDateTime * 1000,
         properties: {
           discussion_id: d.id,
@@ -180,22 +190,20 @@ export const eventProjectionRules: EventProjectionRule[] = [
 
       // Load both newly logged in users (which may match an existing registration) and newly created
       // registrations (which may match an existing user).
-      const emails = [...new Set([...newRegistrations, ...newUsers].map((row) => row.email))];
-      if (emails.length === 0) return [];
+      const userIds = [...new Set([
+        ...newRegistrations.map((r) => r.userId).filter((id): id is string => !!id),
+        ...newUsers.map((u) => u.id),
+      ])];
+      if (userIds.length === 0) return [];
       const [registrations, users] = await Promise.all([
-        db.pg.select().from(courseRegistrationTable.pg).where(inArray(courseRegistrationTable.pg.email, emails)),
-        db.pg.select().from(userTable.pg).where(and(isNotNull(userTable.pg.firstLoggedInAt), inArray(userTable.pg.email, emails))),
+        db.pg.select().from(courseRegistrationTable.pg).where(inArray(courseRegistrationTable.pg.userId, userIds)),
+        db.pg.select().from(userTable.pg).where(and(isNotNull(userTable.pg.firstLoggedInAt), inArray(userTable.pg.id, userIds))),
       ]);
 
-      // Earliest login wins when an email maps to multiple users, so the merge target is deterministic.
-      const userByEmail = new Map<string, typeof users[number]>();
-      for (const user of users) {
-        const existing = userByEmail.get(user.email);
-        if (!existing || user.firstLoggedInAt! < existing.firstLoggedInAt!) userByEmail.set(user.email, user);
-      }
+      const userById = new Map(users.map((user) => [user.id, user] as const));
 
       return registrations.flatMap((registration): Event[] => {
-        const user = userByEmail.get(registration.email);
+        const user = registration.userId ? userById.get(registration.userId) : undefined;
         if (!user) return []; // no account yet, the application stays anonymous
 
         return [{
@@ -291,6 +299,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         .where(filterGteOrNull(courseRegistrationTable.pg.certificateCreatedAt, sinceEpochSeconds));
       const selfServe = await db.pg.select().from(selfServeCourseRegistrationTable.pg)
         .where(filterGteOrNull(selfServeCourseRegistrationTable.pg.certificateCreatedAt, sinceEpochSeconds));
+      const emailByUserId = await getEmailByUserId(db, selfServe.map((r) => r.userId));
 
       return [
         ...facilitated.filter((r) => r.certificateId != null).map((r) => {
@@ -312,7 +321,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
           const courseName = courseTitleById.get(r.courseId);
           return {
             internalUniqueKey: `selfServe:${r.id}`,
-            distinctId: r.email,
+            distinctId: (r.userId ? emailByUserId.get(r.userId) : undefined) ?? null,
             timestampMs: Number(r.certificateCreatedAt) * 1000,
             // self-serve has no round
             properties: {
@@ -340,12 +349,13 @@ export const eventProjectionRules: EventProjectionRule[] = [
         .where(filterGteOrNull(exerciseResponsePgTable.pg.completedAt, since)); // completedAt is ISO text
       if (responses.length === 0) return [];
 
-      const [courses, exercises] = await Promise.all([
+      const [courses, exercises, emailByUserId] = await Promise.all([
         db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg),
         db.pg.select({
           id: exerciseTable.pg.id, courseId: exerciseTable.pg.courseId, title: exerciseTable.pg.title,
           type: exerciseTable.pg.type, unitId: exerciseTable.pg.unitId,
         }).from(exerciseTable.pg),
+        getEmailByUserId(db, responses.map((r) => r.userId?.[0])),
       ]);
       const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
       const exerciseById = new Map(exercises.map((e) => [e.id, e]));
@@ -355,7 +365,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = exercise?.courseId ? courseTitleById.get(exercise.courseId) : undefined;
         return {
           internalUniqueKey: r.id,
-          distinctId: r.email,
+          distinctId: (r.userId?.[0] ? emailByUserId.get(r.userId[0]) : undefined) ?? null,
           // Note: completedAt is mutable (can un-complete and re-complete), the event will
           // capture the *first time* we saw the response in a completed state
           timestampMs: Date.parse(r.completedAt!),
@@ -378,7 +388,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         .where(filterGteOrNull(resourceCompletionPgTable.pg.completedAt, since)); // completedAt is ISO text
       if (completions.length === 0) return [];
 
-      const [unitResources, units] = await Promise.all([
+      const [unitResources, units, emailByUserId] = await Promise.all([
         db.pg.select({
           id: unitResourceTable.pg.id, resourceName: unitResourceTable.pg.resourceName,
           unitId: unitResourceTable.pg.unitId, coreFurtherMaybe: unitResourceTable.pg.coreFurtherMaybe,
@@ -387,34 +397,33 @@ export const eventProjectionRules: EventProjectionRule[] = [
           id: unitTable.pg.id, courseId: unitTable.pg.courseId, courseTitle: unitTable.pg.courseTitle,
           courseSlug: unitTable.pg.courseSlug, title: unitTable.pg.title, unitNumber: unitTable.pg.unitNumber,
         }).from(unitTable.pg),
+        getEmailByUserId(db, completions.map((c) => c.userId?.[0])),
       ]);
       const unitResourceById = new Map(unitResources.map((ur) => [ur.id, ur]));
       const unitById = new Map(units.map((u) => [u.id, u]));
 
-      return completions
-        .filter((c) => c.email) // a null distinctId can't be attributed in PostHog
-        .map((c) => {
-          const unitResource = c.unitResourceId ? unitResourceById.get(c.unitResourceId) : undefined;
-          const unit = unitResource?.unitId ? unitById.get(unitResource.unitId) : undefined;
-          const unitNumber = unit ? Number(unit.unitNumber) : null;
-          return {
-            internalUniqueKey: c.id,
-            distinctId: c.email,
-            // Note: completedAt is mutable (can un-complete and re-complete), the event will
-            // capture the *first time* we saw the resource in a completed state
-            timestampMs: Date.parse(c.completedAt!),
-            properties: {
-              ...(c.resourceId?.[0] ? { resource_id: c.resourceId[0] } : {}),
-              ...(c.unitResourceId ? { unit_resource_id: c.unitResourceId } : {}),
-              ...(unitResource?.resourceName ? { resource_name: unitResource.resourceName } : {}),
-              ...(unitResource?.coreFurtherMaybe ? { core_further_maybe: unitResource.coreFurtherMaybe } : {}),
-              ...(unitResource?.unitId ? { unit_id: unitResource.unitId } : {}),
-              ...(unitNumber != null && Number.isFinite(unitNumber) ? { unit_number: unitNumber } : {}),
-              ...(unit?.title ? { unit_name: unit.title } : {}),
-              ...(unit ? { course_id: unit.courseId, course_name: unit.courseTitle, course_slug: unit.courseSlug } : {}),
-            },
-          };
-        });
+      return completions.map((c) => {
+        const unitResource = c.unitResourceId ? unitResourceById.get(c.unitResourceId) : undefined;
+        const unit = unitResource?.unitId ? unitById.get(unitResource.unitId) : undefined;
+        const unitNumber = unit ? Number(unit.unitNumber) : null;
+        return {
+          internalUniqueKey: c.id,
+          distinctId: (c.userId?.[0] ? emailByUserId.get(c.userId[0]) : undefined) ?? null,
+          // Note: completedAt is mutable (can un-complete and re-complete), the event will
+          // capture the *first time* we saw the resource in a completed state
+          timestampMs: Date.parse(c.completedAt!),
+          properties: {
+            ...(c.resourceId?.[0] ? { resource_id: c.resourceId[0] } : {}),
+            ...(c.unitResourceId ? { unit_resource_id: c.unitResourceId } : {}),
+            ...(unitResource?.resourceName ? { resource_name: unitResource.resourceName } : {}),
+            ...(unitResource?.coreFurtherMaybe ? { core_further_maybe: unitResource.coreFurtherMaybe } : {}),
+            ...(unitResource?.unitId ? { unit_id: unitResource.unitId } : {}),
+            ...(unitNumber != null && Number.isFinite(unitNumber) ? { unit_number: unitNumber } : {}),
+            ...(unit?.title ? { unit_name: unit.title } : {}),
+            ...(unit ? { course_id: unit.courseId, course_name: unit.courseTitle, course_slug: unit.courseSlug } : {}),
+          },
+        };
+      });
     },
   },
   {
@@ -426,15 +435,16 @@ export const eventProjectionRules: EventProjectionRule[] = [
       if (submissions.length === 0) return [];
 
       // The form links each submission to a meet_person (participant). The email and the course/round
-      // both come off that link: meetPerson.email is the distinct id; meetPerson.applicationsBaseRecordId
+      // both come off that link: meetPerson.userId -> user gives the email; meetPerson.applicationsBaseRecordId
       // -> course_registration gives the course and round.
       const participantIds = [...new Set(submissions.flatMap((s) => s.participant ?? []))];
       const meetPersons = participantIds.length
         ? await db.pg.select({
-          id: meetPersonTable.pg.id, email: meetPersonTable.pg.email, applicationsBaseRecordId: meetPersonTable.pg.applicationsBaseRecordId,
+          id: meetPersonTable.pg.id, userId: meetPersonTable.pg.userId, applicationsBaseRecordId: meetPersonTable.pg.applicationsBaseRecordId,
         }).from(meetPersonTable.pg).where(inArray(meetPersonTable.pg.id, participantIds))
         : [];
       const meetPersonById = new Map(meetPersons.map((m) => [m.id, m] as const));
+      const emailByUserId = await getEmailByUserId(db, meetPersons.map((m) => m.userId));
 
       const registrationIds = [...new Set(meetPersons.map((m) => m.applicationsBaseRecordId).filter((id): id is string => !!id))];
       const registrations = registrationIds.length
@@ -459,7 +469,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
         return {
           internalUniqueKey: `${s.id}:${participantId}`,
-          distinctId: meetPerson?.email ?? null,
+          distinctId: (meetPerson?.userId ? emailByUserId.get(meetPerson.userId) : undefined) ?? null,
           timestampMs: Date.parse(s.createdAt!),
           properties: {
             ...(registration?.courseId ? { course_id: registration.courseId } : {}),


### PR DESCRIPTION
# Description

Removes reads of `meetPerson.email`, `selfServeCourseRegistration.email`, `exerciseResponse.email`, and `resourceCompletion.email` in `computed-posthog-events`, ahead of moving those columns to `deprecatedColumns`.

Rows with no resolvable user are skipped, as before with rows missing an email. Events are still keyed by email, the `distinct_id` -> Keycloak `sub` migration (#2713) is separate later work. The only email columns still read are `user.email` and `courseRegistration.email` (the application contact field, since applicants may have no account).

## Issue

#2709

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
