### PR TITLE
[refactor] Delete typography className overrides that restate component defaults (#2820 PR 1/2)

### DIFF
--- a/apps/meet/src/components/AppJoinView.tsx
+++ b/apps/meet/src/components/AppJoinView.tsx
@@ -56,7 +56,7 @@ const AppJoinView: React.FC<AppJoinViewProps> = ({
         </CTALinkOrButton>
       )}
       {secondsToOpen <= 0 && (
-        <p className="mt-4">Button doesn't work? <A href={`https://zoom.us/j/${meetingNumber}?pwd=${meetingPassword}`} className="underline">Join via Zoom website</A></p>
+        <p className="mt-4">Button doesn't work? <A href={`https://zoom.us/j/${meetingNumber}?pwd=${meetingPassword}`}>Join via Zoom website</A></p>
       ) }
     </Page>
   );

--- a/apps/room/src/pages/[roomId].tsx
+++ b/apps/room/src/pages/[roomId].tsx
@@ -142,7 +142,7 @@ const RoomControlPage = withAuth(({ auth }) => {
               </div>
             ) : (
               <div className="flex flex-col gap-4">
-                <P>Currently viewing <A href={room.status.currentUrl} className="underline">{room.status.currentUrl}</A></P>
+                <P>Currently viewing <A href={room.status.currentUrl}>{room.status.currentUrl}</A></P>
                 <CTALinkOrButton onClick={() => setPiCurrentUrl(defaultDisplayUrl)}>
                   Leave {room.status.currentUrl.includes('meet') ? 'meeting' : 'page'}
                 </CTALinkOrButton>

--- a/apps/website/src/components/advising/HowItWorksSection.tsx
+++ b/apps/website/src/components/advising/HowItWorksSection.tsx
@@ -33,7 +33,7 @@ const HowItWorksSection = () => {
               <H4>
                 {step.title}
               </H4>
-              <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+              <P className="text-bluedot-navy/80">
                 {step.body}
               </P>
             </li>

--- a/apps/website/src/components/alumni/RecentAlumniList.tsx
+++ b/apps/website/src/components/alumni/RecentAlumniList.tsx
@@ -68,7 +68,7 @@ const AlumniRow = ({ alum }: { alum: TransformedTestimonial }) => {
         className="size-11 text-size-xs"
       />
       <div className="flex-1 min-w-0">
-        <P className="text-size-sm font-semibold leading-tight text-bluedot-navy truncate">{alum.name}</P>
+        <P className="font-semibold leading-tight truncate">{alum.name}</P>
         <P className="text-size-xs text-bluedot-navy/60 truncate">{alum.jobTitle}</P>
       </div>
       {linkHref && (

--- a/apps/website/src/components/career-transition-grant/ExpectationsSection.tsx
+++ b/apps/website/src/components/career-transition-grant/ExpectationsSection.tsx
@@ -44,7 +44,7 @@ const ExpectationsSection = () => {
                 <H4>
                   {item.title}
                 </H4>
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {item.body}
                 </P>
               </div>

--- a/apps/website/src/components/career-transition-grant/NextStepsSection.tsx
+++ b/apps/website/src/components/career-transition-grant/NextStepsSection.tsx
@@ -33,7 +33,7 @@ const NextStepsSection = () => {
               <H4>
                 {step.title}
               </H4>
-              <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+              <P className="text-bluedot-navy/80">
                 {step.body}
               </P>
             </li>

--- a/apps/website/src/components/career-transition-grant/WhatThisIsForSection.tsx
+++ b/apps/website/src/components/career-transition-grant/WhatThisIsForSection.tsx
@@ -46,7 +46,7 @@ const WhatThisIsForSection = () => {
                 <H4>
                   {title}
                 </H4>
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {description}
                 </P>
               </div>

--- a/apps/website/src/components/courses/Congratulations.tsx
+++ b/apps/website/src/components/courses/Congratulations.tsx
@@ -131,7 +131,7 @@ const ShareCard = ({ title, description, actions, preview }: ShareCardProps) => 
       <div className="flex flex-col gap-3">
         <H3 className="text-size-md">{title}</H3>
         {description && (
-          <P className="text-bluedot-navy text-size-sm leading-relaxed">{description}</P>
+          <P>{description}</P>
         )}
       </div>
       {actions && <div className="flex flex-wrap items-center gap-3">{actions}</div>}
@@ -391,7 +391,7 @@ const Congratulations: React.FC<CongratulationsProps> = ({
             <H2 className="text-[32px] text-white">
               Help more people discover AI safety today
             </H2>
-            <P className="text-size-sm leading-relaxed text-white">
+            <P className="text-white">
               You&apos;ve spent time understanding one of the most important problems of our era. A post or a message to
               the right person can have a real ripple effect.
             </P>
@@ -437,7 +437,7 @@ const Congratulations: React.FC<CongratulationsProps> = ({
         <div className="border-hairline border-bluedot-navy/25 flex flex-col gap-6 rounded-lg bg-white p-10 py-12">
           <div className="flex flex-col gap-3">
             <H3 className="text-size-md">Want to go deeper?</H3>
-            <P className="text-bluedot-navy text-size-sm leading-relaxed">
+            <P>
               <span className="font-semibold">The AGI Strategy course</span> is the natural next step: 25 hours,
               facilitated in small groups with live discussion. No specific background required. New rounds start
               every month.

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -57,7 +57,7 @@ const FeatureCardItem = ({ card, accentColor }: { card: FeatureCard; accentColor
       <card.icon className="size-5" style={{ color: accentColor }} />
       <p className="text-size-sm font-semibold leading-normal text-bluedot-navy">{card.title}</p>
     </div>
-    <P className="text-size-sm leading-relaxed text-bluedot-navy/70">{card.description}</P>
+    <P className="text-bluedot-navy/70">{card.description}</P>
   </div>
 );
 
@@ -135,7 +135,7 @@ export default function CourseCompletionSection({
             <H2 className="text-[28px] md:text-[32px]">
               Join the next {courseTitle} cohort
             </H2>
-            <P className="text-size-sm leading-relaxed text-bluedot-navy">
+            <P>
               Learn alongside field experts and leave with a clear next step.
             </P>
           </div>
@@ -179,12 +179,12 @@ export default function CourseCompletionSection({
                     className="flex flex-col md:flex-row md:items-start gap-2 md:gap-8 py-5 border-t border-bluedot-navy/10"
                   >
                     <div className="md:w-[160px] shrink-0">
-                      <P className="text-size-sm font-semibold leading-snug text-bluedot-navy">
+                      <P className="font-semibold leading-snug">
                         {detail.label}
                       </P>
                     </div>
                     <div className="flex-1 min-w-0">
-                      <P className="text-size-sm leading-relaxed text-bluedot-navy/80 font-normal">
+                      <P className="text-bluedot-navy/80">
                         {detail.description}
                       </P>
                     </div>

--- a/apps/website/src/components/courses/NextStepsChunk.tsx
+++ b/apps/website/src/components/courses/NextStepsChunk.tsx
@@ -17,7 +17,7 @@ const externalLinkClassName = 'font-semibold text-bluedot-normal underline hover
 
 const DigitalMindsNextStepsChunk: React.FC = () => (
   <div className="next-steps-chunk flex flex-col gap-6 mt-8 md:mt-6">
-    <P className="text-size-sm leading-relaxed text-bluedot-navy">
+    <P>
       Congratulations on finishing the Introduction to Digital Minds course! Here are some ways you can continue to learn about and contribute to the digital minds field.
     </P>
 
@@ -115,7 +115,7 @@ const BlueDotNextStepsChunk: React.FC = () => {
 
   return (
     <div className="next-steps-chunk flex flex-col gap-6 mt-8 md:mt-6">
-      <P className="text-size-sm leading-relaxed text-bluedot-navy">
+      <P>
         You&apos;ve got context now. Here&apos;s how you can continue contributing to AI safety.
       </P>
 

--- a/apps/website/src/components/fieldbuilder-week/TheWeekSection.tsx
+++ b/apps/website/src/components/fieldbuilder-week/TheWeekSection.tsx
@@ -54,7 +54,7 @@ const TheWeekSection = () => {
                 <H4>
                   {item.title}
                 </H4>
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {item.body}
                 </P>
               </div>

--- a/apps/website/src/components/fieldbuilder-week/WhatCouldYouBuildSection.tsx
+++ b/apps/website/src/components/fieldbuilder-week/WhatCouldYouBuildSection.tsx
@@ -54,7 +54,7 @@ const WhatCouldYouBuildSection = () => {
                 <H4>
                   {title}
                 </H4>
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {description}
                 </P>
               </div>
@@ -68,7 +68,7 @@ const WhatCouldYouBuildSection = () => {
               <H4>
                 Your idea
               </H4>
-              <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+              <P className="text-bluedot-navy/80">
                 Pitch us whatever you&apos;ve been sitting on. If it brings serious talent into AI safety, we want to hear it.
               </P>
             </div>

--- a/apps/website/src/components/grants/GranteesListSection.tsx
+++ b/apps/website/src/components/grants/GranteesListSection.tsx
@@ -106,7 +106,7 @@ const GranteesListSection = ({
             </H2>
           )}
           {subtitle && (
-            <P className="text-size-sm bd-md:text-size-md leading-relaxed text-bluedot-navy/75 mt-4">
+            <P className="bd-md:text-size-md leading-relaxed text-bluedot-navy/75 mt-4">
               {subtitle}
             </P>
           )}

--- a/apps/website/src/components/homepage/CourseValueProps.tsx
+++ b/apps/website/src/components/homepage/CourseValueProps.tsx
@@ -10,7 +10,7 @@ const Header = () => (
       >
         Start making an impact today
       </h2>
-      <P className="text-size-sm md:text-size-md leading-relaxed opacity-70 max-w-4xl">
+      <P className="md:text-size-md leading-relaxed opacity-70 max-w-4xl">
         Do you want to help build an awesome, safe future with AI? Apply to one of our free courses today.
         We'll help you ensure that humanity safely navigates the transition to transformative AI.
       </P>

--- a/apps/website/src/components/homepage/MergedLadder.tsx
+++ b/apps/website/src/components/homepage/MergedLadder.tsx
@@ -74,7 +74,7 @@ const FoaiRungCard = () => (
           The Future of AI
           <span className="inline-block ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">→</span>
         </H3>
-        <P className="text-size-sm leading-relaxed text-white/85">
+        <P className="text-white/85">
           Free, self-paced, no application. Finish in an evening with a clearer picture of frontier AI and how to help.
         </P>
         <div className="flex flex-wrap gap-2 mt-1">
@@ -129,13 +129,13 @@ const CohortCard = ({ course, featured = false }: { course: CohortCardData; feat
         <div className="flex flex-col gap-3 mt-5">
           <H3 className={clsx(
             'font-medium leading-snug tracking-tight text-white',
-            featured ? 'text-size-lg' : 'text-size-md md:text-size-lg',
+            !featured && 'text-size-md md:text-size-lg',
           )}
           >
             {course.title}
             <span className="inline-block ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">→</span>
           </H3>
-          <P className="text-size-sm leading-relaxed text-white/85">
+          <P className="text-white/85">
             {course.shortDescription}
           </P>
           <div className="flex flex-wrap gap-2 mt-1">

--- a/apps/website/src/components/homepage/StorySection.tsx
+++ b/apps/website/src/components/homepage/StorySection.tsx
@@ -11,11 +11,11 @@ const StorySection = () => {
 
         <div className="flex flex-col gap-8 items-center">
           <div className="flex flex-col">
-            <P className="text-size-sm bd-md:text-size-md leading-relaxed opacity-80 mb-[1em]">
+            <P className="bd-md:text-size-md leading-relaxed opacity-80 mb-[1em]">
               BlueDot Impact is a non-profit talent accelerator based in London and San Francisco. We help people build careers and organizations that positively impact the trajectory of AI - through our courses, career support, events, and startup programs.
             </P>
 
-            <P className="text-size-sm bd-md:text-size-md leading-relaxed opacity-80 mb-0">
+            <P className="bd-md:text-size-md leading-relaxed opacity-80 mb-0">
               Since 2022, we've trained over 7,000 professionals worldwide, from technical staff at frontier AI labs to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M to date.
             </P>
           </div>

--- a/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
@@ -532,7 +532,7 @@ exports[`HomeHeroContent > renders as expected 1`] = `
               class="flex flex-col sm:flex-row items-center gap-4 sm:gap-5 w-full max-w-[1200px] 2xl:max-w-none"
             >
               <p
-                class="bluedot-p not-prose text-bluedot-navy text-size-sm leading-relaxed whitespace-nowrap flex-shrink-0"
+                class="bluedot-p not-prose whitespace-nowrap flex-shrink-0"
               >
                 Our 8,000+ alumni work at
               </p>

--- a/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -20,12 +20,12 @@ exports[`StorySection > renders default as expected 1`] = `
           class="flex flex-col"
         >
           <p
-            class="bluedot-p not-prose text-size-sm bd-md:text-size-md leading-relaxed opacity-80 mb-[1em]"
+            class="bluedot-p not-prose bd-md:text-size-md leading-relaxed opacity-80 mb-[1em]"
           >
             BlueDot Impact is a non-profit talent accelerator based in London and San Francisco. We help people build careers and organizations that positively impact the trajectory of AI - through our courses, career support, events, and startup programs.
           </p>
           <p
-            class="bluedot-p not-prose text-size-sm bd-md:text-size-md leading-relaxed opacity-80 mb-0"
+            class="bluedot-p not-prose bd-md:text-size-md leading-relaxed opacity-80 mb-0"
           >
             Since 2022, we've trained over 7,000 professionals worldwide, from technical staff at frontier AI labs to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M to date.
           </p>

--- a/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
+++ b/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
@@ -22,7 +22,7 @@ const AboutBlueDotSection = ({
           BlueDot Impact is a nonprofit building the workforce and organisations needed to safely navigate AGI. We&apos;ve raised over $35M and trained over 8,000 people since 2022.
         </P>
         {contactEmail && (
-          <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+          <P className="text-bluedot-navy/80">
             For questions, reach out to{' '}
             <a href={`mailto:${contactEmail}`} className="underline hover:no-underline">{contactEmail}</a>
             .

--- a/apps/website/src/components/incubator-week/AboutYouSection.tsx
+++ b/apps/website/src/components/incubator-week/AboutYouSection.tsx
@@ -13,7 +13,7 @@ const AboutYouSection = () => {
           <li>Ready to leave whatever you&apos;re doing now to build</li>
           <li>You don&apos;t need a polished idea - we will help you find one here</li>
         </ul>
-        <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+        <P className="text-bluedot-navy/80">
           Know someone who should be there?{' '}
           <a href={REFERRAL_FORM_URL} target="_blank" rel="noreferrer" className="underline hover:no-underline">Refer them here</a>
           {', '}and we&apos;ll send you $2,000 for each person accepted after your referral.

--- a/apps/website/src/components/incubator-week/LogisticsSection.tsx
+++ b/apps/website/src/components/incubator-week/LogisticsSection.tsx
@@ -33,7 +33,7 @@ const LogisticsSection = () => {
                 </span>
               </div>
               <div className="flex flex-col gap-2">
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {item.body}
                 </P>
               </div>

--- a/apps/website/src/components/incubator-week/TheWeekSection.tsx
+++ b/apps/website/src/components/incubator-week/TheWeekSection.tsx
@@ -44,7 +44,7 @@ const TheWeekSection = () => {
                 <H4>
                   {item.title}
                 </H4>
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {item.body}
                 </P>
               </div>

--- a/apps/website/src/components/incubator-week/WhatThisIsForSection.tsx
+++ b/apps/website/src/components/incubator-week/WhatThisIsForSection.tsx
@@ -53,7 +53,7 @@ const WhatThisIsForSection = () => {
               <li>Lysander Mawby: Mechanistic interpretability; Just wrapped up the FR8 incubator ($100k at $5M val)</li>
             </ul>
           </div>
-          <P className="text-size-sm leading-relaxed text-bluedot-navy/80 pt-4">
+          <P className="text-bluedot-navy/80 pt-4">
             Run by BlueDot Impact. We&apos;ve raised over $35M to build the workforce and organizations needed to safely navigate AGI.
           </P>
         </div>
@@ -70,7 +70,7 @@ const WhatThisIsForSection = () => {
                 <H4>
                   {title}
                 </H4>
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {description}
                 </P>
               </div>

--- a/apps/website/src/components/incubator-week/WhatYouGetSection.tsx
+++ b/apps/website/src/components/incubator-week/WhatYouGetSection.tsx
@@ -49,7 +49,7 @@ const WhatYouGetSection = () => {
                 <H4>
                   {title}
                 </H4>
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {description}
                 </P>
               </div>

--- a/apps/website/src/components/lander/TestimonialCarousel.tsx
+++ b/apps/website/src/components/lander/TestimonialCarousel.tsx
@@ -203,7 +203,7 @@ const TestimonialCarousel = ({
               </H2>
             )}
             {subtitle && (
-              <P className="text-size-sm bd-md:text-size-md font-normal leading-relaxed text-bluedot-navy/80 max-w-full">
+              <P className="bd-md:text-size-md leading-relaxed text-bluedot-navy/80 max-w-full">
                 {subtitle}
               </P>
             )}
@@ -315,10 +315,10 @@ const TestimonialMemberCard = ({ testimonial, hideQuote = false }: { testimonial
 
   const nameRoleBlock = (
     <div className="flex flex-col items-start gap-1 w-full">
-      <P className="text-size-sm font-semibold leading-snug text-bluedot-navy text-left w-full">
+      <P className="font-semibold leading-snug text-left w-full">
         {testimonial.name}
       </P>
-      <P className="text-size-xs font-normal leading-relaxed text-bluedot-navy/60 text-left w-full">
+      <P className="text-size-xs leading-relaxed text-bluedot-navy/60 text-left w-full">
         {testimonial.jobTitle}
       </P>
     </div>
@@ -341,7 +341,7 @@ const TestimonialMemberCard = ({ testimonial, hideQuote = false }: { testimonial
       <div className="flex flex-1 flex-col p-6">
         <div className="flex flex-1 flex-col gap-8">
           {hasQuote ? (
-            <P className="flex-1 text-size-sm font-normal leading-relaxed text-bluedot-navy text-left w-full">
+            <P className="flex-1 text-left w-full">
               {testimonial.quote}
             </P>
           ) : (

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -1084,7 +1084,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                   class="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
                 >
                   <p
-                    class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                    class="bluedot-p not-prose font-semibold leading-snug"
                   >
                     Options
                   </p>
@@ -1111,7 +1111,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                   class="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
                 >
                   <p
-                    class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                    class="bluedot-p not-prose font-semibold leading-snug"
                   >
                     Commitment
                   </p>
@@ -1151,7 +1151,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                   class="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
                 >
                   <p
-                    class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                    class="bluedot-p not-prose font-semibold leading-snug"
                   >
                     Facilitator
                   </p>
@@ -1178,7 +1178,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                   class="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
                 >
                   <p
-                    class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                    class="bluedot-p not-prose font-semibold leading-snug"
                   >
                     Price
                   </p>
@@ -1959,7 +1959,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               src="/images/agi-strategy/bluedot-icon.svg"
             />
             <h3
-              class="bluedot-h3 not-prose max-w-[238px] bd-md:max-w-[496px] text-size-md bd-md:text-[36px] font-semibold text-white leading-normal bd-md:leading-snug"
+              class="bluedot-h3 not-prose max-w-[238px] bd-md:max-w-[496px] text-size-md bd-md:text-[36px] text-white leading-normal bd-md:leading-snug"
             >
               Start building towards a good future today
             </h3>

--- a/apps/website/src/components/lander/components/AlumniStoryCarousel.tsx
+++ b/apps/website/src/components/lander/components/AlumniStoryCarousel.tsx
@@ -235,7 +235,7 @@ const AlumniStoryCarousel = ({
               {title}
             </H2>
             {subtitle && (
-              <P className="text-size-sm bd-md:text-size-md font-normal leading-relaxed text-bluedot-navy/60 italic">
+              <P className="bd-md:text-size-md leading-relaxed text-bluedot-navy/60 italic">
                 {subtitle}
               </P>
             )}
@@ -314,7 +314,7 @@ const AlumniStoryCardContent = ({ story }: { story: AlumniStory }) => (
         className="size-16 bd-md:size-20 text-size-md bd-md:text-size-lg"
       />
       <div className="flex flex-col gap-1 min-w-0 pt-1">
-        <P className="text-size-md font-semibold leading-snug text-bluedot-navy truncate">
+        <P className="text-size-md font-semibold leading-snug truncate">
           {story.name}
         </P>
         <P className="text-size-xs bd-md:text-size-sm leading-relaxed text-bluedot-navy/70">
@@ -325,7 +325,7 @@ const AlumniStoryCardContent = ({ story }: { story: AlumniStory }) => (
 
     {/* Story content */}
     <div className="p-5 bd-md:p-6 flex-grow flex flex-col gap-3">
-      <P className="text-size-sm leading-relaxed text-bluedot-navy/80 line-clamp-5">
+      <P className="text-bluedot-navy/80 line-clamp-5">
         {story.story}
       </P>
       {story.storyUrl && (

--- a/apps/website/src/components/lander/components/CourseBenefitsSection.tsx
+++ b/apps/website/src/components/lander/components/CourseBenefitsSection.tsx
@@ -34,7 +34,7 @@ const CourseBenefitsSection = ({ title, benefits, iconBackgroundColor = 'var(--b
                 <H3 className="text-size-md">
                   {benefitTitle}
                 </H3>
-                <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                <P className="text-bluedot-navy/80">
                   {description}
                 </P>
               </div>

--- a/apps/website/src/components/lander/components/CourseInformationSection.tsx
+++ b/apps/website/src/components/lander/components/CourseInformationSection.tsx
@@ -74,7 +74,7 @@ const CourseInformationSection = ({
                   <div className="flex flex-col bd-md:flex-row px-5 bd-md:px-8 py-0 gap-6 md:gap-8 items-start w-full">
                     {/* Schedule Label (left column, no icon) */}
                     <div className="bd-md:w-[120px] lg:w-[144px] xl:w-40 shrink-0">
-                      <P className="text-size-sm font-semibold leading-snug text-bluedot-navy">
+                      <P className="font-semibold leading-snug">
                         {detail.label}
                       </P>
                     </div>
@@ -87,7 +87,7 @@ const CourseInformationSection = ({
                         accentColor={accentColor}
                         fallbackContent={(
                           <div className="flex flex-col gap-4">
-                            <P className="text-size-sm leading-relaxed text-bluedot-navy/80 font-normal">
+                            <P className="text-bluedot-navy/80">
                               {detail.scheduleDescription}
                             </P>
                             <div className="flex justify-start">
@@ -107,7 +107,7 @@ const CourseInformationSection = ({
                   <div className="flex flex-col md:flex-row items-start px-5 md:px-8 py-0 gap-2 md:gap-8">
                     {/* Label */}
                     <div className="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0">
-                      <P className="text-size-sm font-semibold leading-snug text-bluedot-navy">
+                      <P className="font-semibold leading-snug">
                         {detail.label}
                       </P>
                     </div>

--- a/apps/website/src/components/lander/components/CourseOutcomesSection.tsx
+++ b/apps/website/src/components/lander/components/CourseOutcomesSection.tsx
@@ -68,7 +68,7 @@ const CourseOutcomesSection = ({
                     <H3 className="text-size-md">
                       {outcome.title}
                     </H3>
-                    <P className="text-size-sm leading-relaxed text-bluedot-navy/70">
+                    <P className="text-bluedot-navy/70">
                       {outcome.description}
                     </P>
                     {outcome.linkUrl && (

--- a/apps/website/src/components/lander/components/FieldBuildingSection.tsx
+++ b/apps/website/src/components/lander/components/FieldBuildingSection.tsx
@@ -36,7 +36,7 @@ const FieldBuildingSection = ({
               {title}
             </H2>
           )}
-          <P className="mt-4 text-size-sm bd-md:text-size-md leading-relaxed text-bluedot-navy/70">
+          <P className="mt-4 bd-md:text-size-md leading-relaxed text-bluedot-navy/70">
             {intro}
           </P>
         </div>
@@ -46,13 +46,13 @@ const FieldBuildingSection = ({
             <div key={role.title}>
               <div className="flex flex-col md:flex-row gap-3 md:gap-8 px-5 md:px-8 py-5 md:py-6">
                 <div className="md:w-40 shrink-0">
-                  <P className="text-size-sm font-semibold leading-snug text-bluedot-navy">
+                  <P className="font-semibold leading-snug">
                     {role.title}
                   </P>
                 </div>
 
                 <div className="flex-1 min-w-0">
-                  <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                  <P className="text-bluedot-navy/80">
                     {role.description}
                   </P>
                   <Link

--- a/apps/website/src/components/lander/components/GraduateSection.tsx
+++ b/apps/website/src/components/lander/components/GraduateSection.tsx
@@ -36,7 +36,7 @@ const GraduateSection = () => {
         {/* Container with text and logos */}
         <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-5 w-full max-w-[1200px] 2xl:max-w-none">
           {/* Text */}
-          <P className="text-bluedot-navy text-size-sm leading-relaxed whitespace-nowrap flex-shrink-0">
+          <P className="whitespace-nowrap flex-shrink-0">
             Our 8,000+ alumni work at
           </P>
 

--- a/apps/website/src/components/lander/components/HeroSection.tsx
+++ b/apps/website/src/components/lander/components/HeroSection.tsx
@@ -194,7 +194,7 @@ const HeroSection = ({
                     {title}
                   </HeroH1>
 
-                  <P className="sm:text-lg leading-relaxed opacity-80 text-white whitespace-pre-line">
+                  <P className="sm:text-size-md leading-relaxed opacity-80 text-white whitespace-pre-line">
                     {description}
                   </P>
                 </div>
@@ -251,7 +251,7 @@ const HeroSection = ({
                     {title}
                   </HeroH1>
 
-                  <P className="sm:text-lg leading-relaxed text-bluedot-navy/80 whitespace-pre-line">
+                  <P className="sm:text-size-md leading-relaxed text-bluedot-navy/80 whitespace-pre-line">
                     {description}
                   </P>
                 </div>

--- a/apps/website/src/components/lander/components/HeroSection.tsx
+++ b/apps/website/src/components/lander/components/HeroSection.tsx
@@ -194,7 +194,7 @@ const HeroSection = ({
                     {title}
                   </HeroH1>
 
-                  <P className="text-size-sm sm:text-lg sm:leading-relaxed lg:text-lg leading-relaxed opacity-80 text-white whitespace-pre-line">
+                  <P className="sm:text-lg leading-relaxed opacity-80 text-white whitespace-pre-line">
                     {description}
                   </P>
                 </div>
@@ -251,7 +251,7 @@ const HeroSection = ({
                     {title}
                   </HeroH1>
 
-                  <P className="text-size-sm sm:text-lg sm:leading-relaxed lg:text-lg leading-relaxed text-bluedot-navy/80 whitespace-pre-line">
+                  <P className="sm:text-lg leading-relaxed text-bluedot-navy/80 whitespace-pre-line">
                     {description}
                   </P>
                 </div>

--- a/apps/website/src/components/lander/components/LandingBanner.tsx
+++ b/apps/website/src/components/lander/components/LandingBanner.tsx
@@ -39,7 +39,7 @@ const LandingBanner = ({
             <img src={iconSrc} alt={iconAlt} className="w-8 h-[30px]" />
 
             {/* eslint-disable-next-line @bluedot/custom/no-arbitrary-text-size -- deferred design pick: banner H3 with bespoke text-size-md → 36px ramp paired with viewport-specific max-w */}
-            <H3 className="max-w-[238px] bd-md:max-w-[496px] text-size-md bd-md:text-[36px] font-semibold text-white leading-normal bd-md:leading-snug">
+            <H3 className="max-w-[238px] bd-md:max-w-[496px] text-size-md bd-md:text-[36px] text-white leading-normal bd-md:leading-snug">
               {title}
             </H3>
 

--- a/apps/website/src/components/lander/components/PathwaysSection.tsx
+++ b/apps/website/src/components/lander/components/PathwaysSection.tsx
@@ -65,7 +65,7 @@ const PathwaysSection = ({
                     <H3 className="text-size-md">
                       {pathway.title}
                     </H3>
-                    <P className="text-size-sm leading-relaxed text-bluedot-navy/70">
+                    <P className="text-bluedot-navy/70">
                       {pathway.description}
                     </P>
                     {pathway.linkUrl && pathway.linkText && (

--- a/apps/website/src/components/lander/components/PersonasSection.tsx
+++ b/apps/website/src/components/lander/components/PersonasSection.tsx
@@ -101,13 +101,13 @@ const PersonasSection = ({
                     <div className="p-6 bd-md:p-8 flex flex-col gap-4">
                       {/* Summary */}
                       {persona.summary && (
-                        <P className="text-size-md leading-normal text-bluedot-navy font-semibold">
+                        <P className="text-size-md leading-normal font-semibold">
                           {persona.summary}
                         </P>
                       )}
 
                       {/* Description */}
-                      <P className="text-size-sm leading-relaxed text-bluedot-navy/70">
+                      <P className="text-bluedot-navy/70">
                         {persona.description}
                       </P>
 
@@ -117,7 +117,7 @@ const PersonasSection = ({
                           <Eyebrow className="text-bluedot-navy/60 mb-2">
                             What this looks like
                           </Eyebrow>
-                          <P className="text-size-sm leading-relaxed text-bluedot-navy/80">
+                          <P className="text-bluedot-navy/80">
                             {persona.valueProposition}
                           </P>
                         </div>
@@ -142,7 +142,7 @@ const PersonasSection = ({
           </div>
         )}
         {footerText && (
-          <P className="text-center text-size-sm leading-relaxed text-bluedot-navy/60 mt-10 md:mt-12">
+          <P className="text-center text-bluedot-navy/60 mt-10 md:mt-12">
             {footerText}
           </P>
         )}

--- a/apps/website/src/components/lander/components/PrerequisitesSection.tsx
+++ b/apps/website/src/components/lander/components/PrerequisitesSection.tsx
@@ -60,7 +60,7 @@ const PrerequisitesSection = ({
                     <H3 className="text-size-md">
                       {prereq.title}
                     </H3>
-                    <P className="text-size-sm leading-relaxed text-bluedot-navy/70">
+                    <P className="text-bluedot-navy/70">
                       {prereq.description}
                     </P>
                   </div>

--- a/apps/website/src/components/lander/components/WhoIsThisForSection.tsx
+++ b/apps/website/src/components/lander/components/WhoIsThisForSection.tsx
@@ -45,7 +45,7 @@ const WhoIsThisForSection = ({
               >
                 <IconComponent className="text-white" size={28} />
               </div>
-              <P className="text-size-md leading-relaxed text-bluedot-navy">
+              <P className="text-size-md leading-relaxed">
                 <span className="font-semibold">{boldText}</span>
                 <span> {description}</span>
               </P>

--- a/apps/website/src/components/lander/components/__snapshots__/CourseBenefitsSection.test.tsx.snap
+++ b/apps/website/src/components/lander/components/__snapshots__/CourseBenefitsSection.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`CourseBenefitsSection > renders correctly with default colors 1`] = `
             Take action in less than 30 hours
           </h3>
           <p
-            class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/80"
+            class="bluedot-p not-prose text-bluedot-navy/80"
           >
             You don't need another degree. This AGI Strategy course replaces years of self-study with three frameworks.
           </p>
@@ -83,7 +83,7 @@ exports[`CourseBenefitsSection > renders correctly with default colors 1`] = `
             Join a network of builders
           </h3>
           <p
-            class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/80"
+            class="bluedot-p not-prose text-bluedot-navy/80"
           >
             This course isn't for everyone. We're building a community of people who are energised to take ambitious actions.
           </p>
@@ -120,7 +120,7 @@ exports[`CourseBenefitsSection > renders correctly with default colors 1`] = `
             Get funded to accelerate your impact
           </h3>
           <p
-            class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/80"
+            class="bluedot-p not-prose text-bluedot-navy/80"
           >
             If your final course proposal is strong, you'll receive $10-50k to kickstart your transition into impactful work.
           </p>

--- a/apps/website/src/components/lander/components/__snapshots__/CourseInformationSection.test.tsx.snap
+++ b/apps/website/src/components/lander/components/__snapshots__/CourseInformationSection.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`CourseInformationSection > renders correctly with default colors 1`] = 
               class="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
             >
               <p
-                class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                class="bluedot-p not-prose font-semibold leading-snug"
               >
                 Options
               </p>
@@ -65,7 +65,7 @@ exports[`CourseInformationSection > renders correctly with default colors 1`] = 
               class="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
             >
               <p
-                class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                class="bluedot-p not-prose font-semibold leading-snug"
               >
                 Commitment
               </p>
@@ -105,7 +105,7 @@ exports[`CourseInformationSection > renders correctly with default colors 1`] = 
               class="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
             >
               <p
-                class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                class="bluedot-p not-prose font-semibold leading-snug"
               >
                 Facilitator
               </p>
@@ -132,7 +132,7 @@ exports[`CourseInformationSection > renders correctly with default colors 1`] = 
               class="md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
             >
               <p
-                class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                class="bluedot-p not-prose font-semibold leading-snug"
               >
                 Price
               </p>
@@ -159,7 +159,7 @@ exports[`CourseInformationSection > renders correctly with default colors 1`] = 
               class="bd-md:w-[120px] lg:w-[144px] xl:w-40 shrink-0"
             >
               <p
-                class="bluedot-p not-prose text-size-sm font-semibold leading-snug text-bluedot-navy"
+                class="bluedot-p not-prose font-semibold leading-snug"
               >
                 Schedule
               </p>

--- a/apps/website/src/components/lander/components/__snapshots__/HeroSection.test.tsx.snap
+++ b/apps/website/src/components/lander/components/__snapshots__/HeroSection.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`HeroSection > renders correctly (snapshot) 1`] = `
                 AGI Strategy – Learn how to navigate humanity's most critical decade
               </h1>
               <p
-                class="bluedot-p not-prose sm:text-lg leading-relaxed text-bluedot-navy/80 whitespace-pre-line"
+                class="bluedot-p not-prose sm:text-size-md leading-relaxed text-bluedot-navy/80 whitespace-pre-line"
               >
                 Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
               </p>
@@ -104,7 +104,7 @@ exports[`HeroSection > renders gradient variant correctly (snapshot) 1`] = `
                 The Future of AI
               </h1>
               <p
-                class="bluedot-p not-prose sm:text-lg leading-relaxed opacity-80 text-white whitespace-pre-line"
+                class="bluedot-p not-prose sm:text-size-md leading-relaxed opacity-80 text-white whitespace-pre-line"
               >
                 Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
               </p>

--- a/apps/website/src/components/lander/components/__snapshots__/HeroSection.test.tsx.snap
+++ b/apps/website/src/components/lander/components/__snapshots__/HeroSection.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`HeroSection > renders correctly (snapshot) 1`] = `
                 AGI Strategy – Learn how to navigate humanity's most critical decade
               </h1>
               <p
-                class="bluedot-p not-prose text-size-sm sm:text-lg sm:leading-relaxed lg:text-lg leading-relaxed text-bluedot-navy/80 whitespace-pre-line"
+                class="bluedot-p not-prose sm:text-lg leading-relaxed text-bluedot-navy/80 whitespace-pre-line"
               >
                 Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
               </p>
@@ -104,7 +104,7 @@ exports[`HeroSection > renders gradient variant correctly (snapshot) 1`] = `
                 The Future of AI
               </h1>
               <p
-                class="bluedot-p not-prose text-size-sm sm:text-lg sm:leading-relaxed lg:text-lg leading-relaxed opacity-80 text-white whitespace-pre-line"
+                class="bluedot-p not-prose sm:text-lg leading-relaxed opacity-80 text-white whitespace-pre-line"
               >
                 Artificial General Intelligence is moving from research to reality. Understand the race, the risks, and the strategic decisions that will shape economies, security, and our collective future.
               </p>

--- a/apps/website/src/components/lander/components/__snapshots__/LandingBanner.test.tsx.snap
+++ b/apps/website/src/components/lander/components/__snapshots__/LandingBanner.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`LandingBanner > renders correctly 1`] = `
           src="/images/agi-strategy/bluedot-icon.svg"
         />
         <h3
-          class="bluedot-h3 not-prose max-w-[238px] bd-md:max-w-[496px] text-size-md bd-md:text-[36px] font-semibold text-white leading-normal bd-md:leading-snug"
+          class="bluedot-h3 not-prose max-w-[238px] bd-md:max-w-[496px] text-size-md bd-md:text-[36px] text-white leading-normal bd-md:leading-snug"
         >
           Start building towards a good future today
         </h3>

--- a/apps/website/src/components/lander/components/__snapshots__/PersonasSection.test.tsx.snap
+++ b/apps/website/src/components/lander/components/__snapshots__/PersonasSection.test.tsx.snap
@@ -74,12 +74,12 @@ exports[`PersonasSection > renders correctly with default expanded index 1`] = `
               class="p-6 bd-md:p-8 flex flex-col gap-4"
             >
               <p
-                class="bluedot-p not-prose text-size-md leading-normal text-bluedot-navy font-semibold"
+                class="bluedot-p not-prose text-size-md leading-normal font-semibold"
               >
                 You get the tech. Now you want to know if policy is where you should point it.
               </p>
               <p
-                class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/70"
+                class="bluedot-p not-prose text-bluedot-navy/70"
               >
                 You understand the technology - how the systems work, what scaling means.
               </p>
@@ -92,7 +92,7 @@ exports[`PersonasSection > renders correctly with default expanded index 1`] = `
                   What this looks like
                 </p>
                 <p
-                  class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/80"
+                  class="bluedot-p not-prose text-bluedot-navy/80"
                 >
                   People like you have made this move.
                 </p>
@@ -159,12 +159,12 @@ exports[`PersonasSection > renders correctly with default expanded index 1`] = `
               class="p-6 bd-md:p-8 flex flex-col gap-4"
             >
               <p
-                class="bluedot-p not-prose text-size-md leading-normal text-bluedot-navy font-semibold"
+                class="bluedot-p not-prose text-size-md leading-normal font-semibold"
               >
                 You have options. You're not the type to drift into a default path.
               </p>
               <p
-                class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/70"
+                class="bluedot-p not-prose text-bluedot-navy/70"
               >
                 You're at a top university or recently graduated.
               </p>
@@ -177,7 +177,7 @@ exports[`PersonasSection > renders correctly with default expanded index 1`] = `
                   What this looks like
                 </p>
                 <p
-                  class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/80"
+                  class="bluedot-p not-prose text-bluedot-navy/80"
                 >
                   You'll join a cohort of others at the same stage.
                 </p>
@@ -244,12 +244,12 @@ exports[`PersonasSection > renders correctly with default expanded index 1`] = `
               class="p-6 bd-md:p-8 flex flex-col gap-4"
             >
               <p
-                class="bluedot-p not-prose text-size-md leading-normal text-bluedot-navy font-semibold"
+                class="bluedot-p not-prose text-size-md leading-normal font-semibold"
               >
                 You know how policy works. AI is eating your field.
               </p>
               <p
-                class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/70"
+                class="bluedot-p not-prose text-bluedot-navy/70"
               >
                 You already work in government, a think tank, or policy.
               </p>
@@ -262,7 +262,7 @@ exports[`PersonasSection > renders correctly with default expanded index 1`] = `
                   What this looks like
                 </p>
                 <p
-                  class="bluedot-p not-prose text-size-sm leading-relaxed text-bluedot-navy/80"
+                  class="bluedot-p not-prose text-bluedot-navy/80"
                 >
                   You'll become the person your org turns to on AI.
                 </p>

--- a/apps/website/src/components/lander/components/__snapshots__/WhoIsThisForSection.test.tsx.snap
+++ b/apps/website/src/components/lander/components/__snapshots__/WhoIsThisForSection.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
           </svg>
         </div>
         <p
-          class="bluedot-p not-prose text-size-md leading-relaxed text-bluedot-navy"
+          class="bluedot-p not-prose text-size-md leading-relaxed"
         >
           <span
             class="font-semibold"
@@ -72,7 +72,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
           </svg>
         </div>
         <p
-          class="bluedot-p not-prose text-size-md leading-relaxed text-bluedot-navy"
+          class="bluedot-p not-prose text-size-md leading-relaxed"
         >
           <span
             class="font-semibold"
@@ -107,7 +107,7 @@ exports[`WhoIsThisForSection > renders correctly 1`] = `
           </svg>
         </div>
         <p
-          class="bluedot-p not-prose text-size-md leading-relaxed text-bluedot-navy"
+          class="bluedot-p not-prose text-size-md leading-relaxed"
         >
           <span
             class="font-semibold"

--- a/apps/website/src/components/rapid-grants/HowItWorksSection.tsx
+++ b/apps/website/src/components/rapid-grants/HowItWorksSection.tsx
@@ -76,7 +76,7 @@ const StepCardBody = ({
         <H4 className="bd-md:text-size-lg font-medium tracking-[-0.04em]">
           {title}
         </H4>
-        <P className="text-size-sm leading-relaxed text-bluedot-navy/70">
+        <P className="text-bluedot-navy/70">
           {body}
         </P>
       </div>

--- a/apps/website/src/components/rapid-grants/WhatThisIsForSection.tsx
+++ b/apps/website/src/components/rapid-grants/WhatThisIsForSection.tsx
@@ -47,7 +47,7 @@ const WhatThisIsForSection = () => {
               <H4>
                 {card.title}
               </H4>
-              <P className="text-size-sm leading-relaxed text-bluedot-navy/70">
+              <P className="text-bluedot-navy/70">
                 {card.body}
               </P>
             </div>

--- a/apps/website/src/pages/puzzles/technical-ai-safety.tsx
+++ b/apps/website/src/pages/puzzles/technical-ai-safety.tsx
@@ -256,10 +256,10 @@ const PuzzleTechnicalAiSafetyPage = () => {
           <div className={SECTION_PADDING_CLASS}>
             <div className="max-w-text mx-auto">
               <h2 className={EYEBROW_CLASS}>The puzzle</h2>
-              <P className="mt-4 text-size-md leading-relaxed text-bluedot-navy">
+              <P className="mt-4 text-size-md leading-relaxed">
                 We trained a model on short text inputs to predict eight binary features simultaneously (e.g. contains a person&rsquo;s name, mentions a food, phrased as a question). After a particular layer of this model, seven of these features are represented linearly, where a single direction in the activation space describes that feature. However, one feature is represented in a different way.
               </P>
-              <P className="mt-4 text-size-md leading-relaxed text-bluedot-navy">
+              <P className="mt-4 text-size-md leading-relaxed">
                 Your job is to figure out which feature it is and how it is represented.
               </P>
             </div>

--- a/apps/website/src/pages/puzzles/technical-ai-safety/submitted.tsx
+++ b/apps/website/src/pages/puzzles/technical-ai-safety/submitted.tsx
@@ -79,10 +79,10 @@ const PuzzleSubmittedPage = () => (
       <section>
         <div className={SECTION_PADDING_CLASS}>
           <div className="max-w-text mx-auto space-y-4">
-            <P className="text-size-md leading-relaxed text-bluedot-navy">
+            <P className="text-size-md leading-relaxed">
               Congratulations on submitting your puzzle solution. If you made it this far you&rsquo;re clearly a technical person who likes solving puzzles and is interested in machine learning. At BlueDot we support people like yourself to build careers in technical AI safety. You would solve hard interesting technical problems AND have a positive impact on the world by reducing catastrophic risk from AI.
             </P>
-            <P className="text-size-md leading-relaxed text-bluedot-navy">
+            <P className="text-size-md leading-relaxed">
               Imagine that feature you were looking for was deception or hazardous biological weapon information in a next generation LLM. Identifying and understanding that representation could prevent a lot of harm, and this is still an open technical question. If you&rsquo;re still not sold that AI poses catastrophic risks, take a look at our
               {' '}
               <a
@@ -102,7 +102,7 @@ const PuzzleSubmittedPage = () => (
         <div className={SECTION_PADDING_CLASS}>
           <div className="max-w-text mx-auto">
             <h2 className={EYEBROW_CLASS}>A free book</h2>
-            <P className="mt-4 text-size-md leading-relaxed text-bluedot-navy">
+            <P className="mt-4 text-size-md leading-relaxed">
               Firstly, claim a
               {' '}
               <a
@@ -139,7 +139,7 @@ const PuzzleSubmittedPage = () => (
                     >
                       {o.name}
                     </a>
-                    <P className="mt-1 text-size-sm text-bluedot-navy/80 leading-relaxed">
+                    <P className="mt-1 text-bluedot-navy/80">
                       {o.description}
                     </P>
                   </div>


### PR DESCRIPTION
Part of #2820.

## What this does

PR 1 of 2 for the typography-override audit: the **strictly invisible** cleanup pass. Deletes className tokens on `H1`–`H4` / `P` / `A` that restate the component's own defaults (~130 tokens across 48 files, 66 callsites), so that every surviving override is an honest exception. Zero rendering change by construction.

## Deletion rules

The subtlety: `text-size-*` utilities also set `line-height: 1.2`, and utilities beat the `@layer base` component classes. So "restates the default" is not purely token-equality:

| Pattern | Action | Why it's a no-op |
|---|---|---|
| size-default + matching leading-default together (e.g. `P` with `text-size-sm leading-relaxed`) | delete both | base class supplies both values |
| size-default alongside any explicit `leading-*` (e.g. `text-size-sm font-semibold leading-snug`) | delete size token | `leading-*` wins the line-height cascade with or without the size utility |
| color/weight equal to default (`text-bluedot-navy` on P/H*, `font-normal` on P, `font-semibold` on H3, `underline` on A) | delete | identical computed value |
| responsive size overrides (`bd-md:text-size-md` etc.) | keep, delete only the redundant base token | breakpoint values are real overrides |
| **size-default token alone** (e.g. `<P className="text-size-sm">`) | **not touched** | deleting it would change line-height 1.2 → 1.6 — visible; deferred to PR 2 |

Also folded in: `MergedLadder`'s featured H3 branch dropped its restated `text-size-lg` (explicit `leading-snug` keeps line-height stable), and two `<A className="underline">` in meet/room dropped the redundant prop.

## What this deliberately does not touch (→ PR 2, with audit table + screenshots)

- Muted-body opacity spread (`/60` `/70` `/80` → one canonical step)
- Heading size snaps / carveouts / re-tags
- Hand-rolled eyebrow → `<Eyebrow>` conversions
- Footer on-dark link spelling: `link-on-dark` (cream → lighter) and `text-bluedot-lighter hover:text-white` are **different colors**, not competing spellings of the same thing — unifying is a visible change
- Off-system palette colors (`text-red-600`, `text-gray-500`, `stone-100`) — noted for a separate issue

## Verification

- `apps/website`: 122 test files / 1004 tests pass; 10 snapshots regenerated, diffs are class-removals only
- `tsc --noEmit` + eslint clean on website; meet and room typecheck clean
- Computed-style probes on dev (headless Chromium) for the three riskiest families — muted P (incubator-week), MergedLadder featured H3 (homepage), bold-caption P (agi-strategy lander): font-size / line-height / weight / color all identical to the pre-edit values (16px/25.6px, 24px/30px/500, 16px/20px/600)
- No screenshots: change is a computed-style-verified no-op; the viewport sweep happens in PR 2 where rendering actually changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
