### PR TITLE
Reuse `seedLoggedInUser` utility

### DIFF
--- a/apps/website/src/__tests__/dbTestUtils.tsx
+++ b/apps/website/src/__tests__/dbTestUtils.tsx
@@ -4,7 +4,7 @@ import { unstable_localLink } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
 import { useState } from 'react';
 import {
-  pushTestSchema, resetTestDb, type TestPgAirtableDb, userTable,
+  pushTestSchema, resetTestDb, type TestPgAirtableDb, type User, userTable,
 } from '@bluedot/db';
 import type { AppRouter } from '../server/routers/_app';
 import type { Context } from '../server/context';
@@ -47,11 +47,12 @@ export function setupTestDb() {
 }
 
 // Seeds the userTable row for `testAuthContextLoggedIn`, required by procedures that call getUserFromAuthOrThrow.
-export const seedLoggedInUser = () => testDb.insert(userTable, {
+export const seedLoggedInUser = (overrides: Partial<User> = {}) => testDb.insert(userTable, {
   id: 'test-user',
   email: 'test@example.com',
   name: 'Test User',
   keycloakIdentifier: 'test-sub',
+  ...overrides,
 });
 
 // Server-side caller, for router tests that don't render components

--- a/apps/website/src/components/admin/ImpersonationBadge.test.tsx
+++ b/apps/website/src/components/admin/ImpersonationBadge.test.tsx
@@ -8,7 +8,7 @@ import { ImpersonationBadge } from './ImpersonationBadge';
 import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
 import { TrpcProvider } from '../../__tests__/trpcProvider';
 import {
-  createTrpcDbProvider, setupTestDb, testAuthContextLoggedIn, testDb,
+  createTrpcDbProvider, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testDb,
 } from '../../__tests__/dbTestUtils';
 
 const createMockStorage = () => {
@@ -127,9 +127,7 @@ describe('ImpersonationBadge URL param handling', () => {
   };
 
   test('?impersonate=<email> resolves via admin.searchUsers and writes sessionStorage', async () => {
-    await testDb.insert(userTable, {
-      id: 'rec-admin', email: testAuthContextLoggedIn.auth!.email, name: 'Admin', isAdmin: true, keycloakIdentifier: testAuthContextLoggedIn.auth!.sub,
-    });
+    await seedLoggedInUser({ isAdmin: true });
     await testDb.insert(userTable, {
       id: 'rec-foo', email: 'foo@bar.com', name: 'Foo', keycloakIdentifier: 'foo-sub',
     });
@@ -145,9 +143,7 @@ describe('ImpersonationBadge URL param handling', () => {
 
   test('?impersonate=<email> targeting a never-logged-in user does not start impersonating', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    await testDb.insert(userTable, {
-      id: 'rec-admin', email: testAuthContextLoggedIn.auth!.email, name: 'Admin', isAdmin: true, keycloakIdentifier: testAuthContextLoggedIn.auth!.sub,
-    });
+    await seedLoggedInUser({ isAdmin: true });
     await testDb.insert(userTable, { id: 'rec-ghost', email: 'ghost@bar.com', name: 'Ghost' });
 
     stubLocationSearch('?impersonate=ghost@bar.com');

--- a/apps/website/src/components/my-courses/CourseListRow.test.tsx
+++ b/apps/website/src/components/my-courses/CourseListRow.test.tsx
@@ -4,13 +4,13 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {
-  courseTable, meetPersonTable, roundTable, unitTable, userTable,
+  courseTable, meetPersonTable, roundTable, unitTable,
 } from '@bluedot/db';
 import {
   createMockCourseRegistration, createMockGroup, createMockGroupDiscussion, createMockUnit,
 } from '../../__tests__/testUtils';
 import {
-  createTrpcDbProvider, setupTestDb, testAuthContextLoggedIn, testDb,
+  createTrpcDbProvider, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testDb,
 } from '../../__tests__/dbTestUtils';
 import CourseListRow, { getSubtitle, type FacilitatorRowProps, type ParticipantRowProps } from './CourseListRow';
 import { classifyCourseRegistration } from './useCourseListRow';
@@ -713,7 +713,6 @@ describe('CourseListRow actions', () => {
 describe('CourseListRow modal pre-fill (real tRPC via PGlite)', () => {
   setupTestDb();
 
-  const AUTH_EMAIL = testAuthContextLoggedIn.auth!.email;
   const ROUND = 'round-1';
   const GROUP = 'group-1';
   const COURSE_ID = 'course-1';
@@ -782,14 +781,14 @@ describe('CourseListRow modal pre-fill (real tRPC via PGlite)', () => {
 
   // discussionsAvailable / getFacilitatorsForRound both look up the caller's facilitator record for the round.
   const seedFacilitator = async () => {
-    await testDb.insert(userTable, { id: 'user-1', email: AUTH_EMAIL, name: 'Test User' });
+    await seedLoggedInUser({ id: 'user-1' });
     await testDb.insert(meetPersonTable, {
       id: 'mp-fac', userId: 'user-1', round: ROUND, role: 'Facilitator', expectedDiscussionsFacilitator: [],
     });
   };
 
   const seedParticipant = async () => {
-    await testDb.insert(userTable, { id: 'user-1', email: AUTH_EMAIL, name: 'Test User' });
+    await seedLoggedInUser({ id: 'user-1' });
     await testDb.insert(courseTable, {
       id: COURSE_ID, slug: COURSE_SLUG, title: 'Technical AI Safety', shortDescription: 'T', units: [],
     });

--- a/apps/website/src/components/settings/ProfileNameEditor.test.tsx
+++ b/apps/website/src/components/settings/ProfileNameEditor.test.tsx
@@ -8,7 +8,9 @@ import { userTable } from '@bluedot/db';
 import db from '../../lib/api/db';
 import { server, trpcMsw } from '../../__tests__/trpcMswSetup';
 import { TrpcProvider } from '../../__tests__/trpcProvider';
-import { createTrpcDbProvider, setupTestDb, testAuthContextLoggedIn } from '../../__tests__/dbTestUtils';
+import {
+  createTrpcDbProvider, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn,
+} from '../../__tests__/dbTestUtils';
 import ProfileNameEditor from './ProfileNameEditor';
 
 setupTestDb();
@@ -231,19 +233,15 @@ describe('ProfileNameEditor', () => {
 
 describe('ProfileNameEditor (with DB)', () => {
   test('saves name change to the database', async () => {
-    await db.insert(userTable, {
-      email: 'test@example.com',
-      name: 'John Doe',
-      keycloakIdentifier: 'test-sub',
-    });
+    await seedLoggedInUser();
 
     const { container } = render(
-      <ProfileNameEditor initialName="John Doe" />,
+      <ProfileNameEditor initialName="Test User" />,
       { wrapper: createTrpcDbProvider(testAuthContextLoggedIn) },
     );
 
     const input = container.querySelector<HTMLInputElement>('input[aria-label="Profile name"]')!;
-    expect(input.value).toBe('John Doe');
+    expect(input.value).toBe('Test User');
 
     // Change the name and click Save
     fireEvent.change(input, { target: { value: 'Jane Doe' } });


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

- `seedLoggedInUser()` now takes an optional `Partial<User>` overrides arg
- Converted the remaining hand-rolled caller rows:
  - `CourseListRow.test.tsx` — `seedFacilitator`/`seedParticipant` → `seedLoggedInUser({ id: 'user-1' })`
  - `ImpersonationBadge.test.tsx` — admin callers → `seedLoggedInUser({ isAdmin: true })`
  - `ProfileNameEditor.test.tsx` — manual insert → `seedLoggedInUser()`

Deliberately left manual:
- `users.test.ts` — the user row *is* the subject under test (`users.ensureExists` creates /
  backfills it), so seeding a fully-formed row would defeat the assertions.
- `admin.test.ts` / `context.test.ts` — callers use non-standard identities (`admin-sub`,
  `scoped-sub`), not the `test-sub` caller `seedLoggedInUser()` represents; routing them
  through the helper would mean overriding every field.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2756
