### PR TITLE
Bump keycloak theme to v2.1.0

### DIFF
--- a/apps/login/tools/getBluedotKeycloakTheme.sh
+++ b/apps/login/tools/getBluedotKeycloakTheme.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 cd $(dirname "${BASH_SOURCE[0]:-$0}")/..
 
-FIXED_RELEASE_VERSION="v2.0.0"
+FIXED_RELEASE_VERSION="v2.1.0"
 REPO="bluedotimpact/bluedot-keycloak-theme"
 ASSET_NAME="bluedot-keycloak-theme.jar"
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Bumps keycloak theme to v2.1.0

Notable changes:

1. Google sign in moved above email sign in
2. First/last name (optional) fields added to sign up form

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2723

