### PR TITLE
Add consolidated contact and legal information page

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -4,6 +4,11 @@ module.exports = withDefaultBlueDotNextConfig({
   async redirects() {
     return [
       {
+        source: '/company-information',
+        destination: '/contact',
+        permanent: true,
+      },
+      {
         source: '/running-versions-of-our-courses',
         destination: '/blog/running-versions-of-our-courses',
         permanent: true,

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -31,3 +31,4 @@ All cohort-based courses are free, run fully online, and pair 2–3 hours of wee
 - [Code of Conduct](https://bluedot.org/code-of-conduct): Participation standards for BlueDot courses and community
 - [Attendance Policy](https://bluedot.org/attendance-policy): Course attendance requirements and expectations
 - [Privacy Policy](https://bluedot.org/privacy-policy): How BlueDot Impact handles personal data
+- [Contact & Legal](https://bluedot.org/contact): How to contact BlueDot Impact, plus legal entities and registration details

--- a/apps/website/scripts/sitemap-generator.ts
+++ b/apps/website/scripts/sitemap-generator.ts
@@ -10,6 +10,7 @@ const INCLUDED_ROUTES = [
   ROUTES.home,
   ROUTES.about,
   ROUTES.courses,
+  ROUTES.contact,
   ROUTES.joinUs,
   ROUTES.missions,
   ROUTES.privacyPolicy,

--- a/apps/website/src/__tests__/pages/contact.test.tsx
+++ b/apps/website/src/__tests__/pages/contact.test.tsx
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import {
+  beforeEach, describe, expect, type Mock, test, vi,
+} from 'vitest';
+import { useRouter } from 'next/router';
+import ContactPage from '../../pages/contact';
+import { TrpcProvider } from '../trpcProvider';
+import { server, trpcMsw } from '../trpcMswSetup';
+import { MOCK_NAV_PROGRAMS } from '../testUtils';
+
+vi.mock('next/router', () => ({
+  useRouter: vi.fn(),
+}));
+
+const mockRouter = {
+  asPath: '/contact',
+  pathname: '/contact',
+  push: vi.fn(),
+};
+
+beforeEach(() => {
+  (useRouter as unknown as Mock).mockReturnValue(mockRouter);
+});
+
+describe('ContactPage', () => {
+  test('renders both legal entities without publishing the US street address', async () => {
+    server.use(
+      trpcMsw.courses.getAll.query(() => []),
+      trpcMsw.programs.getAll.query(() => MOCK_NAV_PROGRAMS),
+    );
+
+    const { container } = render(<ContactPage />, { wrapper: TrpcProvider });
+
+    expect(screen.getByRole('heading', { name: 'Contact & legal', level: 1 })).toBeInTheDocument();
+    expect(await screen.findByText(/71-75 Shelton Street/)).toBeInTheDocument();
+    expect(await screen.findByText(/99-4885308/)).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'team@bluedot.org' })).toHaveAttribute('href', 'mailto:team@bluedot.org');
+    expect(screen.getByText(/general questions or feedback/)).toBeInTheDocument();
+    expect(container).not.toHaveTextContent('1680 Mission');
+  });
+});

--- a/apps/website/src/lib/routes.test.ts
+++ b/apps/website/src/lib/routes.test.ts
@@ -54,6 +54,11 @@ describe('ROUTES configuration', () => {
     expect(ROUTES.profile.url).toBe('/profile');
     expect(ROUTES.profile.title).toBe('Profile');
   });
+
+  test('contact links use the consolidated company information page', () => {
+    expect(ROUTES.contact.url).toBe('/contact');
+    expect(ROUTES.contact.title).toBe('Contact & legal');
+  });
 });
 
 describe('shouldRedirectBackAfterLogout', () => {

--- a/apps/website/src/lib/routes.ts
+++ b/apps/website/src/lib/routes.ts
@@ -46,8 +46,8 @@ const blog: BluedotRoute = {
 };
 
 const contact: BluedotRoute = {
-  title: 'Contact us',
-  url: 'mailto:team@bluedot.org',
+  title: 'Contact & legal',
+  url: '/contact',
   parentPages: [home],
 };
 

--- a/apps/website/src/pages/contact.tsx
+++ b/apps/website/src/pages/contact.tsx
@@ -1,0 +1,56 @@
+import {
+  Breadcrumbs,
+  Section,
+} from '@bluedot/ui';
+import Head from 'next/head';
+import MarketingHero from '../components/MarketingHero';
+import MarkdownExtendedRenderer from '../components/courses/MarkdownExtendedRenderer';
+import { ROUTES } from '../lib/routes';
+
+const CURRENT_ROUTE = ROUTES.contact;
+const SUBTITLE = 'How to reach us and details about our nonprofit entities.';
+
+const ContactPage = () => {
+  return (
+    <div>
+      <Head>
+        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
+        <meta
+          name="description"
+          content="Contact details and legal registration information for BlueDot Impact's UK and US entities."
+        />
+      </Head>
+      <MarketingHero title={CURRENT_ROUTE.title} subtitle={SUBTITLE} />
+      <Breadcrumbs route={CURRENT_ROUTE} />
+      <Section className="max-w-3xl">
+        <MarkdownExtendedRenderer>{`
+## Contact
+
+We love hearing from people. For general questions or feedback, email [team@bluedot.org](mailto:team@bluedot.org).
+
+## Legal information
+
+BlueDot Impact operates through two nonprofit entities.
+
+### United Kingdom
+
+**BlueDot Impact Ltd** is a private company limited by guarantee without share capital, registered in England and Wales.
+
+- Company number: [14964572](https://find-and-update.company-information.service.gov.uk/company/14964572)
+- Registered office: 71-75 Shelton Street, Covent Garden, London, United Kingdom, WC2H 9JQ
+
+### United States
+
+**BlueDot Impact US Inc** is a tax-exempt nonprofit organisation recognised under section 501(c)(3) of the US Internal Revenue Code.
+
+- Employer Identification Number (EIN): [99-4885308](https://projects.propublica.org/nonprofits/organizations/994885308)
+`}
+        </MarkdownExtendedRenderer>
+      </Section>
+    </div>
+  );
+};
+
+ContactPage.pageRendersOwnNav = true;
+
+export default ContactPage;

--- a/libraries/ui/src/Footer.test.tsx
+++ b/libraries/ui/src/Footer.test.tsx
@@ -4,7 +4,10 @@ import { Footer } from './Footer';
 
 describe('Footer', () => {
   test('renders default as expected', () => {
-    const { container } = render(<Footer />);
+    const { container, getAllByRole } = render(<Footer />);
+    expect(getAllByRole('link', { name: 'Contact & legal' })).toHaveLength(3);
+    expect(getAllByRole('link', { name: 'Contact & legal' })[0]?.getAttribute('href')).toBe('/contact');
+    expect(container.textContent).not.toContain('1680 Mission');
     expect(container).toMatchSnapshot();
   });
 

--- a/libraries/ui/src/Footer.tsx
+++ b/libraries/ui/src/Footer.tsx
@@ -93,6 +93,7 @@ export const Footer: React.FC<FooterProps> = ({
     { url: 'https://blog.bluedot.org', label: 'Blog', target: '_blank' },
     { url: 'https://donate.stripe.com/5kA3fpgjpdJv6o89AA', label: 'Support us' },
     { url: '/privacy-policy', label: 'Privacy Policy' },
+    { url: '/contact', label: 'Contact & legal' },
     ...(onReportBug ? [{ onClick: onReportBug, label: 'Report a bug' }] : []),
   ];
 
@@ -185,10 +186,7 @@ export const Footer: React.FC<FooterProps> = ({
             {/* Copyright */}
             <div className="mt-12 border-t border-white/10 pt-8 text-size-sm text-bluedot-lighter leading-relaxed bd-md:mt-14 bd-md:pt-10 lg:mt-16 2xl:mt-20">
               <p className="mb-2">
-                &copy; {new Date().getFullYear()}. BlueDot Impact operates as a UK CLG (<A href="https://find-and-update.company-information.service.gov.uk/company/14964572" target="_blank" rel="noopener noreferrer" className="text-bluedot-lighter hover:text-white">14964572</A>) and a US 501(c)3 (<A href="https://projects.propublica.org/nonprofits/organizations/994885308" target="_blank" rel="noopener noreferrer" className="text-bluedot-lighter hover:text-white">99-4885308</A>).
-              </p>
-              <p className="mb-2">
-                US Address: 1680 Mission St. Suite 411, San Francisco, CA 94103
+                &copy; {new Date().getFullYear()}. BlueDot Impact operates as BlueDot Impact Ltd, a UK CLG (<A href="https://find-and-update.company-information.service.gov.uk/company/14964572" target="_blank" rel="noopener noreferrer" className="text-bluedot-lighter hover:text-white">14964572</A>), and BlueDot Impact US Inc, a US 501(c)(3) (<A href="https://projects.propublica.org/nonprofits/organizations/994885308" target="_blank" rel="noopener noreferrer" className="text-bluedot-lighter hover:text-white">99-4885308</A>).
               </p>
               <p>
                 Funded by <A href="https://www.coefficientgiving.org/" target="_blank" rel="noopener noreferrer" className="text-bluedot-lighter hover:text-white">Coefficient Giving</A>.

--- a/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Footer.test.tsx.snap
@@ -171,6 +171,15 @@ exports[`Footer > renders default as expected 1`] = `
                   Privacy Policy
                 </a>
               </li>
+              <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
+                </a>
+              </li>
             </ul>
           </div>
           <div
@@ -275,6 +284,15 @@ exports[`Footer > renders default as expected 1`] = `
                   tabindex="0"
                 >
                   Privacy Policy
+                </a>
+              </li>
+              <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
                 </a>
               </li>
             </ul>
@@ -464,6 +482,15 @@ exports[`Footer > renders default as expected 1`] = `
                   Privacy Policy
                 </a>
               </li>
+              <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
+                </a>
+              </li>
             </ul>
           </div>
           <div
@@ -499,7 +526,7 @@ exports[`Footer > renders default as expected 1`] = `
           >
             © 
             2026
-            . BlueDot Impact operates as a UK CLG (
+            . BlueDot Impact operates as BlueDot Impact Ltd, a UK CLG (
             <a
               class="bluedot-a not-prose text-bluedot-lighter hover:text-white"
               href="https://find-and-update.company-information.service.gov.uk/company/14964572"
@@ -509,7 +536,7 @@ exports[`Footer > renders default as expected 1`] = `
             >
               14964572
             </a>
-            ) and a US 501(c)3 (
+            ), and BlueDot Impact US Inc, a US 501(c)(3) (
             <a
               class="bluedot-a not-prose text-bluedot-lighter hover:text-white"
               href="https://projects.propublica.org/nonprofits/organizations/994885308"
@@ -520,11 +547,6 @@ exports[`Footer > renders default as expected 1`] = `
               99-4885308
             </a>
             ).
-          </p>
-          <p
-            class="mb-2"
-          >
-            US Address: 1680 Mission St. Suite 411, San Francisco, CA 94103
           </p>
           <p>
             Funded by 
@@ -718,6 +740,15 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
                 </a>
               </li>
               <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
+                </a>
+              </li>
+              <li>
                 <button
                   class="text-size-sm leading-snug text-bluedot-lighter hover:text-white font-normal bg-transparent border-none p-0 cursor-pointer"
                   type="button"
@@ -829,6 +860,15 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
                   tabindex="0"
                 >
                   Privacy Policy
+                </a>
+              </li>
+              <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
                 </a>
               </li>
               <li>
@@ -1027,6 +1067,15 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
                 </a>
               </li>
               <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
+                </a>
+              </li>
+              <li>
                 <button
                   class="text-size-sm leading-snug text-bluedot-lighter hover:text-white font-normal bg-transparent border-none p-0 cursor-pointer"
                   type="button"
@@ -1069,7 +1118,7 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
           >
             © 
             2026
-            . BlueDot Impact operates as a UK CLG (
+            . BlueDot Impact operates as BlueDot Impact Ltd, a UK CLG (
             <a
               class="bluedot-a not-prose text-bluedot-lighter hover:text-white"
               href="https://find-and-update.company-information.service.gov.uk/company/14964572"
@@ -1079,7 +1128,7 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
             >
               14964572
             </a>
-            ) and a US 501(c)3 (
+            ), and BlueDot Impact US Inc, a US 501(c)(3) (
             <a
               class="bluedot-a not-prose text-bluedot-lighter hover:text-white"
               href="https://projects.propublica.org/nonprofits/organizations/994885308"
@@ -1090,11 +1139,6 @@ exports[`Footer > renders with "report a bug" when onReportBug is provided 1`] =
               99-4885308
             </a>
             ).
-          </p>
-          <p
-            class="mb-2"
-          >
-            US Address: 1680 Mission St. Suite 411, San Francisco, CA 94103
           </p>
           <p>
             Funded by 
@@ -1287,6 +1331,15 @@ exports[`Footer > renders with optional args 1`] = `
                   Privacy Policy
                 </a>
               </li>
+              <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
+                </a>
+              </li>
             </ul>
           </div>
           <div
@@ -1391,6 +1444,15 @@ exports[`Footer > renders with optional args 1`] = `
                   tabindex="0"
                 >
                   Privacy Policy
+                </a>
+              </li>
+              <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
                 </a>
               </li>
             </ul>
@@ -1580,6 +1642,15 @@ exports[`Footer > renders with optional args 1`] = `
                   Privacy Policy
                 </a>
               </li>
+              <li>
+                <a
+                  class="bluedot-a not-prose text-size-sm leading-snug text-bluedot-lighter hover:text-white no-underline font-normal"
+                  href="/contact"
+                  tabindex="0"
+                >
+                  Contact & legal
+                </a>
+              </li>
             </ul>
           </div>
           <div
@@ -1615,7 +1686,7 @@ exports[`Footer > renders with optional args 1`] = `
           >
             © 
             2026
-            . BlueDot Impact operates as a UK CLG (
+            . BlueDot Impact operates as BlueDot Impact Ltd, a UK CLG (
             <a
               class="bluedot-a not-prose text-bluedot-lighter hover:text-white"
               href="https://find-and-update.company-information.service.gov.uk/company/14964572"
@@ -1625,7 +1696,7 @@ exports[`Footer > renders with optional args 1`] = `
             >
               14964572
             </a>
-            ) and a US 501(c)3 (
+            ), and BlueDot Impact US Inc, a US 501(c)(3) (
             <a
               class="bluedot-a not-prose text-bluedot-lighter hover:text-white"
               href="https://projects.propublica.org/nonprofits/organizations/994885308"
@@ -1636,11 +1707,6 @@ exports[`Footer > renders with optional args 1`] = `
               99-4885308
             </a>
             ).
-          </p>
-          <p
-            class="mb-2"
-          >
-            US Address: 1680 Mission St. Suite 411, San Francisco, CA 94103
           </p>
           <p>
             Funded by 

--- a/libraries/ui/src/constants.ts
+++ b/libraries/ui/src/constants.ts
@@ -1,1 +1,1 @@
-export const contactUsUrl = 'mailto:team@bluedot.org';
+export const contactUsUrl = 'https://bluedot.org/contact';


### PR DESCRIPTION
## Summary

- Add a consolidated **Contact & legal** page at `/contact`
- Put `team@bluedot.org` prominently at the top of the page
- Include the UK registered office and both nonprofit entities' registration details
- Remove the US street address from the global footer
- Link the footer and shared contact actions to `/contact`
- Permanently redirect `/company-information` to `/contact`
- Add the page to the sitemap and `llms.txt`

## Why

Contact and legal information was fragmented: the contact route was a mailto link, while entity details and a US street address appeared globally in the footer. This gives visitors one clearly named place to contact BlueDot or verify its legal entities, without publishing the US street address across the site.

## User impact

Visitors can reach BlueDot at `team@bluedot.org` and find relevant UK and US nonprofit information on one responsive page. Existing `/company-information` links continue to work through a permanent redirect.

## Validation

- Website tests: 127 files / 1,077 tests passed
- UI tests: 24 files / 165 tests passed, 2 skipped
- Website and UI lint passed
- Website typecheck passed
- Redirect verified as HTTP 308
- Mobile and desktop browser visual checks passed
