### PR TITLE
Support withdrawing applications from 'Facilitator applications' page

### DIFF
--- a/apps/website/src/components/courses/DropoutModal.tsx
+++ b/apps/website/src/components/courses/DropoutModal.tsx
@@ -30,6 +30,14 @@ const MAX_ROUNDS_PER_INTENSITY = 3;
 
 type DropoutModalProps = {
   applicantId: string;
+  handleClose: () => void;
+} & (
+  | { variant: 'withdraw' }
+  | { variant?: 'dropOrDefer'; courseSlug: string; currentRoundId: string | null }
+);
+
+type DropOrDeferModalProps = {
+  applicantId: string;
   courseSlug: string;
   currentRoundId: string | null;
   handleClose: () => void;
@@ -52,7 +60,15 @@ const intensityOfRound = (
   return null;
 };
 
-const DropoutModal: React.FC<DropoutModalProps> = ({
+const DropoutModal: React.FC<DropoutModalProps> = (props) => {
+  if (props.variant === 'withdraw') {
+    return <WithdrawConfirm applicantId={props.applicantId} handleClose={props.handleClose} />;
+  }
+
+  return <DropOrDeferModal {...props} />;
+};
+
+const DropOrDeferModal: React.FC<DropOrDeferModalProps> = ({
   applicantId, courseSlug, currentRoundId, handleClose,
 }) => {
   const [dropoutType, setDropoutType] = useState<DropoutType | undefined>();
@@ -294,6 +310,7 @@ const WithdrawConfirm: React.FC<{ applicantId: string; handleClose: () => void }
       void utils.courseRegistrations.getAll.invalidate();
       void utils.myBluedot.myCoursesPage.invalidate();
       void utils.myBluedot.facilitatedCoursesPage.invalidate();
+      void utils.facilitatorApplications.list.invalidate();
     }
 
     handleClose();

--- a/apps/website/src/components/facilitator-applications/ApplicationRow.stories.tsx
+++ b/apps/website/src/components/facilitator-applications/ApplicationRow.stories.tsx
@@ -24,6 +24,16 @@ export const Pending: Story = {
   args: { ...base, status: 'pending' },
 };
 
+export const PendingWithWithdraw: Story = {
+  args: {
+    ...base,
+    status: 'pending',
+    menuItems: [
+      { id: 'withdraw', label: 'Withdraw application', onAction: () => {} },
+    ],
+  },
+};
+
 export const AcceptedWithGoToCourse: Story = {
   args: {
     ...base,

--- a/apps/website/src/pages/facilitator-applications/index.tsx
+++ b/apps/website/src/pages/facilitator-applications/index.tsx
@@ -1,9 +1,10 @@
 import {
-  CTALinkOrButton, ErrorSection, H2, ProgressDots,
+  CTALinkOrButton, ErrorSection, H2, ProgressDots, type OverflowMenuItemProps,
 } from '@bluedot/ui';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import DropoutModal from '../../components/courses/DropoutModal';
 import ApplicationRow from '../../components/facilitator-applications/ApplicationRow';
 import {
   APPLICATION_TABS,
@@ -33,6 +34,24 @@ const sortByNewestFirst = (apps: FacilitatorApplicationListItem[]): FacilitatorA
     if (!bDate) return -1;
     return bDate.localeCompare(aDate);
   });
+};
+
+const buildMenuItems = (
+  app: FacilitatorApplicationListItem,
+  onWithdraw: () => void,
+): OverflowMenuItemProps[] => {
+  const items: OverflowMenuItemProps[] = [];
+
+  if (app.decision === 'Accept' && app.courseSlug) {
+    items.push({ id: 'go-to-course', label: 'Go to course', href: `/courses/${app.courseSlug}` });
+  }
+
+  // Note: Should match rule in `getFacilitatorActions` in `useCourseListRow.tsx`
+  if (app.decision === null && app.roundStatus === 'Future') {
+    items.push({ id: 'withdraw', label: 'Withdraw application', onAction: onWithdraw });
+  }
+
+  return items;
 };
 
 const EMPTY_BY_TAB: Record<ApplicationTab, { title: string; description: string }> = {
@@ -66,6 +85,7 @@ const FacilitatorApplicationsPage = () => {
   const { data, isLoading, error } = trpc.facilitatorApplications.list.useQuery();
 
   const [showAll, setShowAll] = useState(false);
+  const [withdrawingId, setWithdrawingId] = useState<string | null>(null);
 
   const visible = data ? sortByNewestFirst(filterByTab(data, activeTab)) : [];
   const paginate = activeTab === 'past';
@@ -100,31 +120,19 @@ const FacilitatorApplicationsPage = () => {
               ) : (
                 <>
                   <ul className="flex flex-col gap-3">
-                    {displayed.map((app) => {
-                      const menuItems
-                        = app.decision === 'Accept' && app.courseSlug
-                          ? [
-                            {
-                              id: 'go-to-course',
-                              label: 'Go to course',
-                              href: `/courses/${app.courseSlug}`,
-                            },
-                          ]
-                          : undefined;
-                      return (
-                        <ApplicationRow
-                          key={app.id}
-                          id={app.id}
-                          courseTitle={app.courseTitle}
-                          courseSlug={app.courseSlug}
-                          roundName={app.roundName}
-                          roundFirstDiscussionDate={app.roundFirstDiscussionDate}
-                          roundLastDiscussionDate={app.roundLastDiscussionDate}
-                          status={getApplicationStatus(app)}
-                          menuItems={menuItems}
-                        />
-                      );
-                    })}
+                    {displayed.map((app) => (
+                      <ApplicationRow
+                        key={app.id}
+                        id={app.id}
+                        courseTitle={app.courseTitle}
+                        courseSlug={app.courseSlug}
+                        roundName={app.roundName}
+                        roundFirstDiscussionDate={app.roundFirstDiscussionDate}
+                        roundLastDiscussionDate={app.roundLastDiscussionDate}
+                        status={getApplicationStatus(app)}
+                        menuItems={buildMenuItems(app, () => setWithdrawingId(app.id))}
+                      />
+                    ))}
                   </ul>
                   {hiddenCount > 0 && (
                     <div className="flex justify-center">
@@ -139,6 +147,13 @@ const FacilitatorApplicationsPage = () => {
           )}
         </div>
       </MyBlueDotLayout>
+      {withdrawingId && (
+        <DropoutModal
+          variant="withdraw"
+          applicantId={withdrawingId}
+          handleClose={() => setWithdrawingId(null)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Description

Previously, the "Withdraw" option was available from "Facilitated Courses" but not "Facilitator Applications". This PR adds it in the "Facilitator Applications" page, with the same rule as the other page.

There is related cruft that potentially needs cleaning up here:
- Now that "Facilitator Applications" exists, I think we should probably remove pending applications from the "Facilitated Courses" page altogether
- It may be correct to remove the `app.roundStatus === 'Future'` requirement for withdrawing applications. I.e. allow it as long as no decision has been made

I will create an issue for handling these, this PR is designed to fix the user-facing problem before reviewing all the possible states.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="2560" height="1208" alt="image" src="https://github.com/user-attachments/assets/fe5b8c4f-237a-4cef-891a-1bc1bc8e162b" /> | <img width="2560" height="1208" alt="image" src="https://github.com/user-attachments/assets/c7ac17b7-846e-4d0c-bd11-b19ad0a20630" /> |
|  |  | <img width="2560" height="1208" alt="image" src="https://github.com/user-attachments/assets/2116572a-e84a-4fe9-a038-f54c1d4f7d88" /> |
|  |  | <img width="2560" height="1800" alt="image" src="https://github.com/user-attachments/assets/980505b0-27b0-4305-a52c-d06b2c03ee9d" /> |
