### PR TITLE
[feat] Add "Admin tools" link to the profile dropdown for admins

### DIFF
--- a/apps/website/src/components/Nav/_ProfileLinks.tsx
+++ b/apps/website/src/components/Nav/_ProfileLinks.tsx
@@ -25,6 +25,7 @@ export const ProfileLinks: React.FC<{
   const { openBugReport } = useBugReport();
 
   const { data: impersonationAccess } = trpc.admin.canImpersonate.useQuery();
+  const { data: isAdmin } = trpc.admin.isUserAdmin.useQuery();
   const { data: facilitatorData } = trpc.myBluedot.hasFacilitatorRegistrations.useQuery();
   const { data: applicationsData } = trpc.myBluedot.hasFacilitatorRegistrations.useQuery({ includeWithdrawn: true });
   const profileRef = useClickOutside(
@@ -116,6 +117,14 @@ export const ProfileLinks: React.FC<{
             >
               Impersonate a user
             </button>
+          )}
+          {isAdmin && (
+            <A
+              href={ROUTES.admin.url}
+              className={getNavLinkClasses()}
+              onClick={onToggleProfile}
+            >Admin tools
+            </A>
           )}
           <button
             type="button"


### PR DESCRIPTION
# Description

Links to the (pre-existing) `/admin` page,requested by Li-Lian.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | After |
|--------|---|
| 📱  | <img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/b0e76d72-db8c-4781-9088-73d0302ff17a" /> |
| 🖥️ | <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/93a9dee4-5fed-44b3-ac23-68c82f781840" /> |
