### PR TITLE
computed-posthog-events: fall back to the course registration anonymous distinct id for participants who never log in

### DIFF
--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -407,10 +407,12 @@ describe('discussion_attended / discussion_absent', () => {
     await testDb.insert(userTable, {
       id: 'u-att', email: 'attendee@x.com', name: 'attendee', keycloakIdentifier: 'sub-u-att',
     });
-    await testDb.insert(userTable, { id: 'u-nosub', email: 'nosub@x.com', name: 'nosub' }); // no keycloakIdentifier -> skipped
+    await testDb.insert(userTable, { id: 'u-nosub', email: 'nosub@x.com', name: 'nosub' }); // no keycloakIdentifier
     await testDb.insert(meetPersonTable, { id: 'mp1', userId: 'u-att', round: 'rd1' });
+    // no keycloakIdentifier AND no registration link to fall back to -> skipped
     await testDb.insert(meetPersonTable, { id: 'mpNoSub', userId: 'u-nosub', round: 'rd1' });
-    await testDb.insert(meetPersonTable, { id: 'noUser' }); // no linked user -> skipped
+    // no linked user and no registration link -> skipped
+    await testDb.insert(meetPersonTable, { id: 'noUser' });
     await insertDiscussion({
       id: 'd1', participantsExpected: ['mp1', 'mpNoSub', 'noUser'], attendees: ['mp1', 'mpNoSub'], startSec: nowSec - 7200, endSec: nowSec - 3600,
     });

--- a/libraries/computed-posthog-events/src/definitions.test.ts
+++ b/libraries/computed-posthog-events/src/definitions.test.ts
@@ -65,6 +65,18 @@ describe('certificate_issued (two source tables)', () => {
     expect(selfServeCert.distinct_id).toBe('sub-u-ss');
     expect(selfServeCert.properties).not.toHaveProperty('round_id');
   });
+
+  test('facilitated: falls back to the registration anchor when the linked user never logged in', async () => {
+    await testDb.insert(userTable, { id: 'u-nosub', email: 'nosub@x.com', name: 'nosub' }); // no keycloakIdentifier
+    await testDb.insert(courseRegistrationTable, {
+      id: 'cr-anon', courseId: 'c1', email: 'nosub@x.com', userId: 'u-nosub', posthogDistinctId: 'anon-cert-1', certificateId: 'certA', certificateCreatedAt: 1_700_000_000,
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    expect(ph.events.filter((e) => e.event === 'certificate_issued').map((e) => e.distinct_id)).toEqual(['anon-cert-1']);
+  });
 });
 
 describe('since (incremental scans)', () => {
@@ -410,6 +422,22 @@ describe('discussion_attended / discussion_absent', () => {
     expect(ph.events.filter((e) => e.event === 'discussion_absent')).toHaveLength(0);
   });
 
+  test('falls back to the registration anchor when the participant never logged in', async () => {
+    await testDb.insert(userTable, { id: 'u-nosub', email: 'nosub@x.com', name: 'nosub' }); // no keycloakIdentifier
+    await testDb.insert(courseRegistrationTable, {
+      id: 'cr-anon', courseId: 'c1', email: 'nosub@x.com', posthogDistinctId: 'anon-reg-1',
+    });
+    await testDb.insert(meetPersonTable, { id: 'mp1', userId: 'u-nosub', applicationsBaseRecordId: 'cr-anon' });
+    await insertDiscussion({
+      id: 'd1', participantsExpected: ['mp1'], attendees: ['mp1'], startSec: nowSec - 7200, endSec: nowSec - 3600,
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog({ now: NOW });
+
+    expect(ph.events.filter((e) => e.event === 'discussion_attended').map((e) => e.distinct_id)).toEqual(['anon-reg-1']);
+  });
+
   test('since scans only discussions ending on/after it', async () => {
     await seedPeople();
     await insertDiscussion({
@@ -727,6 +755,20 @@ describe('project_submitted', () => {
     });
     expect(result).toMatchObject({ candidates: 1, skipped: 1, sent: 0 });
     expect(ph.events.filter((e) => e.event === 'project_submitted')).toHaveLength(0);
+  });
+
+  test('falls back to the registration anchor (record id) when the participant never logged in', async () => {
+    await testDb.insert(userTable, { id: 'u-nosub', email: 'nosub@x.com', name: 'nosub' }); // no keycloakIdentifier
+    await testDb.insert(courseRegistrationTable, { id: 'cr-anon', courseId: 'c1', email: 'nosub@x.com' }); // no posthogDistinctId
+    await testDb.insert(meetPersonTable, { id: 'mp-anon', userId: 'u-nosub', applicationsBaseRecordId: 'cr-anon' });
+    await testDb.insert(projectSubmissionTable, {
+      id: 'ps1', createdAt: '2026-06-08T01:10:28.000Z', participant: ['mp-anon'],
+    });
+
+    const ph = mockPostHogBackend();
+    await forwardAllEventsToPostHog();
+
+    expect(ph.events.filter((e) => e.event === 'project_submitted').map((e) => e.distinct_id)).toEqual(['cr-anon']);
   });
 
   test('since scans only submissions created on/after it', async () => {

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -33,9 +33,11 @@ const getKeycloakIdentifierByUserId = async (db: PgAirtableDb, userIds: (string 
  * Get the best distinct id that we can for this event (better == easier to
  * join to an identified user)
  */
-const preferredDistinctId = (
-{ keycloakIdentifierByUserId, userId, registration }: { keycloakIdentifierByUserId: Map<string, string>; userId: string | null | undefined; registration: Pick<CourseRegistration, 'id' | 'posthogDistinctId'> | null | undefined; },
-): string | null => (
+const preferredDistinctId = ({ keycloakIdentifierByUserId, userId, registration }: {
+  keycloakIdentifierByUserId: Map<string, string>;
+  userId: string | null | undefined;
+  registration: Pick<CourseRegistration, 'id' | 'posthogDistinctId'> | null | undefined;
+}): string | null => (
   (userId ? keycloakIdentifierByUserId.get(userId) : undefined)
   ?? (registration ? courseRegistrationAnonDistinctId(registration) : null)
 );

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -29,13 +29,12 @@ const getKeycloakIdentifierByUserId = async (db: PgAirtableDb, userIds: (string 
   return new Map(users.flatMap((u) => (u.keycloakIdentifier ? [[u.id, u.keycloakIdentifier] as const] : [])));
 };
 
-// The identity preference for registration-scoped events: the linked user's keycloak sub,
-// else the registration's anon anchor (which identify_applicants merges into the sub person
-// at first login). Never email.
-const keycloakIdentifierOrRegistrationAnchor = (
-  keycloakIdentifierByUserId: Map<string, string>,
-  userId: string | null | undefined,
-  registration: Pick<CourseRegistration, 'id' | 'posthogDistinctId'> | null | undefined,
+/**
+ * Get the best distinct id that we can for this event (better == easier to
+ * join to an identified user)
+ */
+const preferredDistinctId = (
+{ keycloakIdentifierByUserId, userId, registration }: { keycloakIdentifierByUserId: Map<string, string>; userId: string | null | undefined; registration: Pick<CourseRegistration, 'id' | 'posthogDistinctId'> | null | undefined; },
 ): string | null => (
   (userId ? keycloakIdentifierByUserId.get(userId) : undefined)
   ?? (registration ? courseRegistrationAnonDistinctId(registration) : null)
@@ -61,7 +60,6 @@ const calculateDiscussionAttendanceEvents = async (
   const meetPersonById = new Map(meetPersons.map((mp) => [mp.id, mp] as const));
   const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, meetPersons.map((mp) => mp.userId));
 
-  // Participants who never log in still get credited via their linked registration's anon anchor
   const registrationIds = [...new Set(meetPersons.map((mp) => mp.applicationsBaseRecordId).filter((id): id is string => !!id))];
   const registrations = registrationIds.length
     ? await db.pg.select({ id: courseRegistrationTable.pg.id, posthogDistinctId: courseRegistrationTable.pg.posthogDistinctId })
@@ -98,7 +96,7 @@ const calculateDiscussionAttendanceEvents = async (
 
       const meetPerson = meetPersonById.get(meetPersonId);
       const registration = meetPerson?.applicationsBaseRecordId ? registrationById.get(meetPerson.applicationsBaseRecordId) : undefined;
-      const distinctId = keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, meetPerson?.userId, registration);
+      const distinctId = preferredDistinctId({ keycloakIdentifierByUserId, userId: meetPerson?.userId, registration });
       if (!meetPerson || !distinctId) continue;
       const roundName = meetPerson.round ? roundTitleById.get(meetPerson.round) : undefined;
 
@@ -134,7 +132,7 @@ const calculateDropoutEvents = async (
     .where(and(filterGteOrNull(dropoutTable.pg.createdAt, since), eq(dropoutTable.pg.type, type)));
   if (rows.length === 0) return [];
 
-  // The anchor, course and round come off the linked application, not the dropout table's own lookups.
+  // The distinct id, course and round come off the linked application, not the dropout table's own lookups.
   const registrationIds = [...new Set(rows.flatMap((r) => r.applicantId ?? []))];
   const registrations = registrationIds.length
     ? await db.pg.select({
@@ -159,7 +157,7 @@ const calculateDropoutEvents = async (
     const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
     return {
       internalUniqueKey: row.id,
-      distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, registration?.userId, registration),
+      distinctId: preferredDistinctId({ keycloakIdentifierByUserId, userId: registration?.userId, registration }),
       timestampMs: Date.parse(row.createdAt!),
       properties: {
         ...(registration?.courseId ? { course_id: registration.courseId } : {}),
@@ -254,7 +252,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `accept:${r.id}`,
-          distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, r.userId, r),
+          distinctId: preferredDistinctId({ keycloakIdentifierByUserId, userId: r.userId, registration: r }),
           timestampMs: Date.parse(r.acceptedAt!),
           properties: {
             course_id: r.courseId,
@@ -279,7 +277,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `reject:${r.id}`,
-          distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, r.userId, r),
+          distinctId: preferredDistinctId({ keycloakIdentifierByUserId, userId: r.userId, registration: r }),
           timestampMs: Date.parse(r.rejectedAt!),
           properties: {
             course_id: r.courseId,
@@ -304,7 +302,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `withdraw:${r.id}`,
-          distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, r.userId, r),
+          distinctId: preferredDistinctId({ keycloakIdentifierByUserId, userId: r.userId, registration: r }),
           timestampMs: Date.parse(r.withdrawnAt!),
           properties: {
             course_id: r.courseId,
@@ -336,7 +334,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
           const courseName = courseTitleById.get(r.courseId);
           return {
             internalUniqueKey: `courseReg:${r.id}`,
-            distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, r.userId, r),
+            distinctId: preferredDistinctId({ keycloakIdentifierByUserId, userId: r.userId, registration: r }),
             timestampMs: Number(r.certificateCreatedAt) * 1000,
             properties: {
               course_id: r.courseId,
@@ -466,7 +464,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
 
       // The form links each submission to a meet_person (participant). The identity and the course/round
       // both come off that link: meetPerson.userId -> user gives the distinct id; meetPerson.applicationsBaseRecordId
-      // -> course_registration gives the course, round, and the anon-anchor fallback for never-logged-in participants.
+      // -> course_registration gives the course, round, and the anon-distinct-id fallback for never-logged-in participants.
       const participantIds = [...new Set(submissions.flatMap((s) => s.participant ?? []))];
       const meetPersons = participantIds.length
         ? await db.pg.select({
@@ -500,7 +498,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
         return {
           internalUniqueKey: `${s.id}:${participantId}`,
-          distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, meetPerson?.userId, registration),
+          distinctId: preferredDistinctId({ keycloakIdentifierByUserId, userId: meetPerson?.userId, registration }),
           timestampMs: Date.parse(s.createdAt!),
           properties: {
             ...(registration?.courseId ? { course_id: registration.courseId } : {}),

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -29,6 +29,18 @@ const getKeycloakIdentifierByUserId = async (db: PgAirtableDb, userIds: (string 
   return new Map(users.flatMap((u) => (u.keycloakIdentifier ? [[u.id, u.keycloakIdentifier] as const] : [])));
 };
 
+// The identity preference for registration-scoped events: the linked user's keycloak sub,
+// else the registration's anon anchor (which identify_applicants merges into the sub person
+// at first login). Never email.
+const keycloakIdentifierOrRegistrationAnchor = (
+  keycloakIdentifierByUserId: Map<string, string>,
+  userId: string | null | undefined,
+  registration: Pick<CourseRegistration, 'id' | 'posthogDistinctId'> | null | undefined,
+): string | null => (
+  (userId ? keycloakIdentifierByUserId.get(userId) : undefined)
+  ?? (registration ? courseRegistrationAnonDistinctId(registration) : null)
+);
+
 // Mirrors the my-courses UI (deriveStatus in useDiscussionActions.tsx): a participant is `attended` when
 // their meet_person id is in the discussion's attendees, and `absent` once the discussion has ended without it.
 const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
@@ -48,6 +60,14 @@ const calculateDiscussionAttendanceEvents = async (
   const meetPersons = await db.pg.select().from(meetPersonTable.pg).where(inArray(meetPersonTable.pg.id, meetPersonIds));
   const meetPersonById = new Map(meetPersons.map((mp) => [mp.id, mp] as const));
   const keycloakIdentifierByUserId = await getKeycloakIdentifierByUserId(db, meetPersons.map((mp) => mp.userId));
+
+  // Participants who never log in still get credited via their linked registration's anon anchor
+  const registrationIds = [...new Set(meetPersons.map((mp) => mp.applicationsBaseRecordId).filter((id): id is string => !!id))];
+  const registrations = registrationIds.length
+    ? await db.pg.select({ id: courseRegistrationTable.pg.id, posthogDistinctId: courseRegistrationTable.pg.posthogDistinctId })
+      .from(courseRegistrationTable.pg).where(inArray(courseRegistrationTable.pg.id, registrationIds))
+    : [];
+  const registrationById = new Map(registrations.map((r) => [r.id, r] as const));
 
   const roundIds = [...new Set(meetPersons.map((mp) => mp.round).filter((r): r is string => !!r))];
   const rounds = roundIds.length
@@ -77,13 +97,14 @@ const calculateDiscussionAttendanceEvents = async (
       if (kind === 'attended' ? !isAttended : isAttended) continue;
 
       const meetPerson = meetPersonById.get(meetPersonId);
-      const keycloakIdentifier = meetPerson?.userId ? keycloakIdentifierByUserId.get(meetPerson.userId) : undefined;
-      if (!meetPerson || !keycloakIdentifier) continue;
+      const registration = meetPerson?.applicationsBaseRecordId ? registrationById.get(meetPerson.applicationsBaseRecordId) : undefined;
+      const distinctId = keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, meetPerson?.userId, registration);
+      if (!meetPerson || !distinctId) continue;
       const roundName = meetPerson.round ? roundTitleById.get(meetPerson.round) : undefined;
 
       events.push({
         internalUniqueKey: `${meetPersonId}:${d.id}`,
-        distinctId: keycloakIdentifier,
+        distinctId,
         timestampMs: d.startDateTime * 1000,
         properties: {
           discussion_id: d.id,
@@ -138,9 +159,7 @@ const calculateDropoutEvents = async (
     const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
     return {
       internalUniqueKey: row.id,
-      distinctId: registration
-        ? ((registration.userId ? keycloakIdentifierByUserId.get(registration.userId) : undefined) ?? courseRegistrationAnonDistinctId(registration))
-        : null,
+      distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, registration?.userId, registration),
       timestampMs: Date.parse(row.createdAt!),
       properties: {
         ...(registration?.courseId ? { course_id: registration.courseId } : {}),
@@ -235,7 +254,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `accept:${r.id}`,
-          distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? courseRegistrationAnonDistinctId(r),
+          distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, r.userId, r),
           timestampMs: Date.parse(r.acceptedAt!),
           properties: {
             course_id: r.courseId,
@@ -260,7 +279,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `reject:${r.id}`,
-          distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? courseRegistrationAnonDistinctId(r),
+          distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, r.userId, r),
           timestampMs: Date.parse(r.rejectedAt!),
           properties: {
             course_id: r.courseId,
@@ -285,7 +304,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = courseTitleById.get(r.courseId);
         return {
           internalUniqueKey: `withdraw:${r.id}`,
-          distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? courseRegistrationAnonDistinctId(r),
+          distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, r.userId, r),
           timestampMs: Date.parse(r.withdrawnAt!),
           properties: {
             course_id: r.courseId,
@@ -317,7 +336,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
           const courseName = courseTitleById.get(r.courseId);
           return {
             internalUniqueKey: `courseReg:${r.id}`,
-            distinctId: (r.userId ? keycloakIdentifierByUserId.get(r.userId) : undefined) ?? null,
+            distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, r.userId, r),
             timestampMs: Number(r.certificateCreatedAt) * 1000,
             properties: {
               course_id: r.courseId,
@@ -447,7 +466,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
 
       // The form links each submission to a meet_person (participant). The identity and the course/round
       // both come off that link: meetPerson.userId -> user gives the distinct id; meetPerson.applicationsBaseRecordId
-      // -> course_registration gives the course and round.
+      // -> course_registration gives the course, round, and the anon-anchor fallback for never-logged-in participants.
       const participantIds = [...new Set(submissions.flatMap((s) => s.participant ?? []))];
       const meetPersons = participantIds.length
         ? await db.pg.select({
@@ -461,6 +480,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
       const registrations = registrationIds.length
         ? await db.pg.select({
           id: courseRegistrationTable.pg.id,
+          posthogDistinctId: courseRegistrationTable.pg.posthogDistinctId,
           courseId: courseRegistrationTable.pg.courseId,
           roundId: courseRegistrationTable.pg.roundId,
           roundName: courseRegistrationTable.pg.roundName,
@@ -480,7 +500,7 @@ export const eventProjectionRules: EventProjectionRule[] = [
         const courseName = registration?.courseId ? courseTitleById.get(registration.courseId) : undefined;
         return {
           internalUniqueKey: `${s.id}:${participantId}`,
-          distinctId: (meetPerson?.userId ? keycloakIdentifierByUserId.get(meetPerson.userId) : undefined) ?? null,
+          distinctId: keycloakIdentifierOrRegistrationAnchor(keycloakIdentifierByUserId, meetPerson?.userId, registration),
           timestampMs: Date.parse(s.createdAt!),
           properties: {
             ...(registration?.courseId ? { course_id: registration.courseId } : {}),


### PR DESCRIPTION
# Description

When spot-checking the data in PostHog I noticed that there were some events like `certificate_issued` that don't get joined up to a user. It turns out that this is legitimate, and a small fraction of people complete courses without ever logging into the website.

This PR makes it so these will at least be joined up to the same anonymous user by getting a consistent distinct ID off the linked course registration. 

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2713

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories