### PR TITLE
Breadcrumb: CRM "Sync people to customer.io" automation: identify by user id where available

### DIFF
--- a/airtable-automations/crm/sync-people-to-customerio/check-cohort-state.mjs
+++ b/airtable-automations/crm/sync-people-to-customerio/check-cohort-state.mjs
@@ -1,0 +1,37 @@
+// Read-only: print the customer.io state for a set of Persons, looked up by email and user id.
+//
+//   npx dotenv -e apps/website/.env.local -- node check-cohort-state.mjs "email[:uid[:uid]]" ...
+//
+// Each argument is an email optionally followed by colon-separated user ids to also look up directly.
+
+const appHeaders = { Authorization: `Bearer ${process.env.CIO_APP_API_KEY}` };
+if (!process.env.CIO_APP_API_KEY) throw new Error('CIO_APP_API_KEY not set');
+
+async function byEmail(email) {
+  const res = await fetch(`https://api-eu.customer.io/v1/customers?email=${encodeURIComponent(email)}`, { headers: appHeaders });
+  if (!res.ok) throw new Error(`search: HTTP ${res.status}`);
+  return ((await res.json()).results ?? []).map((p) => ({ cio_id: p.cio_id, id: p.id || null }));
+}
+
+async function byId(id) {
+  const res = await fetch(`https://api-eu.customer.io/v1/customers/${encodeURIComponent(id)}/attributes?id_type=id`, { headers: appHeaders });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`get: HTTP ${res.status}`);
+  const c = (await res.json()).customer;
+  return {
+    cio_id: c.identifiers?.cio_id,
+    email: c.identifiers?.email ?? c.attributes?.email ?? null,
+    firstName: c.attributes?.firstName ?? null,
+    lastName: c.attributes?.lastName ?? null,
+  };
+}
+
+for (const arg of process.argv.slice(2)) {
+  const [email, ...uids] = arg.split(':');
+  const profiles = await byEmail(email);
+  console.log(`${email}`);
+  console.log(`  by email (${profiles.length}): ${JSON.stringify(profiles)}`);
+  for (const uid of uids) {
+    console.log(`  by uid ${uid}: ${JSON.stringify(await byId(uid))}`);
+  }
+}

--- a/airtable-automations/crm/sync-people-to-customerio/new-local-scaffold.js
+++ b/airtable-automations/crm/sync-people-to-customerio/new-local-scaffold.js
@@ -97,7 +97,7 @@ async function batchUpdateCustomerIo(batch) {
 async function main() {
   try {
     const persons = await getPersons();
-    const peopleUpdatePayloads = persons.map(person => ({
+    const peopleUpdatePayloads = persons.filter(person => person.userId || person.email).map(person => ({
       type: 'person',
       identifiers: person.userId ? { id: person.userId } : { email: person.email },
       action: 'identify',

--- a/airtable-automations/crm/sync-people-to-customerio/new-local-scaffold.js
+++ b/airtable-automations/crm/sync-people-to-customerio/new-local-scaffold.js
@@ -1,0 +1,122 @@
+// LOCAL SCAFFOLD — a runnable copy of new.js (the version that gets pasted into the Airtable
+// automation). Identical to new.js except the blocks marked LOCAL.
+//
+//   npx dotenv -e apps/website/.env.local -- node new-local-scaffold.js [--live] [--emails a,b,c]
+//
+// Dry-run by default: prints what would be sent instead of sending. --emails restricts the run
+// to Persons whose Primary email exactly matches one of the given addresses.
+
+// LOCAL: credentials come from env (the Airtable version hardcodes these from 1Password)
+const customerIoTrackAuthHeader = `Basic ${Buffer.from(process.env.CIO_TRACK_API_KEY).toString('base64')}`;
+const customerIoAppAuthHeader = `Bearer ${process.env.CIO_APP_API_KEY}`;
+
+// LOCAL: cli flags, plus an Airtable-scripting-style `base` backed by the Airtable REST API
+// (the Airtable version gets `base` as a global). --emails becomes a filterByFormula.
+const LIVE = process.argv.includes('--live');
+const emailsArgIndex = process.argv.indexOf('--emails');
+const cohortEmails = emailsArgIndex >= 0 ? process.argv[emailsArgIndex + 1].split(',').map(e => e.trim().toLowerCase()) : null;
+
+const base = {
+  getTable: () => ({
+    selectRecordsAsync: async ({ fields }) => {
+      const records = [];
+      let offset;
+      do {
+        const params = new URLSearchParams({ pageSize: '100', returnFieldsByFieldId: 'true' });
+        for (const f of fields) params.append('fields[]', f);
+        if (cohortEmails) params.set('filterByFormula', `OR(${cohortEmails.map(e => `LOWER({Primary email}) = "${e}"`).join(', ')})`);
+        if (offset) params.set('offset', offset);
+        const res = await fetch(`https://api.airtable.com/v0/apppOzz9fPg59PxLa/tblMYYK8bL2fRJmv7?${params}`, {
+          headers: { Authorization: `Bearer ${process.env.AIRTABLE_PERSONAL_ACCESS_TOKEN}` },
+        });
+        if (!res.ok) throw new Error(`Airtable list failed: HTTP ${res.status}`);
+        const data = await res.json();
+        records.push(...data.records.map(r => ({
+          getCellValue: (fieldId) => r.fields[fieldId] ?? null,
+          getCellValueAsString: (fieldId) => {
+            const v = r.fields[fieldId];
+            return v == null ? '' : (Array.isArray(v) ? v.join(', ') : String(v));
+          },
+        })));
+        offset = data.offset;
+      } while (offset);
+      return { records };
+    },
+  }),
+};
+
+const fieldIds = {
+  email: 'fldxWudQeM7b4ZHeR',
+  firstName: 'fld2HkQK6ngvW9II6',
+  lastName: 'fldVVmuxiujMvpzAd',
+  userId: 'fldu6Vi0CbymQiA28',
+}
+
+async function getPersons() {
+  const result = await base.getTable('Person').selectRecordsAsync({ fields: Object.values(fieldIds) })
+  return result.records.map(r => {
+    const userIdCell = r.getCellValue(fieldIds.userId);
+    const userIds = (Array.isArray(userIdCell) ? userIdCell : []).filter(v => typeof v === 'string' && v);
+    return {
+      email: r.getCellValueAsString(fieldIds.email),
+      firstName: r.getCellValueAsString(fieldIds.firstName),
+      lastName: r.getCellValueAsString(fieldIds.lastName),
+      // Manually-merged multi-account Persons carry multiple user ids.
+      // There is no canonical one to pick, so only single-id Persons are identified by id.
+      userId: userIds.length === 1 ? userIds[0] : null,
+    }
+  })
+}
+
+async function batchUpdateCustomerIo(batch) {
+  // LOCAL: dry-run guard — without --live, report instead of sending
+  if (!LIVE) {
+    const body = JSON.stringify({ batch });
+    console.log(`dry run: would send ${batch.length} entries (${body.length} bytes, ${batch.filter(e => e.identifiers.id).length} id-keyed)`);
+    if (batch.length <= 10) for (const entry of batch) console.log(`  ${JSON.stringify(entry)}`);
+    return {};
+  }
+
+  const response = await fetch(`https://track-eu.customer.io/api/v2/batch`, {
+    method: 'POST',
+    headers: {
+      'Authorization': customerIoTrackAuthHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      batch
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error creating person in customer.io: ${response.statusText}`)
+  }
+
+  return response.json();
+}
+
+async function main() {
+  try {
+    const persons = await getPersons();
+    const peopleUpdatePayloads = persons.map(person => ({
+      type: 'person',
+      identifiers: person.userId ? { id: person.userId } : { email: person.email },
+      action: 'identify',
+      attributes: {
+        ...(person.userId && person.email ? { email: person.email } : {}),
+        firstName: person.firstName,
+        lastName: person.lastName,
+      }
+    }))
+    const payloadBatches = [];
+    while (peopleUpdatePayloads.length > 0) {
+      payloadBatches.push(peopleUpdatePayloads.splice(0, 1000))
+    }
+    await Promise.all(payloadBatches.map(batch => batchUpdateCustomerIo(batch)))
+  } catch (error) {
+    console.error(`Error in main: ${error}`);
+    throw error;
+  }
+}
+
+main()

--- a/airtable-automations/crm/sync-people-to-customerio/new-local-scaffold.js
+++ b/airtable-automations/crm/sync-people-to-customerio/new-local-scaffold.js
@@ -8,7 +8,6 @@
 
 // LOCAL: credentials come from env (the Airtable version hardcodes these from 1Password)
 const customerIoTrackAuthHeader = `Basic ${Buffer.from(process.env.CIO_TRACK_API_KEY).toString('base64')}`;
-const customerIoAppAuthHeader = `Bearer ${process.env.CIO_APP_API_KEY}`;
 
 // LOCAL: cli flags, plus an Airtable-scripting-style `base` backed by the Airtable REST API
 // (the Airtable version gets `base` as a global). --emails becomes a filterByFormula.

--- a/airtable-automations/crm/sync-people-to-customerio/new.js
+++ b/airtable-automations/crm/sync-people-to-customerio/new.js
@@ -1,7 +1,6 @@
 // Get these from 1Password
 // Configured in https://fly.customer.io/settings/api_credentials
 const customerIoTrackAuthHeader = 'Basic REPLACE_FROM_1PASSWORD';
-const customerIoAppAuthHeader = 'Bearer REPLACE_FROM_1PASSWORD';
 
 const fieldIds = {
   email: 'fldxWudQeM7b4ZHeR',

--- a/airtable-automations/crm/sync-people-to-customerio/new.js
+++ b/airtable-automations/crm/sync-people-to-customerio/new.js
@@ -1,0 +1,72 @@
+// Get these from 1Password
+// Configured in https://fly.customer.io/settings/api_credentials
+const customerIoTrackAuthHeader = 'Basic REPLACE_FROM_1PASSWORD';
+const customerIoAppAuthHeader = 'Bearer REPLACE_FROM_1PASSWORD';
+
+const fieldIds = {
+  email: 'fldxWudQeM7b4ZHeR',
+  firstName: 'fld2HkQK6ngvW9II6',
+  lastName: 'fldVVmuxiujMvpzAd',
+  userId: 'fldu6Vi0CbymQiA28',
+}
+
+async function getPersons() {
+  const result = await base.getTable('Person').selectRecordsAsync({ fields: Object.values(fieldIds) })
+  return result.records.map(r => {
+    const userIdCell = r.getCellValue(fieldIds.userId);
+    const userIds = (Array.isArray(userIdCell) ? userIdCell : []).filter(v => typeof v === 'string' && v);
+    return {
+      email: r.getCellValueAsString(fieldIds.email),
+      firstName: r.getCellValueAsString(fieldIds.firstName),
+      lastName: r.getCellValueAsString(fieldIds.lastName),
+      // Manually-merged multi-account Persons carry multiple user ids.
+      // There is no canonical one to pick, so only single-id Persons are identified by id.
+      userId: userIds.length === 1 ? userIds[0] : null,
+    }
+  })
+}
+
+async function batchUpdateCustomerIo(batch) {
+  const response = await fetch(`https://track-eu.customer.io/api/v2/batch`, {
+    method: 'POST',
+    headers: {
+      'Authorization': customerIoTrackAuthHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      batch
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error creating person in customer.io: ${response.statusText}`)
+  }
+
+  return response.json();
+}
+
+async function main() {
+  try {
+    const persons = await getPersons();
+    const peopleUpdatePayloads = persons.map(person => ({
+      type: 'person',
+      identifiers: person.userId ? { id: person.userId } : { email: person.email },
+      action: 'identify',
+      attributes: {
+        ...(person.userId && person.email ? { email: person.email } : {}),
+        firstName: person.firstName,
+        lastName: person.lastName,
+      }
+    }))
+    const payloadBatches = [];
+    while (peopleUpdatePayloads.length > 0) {
+      payloadBatches.push(peopleUpdatePayloads.splice(0, 1000))
+    }
+    await Promise.all(payloadBatches.map(batch => batchUpdateCustomerIo(batch)))
+  } catch (error) {
+    console.error(`Error in main: ${error}`);
+    throw error;
+  }
+}
+
+main()

--- a/airtable-automations/crm/sync-people-to-customerio/new.js
+++ b/airtable-automations/crm/sync-people-to-customerio/new.js
@@ -47,7 +47,7 @@ async function batchUpdateCustomerIo(batch) {
 async function main() {
   try {
     const persons = await getPersons();
-    const peopleUpdatePayloads = persons.map(person => ({
+    const peopleUpdatePayloads = persons.filter(person => person.userId || person.email).map(person => ({
       type: 'person',
       identifiers: person.userId ? { id: person.userId } : { email: person.email },
       action: 'identify',

--- a/airtable-automations/crm/sync-people-to-customerio/old-local-scaffold.js
+++ b/airtable-automations/crm/sync-people-to-customerio/old-local-scaffold.js
@@ -1,0 +1,134 @@
+// LOCAL SCAFFOLD — a runnable copy of old.js (the currently-deployed automation script).
+// Identical to old.js except the blocks marked LOCAL. Useful for simulating the still-deployed
+// hourly automation running against a cohort mid-rollout.
+//
+//   npx dotenv -e apps/website/.env.local -- node old-local-scaffold.js [--live] [--emails a,b,c]
+
+// LOCAL: credentials come from env (the Airtable version hardcodes these from 1Password)
+const customerIoTrackAuthHeader = `Basic ${Buffer.from(process.env.CIO_TRACK_API_KEY).toString('base64')}`;
+const customerIoAppAuthHeader = `Bearer ${process.env.CIO_APP_API_KEY}`;
+
+// LOCAL: cli flags, plus an Airtable-scripting-style `base` backed by the Airtable REST API
+// (the Airtable version gets `base` as a global). --emails becomes a filterByFormula.
+const LIVE = process.argv.includes('--live');
+const emailsArgIndex = process.argv.indexOf('--emails');
+const cohortEmails = emailsArgIndex >= 0 ? process.argv[emailsArgIndex + 1].split(',').map(e => e.trim().toLowerCase()) : null;
+
+const base = {
+  getTable: () => ({
+    selectRecordsAsync: async ({ fields }) => {
+      const records = [];
+      let offset;
+      do {
+        const params = new URLSearchParams({ pageSize: '100', returnFieldsByFieldId: 'true' });
+        for (const f of fields) params.append('fields[]', f);
+        if (cohortEmails) params.set('filterByFormula', `OR(${cohortEmails.map(e => `LOWER({Primary email}) = "${e}"`).join(', ')})`);
+        if (offset) params.set('offset', offset);
+        const res = await fetch(`https://api.airtable.com/v0/apppOzz9fPg59PxLa/tblMYYK8bL2fRJmv7?${params}`, {
+          headers: { Authorization: `Bearer ${process.env.AIRTABLE_PERSONAL_ACCESS_TOKEN}` },
+        });
+        if (!res.ok) throw new Error(`Airtable list failed: HTTP ${res.status}`);
+        const data = await res.json();
+        records.push(...data.records.map(r => ({
+          getCellValue: (fieldId) => r.fields[fieldId] ?? null,
+          getCellValueAsString: (fieldId) => {
+            const v = r.fields[fieldId];
+            return v == null ? '' : (Array.isArray(v) ? v.join(', ') : String(v));
+          },
+        })));
+        offset = data.offset;
+      } while (offset);
+      return { records };
+    },
+  }),
+};
+
+const fieldIds = {
+  email: 'fldxWudQeM7b4ZHeR',
+  firstName: 'fld2HkQK6ngvW9II6',
+  lastName: 'fldVVmuxiujMvpzAd',
+}
+
+async function getPersons() {
+  const result = await base.getTable('Person').selectRecordsAsync({ fields: Object.values(fieldIds) })
+  return result.records.map(r => ({
+    email: r.getCellValueAsString(fieldIds.email),
+    firstName: r.getCellValueAsString(fieldIds.firstName),
+    lastName: r.getCellValueAsString(fieldIds.lastName),
+  }))
+}
+
+async function batchUpdateCustomerIo(batch) {
+  // LOCAL: dry-run guard — without --live, report instead of sending
+  if (!LIVE) {
+    const body = JSON.stringify({ batch });
+    console.log(`dry run: would send ${batch.length} entries (${body.length} bytes)`);
+    if (batch.length <= 10) for (const entry of batch) console.log(`  ${JSON.stringify(entry)}`);
+    return {};
+  }
+
+  const response = await fetch(`https://track-eu.customer.io/api/v2/batch`, {
+    method: 'POST',
+    headers: {
+      'Authorization': customerIoTrackAuthHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      batch
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error creating person in customer.io: ${response.statusText}`)
+  }
+
+  return response.json();
+}
+
+/** @param {string[][]} arr */
+async function emptyTemporaryColumns(arr) {
+  const headers = arr.shift();
+  const cioIdFieldIndex = headers.findIndex(name => name == 'cio_id')
+  const temporaryFieldIndexes = headers.flatMap((name, index) => name.startsWith('tmp') || name.startsWith('temp') ? [index] : []);
+  const peopleWithTemporaryFields = arr.filter(person => temporaryFieldIndexes.some(index => person[index]))
+  const peopleUpdatePayloads = peopleWithTemporaryFields.map(person => ({
+    type: 'person',
+    identifiers: {
+      email: person.email
+    },
+    action: 'identify',
+    attributes: Object.fromEntries(temporaryFieldIndexes.map(index => [headers[index], null]))
+  }))
+  const payloadBatches = [];
+  while (peopleUpdatePayloads.length > 0) {
+    payloadBatches.push(peopleUpdatePayloads.splice(0, 5000))
+  }
+  await Promise.all(payloadBatches.map(batch => batchUpdateCustomerIo(batch)))
+}
+
+async function main() {
+  try {
+    const persons = await getPersons();
+    const peopleUpdatePayloads = persons.map(person => ({
+      type: 'person',
+      identifiers: {
+        email: person.email
+      },
+      action: 'identify',
+      attributes: {
+        firstName: person.firstName,
+        lastName: person.lastName,
+      }
+    }))
+    const payloadBatches = [];
+    while (peopleUpdatePayloads.length > 0) {
+      payloadBatches.push(peopleUpdatePayloads.splice(0, 2500))
+    }
+    await Promise.all(payloadBatches.map(batch => batchUpdateCustomerIo(batch)))
+  } catch (error) {
+    console.error(`Error in main: ${error}`);
+    throw error;
+  }
+}
+
+main()

--- a/airtable-automations/crm/sync-people-to-customerio/old.js
+++ b/airtable-automations/crm/sync-people-to-customerio/old.js
@@ -1,0 +1,86 @@
+// Get these from 1Password
+// Configured in https://fly.customer.io/settings/api_credentials
+const customerIoTrackAuthHeader = 'Basic REPLACE_FROM_1PASSWORD';
+const customerIoAppAuthHeader = 'Bearer REPLACE_FROM_1PASSWORD';
+
+const fieldIds = {
+  email: 'fldxWudQeM7b4ZHeR',
+  firstName: 'fld2HkQK6ngvW9II6',
+  lastName: 'fldVVmuxiujMvpzAd',
+}
+
+async function getPersons() {
+  const result = await base.getTable('Person').selectRecordsAsync({ fields: Object.values(fieldIds) })
+  return result.records.map(r => ({
+    email: r.getCellValueAsString(fieldIds.email),
+    firstName: r.getCellValueAsString(fieldIds.firstName),
+    lastName: r.getCellValueAsString(fieldIds.lastName),
+  }))
+}
+
+async function batchUpdateCustomerIo(batch) {
+  const response = await fetch(`https://track-eu.customer.io/api/v2/batch`, {
+    method: 'POST',
+    headers: {
+      'Authorization': customerIoTrackAuthHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      batch
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error creating person in customer.io: ${response.statusText}`)
+  }
+
+  return response.json();
+}
+
+/** @param {string[][]} arr */
+async function emptyTemporaryColumns(arr) {
+  const headers = arr.shift();
+  const cioIdFieldIndex = headers.findIndex(name => name == 'cio_id')
+  const temporaryFieldIndexes = headers.flatMap((name, index) => name.startsWith('tmp') || name.startsWith('temp') ? [index] : []);
+  const peopleWithTemporaryFields = arr.filter(person => temporaryFieldIndexes.some(index => person[index]))
+  const peopleUpdatePayloads = peopleWithTemporaryFields.map(person => ({
+    type: 'person',
+    identifiers: {
+      email: person.email
+    },
+    action: 'identify',
+    attributes: Object.fromEntries(temporaryFieldIndexes.map(index => [headers[index], null]))
+  }))
+  const payloadBatches = [];
+  while (peopleUpdatePayloads.length > 0) {
+    payloadBatches.push(peopleUpdatePayloads.splice(0, 5000))
+  }
+  await Promise.all(payloadBatches.map(batch => batchUpdateCustomerIo(batch)))
+}
+
+async function main() {
+  try {
+    const persons = await getPersons();
+    const peopleUpdatePayloads = persons.map(person => ({
+      type: 'person',
+      identifiers: {
+        email: person.email
+      },
+      action: 'identify',
+      attributes: {
+        firstName: person.firstName,
+        lastName: person.lastName,
+      }
+    }))
+    const payloadBatches = [];
+    while (peopleUpdatePayloads.length > 0) {
+      payloadBatches.push(peopleUpdatePayloads.splice(0, 2500))
+    }
+    await Promise.all(payloadBatches.map(batch => batchUpdateCustomerIo(batch)))
+  } catch (error) {
+    console.error(`Error in main: ${error}`);
+    throw error;
+  }
+}
+
+main()


### PR DESCRIPTION
# Description

_I created this PR for the audit trail. This code needs to be manually updated in the Airtable UI, so I'll close it without merging. **The actual change that will be deployed here is pasting the new.js script into [this automation]((https://airtable.com/apppOzz9fPg59PxLa/wflp8Fk3qpzCCukmX/wac1ZS6MXbjKapik1))**._

This changes the hourly [Sync people to customer.io](https://airtable.com/apppOzz9fPg59PxLa/wflp8Fk3qpzCCukmX/wac1ZS6MXbjKapik1) CRM automation to identify people by their site user id where we have one, rather than by email. This gives customer.io profiles a stable identifier that can survive email changes, which is groundwork for supporting email changes properly (#2810).

The first run after deploying will upgrade the whole existing pool in place: email-keyed profiles will gain an `id: userId` identifier. At time of writing the pool is: 47,929 Persons with a known user id, 13,524 without, 7 edge cases (5 linked to multiple course-hub users, and 2 with the same email but different user ids). Deploying this will upgrade the 47,929, and should do nothing in the other cases.

## How to verify

The `old-local-scaffold.js` and `new-local-scaffold.js` files run the real scripts locally, identical to `new.js`/`old.js` apart from the marked `LOCAL:` blocks (e.g. credentials). I ran this procedure on a 5-Person cohort covering all the paths (yes-userId, no-userId, multi-userId, duplicate emails). To reproduce, pick a few test Persons and note their user ids from the Person table, then:
1. Baseline: `npx dotenv -e apps/website/.env.local -- node check-cohort-state.mjs "email:uid" ...`. Everything should be email-only (`id: null`); note the `cio_id`s.
2. New script: `npx dotenv -e apps/website/.env.local -- node new-local-scaffold.js --live --emails "..."`. Re-check ~20s later: profiles keep their `cio_id` and gain `id`; no-userId Persons unchanged; each email still resolves to exactly one profile.
3. Old script (`old-local-scaffold.js --live --emails "..."`, simulates the still-deployed automation running mid-rollout): nothing should change, ids stay attached.
4. New script again (idempotence): nothing should change.

`new-local-scaffold.js` with no flags does a read-only dry run over the full table, it prints each chunk it would send, with sizes and id-keyed counts.

Once this automation is deployed and turned on, we can turn on the [automation to propagate email changes to customer.io](https://airtable.com/apppOzz9fPg59PxLa/wflxUAN18c14rasqe/wdedLvniC4RmuelKQ?index=0), which relies on having a stable `userId`.

## Issue

#2810

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories