### PR TITLE
[fix] Group switch modal: prefill availability form with the registration email, not the account email

### DIFF
--- a/apps/website/src/components/courses/GroupSwitchModal.test.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.test.tsx
@@ -705,6 +705,123 @@ describe('GroupSwitchModal', () => {
     });
   });
 
+  describe('Course registration states', () => {
+    test('form is not shown until the course registration has loaded', async () => {
+      let resolveRegistration!: () => void;
+      const registrationRequested = vi.fn();
+      server.use(trpcMsw.courseRegistrations.getByCourseId.query(() => {
+        registrationRequested();
+        return new Promise((resolve) => {
+          resolveRegistration = () => resolve(mockCourseRegistration);
+        });
+      }));
+
+      render(
+        <GroupSwitchModal
+          handleClose={() => {}}
+          initialUnitNumber={mockUnit1.unitNumber}
+          courseSlug="ai-safety"
+          roundId="round-1"
+        />,
+        { wrapper: TrpcProvider },
+      );
+
+      await waitFor(() => {
+        expect(registrationRequested).toHaveBeenCalled();
+      });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+
+      expect(document.querySelector('.progress-dots')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Reason for group switch request')).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: /I have updated my availability/i })).not.toBeInTheDocument();
+
+      resolveRegistration();
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Reason for group switch request')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Request manual group switch/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: /please update your availability/i }))
+          .toHaveAttribute('href', expect.stringContaining('email=registration%40bluedot.org'));
+      });
+    });
+
+    test('falls back to the account email when the user has no accepted course registration', async () => {
+      server.use(trpcMsw.courseRegistrations.getByCourseId.query(() => null));
+
+      render(
+        <GroupSwitchModal
+          handleClose={() => {}}
+          initialUnitNumber={mockUnit1.unitNumber}
+          courseSlug="ai-safety"
+          roundId="round-1"
+        />,
+        { wrapper: TrpcProvider },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Reason for group switch request')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Request manual group switch/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/To help us assign you to a group which best suits you/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('link', { name: /please update your availability/i }))
+        .toHaveAttribute('href', expect.stringContaining('email=test%40bluedot.org'));
+
+      fireEvent.click(screen.getByRole('checkbox', { name: /I have updated my availability/i }));
+
+      const submitButton = screen.getByRole('button', { name: /Submit group switch request/i });
+      expect(submitButton).not.toBeDisabled();
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockSubmitGroupSwitch).toHaveBeenCalledWith(expect.objectContaining({ isManualRequest: true }));
+      });
+    });
+
+    test('falls back to the account email when the course registration query fails', async () => {
+      server.use(trpcMsw.courseRegistrations.getByCourseId.query(() => {
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to load registration' });
+      }));
+
+      render(
+        <GroupSwitchModal
+          handleClose={() => {}}
+          initialUnitNumber={mockUnit1.unitNumber}
+          courseSlug="ai-safety"
+          roundId="round-1"
+        />,
+        { wrapper: TrpcProvider },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Reason for group switch request')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Request manual group switch/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/To help us assign you to a group which best suits you/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('link', { name: /please update your availability/i }))
+        .toHaveAttribute('href', expect.stringContaining('email=test%40bluedot.org'));
+
+      fireEvent.click(screen.getByRole('checkbox', { name: /I have updated my availability/i }));
+
+      expect(screen.getByRole('button', { name: /Submit group switch request/i })).not.toBeDisabled();
+    });
+  });
+
   describe('Participant without group', () => {
     // Derive mock data from base by setting userIsParticipant to false everywhere
     const mockAvailableGroupsAndDiscussionsNoGroup: DiscussionsAvailable = {

--- a/apps/website/src/components/courses/GroupSwitchModal.test.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.test.tsx
@@ -21,7 +21,7 @@ import type { DiscussionsAvailable } from '../../server/routers/group-switching'
 import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
 import { TrpcProvider } from '../../__tests__/trpcProvider';
 import {
-  createMockCourse, createMockGroupDiscussion, createMockUnit, createMockGroup,
+  createMockCourse, createMockCourseRegistration, createMockGroupDiscussion, createMockUnit, createMockGroup,
 } from '../../__tests__/testUtils';
 
 vi.mock('@bluedot/ui', async () => {
@@ -51,6 +51,10 @@ const mockUser = {
   keycloakIdentifier: null,
   allowedImpersonationTargets: [],
 };
+
+const mockCourseRegistration = createMockCourseRegistration({
+  email: 'registration@bluedot.org',
+});
 
 const mockUnit1 = createMockUnit({
   title: 'Introduction to AI Safety',
@@ -142,6 +146,7 @@ describe('GroupSwitchModal', () => {
     server.use(
       trpcMsw.users.getUser.query(() => mockUser),
       trpcMsw.courses.getBySlug.query(() => mockCourseData),
+      trpcMsw.courseRegistrations.getByCourseId.query(() => mockCourseRegistration),
       trpcMsw.groupSwitching.discussionsAvailable.query(() => mockAvailableGroupsAndDiscussions),
       trpcMsw.groupSwitching.switchGroup.mutation(({ input }) => {
         mockSubmitGroupSwitch(input);
@@ -304,6 +309,9 @@ describe('GroupSwitchModal', () => {
         // UI changes to show manual request form
         expect(screen.getByText(/To help us assign you to a group which best suits you/i)).toBeInTheDocument();
       });
+
+      expect(screen.getByRole('link', { name: /please update your availability/i }))
+        .toHaveAttribute('href', expect.stringContaining('email=registration%40bluedot.org'));
 
       const reasonTextarea = screen.getByLabelText('Reason for group switch request');
       fireEvent.change(reasonTextarea, {

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -63,7 +63,7 @@ export default function GroupSwitchModal({
     },
   );
 
-  const { data: courseRegistration } = trpc.courseRegistrations.getByCourseId.useQuery(
+  const { data: courseRegistration, isLoading: isRegistrationLoading } = trpc.courseRegistrations.getByCourseId.useQuery(
     { courseId: courseData?.course.id ?? '' },
     {
       enabled: !!courseData?.course.id,
@@ -79,7 +79,7 @@ export default function GroupSwitchModal({
   });
 
   const isSubmitting = submitGroupSwitchMutation.isPending;
-  const isLoading = isCourseLoading || isDiscussionsLoading;
+  const isLoading = isCourseLoading || isDiscussionsLoading || isRegistrationLoading;
 
   const groups = availableGroupsAndDiscussions?.groupsAvailable ?? [];
   const discussions = availableGroupsAndDiscussions?.discussionsAvailable?.[selectedUnitNumber] ?? [];
@@ -355,16 +355,16 @@ export default function GroupSwitchModal({
       id: 'availability',
       isVisible: !!user && isManualRequest,
       title: 'Update availability (required)',
-      subtitle: courseRegistration ? (
+      subtitle: user ? (
         <>
           To help us assign you to a group which best suits you, {' '}
           <a
             href={buildAvailabilityFormUrl({
-              email: courseRegistration.email,
+              email: courseRegistration?.email ?? user.email,
               utmSource: 'bluedot-group-switch-modal',
               courseRegistration,
               // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              roundId: courseRegistration.roundId || '',
+              roundId: courseRegistration?.roundId || '',
             })}
             target="_blank"
             rel="noopener noreferrer"

--- a/apps/website/src/components/courses/GroupSwitchModal.tsx
+++ b/apps/website/src/components/courses/GroupSwitchModal.tsx
@@ -355,16 +355,16 @@ export default function GroupSwitchModal({
       id: 'availability',
       isVisible: !!user && isManualRequest,
       title: 'Update availability (required)',
-      subtitle: user ? (
+      subtitle: courseRegistration ? (
         <>
           To help us assign you to a group which best suits you, {' '}
           <a
             href={buildAvailabilityFormUrl({
-              email: user.email,
+              email: courseRegistration.email,
               utmSource: 'bluedot-group-switch-modal',
               courseRegistration,
               // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              roundId: courseRegistration?.roundId || '',
+              roundId: courseRegistration.roundId || '',
             })}
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
# Description

Per the issue description, this is needed to ensure that the link to submit availability goes to the right place after we support changing account emails (#2570)

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2811

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories