### PR TITLE
[chore] infra: remove deprecated certificateCreationToken secret

### DIFF
--- a/apps/infra/Pulumi.prod.yaml
+++ b/apps/infra/Pulumi.prod.yaml
@@ -28,8 +28,6 @@ config:
     secure: v1:xFifyNHW/RrW9Nu2:El+89xjeyp8EiGmgtvyscw129C+CinAwLde1sd6k6xgiorWDbUEaCdvq5jY7xewv
   infra:prodOnlyWebhookDeletion:
     secure: v1:9v9u5E5OOc+3SDxJ:V7AxNmgk9GmkCYegen7P9IEIZyQ=
-  infra:certificateCreationToken:
-    secure: v1:/LmEHmIJhdM2YpOA:NF9rrScCurxLl+Q7KsHLDGaL5gQG0Cq/MXiSHQp7EFq48csaa9Ub3iQGE1hkw9ni
   infra:lumaApiKey:
     secure: v1:Vm3B5jcIwUAYhL0b:+Q0iFfwl5wMPDpRDoRDOYY64MD+h0E6nL8NaQoA+iKiHC2JDH0CnGhZHwNtZBUie
   infra:keycloakPreviewClientId:


### PR DESCRIPTION
# Description

Follow-up to #2813, which renamed the shared Airtable-automation secret to `airtableAutomationToken`. All application and infra code now reference the new secret; the old `certificateCreationToken` Pulumi secret is unused and safe to delete.

Verified no remaining references to `certificateCreationToken` / `CERTIFICATE_CREATION_TOKEN` in tracked files.

## Issue

Fixes #2808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
