### PR TITLE
Cut over computed-posthog-events to using Keycloak's `sub` over email as the user's `distinct_id`

### DIFF
--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -31,14 +31,19 @@ const applicationSubmitted = eventProjectionRules.find((p) => p.eventType === 'a
 
 describe('certificate_issued (two source tables)', () => {
   test('emits from both courseRegistration and selfServe, namespaced; skips rows without a cert', async () => {
+    await testDb.insert(userTable, {
+      id: 'u-fac', email: 'a@x.com', name: 'a', keycloakIdentifier: 'sub-u-fac',
+    });
     await testDb.insert(courseRegistrationTable, {
-      id: 'cr1', courseId: 'c1', email: 'a@x.com', certificateId: 'cert1', certificateCreatedAt: 1_700_000_000, roundId: 'rd1',
+      id: 'cr1', courseId: 'c1', email: 'a@x.com', userId: 'u-fac', certificateId: 'cert1', certificateCreatedAt: 1_700_000_000, roundId: 'rd1',
     });
     await testDb.insert(courseRegistrationTable, { id: 'cr2', courseId: 'c1', email: 'b@x.com' }); // no cert -> not loaded
     await testDb.insert(courseRegistrationTable, {
       id: 'cr3', courseId: 'c1', email: 'd@x.com', certificateCreatedAt: 1_700_000_500,
     }); // cert timestamp but no certificateId -> loaded, but emits nothing
-    await testDb.insert(userTable, { id: 'u-ss', email: 'c@x.com', name: 'c' });
+    await testDb.insert(userTable, {
+      id: 'u-ss', email: 'c@x.com', name: 'c', keycloakIdentifier: 'sub-u-ss',
+    });
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss1', courseId: 'c2', userId: 'u-ss', certificateId: 'sc1', certificateCreatedAt: 1_700_000_001,
     });
@@ -52,27 +57,33 @@ describe('certificate_issued (two source tables)', () => {
     const certs = ph.events.filter((e) => e.event === 'certificate_issued');
     expect(certs.map((e) => String(e.properties.certificate_id)).sort()).toEqual(['cert1', 'sc1']);
     const courseReg = certs.find((e) => e.properties.certificate_id === 'cert1')!;
-    expect(courseReg.distinct_id).toBe('a@x.com');
+    expect(courseReg.distinct_id).toBe('sub-u-fac');
     expect(courseReg.timestamp).toBe(new Date(1_700_000_000 * 1000).toISOString());
     expect(courseReg.properties).toMatchObject({ course_id: 'c1', round_id: 'rd1' });
-    // self-serve emails come from the linked user, and self-serve has no round
+    // self-serve identity comes from the linked user (keycloak sub), and self-serve has no round
     const selfServeCert = certs.find((e) => e.properties.certificate_id === 'sc1')!;
-    expect(selfServeCert.distinct_id).toBe('c@x.com');
+    expect(selfServeCert.distinct_id).toBe('sub-u-ss');
     expect(selfServeCert.properties).not.toHaveProperty('round_id');
   });
 });
 
 describe('since (incremental scans)', () => {
   test('certificate_issued: only rows with certificateCreatedAt >= since (epoch seconds)', async () => {
-    await testDb.insert(courseRegistrationTable, {
-      id: 'old', courseId: 'c1', email: 'old@x.com', certificateId: 'cOld', certificateCreatedAt: 1_600_000_000,
+    await testDb.insert(userTable, {
+      id: 'u-old', email: 'old@x.com', name: 'old', keycloakIdentifier: 'sub-u-old',
+    });
+    await testDb.insert(userTable, {
+      id: 'u-new', email: 'new@x.com', name: 'new', keycloakIdentifier: 'sub-u-new',
     });
     await testDb.insert(courseRegistrationTable, {
-      id: 'new', courseId: 'c1', email: 'new@x.com', certificateId: 'cNew', certificateCreatedAt: 1_700_000_000,
+      id: 'old', courseId: 'c1', email: 'old@x.com', userId: 'u-old', certificateId: 'cOld', certificateCreatedAt: 1_600_000_000,
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'new', courseId: 'c1', email: 'new@x.com', userId: 'u-new', certificateId: 'cNew', certificateCreatedAt: 1_700_000_000,
     });
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2022-01-01T00:00:00.000Z' });
-    expect(ph.events.filter((e) => e.event === 'certificate_issued').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+    expect(ph.events.filter((e) => e.event === 'certificate_issued').map((e) => e.distinct_id)).toEqual(['sub-u-new']);
   });
 
   test('application_accepted: only rows with acceptedAt >= since (ISO text)', async () => {
@@ -84,7 +95,7 @@ describe('since (incremental scans)', () => {
     });
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
-    expect(ph.events.filter((e) => e.event === 'application_accepted').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+    expect(ph.events.filter((e) => e.event === 'application_accepted').map((e) => e.distinct_id)).toEqual(['new']);
   });
 
   test('application_rejected: only rows with rejectedAt >= since (ISO text)', async () => {
@@ -96,7 +107,7 @@ describe('since (incremental scans)', () => {
     });
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
-    expect(ph.events.filter((e) => e.event === 'application_rejected').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+    expect(ph.events.filter((e) => e.event === 'application_rejected').map((e) => e.distinct_id)).toEqual(['new']);
   });
 
   test('application_submitted: only rows with createdAt >= since (ISO text)', async () => {
@@ -116,7 +127,7 @@ describe('since (incremental scans)', () => {
 describe('application_accepted (write-once `Accepted at`)', () => {
   test('emits only for rows with an `Accepted at` timestamp', async () => {
     await testDb.insert(courseRegistrationTable, {
-      id: 'a1', courseId: 'c1', email: 'acc@x.com', acceptedAt: '2026-06-01T10:00:00.000Z',
+      id: 'a1', courseId: 'c1', email: 'acc@x.com', posthogDistinctId: 'anon-a1', acceptedAt: '2026-06-01T10:00:00.000Z',
     });
     await testDb.insert(courseRegistrationTable, {
       id: 'a2', courseId: 'c1', email: 'rej@x.com', decision: 'Reject',
@@ -130,7 +141,8 @@ describe('application_accepted (write-once `Accepted at`)', () => {
 
     const accepts = ph.events.filter((e) => e.event === 'application_accepted');
     expect(accepts).toHaveLength(1);
-    expect(accepts[0]?.distinct_id).toBe('acc@x.com');
+    // no linked user -> falls back to the registration's anon anchor (same as its application_submitted)
+    expect(accepts[0]?.distinct_id).toBe('anon-a1');
     expect(accepts[0]?.timestamp).toBe('2026-06-01T10:00:00.000Z');
   });
 
@@ -171,7 +183,7 @@ describe('application_rejected (write-once `Rejected at`)', () => {
 
     const rejects = ph.events.filter((e) => e.event === 'application_rejected');
     expect(rejects).toHaveLength(1);
-    expect(rejects[0]?.distinct_id).toBe('rej@x.com');
+    expect(rejects[0]?.distinct_id).toBe('a1');
     expect(rejects[0]?.timestamp).toBe('2026-06-01T10:00:00.000Z');
     expect(rejects[0]?.properties).toMatchObject({ course_id: 'c1' });
   });
@@ -300,8 +312,12 @@ describe('discussion_attended / discussion_absent', () => {
     await testDb.insert(unitTable, {
       id: 'u1', courseId: 'c1', courseTitle: 'AGI Strategy', courseSlug: 'agi-strategy', title: 'Intro to AGI', unitNumber: '1', unitStatus: 'Active',
     });
-    await testDb.insert(userTable, { id: 'u-att', email: 'attendee@x.com', name: 'attendee' });
-    await testDb.insert(userTable, { id: 'u-abs', email: 'absentee@x.com', name: 'absentee' });
+    await testDb.insert(userTable, {
+      id: 'u-att', email: 'attendee@x.com', name: 'attendee', keycloakIdentifier: 'sub-u-att',
+    });
+    await testDb.insert(userTable, {
+      id: 'u-abs', email: 'absentee@x.com', name: 'absentee', keycloakIdentifier: 'sub-u-abs',
+    });
     await testDb.insert(meetPersonTable, {
       id: 'mp1', userId: 'u-att', round: 'rd1', numUnits: 8,
     });
@@ -327,8 +343,8 @@ describe('discussion_attended / discussion_absent', () => {
 
     const attended = ph.events.filter((e) => e.event === 'discussion_attended');
     const absent = ph.events.filter((e) => e.event === 'discussion_absent');
-    expect(attended.map((e) => e.distinct_id)).toEqual(['attendee@x.com']);
-    expect(absent.map((e) => e.distinct_id)).toEqual(['absentee@x.com']);
+    expect(attended.map((e) => e.distinct_id)).toEqual(['sub-u-att']);
+    expect(absent.map((e) => e.distinct_id)).toEqual(['sub-u-abs']);
 
     // both attended and absent are timestamped at the discussion's scheduled start
     expect(attended[0]!.timestamp).toBe(new Date((nowSec - 7200) * 1000).toISOString());
@@ -372,21 +388,25 @@ describe('discussion_attended / discussion_absent', () => {
     await forwardAllEventsToPostHog({ now: NOW });
 
     const attended = ph.events.filter((e) => e.event === 'discussion_attended');
-    expect(attended.map((e) => e.distinct_id)).toEqual(['attendee@x.com']);
+    expect(attended.map((e) => e.distinct_id)).toEqual(['sub-u-att']);
   });
 
-  test('skips expected participants we cannot resolve an email for', async () => {
-    await testDb.insert(userTable, { id: 'u-att', email: 'attendee@x.com', name: 'attendee' });
+  test('skips expected participants we cannot resolve an identity for', async () => {
+    await testDb.insert(userTable, {
+      id: 'u-att', email: 'attendee@x.com', name: 'attendee', keycloakIdentifier: 'sub-u-att',
+    });
+    await testDb.insert(userTable, { id: 'u-nosub', email: 'nosub@x.com', name: 'nosub' }); // no keycloakIdentifier -> skipped
     await testDb.insert(meetPersonTable, { id: 'mp1', userId: 'u-att', round: 'rd1' });
+    await testDb.insert(meetPersonTable, { id: 'mpNoSub', userId: 'u-nosub', round: 'rd1' });
     await testDb.insert(meetPersonTable, { id: 'noUser' }); // no linked user -> skipped
     await insertDiscussion({
-      id: 'd1', participantsExpected: ['mp1', 'noUser'], attendees: ['mp1'], startSec: nowSec - 7200, endSec: nowSec - 3600,
+      id: 'd1', participantsExpected: ['mp1', 'mpNoSub', 'noUser'], attendees: ['mp1', 'mpNoSub'], startSec: nowSec - 7200, endSec: nowSec - 3600,
     });
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ now: NOW });
 
-    expect(ph.events.filter((e) => e.event === 'discussion_attended').map((e) => e.distinct_id)).toEqual(['attendee@x.com']);
+    expect(ph.events.filter((e) => e.event === 'discussion_attended').map((e) => e.distinct_id)).toEqual(['sub-u-att']);
     expect(ph.events.filter((e) => e.event === 'discussion_absent')).toHaveLength(0);
   });
 
@@ -429,13 +449,15 @@ describe('exercise_completed', () => {
     testDb.insert(exerciseTable, {
       id, courseId: opts.courseId, unitId: opts.unitId, title: opts.title, type: opts.type, status: 'Core',
     });
-  const seedUser = (id: string, email: string) => testDb.insert(userTable, { id, email, name: email });
+  const seedUser = (id: string, email: string) => testDb.insert(userTable, {
+    id, email, name: email, keycloakIdentifier: `sub-${id}`,
+  });
   const completeExercise = (id: string, userId: string | null, exerciseId: string, completedAt: string | null) =>
     db.pg.insert(exerciseResponsePgTable.pg).values({
       id, exerciseId, response: 'an answer', createdAt: '2026-06-01T00:00:00.000Z', completedAt, userId: userId ? [userId] : null,
     });
 
-  test('emits one event per completed response with the linked user\'s email, enriched with the exercise and course', async () => {
+  test('emits one event per completed response with the linked user\'s keycloak sub, enriched with the exercise and course', async () => {
     await seedCourse('c1', 'AGI Strategy');
     await seedExercise('ex2', {
       courseId: 'c1', unitId: 'u1', title: 'Quiz', type: 'Multiple choice',
@@ -449,8 +471,8 @@ describe('exercise_completed', () => {
 
     const events = ph.events.filter((e) => e.event === 'exercise_completed');
     expect(events).toHaveLength(1);
-    // the user's email, not the response row's own email column
-    expect(events[0]!.distinct_id).toBe('a@x.com');
+    // the user's keycloak sub, not any email
+    expect(events[0]!.distinct_id).toBe('sub-u1');
     expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
     expect(events[0]!.properties).toMatchObject({
       exercise_id: 'ex2',
@@ -484,7 +506,7 @@ describe('exercise_completed', () => {
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
 
-    expect(ph.events.filter((e) => e.event === 'exercise_completed').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+    expect(ph.events.filter((e) => e.event === 'exercise_completed').map((e) => e.distinct_id)).toEqual(['sub-u-new']);
   });
 
   test('send-once across runs: a second run re-sends nothing', async () => {
@@ -517,7 +539,9 @@ describe('resource_completed', () => {
     testDb.insert(unitResourceTable, {
       id, unitId: opts.unitId, resourceName: opts.resourceName, coreFurtherMaybe: opts.coreFurtherMaybe,
     });
-  const seedUser = (id: string, email: string) => testDb.insert(userTable, { id, email, name: email });
+  const seedUser = (id: string, email: string) => testDb.insert(userTable, {
+    id, email, name: email, keycloakIdentifier: `sub-${id}`,
+  });
   const completeResource = (
     id: string, userId: string | null, unitResourceId: string | null, completedAt: string | null,
     resourceId?: string,
@@ -531,7 +555,7 @@ describe('resource_completed', () => {
       completedAt,
     });
 
-  test('emits one event per completed resource with the linked user\'s email, enriched with the unit_resource and unit', async () => {
+  test('emits one event per completed resource with the linked user\'s keycloak sub, enriched with the unit_resource and unit', async () => {
     await seedUnit('u1', { unitNumber: '2', title: 'What is AGI?' });
     await seedUnitResource('ur1', { unitId: 'u1', resourceName: 'The Bitter Lesson', coreFurtherMaybe: 'Core' });
     await seedUser('user1', 'a@x.com');
@@ -542,8 +566,8 @@ describe('resource_completed', () => {
 
     const events = ph.events.filter((e) => e.event === 'resource_completed');
     expect(events).toHaveLength(1);
-    // the user's email, not the completion row's own email column
-    expect(events[0]!.distinct_id).toBe('a@x.com');
+    // the user's keycloak sub, not any email
+    expect(events[0]!.distinct_id).toBe('sub-user1');
     expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
     expect(events[0]!.properties).toMatchObject({
       resource_id: 'res1',
@@ -588,7 +612,7 @@ describe('resource_completed', () => {
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
 
-    expect(ph.events.filter((e) => e.event === 'resource_completed').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+    expect(ph.events.filter((e) => e.event === 'resource_completed').map((e) => e.distinct_id)).toEqual(['sub-u-new']);
   });
 
   test('send-once across runs: a second run re-sends nothing', async () => {
@@ -606,7 +630,7 @@ describe('resource_completed', () => {
 });
 
 describe('project_submitted', () => {
-  // distinct id (email) and course/round are all resolved via the participant link, not stored on the row:
+  // distinct id (keycloak sub) and course/round are all resolved via the participant link, not stored on the row:
   // submission.participant -> meetPerson.userId -> user, and meetPerson.applicationsBaseRecordId -> course_registration.
   const seedRegisteredParticipant = async () => {
     await testDb.insert(courseTable, {
@@ -615,7 +639,9 @@ describe('project_submitted', () => {
     await testDb.insert(courseRegistrationTable, {
       id: 'cr1', courseId: 'c1', email: 'a@x.com', roundId: 'rd1', roundName: 'AGI Strategy (2026 Mar W14) - Intensive',
     });
-    await testDb.insert(userTable, { id: 'u1', email: 'a@x.com', name: 'a' });
+    await testDb.insert(userTable, {
+      id: 'u1', email: 'a@x.com', name: 'a', keycloakIdentifier: 'sub-u1',
+    });
     await testDb.insert(meetPersonTable, {
       id: 'mp1', userId: 'u1', applicationsBaseRecordId: 'cr1',
     });
@@ -636,7 +662,7 @@ describe('project_submitted', () => {
 
     const events = ph.events.filter((e) => e.event === 'project_submitted');
     expect(events).toHaveLength(1);
-    expect(events[0]!.distinct_id).toBe('a@x.com');
+    expect(events[0]!.distinct_id).toBe('sub-u1');
     expect(events[0]!.timestamp).toBe('2026-06-08T01:10:28.000Z');
     expect(events[0]!.properties).toMatchObject({
       course_id: 'c1',
@@ -648,8 +674,10 @@ describe('project_submitted', () => {
     });
   });
 
-  test('emits with email but no course/round when the participant has no registration', async () => {
-    await testDb.insert(userTable, { id: 'u2', email: 'solo@x.com', name: 'solo' });
+  test('emits with the identity but no course/round when the participant has no registration', async () => {
+    await testDb.insert(userTable, {
+      id: 'u2', email: 'solo@x.com', name: 'solo', keycloakIdentifier: 'sub-u2',
+    });
     await testDb.insert(meetPersonTable, { id: 'mp2', userId: 'u2' }); // no applicationsBaseRecordId
     await testDb.insert(projectSubmissionTable, {
       id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', link: 'https://example.com/p', participant: ['mp2'],
@@ -659,15 +687,17 @@ describe('project_submitted', () => {
     await forwardAllEventsToPostHog();
 
     const event = ph.events.find((e) => e.event === 'project_submitted')!;
-    expect(event.distinct_id).toBe('solo@x.com');
+    expect(event.distinct_id).toBe('sub-u2');
     expect(event.properties).toMatchObject({ project_url: 'https://example.com/p' });
     expect(event.properties).not.toHaveProperty('course_id');
     expect(event.properties).not.toHaveProperty('round_id');
   });
 
   test('group projects fan out: one event per participant, each keyed and attributed separately', async () => {
-    await seedRegisteredParticipant(); // mp1 -> a@x.com (course c1, round rd1)
-    await testDb.insert(userTable, { id: 'u2', email: 'b@x.com', name: 'b' });
+    await seedRegisteredParticipant(); // mp1 -> sub-u1 (course c1, round rd1)
+    await testDb.insert(userTable, {
+      id: 'u2', email: 'b@x.com', name: 'b', keycloakIdentifier: 'sub-u2',
+    });
     await testDb.insert(meetPersonTable, { id: 'mp2', userId: 'u2', applicationsBaseRecordId: 'cr1' });
     await testDb.insert(projectSubmissionTable, {
       id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', projectTitle: 'Group plan', participant: ['mp1', 'mp2'],
@@ -677,13 +707,13 @@ describe('project_submitted', () => {
     await forwardAllEventsToPostHog();
 
     const events = ph.events.filter((e) => e.event === 'project_submitted');
-    expect(events.map((e) => e.distinct_id).sort()).toEqual(['a@x.com', 'b@x.com']);
+    expect(events.map((e) => e.distinct_id).sort()).toEqual(['sub-u1', 'sub-u2']);
     // distinct uuids (derived from the per-participant internalUniqueKey) so neither is dropped as a duplicate
     expect(new Set(events.map((e) => e.uuid)).size).toBe(2);
     expect(events.every((e) => e.properties.project_title === 'Group plan' && e.properties.course_id === 'c1')).toBe(true);
   });
 
-  test('skips submissions whose participant resolves to no email (nothing to attribute to)', async () => {
+  test('skips submissions whose participant resolves to no identity (nothing to attribute to)', async () => {
     await testDb.insert(projectSubmissionTable, {
       id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', link: 'https://example.com/p', participant: ['unknown'],
     });
@@ -704,7 +734,9 @@ describe('project_submitted', () => {
     await testDb.insert(projectSubmissionTable, {
       id: 'old', createdAt: '2026-01-01T00:00:00.000Z', participant: ['mp1'],
     });
-    await testDb.insert(userTable, { id: 'u-new', email: 'new@x.com', name: 'new' });
+    await testDb.insert(userTable, {
+      id: 'u-new', email: 'new@x.com', name: 'new', keycloakIdentifier: 'sub-u-new',
+    });
     await testDb.insert(meetPersonTable, { id: 'mp2', userId: 'u-new' });
     await testDb.insert(projectSubmissionTable, {
       id: 'new', createdAt: '2026-06-01T00:00:00.000Z', participant: ['mp2'],
@@ -713,7 +745,7 @@ describe('project_submitted', () => {
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
 
-    expect(ph.events.filter((e) => e.event === 'project_submitted').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+    expect(ph.events.filter((e) => e.event === 'project_submitted').map((e) => e.distinct_id)).toEqual(['sub-u-new']);
   });
 
   test('send-once across runs: a second run re-sends nothing', async () => {
@@ -747,7 +779,7 @@ describe('application_withdrawn', () => {
 
     const events = ph.events.filter((e) => e.event === 'application_withdrawn');
     expect(events).toHaveLength(1);
-    expect(events[0]!.distinct_id).toBe('a@x.com');
+    expect(events[0]!.distinct_id).toBe('cr1');
     expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
     expect(events[0]!.properties).toMatchObject({
       course_id: 'c1',
@@ -771,7 +803,7 @@ describe('application_withdrawn', () => {
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog({ since: '2026-03-01T00:00:00.000Z' });
-    expect(ph.events.filter((e) => e.event === 'application_withdrawn').map((e) => e.distinct_id)).toEqual(['new@x.com']);
+    expect(ph.events.filter((e) => e.event === 'application_withdrawn').map((e) => e.distinct_id)).toEqual(['new']);
   });
 
   test('send-once across runs: a second run re-sends nothing', async () => {
@@ -791,8 +823,11 @@ describe('course_dropped_out / course_deferred', () => {
     await testDb.insert(courseTable, {
       id: 'c1', slug: 'agi-strategy', shortDescription: 'x', title: 'AGI Strategy', units: [], status: 'Active',
     });
+    await testDb.insert(userTable, {
+      id: 'u1', email: 'a@x.com', name: 'a', keycloakIdentifier: 'sub-u1',
+    });
     await testDb.insert(courseRegistrationTable, {
-      id: 'cr1', courseId: 'c1', email: 'a@x.com', roundId: 'rd1', roundName: 'AGI Strategy (2026 Mar W14) - Intensive',
+      id: 'cr1', courseId: 'c1', email: 'a@x.com', userId: 'u1', roundId: 'rd1', roundName: 'AGI Strategy (2026 Mar W14) - Intensive',
     });
   };
 
@@ -812,7 +847,7 @@ describe('course_dropped_out / course_deferred', () => {
 
     const events = ph.events.filter((e) => e.event === 'course_dropped_out');
     expect(events).toHaveLength(1);
-    expect(events[0]!.distinct_id).toBe('a@x.com');
+    expect(events[0]!.distinct_id).toBe('sub-u1');
     expect(events[0]!.timestamp).toBe('2026-06-10T10:00:00.000Z');
     expect(events[0]!.properties).toMatchObject({
       course_id: 'c1',
@@ -834,15 +869,24 @@ describe('course_dropped_out / course_deferred', () => {
     const deferred = ph.events.filter((e) => e.event === 'course_deferred');
     expect(dropped.map((e) => e.timestamp)).toEqual(['2026-06-10T10:00:00.000Z']);
     expect(deferred.map((e) => e.timestamp)).toEqual(['2026-06-12T10:00:00.000Z']);
-    expect(deferred[0]!.distinct_id).toBe('a@x.com');
+    expect(deferred[0]!.distinct_id).toBe('sub-u1');
   });
 
-  test('skips a dropout whose application cannot be resolved (no email to attribute)', async () => {
+  test('skips a dropout whose application cannot be resolved (no identity to attribute)', async () => {
     await seedDropout('do1', 'Drop out', { applicantId: 'missing' });
 
     const ph = mockPostHogBackend();
     await forwardAllEventsToPostHog();
     expect(ph.events.filter((e) => e.event === 'course_dropped_out')).toHaveLength(0);
+  });
+
+  test('falls back to the registration anchor when the applicant never logged in', async () => {
+    await testDb.insert(courseRegistrationTable, { id: 'cr-nouser', courseId: 'c1', email: 'a@x.com' });
+    await seedDropout('do1', 'Drop out', { applicantId: 'cr-nouser' });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+    expect(ph.events.filter((e) => e.event === 'course_dropped_out').map((e) => e.distinct_id)).toEqual(['cr-nouser']);
   });
 
   test('since scans only dropouts created on/after it', async () => {
@@ -868,6 +912,48 @@ describe('course_dropped_out / course_deferred', () => {
   });
 });
 
+describe('identity model: registration events share the anon anchor, identify joins it to the sub', () => {
+  const seedCourse = () => testDb.insert(courseTable, {
+    id: 'c1', slug: 'agi-strategy', shortDescription: 'x', title: 'AGI Strategy', units: [], status: 'Active',
+  });
+
+  test('logged-in applicant: submitted lands on the anchor, accepted on the sub, and the identify merges the two', async () => {
+    await seedCourse();
+    await testDb.insert(userTable, {
+      id: 'u1', email: 'a@x.com', name: 'a', keycloakIdentifier: 'sub-u1', firstLoggedInAt: '2026-05-02T00:00:00.000Z',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'cr1', courseId: 'c1', email: 'a@x.com', userId: 'u1', posthogDistinctId: 'anon-1', createdAt: '2026-05-01T00:00:00.000Z', acceptedAt: '2026-05-03T00:00:00.000Z',
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    expect(ph.events.find((e) => e.event === 'application_submitted')!.distinct_id).toBe('anon-1');
+    // decision events go straight to the sub once the user exists
+    expect(ph.events.find((e) => e.event === 'application_accepted')!.distinct_id).toBe('sub-u1');
+    // ...and the identify merges the anon anchor (submitted + any browsing) into that same sub person
+    const identify = ph.events.find((e) => e.event === '$identify')!;
+    expect(identify.distinct_id).toBe('sub-u1');
+    expect(identify.properties.$anon_distinct_id).toBe('anon-1');
+  });
+
+  test('never-logged-in applicant: the whole funnel accumulates on one anon anchor, with no identify', async () => {
+    await seedCourse();
+    await testDb.insert(courseRegistrationTable, {
+      id: 'cr1', courseId: 'c1', email: 'a@x.com', createdAt: '2026-05-01T00:00:00.000Z', rejectedAt: '2026-05-03T00:00:00.000Z',
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    const funnel = ph.events.filter((e) => e.event.startsWith('application_'));
+    expect(funnel).toHaveLength(2);
+    expect(new Set(funnel.map((e) => e.distinct_id))).toEqual(new Set(['cr1']));
+    expect(ph.events.filter((e) => e.event === '$identify')).toHaveLength(0);
+  });
+});
+
 describe('identify_applicants', () => {
   const identifyApplicants = eventProjectionRules.find((p) => p.eventType === 'identify_applicants')!;
 
@@ -881,8 +967,12 @@ describe('identify_applicants', () => {
     })
   );
 
-  const seedLoggedInUser = (id: string, email: string, opts: { firstLoggedInAt?: string | null } = {}) => testDb.insert(userTable, {
-    id, email, name: email, firstLoggedInAt: opts.firstLoggedInAt === undefined ? '2026-05-02T00:00:00.000Z' : opts.firstLoggedInAt,
+  const seedLoggedInUser = (id: string, email: string, opts: { firstLoggedInAt?: string | null; keycloakIdentifier?: string | null } = {}) => testDb.insert(userTable, {
+    id,
+    email,
+    name: email,
+    firstLoggedInAt: opts.firstLoggedInAt === undefined ? '2026-05-02T00:00:00.000Z' : opts.firstLoggedInAt,
+    keycloakIdentifier: opts.keycloakIdentifier === undefined ? `sub-${id}` : opts.keycloakIdentifier,
   });
 
   test('a new login joins an application created before `since`', async () => {
@@ -893,7 +983,7 @@ describe('identify_applicants', () => {
     await runIdentifyApplicants({ since: '2026-03-01T00:00:00.000Z' });
 
     const identify = ph.events.find((e) => e.event === '$identify')!;
-    expect(identify.distinct_id).toBe('a@x.com');
+    expect(identify.distinct_id).toBe('sub-u1');
     expect(identify.properties).toMatchObject({ $anon_distinct_id: 'anon-1', $set: { email: 'a@x.com' } });
   });
 
@@ -905,7 +995,7 @@ describe('identify_applicants', () => {
     await runIdentifyApplicants({ since: '2026-03-01T00:00:00.000Z' });
 
     const identify = ph.events.find((e) => e.event === '$identify')!;
-    expect(identify.distinct_id).toBe('a@x.com');
+    expect(identify.distinct_id).toBe('sub-u1');
     expect(identify.properties).toMatchObject({ $anon_distinct_id: 'anon-1' });
   });
 
@@ -962,6 +1052,16 @@ describe('identify_applicants', () => {
 
     const identifies = ph.events.filter((e) => e.event === '$identify');
     expect(identifies).toHaveLength(1);
-    expect(identifies[0]!.distinct_id).toBe('new@x.com');
+    expect(identifies[0]!.distinct_id).toBe('sub-u-linked');
+  });
+
+  test('skips the identify when the user has no keycloakIdentifier', async () => {
+    await seedRegistration('cr1', 'a@x.com', { posthogDistinctId: 'anon-1', userId: 'u1' });
+    await seedLoggedInUser('u1', 'a@x.com', { keycloakIdentifier: null });
+
+    const ph = mockPostHogBackend();
+    await runIdentifyApplicants();
+
+    expect(ph.events).toHaveLength(0);
   });
 });

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -20,12 +20,13 @@ const courseRegistrationAnonDistinctId = (r: Pick<CourseRegistration, 'id' | 'po
   r.posthogDistinctId || r.id
 );
 
-const getEmailByUserId = async (db: PgAirtableDb, userIds: (string | null | undefined)[]): Promise<Map<string, string>> => {
+// The PostHog identity is the Keycloak `sub`; users without one resolve to nothing and are skipped
+const getKeycloakIdentifierByUserId = async (db: PgAirtableDb, userIds: (string | null | undefined)[]): Promise<Map<string, string>> => {
   const ids = [...new Set(userIds.filter((id): id is string => !!id))];
   if (ids.length === 0) return new Map();
-  const users = await db.pg.select({ id: userTable.pg.id, email: userTable.pg.email })
+  const users = await db.pg.select({ id: userTable.pg.id, keycloakIdentifier: userTable.pg.keycloakIdentifier })
     .from(userTable.pg).where(inArray(userTable.pg.id, ids));
-  return new Map(users.map((u) => [u.id, u.email]));
+  return new Map(users.flatMap((u) => (u.keycloakIdentifier ? [[u.id, u.keycloakIdentifier] as const] : [])));
 };
 
 // Mirrors the my-courses UI (deriveStatus in useDiscussionActions.tsx): a participant is `attended` when
@@ -46,7 +47,7 @@ const calculateDiscussionAttendanceEvents = async (
   if (meetPersonIds.length === 0) return [];
   const meetPersons = await db.pg.select().from(meetPersonTable.pg).where(inArray(meetPersonTable.pg.id, meetPersonIds));
   const meetPersonById = new Map(meetPersons.map((mp) => [mp.id, mp] as const));
-  const emailByUserId = await getEmailByUserId(db, meetPersons.map((mp) => mp.userId));
+  const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, meetPersons.map((mp) => mp.userId));
 
   const roundIds = [...new Set(meetPersons.map((mp) => mp.round).filter((r): r is string => !!r))];
   const rounds = roundIds.length
@@ -76,13 +77,13 @@ const calculateDiscussionAttendanceEvents = async (
       if (kind === 'attended' ? !isAttended : isAttended) continue;
 
       const meetPerson = meetPersonById.get(meetPersonId);
-      const email = meetPerson?.userId ? emailByUserId.get(meetPerson.userId) : undefined;
-      if (!meetPerson || !email) continue;
+      const keycloakIdentifier = meetPerson?.userId ? keycloakIdentifierByUserId.get(meetPerson.userId) : undefined;
+      if (!meetPerson || !keycloakIdentifier) continue;
       const roundName = meetPerson.round ? roundTitleById.get(meetPerson.round) : undefined;
 
       events.push({
         internalUniqueKey: `${meetPersonId}:${d.id}`,
-        distinctId: email,
+        distinctId: keycloakIdentifier,
         timestampMs: d.startDateTime * 1000,
         properties: {
           discussion_id: d.id,
@@ -112,18 +113,20 @@ const calculateDropoutEvents = async (
     .where(and(filterGteOrNull(dropoutTable.pg.createdAt, since), eq(dropoutTable.pg.type, type)));
   if (rows.length === 0) return [];
 
-  // Identity, course and round come off the linked application, not the dropout table's own email lookup.
+  // The anchor, course and round come off the linked application, not the dropout table's own lookups.
   const registrationIds = [...new Set(rows.flatMap((r) => r.applicantId ?? []))];
   const registrations = registrationIds.length
     ? await db.pg.select({
       id: courseRegistrationTable.pg.id,
-      email: courseRegistrationTable.pg.email,
+      userId: courseRegistrationTable.pg.userId,
+      posthogDistinctId: courseRegistrationTable.pg.posthogDistinctId,
       courseId: courseRegistrationTable.pg.courseId,
       roundId: courseRegistrationTable.pg.roundId,
       roundName: courseRegistrationTable.pg.roundName,
     }).from(courseRegistrationTable.pg).where(inArray(courseRegistrationTable.pg.id, registrationIds))
     : [];
   const registrationById = new Map(registrations.map((r) => [r.id, r] as const));
+  const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, registrations.map((r) => r.userId));
 
   const courses = registrations.length
     ? await db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg)
@@ -135,7 +138,9 @@ const calculateDropoutEvents = async (
     const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
     return {
       internalUniqueKey: row.id,
-      distinctId: registration?.email ?? null,
+      distinctId: registration
+        ? ((registration.userId ? keycloakIdentifierByUserId.get(registration.userId) : undefined) ?? courseRegistrationAnonDistinctId(registration))
+        : null,
       timestampMs: Date.parse(row.createdAt!),
       properties: {
         ...(registration?.courseId ? { course_id: registration.courseId } : {}),
@@ -204,12 +209,12 @@ export const eventProjectionRules: EventProjectionRule[] = [
 
       return registrations.flatMap((registration): Event[] => {
         const user = registration.userId ? userById.get(registration.userId) : undefined;
-        if (!user) return []; // no account yet, the application stays anonymous
+        if (!user?.keycloakIdentifier) return []; // no logged-in account yet, the application stays anonymous
 
         return [{
           type: 'identify',
           internalUniqueKey: `identify_applicants:${registration.id}`,
-          distinctId: user.email,
+          distinctId: user.keycloakIdentifier,
           anonDistinctId: courseRegistrationAnonDistinctId(registration),
           timestampMs: Date.parse(user.firstLoggedInAt!),
           set: { email: user.email },
@@ -224,12 +229,13 @@ export const eventProjectionRules: EventProjectionRule[] = [
       const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
       const rows = await db.pg.select().from(courseRegistrationTable.pg)
         .where(filterGteOrNull(courseRegistrationTable.pg.acceptedAt, since)); // acceptedAt is ISO text
+      const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, rows.map((r) => r.userId));
 
       return rows.map((r) => {
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `accept:${r.id}`,
-          distinctId: r.email,
+          distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? courseRegistrationAnonDistinctId(r),
           timestampMs: Date.parse(r.acceptedAt!),
           properties: {
             course_id: r.courseId,
@@ -248,12 +254,13 @@ export const eventProjectionRules: EventProjectionRule[] = [
       const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
       const rows = await db.pg.select().from(courseRegistrationTable.pg)
         .where(filterGteOrNull(courseRegistrationTable.pg.rejectedAt, since)); // rejectedAt is ISO text
+      const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, rows.map((r) => r.userId));
 
       return rows.map((r) => {
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `reject:${r.id}`,
-          distinctId: r.email,
+          distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? courseRegistrationAnonDistinctId(r),
           timestampMs: Date.parse(r.rejectedAt!),
           properties: {
             course_id: r.courseId,
@@ -272,12 +279,13 @@ export const eventProjectionRules: EventProjectionRule[] = [
       const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
       const rows = await db.pg.select().from(courseRegistrationTable.pg)
         .where(filterGteOrNull(courseRegistrationTable.pg.withdrawnAt, since)); // withdrawnAt is ISO text
+      const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, rows.map((r) => r.userId));
 
       return rows.map((r) => {
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `withdraw:${r.id}`,
-          distinctId: r.email,
+          distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? courseRegistrationAnonDistinctId(r),
           timestampMs: Date.parse(r.withdrawnAt!),
           properties: {
             course_id: r.courseId,
@@ -299,14 +307,17 @@ export const eventProjectionRules: EventProjectionRule[] = [
         .where(filterGteOrNull(courseRegistrationTable.pg.certificateCreatedAt, sinceEpochSeconds));
       const selfServe = await db.pg.select().from(selfServeCourseRegistrationTable.pg)
         .where(filterGteOrNull(selfServeCourseRegistrationTable.pg.certificateCreatedAt, sinceEpochSeconds));
-      const emailByUserId = await getEmailByUserId(db, selfServe.map((r) => r.userId));
+      const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, [
+        ...facilitated.map((r) => r.userId),
+        ...selfServe.map((r) => r.userId),
+      ]);
 
       return [
         ...facilitated.filter((r) => r.certificateId != null).map((r) => {
           const courseName = courseTitleById.get(r.courseId);
           return {
             internalUniqueKey: `courseReg:${r.id}`,
-            distinctId: r.email,
+            distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? null,
             timestampMs: Number(r.certificateCreatedAt) * 1000,
             properties: {
               course_id: r.courseId,
@@ -321,7 +332,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
           const courseName = courseTitleById.get(r.courseId);
           return {
             internalUniqueKey: `selfServe:${r.id}`,
-            distinctId: (r.userId ? emailByUserId.get(r.userId) : undefined) ?? null,
+            distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? null,
             timestampMs: Number(r.certificateCreatedAt) * 1000,
             // self-serve has no round
             properties: {
@@ -349,13 +360,13 @@ export const eventProjectionRules: EventProjectionRule[] = [
         .where(filterGteOrNull(exerciseResponsePgTable.pg.completedAt, since)); // completedAt is ISO text
       if (responses.length === 0) return [];
 
-      const [courses, exercises, emailByUserId] = await Promise.all([
+      const [courses, exercises, keycloakIdentifierByUserId] = await Promise.all([
         db.pg.select({ id: courseTable.pg.id, title: courseTable.pg.title }).from(courseTable.pg),
         db.pg.select({
           id: exerciseTable.pg.id, courseId: exerciseTable.pg.courseId, title: exerciseTable.pg.title,
           type: exerciseTable.pg.type, unitId: exerciseTable.pg.unitId,
         }).from(exerciseTable.pg),
-        getEmailByUserId(db, responses.map((r) => r.userId?.[0])),
+        getKeycloakIdentifierByUserId(db, responses.map((r) => r.userId?.[0])),
       ]);
       const courseTitleById = new Map(courses.map((c) => [c.id, c.title]));
       const exerciseById = new Map(exercises.map((e) => [e.id, e]));
@@ -365,7 +376,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = exercise?.courseId ? courseTitleById.get(exercise.courseId) : undefined;
         return {
           internalUniqueKey: r.id,
-          distinctId: (r.userId?.[0] ? emailByUserId.get(r.userId[0]) : undefined) ?? null,
+          distinctId: (r.userId?.[0] ? keycloakIdentifierByUserId.get(r.userId[0]) : undefined) ?? null,
           // Note: completedAt is mutable (can un-complete and re-complete), the event will
           // capture the *first time* we saw the response in a completed state
           timestampMs: Date.parse(r.completedAt!),
@@ -388,7 +399,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         .where(filterGteOrNull(resourceCompletionPgTable.pg.completedAt, since)); // completedAt is ISO text
       if (completions.length === 0) return [];
 
-      const [unitResources, units, emailByUserId] = await Promise.all([
+      const [unitResources, units, keycloakIdentifierByUserId] = await Promise.all([
         db.pg.select({
           id: unitResourceTable.pg.id, resourceName: unitResourceTable.pg.resourceName,
           unitId: unitResourceTable.pg.unitId, coreFurtherMaybe: unitResourceTable.pg.coreFurtherMaybe,
@@ -397,7 +408,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
           id: unitTable.pg.id, courseId: unitTable.pg.courseId, courseTitle: unitTable.pg.courseTitle,
           courseSlug: unitTable.pg.courseSlug, title: unitTable.pg.title, unitNumber: unitTable.pg.unitNumber,
         }).from(unitTable.pg),
-        getEmailByUserId(db, completions.map((c) => c.userId?.[0])),
+        getKeycloakIdentifierByUserId(db, completions.map((c) => c.userId?.[0])),
       ]);
       const unitResourceById = new Map(unitResources.map((ur) => [ur.id, ur]));
       const unitById = new Map(units.map((u) => [u.id, u]));
@@ -408,7 +419,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const unitNumber = unit ? Number(unit.unitNumber) : null;
         return {
           internalUniqueKey: c.id,
-          distinctId: (c.userId?.[0] ? emailByUserId.get(c.userId[0]) : undefined) ?? null,
+          distinctId: (c.userId?.[0] ? keycloakIdentifierByUserId.get(c.userId[0]) : undefined) ?? null,
           // Note: completedAt is mutable (can un-complete and re-complete), the event will
           // capture the *first time* we saw the resource in a completed state
           timestampMs: Date.parse(c.completedAt!),
@@ -434,8 +445,8 @@ export const eventProjectionRules: EventProjectionRule[] = [
         .where(filterGteOrNull(projectSubmissionTable.pg.createdAt, since));
       if (submissions.length === 0) return [];
 
-      // The form links each submission to a meet_person (participant). The email and the course/round
-      // both come off that link: meetPerson.userId -> user gives the email; meetPerson.applicationsBaseRecordId
+      // The form links each submission to a meet_person (participant). The identity and the course/round
+      // both come off that link: meetPerson.userId -> user gives the distinct id; meetPerson.applicationsBaseRecordId
       // -> course_registration gives the course and round.
       const participantIds = [...new Set(submissions.flatMap((s) => s.participant ?? []))];
       const meetPersons = participantIds.length
@@ -444,7 +455,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         }).from(meetPersonTable.pg).where(inArray(meetPersonTable.pg.id, participantIds))
         : [];
       const meetPersonById = new Map(meetPersons.map((m) => [m.id, m] as const));
-      const emailByUserId = await getEmailByUserId(db, meetPersons.map((m) => m.userId));
+      const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, meetPersons.map((m) => m.userId));
 
       const registrationIds = [...new Set(meetPersons.map((m) => m.applicationsBaseRecordId).filter((id): id is string => !!id))];
       const registrations = registrationIds.length
@@ -469,7 +480,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
         return {
           internalUniqueKey: `${s.id}:${participantId}`,
-          distinctId: (meetPerson?.userId ? emailByUserId.get(meetPerson.userId) : undefined) ?? null,
+          distinctId: (meetPerson?.userId ? keycloakIdentifierByUserId.get(meetPerson.userId) : undefined) ?? null,
           timestampMs: Date.parse(s.createdAt!),
           properties: {
             ...(registration?.courseId ? { course_id: registration.courseId } : {}),


### PR DESCRIPTION
# Description

See the [migration plan](https://github.com/bluedotimpact/bluedot/issues/2713#issuecomment-4925885638), this covers "PR 4" and "PR 5":

> - [ ] PR 4: Flip the 'identify_applicants' event definition from `distinctId: user.email` to `distinctId: user.keycloakIdentifier`. This submits identify events for both new users and new applications by existing users. It's safe to flip without any `alias` step because:
>   a. For new users: They will have already hit the `posthog.alias(auth.sub, auth.email)` in step 2
>   b. For new applications against existing users: They will have hit the `posthog.alias(auth.sub, auth.email)` from the backfill in step 3
> - [ ] PR 5 (could potentially be combined with PR 4): Flip all the other events in computed-posthog-events to use `keycloakIdentifier` as the `distinctId`

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2713

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories