### PR TITLE
Deprecate `email` fields on `resourceCompletion` and `exerciseResponse` tables

### DIFF
--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -319,7 +319,6 @@ export const createMockExercise = (overrides: Partial<Exercise> = {}): Exercise 
 });
 
 export const createMockResourceCompletion = (overrides: Partial<ResourceCompletion> = {}): ResourceCompletion => ({
-  email: '',
   feedback: null,
   id: MOCK_RESOURCE_COMPLETION_ID,
   resourceFeedback: RESOURCE_FEEDBACK.NO_RESPONSE,

--- a/apps/website/src/components/courses/ResourceListItem.tsx
+++ b/apps/website/src/components/courses/ResourceListItem.tsx
@@ -142,7 +142,6 @@ export const ResourceListItem: React.FC<ResourceListItemProps> = ({
             // If no existing item and isCompleted is true, add a new item
             newArray.push({
               id: unitResourceId,
-              email: auth?.email ?? '',
               unitResourceId,
               feedback: updatedFields.feedback ?? '',
               resourceFeedback: updatedFields.resourceFeedback ?? RESOURCE_FEEDBACK.NO_RESPONSE,

--- a/apps/website/src/components/courses/exercises/Exercise.stories.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.stories.tsx
@@ -37,7 +37,6 @@ const multipleChoiceExercise = {
 
 const savedResponse = {
   id: 'response-1',
-  email: 'test+storybook@bluedot.org',
   exerciseId: EXERCISE_ID,
   response: 'I believe a better future involves more equitable access to education and healthcare globally.',
   completed: false,

--- a/apps/website/src/components/courses/exercises/Exercise.test.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.test.tsx
@@ -100,7 +100,6 @@ describe('Exercise', () => {
   test('completion checkbox is enabled when exercise has a saved response', async () => {
     server.use(trpcMsw.exercises.getExerciseResponse.query(() => ({
       id: 'resp-1',
-      email: 'test@example.com',
       completedAt: null,
       createdAt: null,
       exerciseId: 'ex1',
@@ -118,7 +117,6 @@ describe('Exercise', () => {
   test('completion checkbox is disabled when exercise has no response', async () => {
     server.use(trpcMsw.exercises.getExerciseResponse.query(() => ({
       id: 'resp-2',
-      email: 'test@example.com',
       completedAt: null,
       createdAt: null,
       exerciseId: 'ex1',
@@ -140,7 +138,6 @@ describe('Exercise', () => {
     server.use(
       trpcMsw.exercises.getExerciseResponse.query(() => ({
         id: 'resp-3',
-        email: 'test@example.com',
         completedAt: null,
         createdAt: null,
         exerciseId: 'ex1',

--- a/apps/website/src/components/courses/exercises/Exercise.tsx
+++ b/apps/website/src/components/courses/exercises/Exercise.tsx
@@ -88,7 +88,6 @@ const Exercise: React.FC<ExerciseProps> = ({
 
       utils.exercises.getExerciseResponse.setData({ exerciseId }, {
         id: previousResponse?.id ?? 'optimistic',
-        email: previousResponse?.email ?? auth?.email ?? '',
         exerciseId,
         response: newData.response,
         completedAt: newCompletedAt,

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -147,12 +147,16 @@ export const courseTable = pgAirtable('course', {
 export const exerciseResponsePgTable = deprecationSafePgTable('exercise_response', {
   columns: {
     id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
-    email: text(),
     exerciseId: text().notNull(),
     response: text().notNull(),
     createdAt: text(),
     completedAt: text(),
     userId: text().array(),
+  },
+  deprecatedColumns: {
+    // Keep until ~2026-08-01: while deprecated, the old email values stay in the column,
+    // so restoring is just moving this back into `columns`
+    email: text(),
   },
 });
 
@@ -1548,7 +1552,6 @@ export const resourceCompletionPgTable = deprecationSafePgTable('resource_comple
   columns: {
     id: text('id').primaryKey().default(sql`gen_random_uuid()::text`),
     unitResourceId: text(),
-    email: text(),
     feedback: text(),
     resourceFeedback: numeric({ mode: 'number' }).$type<ResourceFeedbackValue>().default(RESOURCE_FEEDBACK.NO_RESPONSE),
     resourceId: text().array(),
@@ -1559,6 +1562,9 @@ export const resourceCompletionPgTable = deprecationSafePgTable('resource_comple
   },
   deprecatedColumns: {
     createdByUserId: text().array(),
+    // Keep until ~2026-08-01: while deprecated, the old email values stay in the column,
+    // so restoring is just moving this back into `columns`
+    email: text(),
   },
 });
 


### PR DESCRIPTION
# Description

Uses of these fields were just removed in #2802, this PR actually deprecates them.

Note: Moving these to `deprecatedColumns` doesn't actually delete the data. Because these tables only exist in Postgres and not Airtable, once the columns are fully deleted, so I propose leaving these in `deprecatedColumns` for a couple of weeks just in case we catch any bugs that require us to restore the data.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2709

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
