### PR TITLE
Remove writes to `email` fields on `resourceCompletion` and `exerciseResponse` tables

### DIFF
--- a/apps/website/src/__tests__/pages/admin/exercises.test.tsx
+++ b/apps/website/src/__tests__/pages/admin/exercises.test.tsx
@@ -64,13 +64,13 @@ async function seedTargetResponses() {
     id: 'ex-b1', courseId: 'course-b', unitId: 'unit-b', title: 'Governance prompt', exerciseNumber: '1.1', type: 'Free text',
   });
   await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-    id: 'resp-a1', email: TARGET_EMAIL, userId: ['target-id'], exerciseId: 'ex-a1', response: 'thinking about safety mechanisms', createdAt: '2026-04-30T10:00:00Z', completedAt: '2026-05-01T10:00:00Z',
+    id: 'resp-a1', userId: ['target-id'], exerciseId: 'ex-a1', response: 'thinking about safety mechanisms', createdAt: '2026-04-30T10:00:00Z', completedAt: '2026-05-01T10:00:00Z',
   });
   await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-    id: 'resp-a2', email: TARGET_EMAIL, userId: ['target-id'], exerciseId: 'ex-a2', response: 'draft in progress', createdAt: '2026-05-03T10:00:00Z', completedAt: null,
+    id: 'resp-a2', userId: ['target-id'], exerciseId: 'ex-a2', response: 'draft in progress', createdAt: '2026-05-03T10:00:00Z', completedAt: null,
   });
   await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-    id: 'resp-b1', email: TARGET_EMAIL, userId: ['target-id'], exerciseId: 'ex-b1', response: 'policy considerations are important', createdAt: '2026-04-29T10:00:00Z', completedAt: '2026-05-02T10:00:00Z',
+    id: 'resp-b1', userId: ['target-id'], exerciseId: 'ex-b1', response: 'policy considerations are important', createdAt: '2026-04-29T10:00:00Z', completedAt: '2026-05-02T10:00:00Z',
   });
 }
 

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -339,12 +339,12 @@ describe('certificates.getStatus', () => {
 describe('issueFoaiCertificateIfComplete', () => {
   const FOAI_USER_ID = 'user-foai';
 
-  const setupCompletedFoaiExercises = async (email: string) => {
+  const setupCompletedFoaiExercises = async () => {
     await testDb.insert(exerciseTable, {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email, userId: [FOAI_USER_ID], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
   };
 
@@ -355,7 +355,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     await testDb.insert(courseRegistrationTable, {
       id: 'reg-foai', email: 'test@example.com', userId: 'test-user', courseId: FOAI_COURSE_ID, decision: 'Accept',
     });
-    await setupCompletedFoaiExercises('test@example.com');
+    await setupCompletedFoaiExercises();
 
     expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(true);
 
@@ -372,7 +372,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     await testDb.insert(courseRegistrationTable, {
       id: 'reg-foai', email: 'test@example.com', userId: 'test-user', courseId: FOAI_COURSE_ID, decision: 'Accept',
     });
-    await setupCompletedFoaiExercises('test@example.com');
+    await setupCompletedFoaiExercises();
 
     expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(false);
 
@@ -403,7 +403,7 @@ describe('issueFoaiCertificateIfComplete', () => {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Required', exerciseNumber: '1',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email: 'test@example.com', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
     // Further/Maybe exercises with no completed response — must not block the certificate.
     await testDb.insert(exerciseTable, {
@@ -431,7 +431,7 @@ describe('issueFoaiCertificateIfComplete', () => {
     expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(false);
 
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-core', email: 'test@example.com', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-core', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-core', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-core', response: 'done', completedAt: '2026-01-01',
     });
 
     expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(true);

--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -171,7 +171,7 @@ describe('courses.getCourseProgress', () => {
     await seedExercise('ex-core');
 
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r-core', email: 'test@example.com', userId: ['test-user'], exerciseId: 'ex-core', response: 'x', completedAt: '2026-01-01',
+      id: 'r-core', userId: ['test-user'], exerciseId: 'ex-core', response: 'x', completedAt: '2026-01-01',
     });
 
     const { courseProgress } = await caller.courses.getCourseProgress({ courseSlug: 'core-prog' });
@@ -190,10 +190,10 @@ describe('courses.getCourseProgress', () => {
 
     // Complete the non-required exercises; they must not move the progress numbers.
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r-further', email: 'test@example.com', userId: ['test-user'], exerciseId: 'ex-further', response: 'x', completedAt: '2026-01-01',
+      id: 'r-further', userId: ['test-user'], exerciseId: 'ex-further', response: 'x', completedAt: '2026-01-01',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r-maybe', email: 'test@example.com', userId: ['test-user'], exerciseId: 'ex-maybe', response: 'x', completedAt: '2026-01-01',
+      id: 'r-maybe', userId: ['test-user'], exerciseId: 'ex-maybe', response: 'x', completedAt: '2026-01-01',
     });
 
     const { courseProgress } = await caller.courses.getCourseProgress({ courseSlug: 'further-prog' });

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -86,7 +86,6 @@ describe('exercises.saveExerciseResponse', () => {
     });
 
     expect(result).toMatchObject({
-      email: 'test@example.com',
       exerciseId: 'exercise-1',
       response: 'My first answer',
       completedAt: null,
@@ -206,7 +205,7 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
       id: 'foai-ex-2', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Action plan', exerciseNumber: '2',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email: CALLER_EMAIL, userId: ['test-user'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1', userId: ['test-user'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
 
     const before = Math.floor(Date.now() / 1000);
@@ -291,7 +290,7 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
       id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email: CALLER_EMAIL, userId: ['test-user'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1', userId: ['test-user'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
     });
 
     const result = await caller.exercises.saveExerciseResponse({
@@ -507,7 +506,6 @@ describe('exercises.getGroupExerciseResponses', () => {
     await seedFacilitatorFlow();
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
-      email: 'participant@example.com',
       userId: ['up-user'],
       exerciseId: 'ex-1',
       response: 'My answer',
@@ -530,7 +528,6 @@ describe('exercises.getGroupExerciseResponses', () => {
     await seedFacilitatorFlow();
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
-      email: 'participant@example.com',
       userId: ['up-user'],
       exerciseId: 'ex-1',
       response: 'Work in progress',
@@ -574,7 +571,6 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
       id: 'resp-1',
-      email: 'noname@example.com',
       userId: ['noname-user'],
       exerciseId: 'ex-1',
       response: 'An answer',

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -96,7 +96,6 @@ export const exercisesRouter = router({
         : await db.pg
           .insert(exerciseResponsePgTable.pg)
           .values({
-            email: ctx.auth.email,
             exerciseId: input.exerciseId,
             response: input.response,
             // Airtable defaulted this field to now(); without Airtable it must be set in code

--- a/apps/website/src/server/routers/resources.test.ts
+++ b/apps/website/src/server/routers/resources.test.ts
@@ -16,7 +16,6 @@ import {
 setupTestDb();
 
 const caller = createCaller(testAuthContextLoggedIn);
-const CALLER_EMAIL = testAuthContextLoggedIn.auth!.email;
 
 // The authenticated user's row is assumed to exist by the userId-scoped routes.
 beforeEach(async () => {
@@ -65,7 +64,6 @@ describe('resources.saveResourceCompletion', () => {
   test('updates an existing completion without touching the FK fields', async () => {
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'rc-1',
-      email: CALLER_EMAIL,
       unitResourceId: 'ur-1',
       resourceId: ['resource-original'],
       userId: ['test-user'],
@@ -96,7 +94,6 @@ describe('resources.saveResourceCompletion', () => {
   test('clears completedAt when isCompleted is false', async () => {
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'rc-1',
-      email: CALLER_EMAIL,
       userId: ['test-user'],
       unitResourceId: 'ur-1',
       completedAt: '2026-01-01T00:00:00.000Z',
@@ -113,7 +110,6 @@ describe('resources.saveResourceCompletion', () => {
   test('preserves completedAt when isCompleted is omitted', async () => {
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
       id: 'rc-1',
-      email: CALLER_EMAIL,
       userId: ['test-user'],
       unitResourceId: 'ur-1',
       completedAt: '2026-01-01T00:00:00.000Z',

--- a/apps/website/src/server/routers/resources.ts
+++ b/apps/website/src/server/routers/resources.ts
@@ -92,7 +92,6 @@ export const resourcesRouter = router({
         : await db.pg
           .insert(resourceCompletionPgTable.pg)
           .values({
-            email: ctx.auth.email,
             unitResourceId: input.unitResourceId,
             completedAt: completedAt ?? null,
             feedback: input.feedback ?? '',

--- a/libraries/computed-airtable-fields/src/core.test.ts
+++ b/libraries/computed-airtable-fields/src/core.test.ts
@@ -35,10 +35,10 @@ describe('recomputeValues', () => {
     await testDb.insert(exerciseTable, { id: 'ex-1' });
     await testDb.insert(exerciseTable, { id: 'ex-2' });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', email: 'a@example.com', exerciseId: 'ex-1', response: 'done', completedAt: new Date().toISOString(),
+      id: 'resp-1', exerciseId: 'ex-1', response: 'done', completedAt: new Date().toISOString(),
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-2', email: 'b@example.com', exerciseId: 'ex-1', response: 'done', completedAt: new Date().toISOString(),
+      id: 'resp-2', exerciseId: 'ex-1', response: 'done', completedAt: new Date().toISOString(),
     });
 
     const result = await recomputeValues({

--- a/libraries/computed-airtable-fields/src/definitions.test.ts
+++ b/libraries/computed-airtable-fields/src/definitions.test.ts
@@ -52,18 +52,18 @@ describe('exercise.computedNumResponses', () => {
     await testDb.insert(exerciseTable, { id: 'ex-other' });
     // ex-1: 2 completed, 1 in-progress → 2
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r1', email: 'a@x', exerciseId: 'ex-1', response: '', completedAt: '2026-01-01',
+      id: 'r1', exerciseId: 'ex-1', response: '', completedAt: '2026-01-01',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r2', email: 'b@x', exerciseId: 'ex-1', response: '', completedAt: '2026-01-02',
+      id: 'r2', exerciseId: 'ex-1', response: '', completedAt: '2026-01-02',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r3', email: 'c@x', exerciseId: 'ex-1', response: '', completedAt: null,
+      id: 'r3', exerciseId: 'ex-1', response: '', completedAt: null,
     });
     // ex-2: 0 completed → 0
     // ex-other not in input → not in output
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'r4', email: 'd@x', exerciseId: 'ex-other', response: '', completedAt: '2026-01-03',
+      id: 'r4', exerciseId: 'ex-other', response: '', completedAt: '2026-01-03',
     });
 
     const result = await compute()(db, ['ex-1', 'ex-2']);
@@ -83,14 +83,14 @@ describe('resource.computedNumCompletions', () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
     await testDb.insert(resourceTable, { id: 'res-2' });
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'],
+      id: 'c1', completedAt: COMPLETED_AT, resourceId: ['res-1'],
     });
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c2', email: 'b@x', completedAt: COMPLETED_AT, resourceId: ['res-1', 'res-2'],
+      id: 'c2', completedAt: COMPLETED_AT, resourceId: ['res-1', 'res-2'],
     });
     // Not counted: not completed (completedAt null)
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c3', email: 'c@x', resourceId: ['res-1'],
+      id: 'c3', resourceId: ['res-1'],
     });
 
     const result = await compute()(db, ['res-1', 'res-2']);
@@ -110,21 +110,21 @@ describe('resource.computedAverageRating', () => {
   test('returns mean of resourceFeedback over completed rows, ignoring NO_RESPONSE and null', async () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
+      id: 'c1', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
     });
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c2', email: 'b@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
+      id: 'c2', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.LIKE,
     });
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c3', email: 'c@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
+      id: 'c3', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
     });
     // Ignored: NO_RESPONSE
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c4', email: 'd@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
+      id: 'c4', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
     });
     // Ignored: rated but then un-completed (completedAt null), e.g. user rated then unticked the resource
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c5', email: 'e@x', resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
+      id: 'c5', resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.DISLIKE,
     });
 
     const result = await compute()(db, ['res-1']);
@@ -135,7 +135,7 @@ describe('resource.computedAverageRating', () => {
   test('returns null when no ratings exist for a resource', async () => {
     await testDb.insert(resourceTable, { id: 'res-1' });
     await testDb.pg.insert(resourceCompletionPgTable.pg).values({
-      id: 'c1', email: 'a@x', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
+      id: 'c1', completedAt: COMPLETED_AT, resourceId: ['res-1'], resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,
     });
     const result = await compute()(db, ['res-1']);
     expect(result['res-1']).toBeNull();

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -432,7 +432,7 @@ describe('exercise_completed', () => {
   const seedUser = (id: string, email: string) => testDb.insert(userTable, { id, email, name: email });
   const completeExercise = (id: string, userId: string | null, exerciseId: string, completedAt: string | null) =>
     db.pg.insert(exerciseResponsePgTable.pg).values({
-      id, email: 'row@x.com', exerciseId, response: 'an answer', createdAt: '2026-06-01T00:00:00.000Z', completedAt, userId: userId ? [userId] : null,
+      id, exerciseId, response: 'an answer', createdAt: '2026-06-01T00:00:00.000Z', completedAt, userId: userId ? [userId] : null,
     });
 
   test('emits one event per completed response with the linked user\'s email, enriched with the exercise and course', async () => {
@@ -524,7 +524,6 @@ describe('resource_completed', () => {
   ) =>
     db.pg.insert(resourceCompletionPgTable.pg).values({
       id,
-      email: 'row@x.com',
       userId: userId ? [userId] : null,
       unitResourceId,
       resourceId: resourceId ? [resourceId] : null,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -147,7 +147,7 @@ export const courseTable = pgAirtable('course', {
 export const exerciseResponsePgTable = deprecationSafePgTable('exercise_response', {
   columns: {
     id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
-    email: text().notNull(),
+    email: text(),
     exerciseId: text().notNull(),
     response: text().notNull(),
     createdAt: text(),


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

More cleanup following the migration from email to `keycloakIdentifier` as the primary identifier for users.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2709

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories