### PR TITLE
Cut over website to identify to PostHog by keycloak sub instead of email

### DIFF
--- a/apps/website/src/lib/utils.test.ts
+++ b/apps/website/src/lib/utils.test.ts
@@ -6,12 +6,12 @@ import {
   beforeEach,
   afterEach,
 } from 'vitest';
+import { useAuthStore } from '@bluedot/ui/src/utils/auth';
 import { type AxiosError, type AxiosResponse } from 'axios';
 const mockGetSessionId = vi.fn<() => string | null>();
 const mockGetDistinctId = vi.fn<() => string | null>();
-const mockIsIdentified = vi.fn<() => boolean>(() => false);
 vi.mock('posthog-js', () => ({
-  default: { get_session_id: () => mockGetSessionId(), get_distinct_id: () => mockGetDistinctId(), _isIdentified: () => mockIsIdentified() },
+  default: { get_session_id: () => mockGetSessionId(), get_distinct_id: () => mockGetDistinctId() },
 }));
 
 const {
@@ -358,23 +358,25 @@ describe('buildApplicationUrl', () => {
       .toBe('https://example.com/apply?foo=bar&prefill_Source=twitter');
   });
 
-  it('appends prefill_PostHog Distinct ID (URL-encoded) while the user is anonymous', () => {
+  it('appends prefill_PostHog Distinct ID (URL-encoded) while logged out', () => {
     mockGetDistinctId.mockReturnValue('0190abcd-1234-7000-8000-abcdef012345');
-    mockIsIdentified.mockReturnValue(false);
     expect(buildApplicationUrl('https://example.com/apply', null))
       .toBe('https://example.com/apply?prefill_PostHog%20Distinct%20ID=0190abcd-1234-7000-8000-abcdef012345');
   });
 
-  it('does not append the distinct id once identified', () => {
-    mockGetDistinctId.mockReturnValue('keycloak-sub-123');
-    mockIsIdentified.mockReturnValue(true);
-    expect(buildApplicationUrl('https://example.com/apply', null)).toBe('https://example.com/apply');
+  it('does not append the distinct id when logged in', () => {
+    mockGetDistinctId.mockReturnValue('0190abcd-1234-7000-8000-abcdef012345');
+    useAuthStore.setState({ auth: { expiresAt: Date.now() + 3600_000 } as never });
+    try {
+      expect(buildApplicationUrl('https://example.com/apply', null)).toBe('https://example.com/apply');
+    } finally {
+      useAuthStore.setState({ auth: null });
+    }
   });
 
   it('appends session id and anonymous distinct id together', () => {
     mockGetSessionId.mockReturnValue('sess-123');
     mockGetDistinctId.mockReturnValue('anon-abc');
-    mockIsIdentified.mockReturnValue(false);
     expect(buildApplicationUrl('https://example.com/apply', null))
       .toBe('https://example.com/apply?prefill_PostHog%20Session%20ID=sess-123&prefill_PostHog%20Distinct%20ID=anon-abc');
   });

--- a/apps/website/src/lib/utils.test.ts
+++ b/apps/website/src/lib/utils.test.ts
@@ -9,8 +9,9 @@ import {
 import { type AxiosError, type AxiosResponse } from 'axios';
 const mockGetSessionId = vi.fn<() => string | null>();
 const mockGetDistinctId = vi.fn<() => string | null>();
+const mockIsIdentified = vi.fn<() => boolean>(() => false);
 vi.mock('posthog-js', () => ({
-  default: { get_session_id: () => mockGetSessionId(), get_distinct_id: () => mockGetDistinctId() },
+  default: { get_session_id: () => mockGetSessionId(), get_distinct_id: () => mockGetDistinctId(), _isIdentified: () => mockIsIdentified() },
 }));
 
 const {
@@ -357,20 +358,23 @@ describe('buildApplicationUrl', () => {
       .toBe('https://example.com/apply?foo=bar&prefill_Source=twitter');
   });
 
-  it('appends prefill_PostHog Distinct ID (URL-encoded) when the distinct id is anonymous', () => {
+  it('appends prefill_PostHog Distinct ID (URL-encoded) while the user is anonymous', () => {
     mockGetDistinctId.mockReturnValue('0190abcd-1234-7000-8000-abcdef012345');
+    mockIsIdentified.mockReturnValue(false);
     expect(buildApplicationUrl('https://example.com/apply', null))
       .toBe('https://example.com/apply?prefill_PostHog%20Distinct%20ID=0190abcd-1234-7000-8000-abcdef012345');
   });
 
-  it('does not append the distinct id once it is the email (already identified)', () => {
-    mockGetDistinctId.mockReturnValue('user@example.com');
+  it('does not append the distinct id once identified', () => {
+    mockGetDistinctId.mockReturnValue('keycloak-sub-123');
+    mockIsIdentified.mockReturnValue(true);
     expect(buildApplicationUrl('https://example.com/apply', null)).toBe('https://example.com/apply');
   });
 
   it('appends session id and anonymous distinct id together', () => {
     mockGetSessionId.mockReturnValue('sess-123');
     mockGetDistinctId.mockReturnValue('anon-abc');
+    mockIsIdentified.mockReturnValue(false);
     expect(buildApplicationUrl('https://example.com/apply', null))
       .toBe('https://example.com/apply?prefill_PostHog%20Session%20ID=sess-123&prefill_PostHog%20Distinct%20ID=anon-abc');
   });

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -205,11 +205,11 @@ export const buildApplicationUrl = (
   const sessionId = posthog.get_session_id?.();
   if (sessionId) urlObj.searchParams.set('prefill_PostHog Session ID', sessionId);
 
-  // Forward the distinct id only while it's still anonymous (a uuid). Once the user is identified
-  // it's their email — which we don't want to leak into the external form, and there is no need
-  // to identify them then anyway.
+  // Forward the distinct id only while the user is anonymous. Once identified it's their
+  // keycloak sub, and there is no need to capture it: their registration gets linked to
+  // their account instead.
   const distinctId = posthog.get_distinct_id?.();
-  if (distinctId && !distinctId.includes('@')) urlObj.searchParams.set('prefill_PostHog Distinct ID', distinctId);
+  if (distinctId && !posthog._isIdentified?.()) urlObj.searchParams.set('prefill_PostHog Distinct ID', distinctId);
 
   // URLSearchParams encodes spaces as '+', but miniextensions requires '%20'
   return urlObj.toString()

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { addQueryParam } from '@bluedot/ui/src/utils/addQueryParam';
+import { useAuthStore } from '@bluedot/ui/src/utils/auth';
 import { type AxiosError } from 'axios';
 import posthog from 'posthog-js';
 
@@ -205,13 +206,11 @@ export const buildApplicationUrl = (
   const sessionId = posthog.get_session_id?.();
   if (sessionId) urlObj.searchParams.set('prefill_PostHog Session ID', sessionId);
 
-  // Forward the distinct id only while the user is anonymous. Once identified it's their
-  // keycloak sub, and there is no need to capture it: their registration gets linked to
-  // their account instead. _isIdentified is internal to posthog-js, so treat it as possibly
-  // absent and fail closed (forward nothing) rather than leaking identified ids.
-  const isIdentified = (posthog._isIdentified as (() => boolean) | undefined)?.();
+  // Forward the distinct id only for logged-out visitors. Logged-in users are identified to
+  // PostHog (by keycloak sub), and there is no need to capture their id: their registration
+  // gets linked to their account instead.
   const distinctId = posthog.get_distinct_id?.();
-  if (distinctId && isIdentified === false) urlObj.searchParams.set('prefill_PostHog Distinct ID', distinctId);
+  if (distinctId && !useAuthStore.getState().auth) urlObj.searchParams.set('prefill_PostHog Distinct ID', distinctId);
 
   // URLSearchParams encodes spaces as '+', but miniextensions requires '%20'
   return urlObj.toString()

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -207,9 +207,11 @@ export const buildApplicationUrl = (
 
   // Forward the distinct id only while the user is anonymous. Once identified it's their
   // keycloak sub, and there is no need to capture it: their registration gets linked to
-  // their account instead.
+  // their account instead. _isIdentified is internal to posthog-js, so treat it as possibly
+  // absent and fail closed (forward nothing) rather than leaking identified ids.
+  const isIdentified = (posthog._isIdentified as (() => boolean) | undefined)?.();
   const distinctId = posthog.get_distinct_id?.();
-  if (distinctId && !posthog._isIdentified?.()) urlObj.searchParams.set('prefill_PostHog Distinct ID', distinctId);
+  if (distinctId && isIdentified === false) urlObj.searchParams.set('prefill_PostHog Distinct ID', distinctId);
 
   // URLSearchParams encodes spaces as '+', but miniextensions requires '%20'
   return urlObj.toString()

--- a/libraries/ui/src/utils/auth.test.tsx
+++ b/libraries/ui/src/utils/auth.test.tsx
@@ -88,19 +88,19 @@ describe('auth', () => {
       expect(state.auth).toEqual(auth);
     });
 
-    test('should identify by email and alias the sub onto the same person on login', () => {
+    test('should identify by the keycloak sub, with the email as a person property, on login', () => {
       const auth = createAuth({ sub: 'keycloak-sub-123', email: 'user@bluedot.org' });
       useAuthStore.getState().setAuth(auth);
 
-      expect(posthog.identify).toHaveBeenCalledWith('user@bluedot.org', { email: 'user@bluedot.org' });
-      expect(posthog.alias).toHaveBeenCalledWith('keycloak-sub-123', 'user@bluedot.org');
+      expect(posthog.identify).toHaveBeenCalledWith('keycloak-sub-123', { email: 'user@bluedot.org' });
+      expect(posthog.alias).not.toHaveBeenCalled();
     });
 
-    test('should not alias when sub is absent', () => {
-      const auth = createAuth({ sub: undefined });
+    test('falls back to identifying by email when sub is absent (pre-#2755 stored sessions)', () => {
+      const auth = createAuth({ sub: undefined, email: 'user@bluedot.org' });
       useAuthStore.getState().setAuth(auth);
 
-      expect(posthog.alias).not.toHaveBeenCalled();
+      expect(posthog.identify).toHaveBeenCalledWith('user@bluedot.org', { email: 'user@bluedot.org' });
     });
 
     test('should keep new token when replacing soon-to-expire token', () => {

--- a/libraries/ui/src/utils/auth.tsx
+++ b/libraries/ui/src/utils/auth.tsx
@@ -113,13 +113,11 @@ export const useAuthStore = create<{
 
     set({ auth });
 
-    posthog.identify(auth.email, {
+    // Sessions stored before #2755 (2026-07-08) have no sub until their first token refresh;
+    // the email person is aliased to the sub, so both resolve to the same PostHog person.
+    posthog.identify(auth.sub ?? auth.email, {
       email: auth.email,
     });
-
-    if (auth.sub) {
-      posthog.alias(auth.sub, auth.email);
-    }
 
     const now = Date.now();
     const expiresInMs = auth.expiresAt - now;


### PR DESCRIPTION
# Description

This is the final step to cut PostHog over to solely identifying users by the Keycloak `sub` value rather than email. There is just a `auth.sub ?? auth.email` left in to catch users who haven't refreshed their auth since the migration started.

## Issue

#2713

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories