### PR TITLE
Remove writes to `email` fields on `meetPerson` and `selfServeCourseRegistration`, and deprecate them from the schema

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -259,7 +259,6 @@ export const createMockMeetPerson = (overrides: Partial<MeetPerson> = {}): MeetP
   numUnits: null,
   groupsAsParticipant: [],
   autoNumberId: 1,
-  email: 'test@example.com',
   courseFeedbackForm: null,
   courseFeedback: null,
   hasSentInactiveEmail: false,

--- a/apps/website/src/components/courses/AddParticipantModal.test.tsx
+++ b/apps/website/src/components/courses/AddParticipantModal.test.tsx
@@ -29,19 +29,19 @@ async function seed() {
   });
   await testDb.insert(roundTable, { id: ROUND, title: 'Round 1', course: 'rec-course' });
   await testDb.insert(meetPersonTable, {
-    id: FACILITATOR, email: testAuthContextLoggedIn.auth!.email, userId: 'test-user', round: ROUND, role: 'Facilitator',
+    id: FACILITATOR, userId: 'test-user', round: ROUND, role: 'Facilitator',
   });
   await testDb.insert(groupTable, {
     id: GROUP, groupName: 'Group A', round: ROUND, facilitator: [FACILITATOR], participants: [],
   });
   await testDb.insert(meetPersonTable, {
-    id: ALICE, email: 'a@example.com', name: 'Alice Anand', round: ROUND, role: 'Participant',
+    id: ALICE, name: 'Alice Anand', round: ROUND, role: 'Participant',
   });
   await testDb.insert(meetPersonTable, {
-    id: BOB, email: 'b@example.com', name: 'Bob Bryson', round: ROUND, role: 'Participant',
+    id: BOB, name: 'Bob Bryson', round: ROUND, role: 'Participant',
   });
   await testDb.insert(meetPersonTable, {
-    id: CARLA, email: 'c@example.com', name: 'Carla Chen', round: ROUND, role: 'Participant',
+    id: CARLA, name: 'Carla Chen', round: ROUND, role: 'Participant',
   });
 }
 

--- a/apps/website/src/components/courses/ParticipantFeedbackModal.test.tsx
+++ b/apps/website/src/components/courses/ParticipantFeedbackModal.test.tsx
@@ -37,10 +37,10 @@ async function seed() {
   });
   await testDb.insert(roundTable, { id: ROUND, title: 'Round 1', course: 'rec-course' });
   await testDb.insert(meetPersonTable, {
-    id: FACILITATOR, email: testAuthContextLoggedIn.auth!.email, userId: 'test-user', round: ROUND, role: 'Facilitator',
+    id: FACILITATOR, userId: 'test-user', round: ROUND, role: 'Facilitator',
   });
   await testDb.insert(meetPersonTable, {
-    id: ALICE, email: 'a@example.com', name: 'Alice Anand', round: ROUND, role: 'Participant',
+    id: ALICE, name: 'Alice Anand', round: ROUND, role: 'Participant',
   });
   await testDb.insert(groupTable, {
     id: GROUP, groupName: 'Group A', round: ROUND, facilitator: [FACILITATOR], participants: [ALICE],

--- a/apps/website/src/components/my-courses/CourseListRow.test.tsx
+++ b/apps/website/src/components/my-courses/CourseListRow.test.tsx
@@ -784,7 +784,7 @@ describe('CourseListRow modal pre-fill (real tRPC via PGlite)', () => {
   const seedFacilitator = async () => {
     await testDb.insert(userTable, { id: 'user-1', email: AUTH_EMAIL, name: 'Test User' });
     await testDb.insert(meetPersonTable, {
-      id: 'mp-fac', email: AUTH_EMAIL, userId: 'user-1', round: ROUND, role: 'Facilitator', expectedDiscussionsFacilitator: [],
+      id: 'mp-fac', userId: 'user-1', round: ROUND, role: 'Facilitator', expectedDiscussionsFacilitator: [],
     });
   };
 
@@ -795,7 +795,7 @@ describe('CourseListRow modal pre-fill (real tRPC via PGlite)', () => {
     });
     await testDb.insert(roundTable, { id: ROUND, title: 'Round 1', course: COURSE_ID });
     await testDb.insert(meetPersonTable, {
-      id: 'mp-part', email: AUTH_EMAIL, round: ROUND, role: 'Participant',
+      id: 'mp-part', round: ROUND, role: 'Participant',
     });
   };
 

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -120,7 +120,7 @@ describe('certificates.verifyOwnership', () => {
 
   test('returns { isOwner: true } when the self-serve registration userId matches the caller', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
-      id: 'ss-reg-1', email: 'test@example.com', userId: 'test-user', courseId: FOAI_COURSE_ID, certificateId: 'cert-ss',
+      id: 'ss-reg-1', userId: 'test-user', courseId: FOAI_COURSE_ID, certificateId: 'cert-ss',
     });
 
     const result = await createCaller(testAuthContextLoggedIn)
@@ -192,7 +192,6 @@ describe('certificates.getStatus', () => {
     });
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'reg1',
-      email: 'test@example.com',
       userId: 'test-user',
       courseId: FOAI_COURSE_ID,
       certificateId: 'cert-1',
@@ -223,7 +222,6 @@ describe('certificates.getStatus', () => {
     });
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'reg1',
-      email: 'test@example.com',
       userId: 'test-user',
       courseId: FOAI_COURSE_ID,
       certificateId: 'cert-1',
@@ -236,7 +234,7 @@ describe('certificates.getStatus', () => {
 
   test('returns exercises-incomplete for FOAI registrations without a certificate', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
-      id: 'ss-reg-foai', email: 'test@example.com', userId: 'test-user', courseId: FOAI_COURSE_ID,
+      id: 'ss-reg-foai', userId: 'test-user', courseId: FOAI_COURSE_ID,
     });
 
     const result = await createCaller(testAuthContextLoggedIn).certificates.getStatus({ courseId: FOAI_COURSE_ID });
@@ -352,7 +350,7 @@ describe('issueFoaiCertificateIfComplete', () => {
 
   test('issues the certificate on the self-serve row only', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
-      id: 'ss-1', email: 'test@example.com', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+      id: 'ss-1', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
     });
     await testDb.insert(courseRegistrationTable, {
       id: 'reg-foai', email: 'test@example.com', userId: 'test-user', courseId: FOAI_COURSE_ID, decision: 'Accept',
@@ -399,7 +397,7 @@ describe('issueFoaiCertificateIfComplete', () => {
 
   test('issues the certificate even when a Further or Maybe exercise is incomplete', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
-      id: 'ss-1', email: 'test@example.com', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+      id: 'ss-1', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
     });
     await testDb.insert(exerciseTable, {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Required', exerciseNumber: '1',
@@ -424,7 +422,7 @@ describe('issueFoaiCertificateIfComplete', () => {
 
   test('does not issue the certificate while a Core exercise is incomplete, and issues once it is completed', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
-      id: 'ss-1', email: 'test@example.com', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+      id: 'ss-1', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
     });
     await testDb.insert(exerciseTable, {
       id: 'foai-ex-core', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Core', exerciseNumber: '1',

--- a/apps/website/src/server/routers/course-registrations.test.ts
+++ b/apps/website/src/server/routers/course-registrations.test.ts
@@ -132,7 +132,7 @@ describe('courseRegistrations.getRoundStartDates', () => {
 describe('courseRegistrations self-serve aliases', () => {
   test('ensureExists and ensureSelfServeRegistrationExists both return the self-serve registration', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
-      id: 'ss-foai', email: 'test@example.com', userId: 'test-user', courseId: FOAI_COURSE_ID,
+      id: 'ss-foai', userId: 'test-user', courseId: FOAI_COURSE_ID,
     });
     const caller = createCaller(testAuthContextLoggedIn);
 

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -59,14 +59,12 @@ async function seedFacilitatorFlow() {
 
   await testDb.insert(meetPersonTable, {
     id: 'meet-facilitator',
-    email: CALLER_EMAIL,
     applicationsBaseRecordId: 'reg-facilitator',
     role: 'Facilitator',
   });
 
   await testDb.insert(meetPersonTable, {
     id: 'meet-participant',
-    email: 'participant@example.com',
     userId: 'up-user',
     name: 'Alice',
     role: 'Participant',
@@ -188,7 +186,6 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
   async function seedFoaiRegistration() {
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss-foai',
-      email: CALLER_EMAIL,
       userId: 'test-user',
       courseId: FOAI_COURSE_ID,
     });
@@ -268,7 +265,6 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
   test('is a no-op when the certificate is already issued', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss-foai',
-      email: CALLER_EMAIL,
       userId: 'test-user',
       courseId: FOAI_COURSE_ID,
       certificateId: 'ss-foai',
@@ -363,11 +359,10 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: 'meet-facilitator',
-      email: CALLER_EMAIL,
       applicationsBaseRecordId: 'reg-1',
       role: 'Facilitator',
     });
-    await testDb.insert(meetPersonTable, { id: 'meet-participant', email: 'participant@example.com', name: 'Alice' });
+    await testDb.insert(meetPersonTable, { id: 'meet-participant', name: 'Alice' });
     await testDb.insert(groupTable, {
       id: 'group-1',
       facilitator: ['meet-facilitator'],
@@ -395,11 +390,10 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: 'meet-facilitator',
-      email: CALLER_EMAIL,
       applicationsBaseRecordId: 'reg-1',
       role: 'Facilitator',
     });
-    await testDb.insert(meetPersonTable, { id: 'meet-participant', email: 'participant@example.com', name: 'Alice' });
+    await testDb.insert(meetPersonTable, { id: 'meet-participant', name: 'Alice' });
     await testDb.insert(groupTable, {
       id: 'group-1',
       facilitator: ['meet-facilitator'],
@@ -445,12 +439,11 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: 'meet-facilitator',
-      email: CALLER_EMAIL,
       applicationsBaseRecordId: 'reg-1',
       role: 'Facilitator',
     });
     await testDb.insert(meetPersonTable, {
-      id: 'meet-participant', email: 'participant@example.com', userId: 'up-user', name: 'Alice',
+      id: 'meet-participant', userId: 'up-user', name: 'Alice',
     });
     await testDb.insert(groupTable, {
       id: 'group-1',
@@ -480,7 +473,6 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: 'meet-1',
-      email: CALLER_EMAIL,
       applicationsBaseRecordId: 'reg-1',
       role: 'Participant',
     });
@@ -565,13 +557,11 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: 'meet-facilitator',
-      email: CALLER_EMAIL,
       applicationsBaseRecordId: 'reg-facilitator',
       role: 'Facilitator',
     });
     await testDb.insert(meetPersonTable, {
       id: 'meet-participant',
-      email: 'noname@example.com',
       userId: 'noname-user',
       name: null,
       role: 'Participant',
@@ -618,13 +608,12 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: `meet-facilitator-${suffix}`,
-      email: CALLER_EMAIL,
       applicationsBaseRecordId: `reg-${suffix}`,
       role: 'Facilitator',
       round: `round-${suffix}`,
     });
     await testDb.insert(meetPersonTable, {
-      id: `meet-participant-${suffix}`, email: `${suffix}@example.com`, userId: `user-${suffix}`, name: `Participant ${suffix}`,
+      id: `meet-participant-${suffix}`, userId: `user-${suffix}`, name: `Participant ${suffix}`,
     });
     await testDb.insert(groupTable, {
       id: `group-${suffix}`,
@@ -696,7 +685,6 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: 'meet-self-as-participant',
-      email: CALLER_EMAIL,
       applicationsBaseRecordId: 'reg-new',
       role: 'Participant',
     });

--- a/apps/website/src/server/routers/facilitator-applications.test.ts
+++ b/apps/website/src/server/routers/facilitator-applications.test.ts
@@ -67,7 +67,6 @@ const seedDiscussion = (id: string, endDateTime: number) =>
 const seedMeetPerson = (id: string, applicationsBaseRecordId: string, expectedDiscussionsFacilitator: string[]) =>
   testDb.insert(meetPersonTable, {
     id,
-    email: CALLER_EMAIL,
     userId: 'test-user',
     applicationsBaseRecordId,
     role: 'Facilitator',

--- a/apps/website/src/server/routers/facilitators.test.ts
+++ b/apps/website/src/server/routers/facilitators.test.ts
@@ -28,7 +28,6 @@ vi.mock('../airtableFieldOptions', () => ({
 setupTestDb();
 beforeEach(seedLoggedInUser);
 
-const FACILITATOR_EMAIL = 'test@example.com';
 const FACILITATOR_ID = 'facilitator-1';
 const PARTICIPANT_1 = 'participant-1';
 const PARTICIPANT_2 = 'participant-2';
@@ -57,26 +56,22 @@ async function seedFacilitatorGroup() {
   });
   await testDb.insert(meetPersonTable, {
     id: FACILITATOR_ID,
-    email: FACILITATOR_EMAIL,
     userId: 'test-user',
     round: ROUND_ID,
     role: 'Facilitator',
   });
   await testDb.insert(meetPersonTable, {
     id: PARTICIPANT_1,
-    email: 'p1@example.com',
     round: ROUND_ID,
     role: 'Participant',
   });
   await testDb.insert(meetPersonTable, {
     id: PARTICIPANT_2,
-    email: 'p2@example.com',
     round: ROUND_ID,
     role: 'Participant',
   });
   await testDb.insert(meetPersonTable, {
     id: OUTSIDER,
-    email: 'outsider@example.com',
     round: ROUND_ID,
     role: 'Participant',
   });
@@ -93,7 +88,6 @@ async function seedFacilitatorGroup() {
 async function seedSecondGroup() {
   await testDb.insert(meetPersonTable, {
     id: PARTICIPANT_3,
-    email: 'p3@example.com',
     round: ROUND_ID,
     role: 'Participant',
   });
@@ -109,7 +103,6 @@ async function seedSecondGroup() {
 async function seedDropIn() {
   await testDb.insert(meetPersonTable, {
     id: DROP_IN,
-    email: 'dropin@example.com',
     name: 'Drop In',
     round: ROUND_ID,
     role: 'Participant',
@@ -236,7 +229,6 @@ describe('facilitators.savePeerFeedback', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'other-round-participant',
-      email: 'other-round@example.com',
       round: 'different-round',
       role: 'Participant',
     });
@@ -271,7 +263,6 @@ describe('facilitators.savePeerFeedback', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'participant-self',
-      email: FACILITATOR_EMAIL,
       userId: 'test-user',
       round: ROUND_ID,
       role: 'Participant',
@@ -287,7 +278,6 @@ describe('facilitators.savePeerFeedback', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'other-facilitator',
-      email: 'other@example.com',
       userId: 'user-other',
       round: ROUND_ID,
       role: 'Facilitator',
@@ -303,7 +293,6 @@ describe('facilitators.savePeerFeedback', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'unlinked-facilitator',
-      email: FACILITATOR_EMAIL,
       round: ROUND_ID,
       role: 'Facilitator',
     });
@@ -353,7 +342,6 @@ describe('facilitators.getFeedbackFormData', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'other-facilitator',
-      email: 'other@example.com',
       userId: 'user-other',
       round: ROUND_ID,
       role: 'Facilitator',
@@ -416,7 +404,6 @@ describe('facilitators.getFeedbackFormData', () => {
     await seedDropIn();
     await testDb.insert(meetPersonTable, {
       id: DROP_IN_2,
-      email: 'dropin2@example.com',
       name: 'Drop In Two',
       round: ROUND_ID,
       role: 'Participant',
@@ -440,7 +427,6 @@ describe('facilitators.getFeedbackFormData', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'co-facilitator',
-      email: 'co@example.com',
       name: 'Co Facilitator',
       round: ROUND_ID,
       role: 'Facilitator',
@@ -470,14 +456,12 @@ describe('facilitators.searchAddableParticipants', () => {
     await seedDropIn();
     await testDb.insert(meetPersonTable, {
       id: 'co-facilitator',
-      email: 'co@example.com',
       name: 'Co Facilitator',
       round: ROUND_ID,
       role: 'Facilitator',
     });
     await testDb.insert(meetPersonTable, {
       id: 'other-round-participant',
-      email: 'otherround@example.com',
       name: 'Other Round',
       round: 'different-round',
       role: 'Participant',
@@ -504,14 +488,12 @@ describe('facilitators.searchAddableParticipants', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'alice',
-      email: 'alice@example.com',
       name: 'Alice Adams',
       round: ROUND_ID,
       role: 'Participant',
     });
     await testDb.insert(meetPersonTable, {
       id: 'bob',
-      email: 'bob@example.com',
       name: 'Bob Baker',
       round: ROUND_ID,
       role: 'Participant',
@@ -530,7 +512,6 @@ describe('facilitators.getFacilitatorsForRound', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'other-facilitator',
-      email: 'other@example.com',
       name: 'Other Facilitator',
       userId: 'user-other',
       round: ROUND_ID,
@@ -546,7 +527,6 @@ describe('facilitators.getFacilitatorsForRound', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'unlinked-facilitator',
-      email: FACILITATOR_EMAIL,
       round: 'round-2',
       role: 'Facilitator',
     });
@@ -599,7 +579,6 @@ describe('facilitators.submitFeedback', () => {
     await seedFacilitatorGroup();
     await testDb.insert(meetPersonTable, {
       id: 'participant-self',
-      email: FACILITATOR_EMAIL,
       userId: 'test-user',
       round: ROUND_ID,
       role: 'Participant',

--- a/apps/website/src/server/routers/group-discussions.test.ts
+++ b/apps/website/src/server/routers/group-discussions.test.ts
@@ -48,7 +48,6 @@ describe('groupDiscussions.getByCourseSlug', () => {
 
     await testDb.insert(meetPersonTable, {
       id: 'facilitator-1',
-      email: CALLER_EMAIL,
       applicationsBaseRecordId: 'reg-1',
       round: 'round-without-discussion',
       role: 'Facilitator',

--- a/apps/website/src/server/routers/group-switching.test.ts
+++ b/apps/website/src/server/routers/group-switching.test.ts
@@ -442,7 +442,6 @@ async function seedCourseWithGroups() {
 
   await testDb.insert(meetPersonTable, {
     id: 'participant-1',
-    email: 'test@example.com',
     userId: 'test-user',
     applicationsBaseRecordId: 'reg-1',
     round: 'round-1',
@@ -604,7 +603,6 @@ describe('groupSwitching.discussionsAvailable', () => {
 
     await testDb.insert(meetPersonTable, {
       id: 'participant-1',
-      email: 'test@example.com',
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-1',
       round: 'round-1',
@@ -682,7 +680,6 @@ describe('groupSwitching.discussionsAvailable', () => {
 
     await testDb.insert(meetPersonTable, {
       id: 'participant-1',
-      email: 'test@example.com',
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-1',
       round: 'round-1',
@@ -780,7 +777,6 @@ describe('groupSwitching.discussionsAvailable', () => {
 
     await testDb.insert(meetPersonTable, {
       id: 'participant-1',
-      email: 'test@example.com',
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-1',
       round: 'round-1',
@@ -887,7 +883,6 @@ describe('groupSwitching.discussionsAvailable', () => {
 
     await testDb.insert(meetPersonTable, {
       id: 'participant-1',
-      email: 'test@example.com',
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-1',
       round: 'round-1',

--- a/apps/website/src/server/routers/meet-person.test.ts
+++ b/apps/website/src/server/routers/meet-person.test.ts
@@ -13,7 +13,6 @@ import {
 setupTestDb();
 
 const caller = createCaller(testAuthContextLoggedIn);
-const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;
 
 // The authenticated user's row is assumed to exist by the userId-scoped routes.
 beforeEach(async () => {
@@ -29,7 +28,6 @@ describe('meetPerson.getGroupParticipants', () => {
   test('throws NOT_FOUND when caller is not a member of the group', async () => {
     await testDb.insert(meetPersonTable, {
       id: 'mp-someone-else',
-      email: 'someone-else@example.com',
       applicationsBaseRecordId: 'reg-someone-else',
       round: 'round-1',
       role: 'Participant',
@@ -49,7 +47,6 @@ describe('meetPerson.getGroupParticipants', () => {
   test('returns facilitators + co-participants, sorted alphabetically, excluding the caller (participant caller)', async () => {
     await testDb.insert(meetPersonTable, {
       id: 'mp-me',
-      email: CALLER_EMAIL,
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-me',
       round: 'round-1',
@@ -57,16 +54,16 @@ describe('meetPerson.getGroupParticipants', () => {
       groupsAsParticipant: ['group-1'],
     });
     await testDb.insert(meetPersonTable, {
-      id: 'mp-fac-zara', email: 'zara-fac@example.com', applicationsBaseRecordId: 'reg-fac-zara', round: 'round-1', role: 'Facilitator', name: 'Zara Facilitator',
+      id: 'mp-fac-zara', applicationsBaseRecordId: 'reg-fac-zara', round: 'round-1', role: 'Facilitator', name: 'Zara Facilitator',
     });
     await testDb.insert(meetPersonTable, {
-      id: 'mp-fac-alice', email: 'alice-fac@example.com', applicationsBaseRecordId: 'reg-fac-alice', round: 'round-1', role: 'Facilitator', name: 'Alice Facilitator',
+      id: 'mp-fac-alice', applicationsBaseRecordId: 'reg-fac-alice', round: 'round-1', role: 'Facilitator', name: 'Alice Facilitator',
     });
     await testDb.insert(meetPersonTable, {
-      id: 'mp-p-bob', email: 'bob@example.com', applicationsBaseRecordId: 'reg-p-bob', round: 'round-1', role: 'Participant', name: 'Bob Participant',
+      id: 'mp-p-bob', applicationsBaseRecordId: 'reg-p-bob', round: 'round-1', role: 'Participant', name: 'Bob Participant',
     });
     await testDb.insert(meetPersonTable, {
-      id: 'mp-p-yara', email: 'yara@example.com', applicationsBaseRecordId: 'reg-p-yara', round: 'round-1', role: 'Participant', name: 'Yara Participant',
+      id: 'mp-p-yara', applicationsBaseRecordId: 'reg-p-yara', round: 'round-1', role: 'Participant', name: 'Yara Participant',
     });
 
     await testDb.insert(groupTable, {
@@ -86,7 +83,6 @@ describe('meetPerson.getGroupParticipants', () => {
   test('authorizes facilitator caller via group.facilitator membership', async () => {
     await testDb.insert(meetPersonTable, {
       id: 'mp-me-fac',
-      email: CALLER_EMAIL,
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-me-fac',
       round: 'round-1',
@@ -94,7 +90,7 @@ describe('meetPerson.getGroupParticipants', () => {
       // No groupsAsParticipant
     });
     await testDb.insert(meetPersonTable, {
-      id: 'mp-p-bob', email: 'bob@example.com', applicationsBaseRecordId: 'reg-p-bob', round: 'round-1', role: 'Participant', name: 'Bob Participant',
+      id: 'mp-p-bob', applicationsBaseRecordId: 'reg-p-bob', round: 'round-1', role: 'Participant', name: 'Bob Participant',
     });
 
     await testDb.insert(groupTable, {

--- a/apps/website/src/server/routers/my-bluedot.test.ts
+++ b/apps/website/src/server/routers/my-bluedot.test.ts
@@ -84,7 +84,6 @@ describe('myCoursesPage.getOverview', () => {
 
     await testDb.insert(meetPersonTable, {
       id: 'mp-p',
-      email: CALLER_EMAIL,
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-p',
       round: 'round-p',
@@ -94,7 +93,6 @@ describe('myCoursesPage.getOverview', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: 'mp-f',
-      email: CALLER_EMAIL,
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-f',
       round: 'round-f',
@@ -194,7 +192,6 @@ describe('myCoursesPage.getOverview', () => {
 
     await testDb.insert(meetPersonTable, {
       id: 'mp-active',
-      email: CALLER_EMAIL,
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-active',
       round: 'round-active',
@@ -204,7 +201,6 @@ describe('myCoursesPage.getOverview', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: 'mp-dropped',
-      email: CALLER_EMAIL,
       userId: 'test-user',
       applicationsBaseRecordId: 'reg-dropped',
       round: 'round-dropped',
@@ -339,7 +335,6 @@ describe('myCoursesPage.getOverview', () => {
 
       await testDb.insert(meetPersonTable, {
         id: 'mp-dropped',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         applicationsBaseRecordId: 'reg-dropped',
         round: 'round-dropped',
@@ -388,7 +383,6 @@ describe('myCoursesPage.getOverview', () => {
 
       await testDb.insert(meetPersonTable, {
         id: 'mp-self',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         applicationsBaseRecordId: 'reg-1',
         round: 'round-1',
@@ -398,13 +392,13 @@ describe('myCoursesPage.getOverview', () => {
       });
       // Three facilitators on the group: two with usable names, one with both names blank.
       await testDb.insert(meetPersonTable, {
-        id: 'fac-full', email: 'fac-full@example.com', firstName: 'Full', lastName: 'Name', role: 'Facilitator',
+        id: 'fac-full', firstName: 'Full', lastName: 'Name', role: 'Facilitator',
       });
       await testDb.insert(meetPersonTable, {
-        id: 'fac-first-only', email: 'fac-first-only@example.com', firstName: 'Firstonly', lastName: null, role: 'Facilitator',
+        id: 'fac-first-only', firstName: 'Firstonly', lastName: null, role: 'Facilitator',
       });
       await testDb.insert(meetPersonTable, {
-        id: 'fac-blank', email: 'fac-blank@example.com', firstName: '', lastName: '', role: 'Facilitator',
+        id: 'fac-blank', firstName: '', lastName: '', role: 'Facilitator',
       });
       await testDb.insert(groupTable, {
         id: 'group-1',
@@ -425,7 +419,6 @@ describe('myCoursesPage.getOverview', () => {
 
       await testDb.insert(meetPersonTable, {
         id: 'mp-1',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         applicationsBaseRecordId: 'reg-1',
         round: 'round-1',
@@ -463,7 +456,6 @@ describe('myCoursesPage.getOverview', () => {
 
       await testDb.insert(meetPersonTable, {
         id: 'mp-1',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         applicationsBaseRecordId: 'reg-1',
         round: 'round-1',
@@ -506,7 +498,6 @@ describe('myCoursesPage.getOverview', () => {
 
       await testDb.insert(meetPersonTable, {
         id: 'mp-x',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         applicationsBaseRecordId: 'reg-x',
         round: 'round-x',
@@ -516,7 +507,6 @@ describe('myCoursesPage.getOverview', () => {
       });
       await testDb.insert(meetPersonTable, {
         id: 'mp-y',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         applicationsBaseRecordId: 'reg-y',
         round: 'round-y',
@@ -566,7 +556,6 @@ describe('myCoursesPage.getOverview', () => {
 
       await testDb.insert(meetPersonTable, {
         id: 'mp-x',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         applicationsBaseRecordId: 'reg-x',
         round: 'round-x',
@@ -576,7 +565,6 @@ describe('myCoursesPage.getOverview', () => {
       });
       await testDb.insert(meetPersonTable, {
         id: 'mp-y',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         applicationsBaseRecordId: 'reg-y',
         round: 'round-y',
@@ -652,7 +640,6 @@ describe('myCoursesPage.getOverview', () => {
       await seedFoaiCourse();
       await testDb.insert(selfServeCourseRegistrationTable, {
         id: 'ss-foai',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         courseId: FOAI_COURSE_ID,
         certificateId: 'ss-foai',
@@ -681,7 +668,6 @@ describe('myCoursesPage.getOverview', () => {
       await seedFoaiCourse();
       await testDb.insert(selfServeCourseRegistrationTable, {
         id: 'ss-foai',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         courseId: FOAI_COURSE_ID,
       });
@@ -703,7 +689,6 @@ describe('myCoursesPage.getOverview', () => {
       });
       await testDb.insert(selfServeCourseRegistrationTable, {
         id: 'ss-foai',
-        email: CALLER_EMAIL,
         userId: 'test-user',
         courseId: FOAI_COURSE_ID,
       });
@@ -876,7 +861,6 @@ describe('myBluedot.facilitatedCoursesPage', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: MEET_PERSON_ID,
-      email: CALLER_EMAIL,
       userId: 'test-user',
       applicationsBaseRecordId: REG_ID,
       round: ROUND_ID,
@@ -1097,7 +1081,6 @@ describe('myBluedot.facilitatedCoursesPage', () => {
     });
     await testDb.insert(meetPersonTable, {
       id: MEET_PERSON_ID,
-      email: CALLER_EMAIL,
       userId: 'test-user',
       applicationsBaseRecordId: REG_ID,
       round: ROUND_ID,

--- a/apps/website/src/server/routers/self-serve-course-registrations.test.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.test.ts
@@ -25,7 +25,7 @@ describe('selfServeCourseRegistrations.ensureExists', () => {
   test('returns the existing self-serve registration', async () => {
     await seedLoggedInUser();
     await testDb.insert(selfServeCourseRegistrationTable, {
-      id: 'ss-foai', email: 'test@example.com', userId: 'test-user', courseId: FOAI_COURSE_ID,
+      id: 'ss-foai', userId: 'test-user', courseId: FOAI_COURSE_ID,
     });
 
     const result = await createCaller(testAuthContextLoggedIn)

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -303,7 +303,7 @@ describe('discussion_attended / discussion_absent', () => {
     await testDb.insert(userTable, { id: 'u-att', email: 'attendee@x.com', name: 'attendee' });
     await testDb.insert(userTable, { id: 'u-abs', email: 'absentee@x.com', name: 'absentee' });
     await testDb.insert(meetPersonTable, {
-      id: 'mp1', email: 'row@x.com', userId: 'u-att', round: 'rd1', numUnits: 8,
+      id: 'mp1', userId: 'u-att', round: 'rd1', numUnits: 8,
     });
     await testDb.insert(meetPersonTable, {
       id: 'mp2', userId: 'u-abs', round: 'rd1', numUnits: 8,
@@ -378,7 +378,7 @@ describe('discussion_attended / discussion_absent', () => {
   test('skips expected participants we cannot resolve an email for', async () => {
     await testDb.insert(userTable, { id: 'u-att', email: 'attendee@x.com', name: 'attendee' });
     await testDb.insert(meetPersonTable, { id: 'mp1', userId: 'u-att', round: 'rd1' });
-    await testDb.insert(meetPersonTable, { id: 'noUser', email: 'unused@x.com' }); // no linked user -> skipped
+    await testDb.insert(meetPersonTable, { id: 'noUser' }); // no linked user -> skipped
     await insertDiscussion({
       id: 'd1', participantsExpected: ['mp1', 'noUser'], attendees: ['mp1'], startSec: nowSec - 7200, endSec: nowSec - 3600,
     });
@@ -618,7 +618,7 @@ describe('project_submitted', () => {
     });
     await testDb.insert(userTable, { id: 'u1', email: 'a@x.com', name: 'a' });
     await testDb.insert(meetPersonTable, {
-      id: 'mp1', email: 'row@x.com', userId: 'u1', applicationsBaseRecordId: 'cr1',
+      id: 'mp1', userId: 'u1', applicationsBaseRecordId: 'cr1',
     });
   };
 

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -484,10 +484,6 @@ export const meetPersonTable = pgAirtable('meet_person', {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fldRtqMTFX50uqLw5',
     },
-    email: {
-      pgColumn: text(),
-      airtableId: 'fld9BqZjF67r9Ce6O',
-    },
     numUnits: {
       pgColumn: numeric({ mode: 'number' }),
       airtableId: 'fld1ICMPmCd5y7B17',
@@ -522,6 +518,13 @@ export const meetPersonTable = pgAirtable('meet_person', {
     slackProfileUrl: {
       pgColumn: text(),
       airtableId: 'fldGhn89JZWlISRvc',
+    },
+  },
+  deprecatedColumns: {
+    email: {
+      pgColumn: text(),
+      airtableId: 'fld9BqZjF67r9Ce6O',
+      deprecated: true,
     },
   },
 });
@@ -1432,10 +1435,6 @@ export const selfServeCourseRegistrationTable = pgAirtable('self_serve_course_re
   baseId: APPLICATIONS_BASE_ID,
   tableId: 'tbla338CpAd0FF96g',
   columns: {
-    email: {
-      pgColumn: text(),
-      airtableId: 'fldlSug1fEym6YizF',
-    },
     userId: {
       pgColumn: text(),
       airtableId: 'fldjByk8yK33Wslqs',
@@ -1468,6 +1467,13 @@ export const selfServeCourseRegistrationTable = pgAirtable('self_serve_course_re
     createdAt: {
       pgColumn: text(),
       airtableId: 'fldRiPmXA2UB9M9j5',
+    },
+  },
+  deprecatedColumns: {
+    email: {
+      pgColumn: text(),
+      airtableId: 'fldlSug1fEym6YizF',
+      deprecated: true,
     },
   },
 });


### PR DESCRIPTION
# Description

More cleanup following the migration from email to `keycloakIdentifier` as the primary identifier for users. All reads of non-authoritative email fields have already been removed. This removes writes and deprecated the fields on the `meetPerson` and `selfServeCourseRegistration` tables.

There are some remaining tables to clean up after this:
- `exercise_response` and `resource_completion`: Left to a a standalone PR because removing the field is irreversible as there's no Airtable primary
- `course_builder_user`: Left to a standalone PR because this requires dropping the entire table, and again I want to be careful with that

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2709

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories