### PR TITLE
[refactor] Simplify facilitator access check in verifyFacilitatorById

### DIFF
--- a/apps/website/src/server/routers/facilitators.test.ts
+++ b/apps/website/src/server/routers/facilitators.test.ts
@@ -351,6 +351,38 @@ describe('facilitators.getFeedbackFormData', () => {
       .rejects.toThrow('Not found');
   });
 
+  test('allows an admin (not impersonating) to access another facilitator\'s form', async () => {
+    await seedFacilitatorGroup();
+    await testDb.insert(userTable, {
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
+    });
+    const adminCaller = createCaller({
+      ...testAuthContextLoggedIn,
+      auth: { ...testAuthContextLoggedIn.auth!, sub: 'admin-sub' },
+    });
+
+    const result = await adminCaller.facilitators.getFeedbackFormData({ meetPersonId: FACILITATOR_ID });
+    expect(result.meetPersonId).toBe(FACILITATOR_ID);
+  });
+
+  test('rejects an admin impersonating a user who is not the facilitator', async () => {
+    await seedFacilitatorGroup();
+    await testDb.insert(userTable, {
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
+    });
+    await testDb.insert(userTable, {
+      id: 'user-other', email: 'other@example.com', name: 'Other', keycloakIdentifier: 'other-sub',
+    });
+    const impersonatingCaller = createCaller({
+      ...testAuthContextLoggedIn,
+      auth: { ...testAuthContextLoggedIn.auth!, sub: 'other-sub' },
+      impersonation: { adminEmail: 'admin@example.com', adminSub: 'admin-sub', targetEmail: 'other@example.com' },
+    });
+
+    await expect(impersonatingCaller.facilitators.getFeedbackFormData({ meetPersonId: FACILITATOR_ID }))
+      .rejects.toThrow('Not found');
+  });
+
   test('errors when the facilitator meetPerson has no linked user', async () => {
     await seedFacilitatorGroup();
     await testDb.insert(userTable, {

--- a/apps/website/src/server/routers/facilitators.ts
+++ b/apps/website/src/server/routers/facilitators.ts
@@ -20,9 +20,7 @@ import {
 import { TRPCError } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
-import {
-  checkAdminAccess, getUserFromAuthOrThrow, impersonationRealIdentity, protectedProcedure, router,
-} from '../trpc';
+import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 import { getFieldOptions } from '../airtableFieldOptions';
 
 // Options whose Airtable name starts with "[!]" are "actionable" — flagging the participant
@@ -62,7 +60,7 @@ const getFacilitator = async (roundId: string, userId: string) => {
   return facilitator;
 };
 
-async function verifyFacilitatorById(meetPersonId: string, ctx: { auth: { sub: string }; impersonation?: { adminSub: string } | null }) {
+async function verifyFacilitatorById(meetPersonId: string, ctx: { auth: { sub: string } }) {
   const [user, meetPerson] = await Promise.all([
     getUserFromAuthOrThrow(ctx.auth),
     db.getFirst(meetPersonTable, {
@@ -74,12 +72,8 @@ async function verifyFacilitatorById(meetPersonId: string, ctx: { auth: { sub: s
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Not found' });
   }
 
-  if (meetPerson.userId !== user.id) {
-    // During impersonation, check the real admin's permissions, not the impersonated user's.
-    const isAdmin = await checkAdminAccess(impersonationRealIdentity(ctx));
-    if (!isAdmin) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Not found' });
-    }
+  if (meetPerson.userId !== user.id && user.isAdmin !== true) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Not found' });
   }
 
   return meetPerson;


### PR DESCRIPTION
# Description

From the Issue:
> `verifyFacilitatorById` (apps/website/src/server/routers/facilitators.ts, ~line 72) allows the calling user to access a facilitator feedback form if the _real user_ is an admin, even if the user they are impersonating is not. This is over-complicated, we should instead just make it judge based on the impersonated user, and require the admin to clear impersonation if they want to access all forms.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2757

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories