### PR TITLE
Add customer.io email-change primitives (unused, tested)

### DIFF
--- a/apps/website/src/lib/api/customerio.test.ts
+++ b/apps/website/src/lib/api/customerio.test.ts
@@ -313,7 +313,7 @@ describe('sendEmailChangeVerification', () => {
     const fetchMock = vi.fn(async () => jsonResponse(200, { delivery_id: 'd1' }));
     vi.stubGlobal('fetch', fetchMock);
 
-    await sendEmailChangeVerification({ oldEmail: '  Old@Example.COM ', newEmail: ' New@Example.com ', confirmUrl: 'http://localhost:8000/account/confirm-email-change?token=abc' });
+    await sendEmailChangeVerification({ oldEmail: '  Old@Example.COM ', newEmail: ' New@Example.com ', confirmUrl: 'http://localhost:8000/account/confirm-email-change?token=abc&uid=u1' });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0]! as unknown as [string, { method: string; body: string }];
@@ -323,7 +323,8 @@ describe('sendEmailChangeVerification', () => {
     expect(body.to).toBe('new@example.com');
     expect(body.identifiers).toEqual({ email: 'old@example.com' });
     expect(body.send_to_unsubscribed).toBe(true);
-    expect(body.body).toContain('http://localhost:8000/account/confirm-email-change?token=abc');
+    expect(body.body).toContain('http://localhost:8000/account/confirm-email-change?token=abc&#38;uid=u1');
+    expect(body.body).not.toContain('token=abc&uid=u1');
     expect(body.subject).toBeTruthy();
   });
 

--- a/apps/website/src/lib/api/customerio.test.ts
+++ b/apps/website/src/lib/api/customerio.test.ts
@@ -1,0 +1,352 @@
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import { sendEmailChangeVerification, updateCustomerIoEmail } from './customerio';
+import env from './env';
+
+vi.mock('./env', () => ({
+  default: {
+    APP_NAME: 'test-app',
+    ALERTS_SLACK_BOT_TOKEN: 'fake-token',
+    ALERTS_SLACK_CHANNEL_ID: 'fake-channel',
+    CIO_APP_API_KEY: 'fake-app-key',
+    CIO_TRACK_API_KEY: 'fake-track-key',
+  },
+}));
+
+/**
+ * In-memory model of the customer.io EU workspace, matching the (partly undocumented)
+ * semantics we verified against production:
+ *  - profiles are resolved by `id` or `email` identifier; email resolution is case-insensitive;
+ *  - an id-keyed identify carrying an email owned by an email-only profile CLAIMS that profile
+ *    in place (same cio_id, id attached) rather than creating a duplicate;
+ *  - an identify whose email is owned by a DIFFERENT profile silently drops the email update
+ *    (no error, other attributes still apply) — which is why verify-after-write is mandatory;
+ *  - there is no merge API on api-eu; conflicts are surfaced as errors for manual resolution.
+ *
+ * These semantics were validated against the real production workspace with a live-fire
+ * model-based test, which is preserved on the `wh-2810-cio-livetest-2026-07-archive` git branch,
+ * file `apps/website/src/lib/api/customerio.prod.test.ts`.
+ */
+type FakeProfile = { cio_id: string; id?: string; email: string };
+
+type FakeCio = {
+  profiles: FakeProfile[];
+  applyWrites: boolean;
+  identifyCalls: { id: string; email: string }[];
+};
+
+const makeFakeCio = (profiles: FakeProfile[], { applyWrites = true }: { applyWrites?: boolean } = {}): FakeCio => ({
+  profiles,
+  applyWrites,
+  identifyCalls: [],
+});
+
+const applyIdentify = (cio: FakeCio, id: string, email: string) => {
+  const owner = cio.profiles.find((p) => p.email === email);
+  const mine = cio.profiles.find((p) => p.id === id);
+  if (owner && owner !== mine) {
+    if (!owner.id && !mine) {
+      owner.id = id;
+      return;
+    }
+
+    return;
+  }
+
+  if (mine) {
+    mine.email = email;
+    return;
+  }
+
+  cio.profiles.push({ cio_id: `cio-${id}`, id, email });
+};
+
+const jsonResponse = (status: number, body: unknown) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+  text: async () => JSON.stringify(body),
+}) as unknown as Response;
+
+const installFakeCio = (cio: FakeCio) => {
+  const fetchMock = vi.fn(async (input: unknown, init?: { method?: string; body?: string }) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? 'GET';
+
+    if (url.host === 'api-eu.customer.io') {
+      if (url.pathname === '/v1/customers') {
+        const email = url.searchParams.get('email');
+        const results = cio.profiles
+          .filter((p) => p.email === email)
+          .map((p) => ({ cio_id: p.cio_id, id: p.id, email: p.email }));
+        return jsonResponse(200, { results });
+      }
+
+      const attributesMatch = /^\/v1\/customers\/([^/]+)\/attributes$/.exec(url.pathname);
+      if (attributesMatch && url.searchParams.get('id_type') === 'id') {
+        const profile = cio.profiles.find((p) => p.id === decodeURIComponent(attributesMatch[1]!));
+        if (!profile) return jsonResponse(404, { meta: { error: 'not found' } });
+        return jsonResponse(200, {
+          customer: {
+            identifiers: { cio_id: profile.cio_id, id: profile.id, email: profile.email },
+            attributes: { email: profile.email },
+          },
+        });
+      }
+    }
+
+    if (url.host === 'track-eu.customer.io') {
+      if (url.pathname === '/api/v2/batch' && method === 'POST') {
+        const body = JSON.parse(init?.body ?? '{}') as { batch: { identifiers: { id: string }; attributes: { email: string } }[] };
+        const entry = body.batch[0]!;
+        cio.identifyCalls.push({ id: entry.identifiers.id, email: entry.attributes.email });
+        if (cio.applyWrites) applyIdentify(cio, entry.identifiers.id, entry.attributes.email);
+        return jsonResponse(200, {});
+      }
+    }
+
+    return jsonResponse(500, { error: `unexpected request: ${method} ${url.href}` });
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+const runToCompletion = async (promise: Promise<void>) => {
+  const outcome: { settled: boolean; error?: Error } = { settled: false };
+  promise.then(
+    () => {
+      outcome.settled = true;
+    },
+    (error: unknown) => {
+      outcome.settled = true;
+      outcome.error = error instanceof Error ? error : new Error(JSON.stringify(error));
+    },
+  );
+  while (!outcome.settled) {
+    // eslint-disable-next-line no-await-in-loop
+    await vi.advanceTimersByTimeAsync(1000);
+  }
+
+  if (outcome.error) throw outcome.error;
+};
+
+describe('updateCustomerIoEmail', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  test('skips when neither an id profile nor an old-email profile exists', async () => {
+    const cio = makeFakeCio([]);
+    installFakeCio(cio);
+
+    await runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' }));
+
+    expect(cio.identifyCalls).toEqual([]);
+  });
+
+  test('throws without any request when the API keys are not configured', async () => {
+    const cio = makeFakeCio([]);
+    const fetchMock = installFakeCio(cio);
+    const mutableEnv = env as { CIO_APP_API_KEY?: string };
+    mutableEnv.CIO_APP_API_KEY = undefined;
+
+    try {
+      await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
+        .rejects.toThrow('not configured');
+    } finally {
+      mutableEnv.CIO_APP_API_KEY = 'fake-app-key';
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('claims an email-only old-email profile and renames it', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', email: 'old@example.com' }]);
+    installFakeCio(cio);
+
+    await runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' }));
+
+    expect(cio.identifyCalls).toEqual([
+      { id: 'u1', email: 'old@example.com' },
+      { id: 'u1', email: 'new@example.com' },
+    ]);
+    expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+  });
+
+  test('normalizes emails before use', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', email: 'old@example.com' }]);
+    installFakeCio(cio);
+
+    await runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: '  Old@Example.COM ', newEmail: ' New@Example.com' }));
+
+    expect(cio.identifyCalls).toEqual([
+      { id: 'u1', email: 'old@example.com' },
+      { id: 'u1', email: 'new@example.com' },
+    ]);
+    expect(cio.profiles[0]!.email).toBe('new@example.com');
+  });
+
+  test('renames an existing id profile even when its email no longer matches the old email', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', id: 'u1', email: 'stale@example.com' }]);
+    installFakeCio(cio);
+
+    await runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' }));
+
+    expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'new@example.com' }]);
+    expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+  });
+
+  test('does nothing when the id profile already has the new email', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+    installFakeCio(cio);
+
+    await runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' }));
+
+    expect(cio.identifyCalls).toEqual([]);
+  });
+
+  test('refuses to claim an old-email profile owned by a different user id', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', id: 'u2', email: 'old@example.com' }]);
+    installFakeCio(cio);
+
+    await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
+      .rejects.toThrow('different user id (u2)');
+
+    expect(cio.identifyCalls).toEqual([]);
+  });
+
+  test('refuses to claim when multiple profiles own the old email', async () => {
+    const cio = makeFakeCio([
+      { cio_id: 'c1', email: 'old@example.com' },
+      { cio_id: 'c2', email: 'old@example.com' },
+    ]);
+    installFakeCio(cio);
+
+    await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
+      .rejects.toThrow('multiple customer.io profiles own the old email');
+
+    expect(cio.identifyCalls).toEqual([]);
+  });
+
+  test('throws without renaming when the claim never becomes visible', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', email: 'old@example.com' }], { applyWrites: false });
+    installFakeCio(cio);
+
+    await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
+      .rejects.toThrow('claiming the old-email profile did not complete');
+
+    expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'old@example.com' }]);
+  });
+
+  test('throws without deleting anything when another profile owns the new email', async () => {
+    const cio = makeFakeCio([
+      { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
+      { cio_id: 'c2', email: 'new@example.com' },
+    ]);
+    installFakeCio(cio);
+
+    await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
+      .rejects.toThrow('already owned by cio_c2');
+
+    expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'new@example.com' }]);
+    expect(cio.profiles.find((p) => p.cio_id === 'c1')!.email).toBe('old@example.com');
+    expect(cio.profiles).toHaveLength(2);
+  });
+
+  test('names the owning user id when the conflicting profile carries one', async () => {
+    const cio = makeFakeCio([
+      { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
+      { cio_id: 'c2', id: 'u2', email: 'new@example.com' },
+    ]);
+    installFakeCio(cio);
+
+    await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
+      .rejects.toThrow('already owned by cio_c2 (user id u2)');
+
+    expect(cio.profiles).toHaveLength(2);
+  });
+
+  test('throws when the rename never verifies and no conflicting profile exists', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', id: 'u1', email: 'old@example.com' }], { applyWrites: false });
+    installFakeCio(cio);
+
+    await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
+      .rejects.toThrow('no conflicting profile was found');
+
+    expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'new@example.com' }]);
+  });
+
+  test('succeeds without throwing when the rename lands late, after verify polling gave up', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', id: 'u1', email: 'old@example.com' }], { applyWrites: false });
+    const fetchMock = installFakeCio(cio);
+    const base = fetchMock.getMockImplementation()!;
+    let attributesCalls = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      const result = await base(input, init);
+      if (String(input).includes('/attributes')) {
+        attributesCalls += 1;
+        if (attributesCalls === 7) cio.profiles[0]!.email = 'new@example.com';
+      }
+
+      return result;
+    });
+
+    await runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' }));
+
+    expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+  });
+});
+
+describe('sendEmailChangeVerification', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('sends an inline transactional email to the new address, keyed to the old-email profile', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { delivery_id: 'd1' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await sendEmailChangeVerification({ oldEmail: '  Old@Example.COM ', newEmail: ' New@Example.com ', confirmUrl: 'http://localhost:8000/account/confirm-email-change?token=abc' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]! as unknown as [string, { method: string; body: string }];
+    expect(url).toBe('https://api-eu.customer.io/v1/send/email');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body) as { to: string; identifiers: { email: string }; send_to_unsubscribed: boolean; body: string; subject: string };
+    expect(body.to).toBe('new@example.com');
+    expect(body.identifiers).toEqual({ email: 'old@example.com' });
+    expect(body.send_to_unsubscribed).toBe(true);
+    expect(body.body).toContain('http://localhost:8000/account/confirm-email-change?token=abc');
+    expect(body.subject).toBeTruthy();
+  });
+
+  test('throws when the send fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(400, { meta: { error: 'bad' } })));
+
+    await expect(sendEmailChangeVerification({ oldEmail: 'old@example.com', newEmail: 'new@example.com', confirmUrl: 'https://bluedot.org/x' }))
+      .rejects.toThrow('HTTP 400');
+  });
+
+  test('throws when the App API key is not configured', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const mutableEnv = env as { CIO_APP_API_KEY?: string };
+    mutableEnv.CIO_APP_API_KEY = undefined;
+
+    try {
+      await expect(sendEmailChangeVerification({ oldEmail: 'old@example.com', newEmail: 'new@example.com', confirmUrl: 'https://bluedot.org/x' }))
+        .rejects.toThrow('not configured');
+    } finally {
+      mutableEnv.CIO_APP_API_KEY = 'fake-app-key';
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/website/src/lib/api/customerio.test.ts
+++ b/apps/website/src/lib/api/customerio.test.ts
@@ -216,6 +216,15 @@ describe('updateCustomerIoEmail', () => {
     expect(cio.identifyCalls).toEqual([]);
   });
 
+  test('does nothing when the id profile already has the new email, whatever casing the caller stored it in', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+    installFakeCio(cio);
+
+    await runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'Old@Example.com', newEmail: 'New@Example.COM' }));
+
+    expect(cio.identifyCalls).toEqual([]);
+  });
+
   test('refuses to claim an old-email profile owned by a different user id', async () => {
     const cio = makeFakeCio([{ cio_id: 'c1', id: 'u2', email: 'old@example.com' }]);
     installFakeCio(cio);

--- a/apps/website/src/lib/api/customerio.test.ts
+++ b/apps/website/src/lib/api/customerio.test.ts
@@ -42,8 +42,11 @@ const makeFakeCio = (profiles: FakeProfile[], { applyWrites = true }: { applyWri
   identifyCalls: [],
 });
 
-const applyIdentify = (cio: FakeCio, id: string, email: string) => {
-  const owner = cio.profiles.find((p) => p.email === email);
+const sameEmail = (a: string | null, b: string | null) => a !== null && b !== null && a.toLowerCase() === b.toLowerCase();
+
+const applyIdentify = (cio: FakeCio, id: string, rawEmail: string) => {
+  const email = rawEmail.toLowerCase();
+  const owner = cio.profiles.find((p) => sameEmail(p.email, email));
   const mine = cio.profiles.find((p) => p.id === id);
   if (owner && owner !== mine) {
     if (!owner.id && !mine) {
@@ -78,7 +81,7 @@ const installFakeCio = (cio: FakeCio) => {
       if (url.pathname === '/v1/customers') {
         const email = url.searchParams.get('email');
         const results = cio.profiles
-          .filter((p) => p.email === email)
+          .filter((p) => sameEmail(p.email, email))
           .map((p) => ({ cio_id: p.cio_id, id: p.id, email: p.email }));
         return jsonResponse(200, { results });
       }
@@ -134,6 +137,7 @@ const runToCompletion = async (promise: Promise<void>) => {
 
 describe('updateCustomerIoEmail', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
@@ -281,6 +285,27 @@ describe('updateCustomerIoEmail', () => {
       .rejects.toThrow('no conflicting profile was found');
 
     expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'new@example.com' }]);
+  });
+
+  test('keeps polling when a read fails while verifying the rename', async () => {
+    const cio = makeFakeCio([{ cio_id: 'c1', id: 'u1', email: 'old@example.com' }]);
+    const fetchMock = installFakeCio(cio);
+    const base = fetchMock.getMockImplementation()!;
+    let attributesCalls = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).includes('/attributes')) {
+        attributesCalls += 1;
+        if (attributesCalls === 2) throw new Error('network blip');
+        if (attributesCalls === 3) return jsonResponse(500, { meta: { error: 'server error' } });
+      }
+
+      return base(input, init);
+    });
+
+    await runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' }));
+
+    expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'new@example.com' }]);
+    expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
   });
 
   test('succeeds without throwing when the rename lands late, after verify polling gave up', async () => {

--- a/apps/website/src/lib/api/customerio.ts
+++ b/apps/website/src/lib/api/customerio.ts
@@ -96,7 +96,7 @@ export async function updateCustomerIoEmail({ userId, oldEmail: oldEmailRaw, new
       throw new Error(`Email update aborted for user ${userId}: the old-email profile is owned by a different user id (${cioProfileByOldEmail.id})`);
     }
 
-    // Changing email requires setting a stable `id` for the profile, so the email itself can mutated.
+    // Changing email requires setting a stable `id` for the profile, so the email itself can be mutated.
     // If the profile has no id, add one (the userId) and wait for this change to propagate.
     if (!cioProfileByOldEmail.id) {
       await identify({ userId, email: oldEmail });
@@ -120,7 +120,10 @@ export async function updateCustomerIoEmail({ userId, oldEmail: oldEmailRaw, new
   throw new Error(`Email update failed for user ${userId}: the new email is already owned by ${owners}`);
 }
 
+const escapeHtml = (value: string) => value.replace(/[&<>"']/g, (char) => `&#${char.charCodeAt(0)};`);
+
 export async function sendEmailChangeVerification({ oldEmail, newEmail, confirmUrl }: { oldEmail: string; newEmail: string; confirmUrl: string }): Promise<void> {
+  const safeConfirmUrl = escapeHtml(confirmUrl);
   const res = await fetch(`${CIO_API_BASE}/send/email`, {
     method: 'POST',
     headers: { ...appHeaders(), 'Content-Type': 'application/json' },
@@ -134,8 +137,8 @@ export async function sendEmailChangeVerification({ oldEmail, newEmail, confirmU
       subject: 'Confirm your new email address',
       body: [
         '<p>A change of your BlueDot Impact account email to this address has been requested.</p>',
-        `<p><a href="${confirmUrl}">Confirm this email address</a></p>`,
-        `<p>Or copy this link into your browser: ${confirmUrl}</p>`,
+        `<p><a href="${safeConfirmUrl}">Confirm this email address</a></p>`,
+        `<p>Or copy this link into your browser: ${safeConfirmUrl}</p>`,
         '<p>This link expires in 48 hours. If you did not expect this, you can safely ignore this email and nothing will change.</p>',
       ].join('\n'),
     }),

--- a/apps/website/src/lib/api/customerio.ts
+++ b/apps/website/src/lib/api/customerio.ts
@@ -1,0 +1,146 @@
+import env from './env';
+import { normaliseEmail } from './utils';
+
+export const CIO_API_BASE = 'https://api-eu.customer.io/v1';
+export const CIO_TRACK_V1_BASE = 'https://track-eu.customer.io/api/v1';
+const CIO_TRACK_V2_BASE = 'https://track-eu.customer.io/api/v2';
+
+const POLL_INTERVAL_MS = 5000;
+const VERIFY_POLL_ATTEMPTS = 6;
+
+type CioProfileSummary = { cio_id: string; id?: string | null; email?: string | null };
+
+type CioProfile = {
+  identifiers?: { cio_id?: string; id?: string | null; email?: string | null };
+  attributes?: Record<string, unknown>;
+};
+
+const appHeaders = () => {
+  if (!env.CIO_APP_API_KEY) throw new Error('customer.io App API key is not configured');
+  return { Authorization: `Bearer ${env.CIO_APP_API_KEY}` };
+};
+
+const trackHeaders = () => {
+  if (!env.CIO_TRACK_API_KEY) throw new Error('customer.io Track API key is not configured');
+  return {
+    Authorization: `Basic ${Buffer.from(env.CIO_TRACK_API_KEY).toString('base64')}`,
+    'Content-Type': 'application/json',
+  };
+};
+
+async function getProfileById(userId: string): Promise<CioProfile | null> {
+  const res = await fetch(`${CIO_API_BASE}/customers/${encodeURIComponent(userId)}/attributes?id_type=id`, { headers: appHeaders() });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to fetch customer.io profile by id: HTTP ${res.status}`);
+  const data = await res.json() as { customer?: CioProfile };
+  return data.customer ?? null;
+}
+
+async function searchProfilesByEmail(email: string): Promise<CioProfileSummary[]> {
+  const res = await fetch(`${CIO_API_BASE}/customers?email=${encodeURIComponent(email)}`, { headers: appHeaders() });
+  if (!res.ok) throw new Error(`Failed to search customer.io profiles by email: HTTP ${res.status}`);
+  const data = await res.json() as { results?: CioProfileSummary[] };
+  return data.results ?? [];
+}
+
+async function identify({ userId, email }: { userId: string; email: string }): Promise<void> {
+  const res = await fetch(`${CIO_TRACK_V2_BASE}/batch`, {
+    method: 'POST',
+    headers: trackHeaders(),
+    body: JSON.stringify({
+      batch: [{
+        type: 'person',
+        identifiers: { id: userId },
+        action: 'identify',
+        attributes: { email },
+      }],
+    }),
+  });
+  if (!res.ok) throw new Error(`customer.io identify failed: HTTP ${res.status}`);
+}
+
+const profileEmail = (profile: CioProfile | null): string | null => {
+  const email = profile?.identifiers?.email ?? profile?.attributes?.email;
+  return typeof email === 'string' ? normaliseEmail(email) : null;
+};
+
+async function emailIsVisible({ userId, email }: { userId: string; email: string }): Promise<boolean> {
+  for (let attempt = 0; attempt < VERIFY_POLL_ATTEMPTS; attempt++) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => {
+      setTimeout(resolve, POLL_INTERVAL_MS);
+    });
+    // eslint-disable-next-line no-await-in-loop
+    if (profileEmail(await getProfileById(userId)) === email) return true;
+  }
+
+  return false;
+}
+
+export async function updateCustomerIoEmail({ userId, oldEmail: oldEmailRaw, newEmail: newEmailRaw }: { userId: string; oldEmail: string; newEmail: string }): Promise<void> {
+  const oldEmail = normaliseEmail(oldEmailRaw);
+  const newEmail = normaliseEmail(newEmailRaw);
+
+  const cioProfileByUserId = await getProfileById(userId);
+  if (cioProfileByUserId) {
+    if (profileEmail(cioProfileByUserId) === newEmail) return;
+  } else {
+    const cioProfilesByOldEmail = await searchProfilesByEmail(oldEmail);
+    if (cioProfilesByOldEmail.length === 0) return;
+    if (cioProfilesByOldEmail.length > 1) {
+      throw new Error(`Email update aborted for user ${userId}: multiple customer.io profiles own the old email`);
+    }
+
+    const cioProfileByOldEmail = cioProfilesByOldEmail[0]!;
+    if (cioProfileByOldEmail.id && cioProfileByOldEmail.id !== userId) {
+      throw new Error(`Email update aborted for user ${userId}: the old-email profile is owned by a different user id (${cioProfileByOldEmail.id})`);
+    }
+
+    // Changing email requires setting a stable `id` for the profile, so the email itself can mutated.
+    // If the profile has no id, add one (the userId) and wait for this change to propagate.
+    if (!cioProfileByOldEmail.id) {
+      await identify({ userId, email: oldEmail });
+      if (!(await emailIsVisible({ userId, email: oldEmail }))) {
+        throw new Error(`Email update failed for user ${userId}: claiming the old-email profile did not complete`);
+      }
+    }
+  }
+
+  // Update the CIO profile with the new email, and wait for it to propagate
+  await identify({ userId, email: newEmail });
+  if (await emailIsVisible({ userId, email: newEmail })) return;
+
+  const newEmailProfiles = await searchProfilesByEmail(newEmail);
+  if (newEmailProfiles.some((profile) => profile.id === userId)) return;
+  if (newEmailProfiles.length === 0) {
+    throw new Error(`Email update failed for user ${userId}: rename did not verify and no conflicting profile was found`);
+  }
+
+  const owners = newEmailProfiles.map((profile) => (profile.id ? `cio_${profile.cio_id} (user id ${profile.id})` : `cio_${profile.cio_id}`)).join(', ');
+  throw new Error(`Email update failed for user ${userId}: the new email is already owned by ${owners}`);
+}
+
+export async function sendEmailChangeVerification({ oldEmail, newEmail, confirmUrl }: { oldEmail: string; newEmail: string; confirmUrl: string }): Promise<void> {
+  const res = await fetch(`${CIO_API_BASE}/send/email`, {
+    method: 'POST',
+    headers: { ...appHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      // Important: Use oldEmail as the identifier (correct until they click through in the email to
+      // accept the new one, and prevents an orphaned profile from being created), but send *to* the new email
+      to: normaliseEmail(newEmail),
+      identifiers: { email: normaliseEmail(oldEmail) },
+      send_to_unsubscribed: true,
+      from: 'BlueDot Impact <team@bluedot.org>',
+      subject: 'Confirm your new email address',
+      body: [
+        '<p>A change of your BlueDot Impact account email to this address has been requested.</p>',
+        `<p><a href="${confirmUrl}">Confirm this email address</a></p>`,
+        `<p>Or copy this link into your browser: ${confirmUrl}</p>`,
+        '<p>This link expires in 48 hours. If you did not expect this, you can safely ignore this email and nothing will change.</p>',
+      ].join('\n'),
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`customer.io verification email send failed: HTTP ${res.status}`);
+  }
+}

--- a/apps/website/src/lib/api/customerio.ts
+++ b/apps/website/src/lib/api/customerio.ts
@@ -1,3 +1,4 @@
+import { logger } from '@bluedot/ui/src/api';
 import env from './env';
 import { normaliseEmail } from './utils';
 
@@ -70,8 +71,12 @@ async function emailIsVisible({ userId, email }: { userId: string; email: string
     await new Promise((resolve) => {
       setTimeout(resolve, POLL_INTERVAL_MS);
     });
-    // eslint-disable-next-line no-await-in-loop
-    if (profileEmail(await getProfileById(userId)) === email) return true;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      if (profileEmail(await getProfileById(userId)) === email) return true;
+    } catch (error) {
+      logger.warn(`Failed to read the customer.io profile for user ${userId} while verifying an email change:`, error);
+    }
   }
 
   return false;

--- a/apps/website/src/server/routers/subscription-preferences.ts
+++ b/apps/website/src/server/routers/subscription-preferences.ts
@@ -3,10 +3,8 @@ import { TRPCError } from '@trpc/server';
 import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import { z } from 'zod';
 import { publicProcedure, router } from '../trpc';
+import { CIO_API_BASE, CIO_TRACK_V1_BASE } from '../../lib/api/customerio';
 import env from '../../lib/api/env';
-
-const CIO_API_BASE = 'https://api-eu.customer.io/v1';
-const CIO_TRACK_BASE = 'https://track-eu.customer.io/api/v1';
 
 const HIRING_TOPIC_ID = 16;
 const HIRING_SEGMENT_ID = 365;
@@ -136,7 +134,7 @@ export const subscriptionPreferencesRouter = router({
 
       let res: Response;
       try {
-        res = await fetch(`${CIO_TRACK_BASE}/customers/cio_${input.cid}`, {
+        res = await fetch(`${CIO_TRACK_V1_BASE}/customers/cio_${input.cid}`, {
           method: 'PUT',
           headers: {
             Authorization: `Basic ${Buffer.from(trackApiKey).toString('base64')}`,


### PR DESCRIPTION
# Description

Part of the work to allow users to change their email (#2570), specifically making customer.io handle this correctly (#2810).

This PR adds `updateCustomerIoEmail({ userId, oldEmail, newEmail })`, which tries to keep a stable customer.io profile pinned to the userId, and change the email from `oldEmail` to `newEmail`. There are edge cases where e.g. the `newEmail` already exists in customer.io (which can happen if a user applied to ~any BlueDot thing under the new email already), it's best to look at the tests to see how that is handled in each case.

I also added `sendEmailChangeVerification` in this PR, in order to meaningfully test more of `updateCustomerIoEmail`, but `sendEmailChangeVerification` isn't yet used by anything in this PR. It will be adopted by the actual email-change flow when that exists.

I ran some tests against the prod environment in preparing this branch, per the comment in the test file you can review these tests here:
> These semantics were validated against the real production workspace with a live-fire
> model-based test, which is preserved on the `wh-2810-cio-livetest-2026-07-archive` git branch,
> file `apps/website/src/lib/api/customerio.prod.test.ts`.
I'm not committing these tests themselves because they're not practical to maintain (they create and delete real users in customer.io every time).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2810

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories