### PR TITLE
[chore] Regenerate landing-page hero snapshots after HeroH1 consolidation

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -552,7 +552,7 @@ exports[`AboutPage > should render correctly 1`] = `
             class="flex flex-col gap-6 max-w-[780px]"
           >
             <h1
-              class="bluedot-h1 text-white text-size-xl leading-tight font-normal tracking-tighter text-left"
+              class="bluedot-h1 text-color-text-on-dark text-[40px] md:text-[56px] lg:text-[64px] xl:text-[72px] font-normal tracking-tighter text-left"
             >
               About us
             </h1>

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -552,7 +552,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
             class="flex flex-col gap-6 max-w-[780px]"
           >
             <h1
-              class="bluedot-h1 text-white text-size-xl leading-tight font-normal tracking-tighter text-left"
+              class="bluedot-h1 text-color-text-on-dark text-[40px] md:text-[56px] lg:text-[64px] xl:text-[72px] font-normal tracking-tighter text-left"
             >
               Work with us
             </h1>

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -579,7 +579,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                 COHORT-BASED COURSE
               </p>
               <h1
-                class="bluedot-h1 text-white text-center text-size-xl leading-tight tracking-tighter font-semibold"
+                class="bluedot-h1 text-color-text-on-dark text-center text-[40px] md:text-[56px] lg:text-[64px] xl:text-[72px] tracking-tighter font-semibold"
               >
                 AGI Strategy
               </h1>
@@ -632,7 +632,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                   COHORT-BASED COURSE
                 </p>
                 <h1
-                  class="bluedot-h1 text-white tracking-tighter text-[40px] xl:text-5xl leading-tight font-semibold text-left"
+                  class="bluedot-h1 text-color-text-on-dark md:text-[56px] lg:text-[64px] tracking-tighter text-[40px] xl:text-5xl leading-tight font-semibold text-left"
                 >
                   AGI Strategy
                 </h1>

--- a/apps/website/src/components/lander/components/__snapshots__/HeroSection.test.tsx.snap
+++ b/apps/website/src/components/lander/components/__snapshots__/HeroSection.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`HeroSection > renders correctly (snapshot) 1`] = `
               class="space-y-5 sm:space-y-4"
             >
               <h1
-                class="bluedot-h1 tracking-tighter text-[32px] sm:text-[40px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-left text-bluedot-navy"
+                class="bluedot-h1 md:text-[56px] tracking-tighter text-[32px] sm:text-[40px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-left text-bluedot-navy"
               >
                 AGI Strategy – Learn how to navigate humanity's most critical decade
               </h1>
@@ -99,7 +99,7 @@ exports[`HeroSection > renders gradient variant correctly (snapshot) 1`] = `
                 COHORT-BASED COURSE
               </p>
               <h1
-                class="bluedot-h1 text-white tracking-tighter text-[32px] sm:text-[40px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-left"
+                class="bluedot-h1 text-color-text-on-dark md:text-[56px] tracking-tighter text-[32px] sm:text-[40px] lg:text-[40px] xl:text-5xl leading-tight font-semibold text-left"
               >
                 The Future of AI
               </h1>


### PR DESCRIPTION
# Description

The HeroH1 consolidation in #2790 changed the `<h1>` typography classes (`text-white` → `text-color-text-on-dark`, `text-size-xl` → explicit responsive `text-[40px] md:text-[56px] lg:text-[64px] xl:text-[72px]`) but did not regenerate the landing-page snapshots that render it. As a result these snapshot tests are currently **red on `master`**:

- `HeroSection` (2 snapshots)
- `AgiStrategyLander`
- `about` page
- `join-us` page

This PR just regenerates those 4 snapshot files (`vitest -u`). The diff is entirely `<h1>` className changes matching the new HeroH1 output — no component, markup, or behaviour changes. All 14 tests in the affected files pass after regeneration.

## Issue

<!-- Follow-up cleanup after #2790 -->

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories
