### PR TITLE
[chore] soften CTG check-in copy and remove stale timing banners

### DIFF
--- a/apps/website/src/components/career-transition-grant/ExpectationsSection.tsx
+++ b/apps/website/src/components/career-transition-grant/ExpectationsSection.tsx
@@ -12,14 +12,14 @@ const EXPECTATIONS = [
     body: 'Short async updates to your BlueDot point of contact on what you did, who you talked to, what you learned, and how your thinking is evolving.',
   },
   {
-    cadence: 'Monthly',
-    title: 'Check-in',
-    body: 'Every month, a more structured conversation to review progress and discuss what support you need.',
+    cadence: 'Ongoing',
+    title: 'Check-ins',
+    body: 'Structured conversations throughout your grant to review progress and plan next steps.',
   },
   {
     cadence: 'At the end',
     title: 'Grant report',
-    body: 'A short (1-2 page) summary of what you achieved during the grant and what you will be doing next.',
+    body: 'A summary of what you achieved during the grant and what you will be doing next.',
   },
 ];
 

--- a/apps/website/src/pages/programs/advising.tsx
+++ b/apps/website/src/pages/programs/advising.tsx
@@ -2,7 +2,6 @@ import { Breadcrumbs } from '@bluedot/ui';
 import type { GetStaticProps } from 'next';
 import Head from 'next/head';
 import MarketingHero from '../../components/MarketingHero';
-import AnnouncementBanner from '../../components/AnnouncementBanner';
 import GrantStatsStrip from '../../components/grants/sections/GrantStatsStrip';
 import GrantFaqSection from '../../components/grants/sections/GrantFaqSection';
 import GrantCta from '../../components/grants/sections/GrantCta';
@@ -51,15 +50,6 @@ const OneOnOneAdvisingPage = ({ programName, programDescription }: ProgramDetail
           { label: 'Avg days to decision', value: avgDaysToDecisionLabel },
         ]}
       />
-      <AnnouncementBanner
-        className="advising-capacity-notice border-t"
-        label="A note on timing"
-        dismissible={false}
-      >
-        Many team members are relocating to San Francisco over the next few
-        weeks. Applications are open as usual, but reviews will be slower than
-        normal until early July. Thanks for your patience!
-      </AnnouncementBanner>
       <WhatThisIsForSection />
       <WhoYouAreSection />
       <WhatToExpectSection />

--- a/apps/website/src/pages/programs/career-transition-grant.tsx
+++ b/apps/website/src/pages/programs/career-transition-grant.tsx
@@ -2,7 +2,6 @@ import { Breadcrumbs } from '@bluedot/ui';
 import type { GetStaticProps } from 'next';
 import Head from 'next/head';
 import MarketingHero from '../../components/MarketingHero';
-import AnnouncementBanner from '../../components/AnnouncementBanner';
 import GrantStatsStrip from '../../components/grants/sections/GrantStatsStrip';
 import GrantFaqSection from '../../components/grants/sections/GrantFaqSection';
 import GrantCta from '../../components/grants/sections/GrantCta';
@@ -53,15 +52,6 @@ const CareerTransitionGrantPage = ({ programName, programDescription }: ProgramD
           { label: 'Avg days to decision', value: avgDaysToDecisionLabel },
         ]}
       />
-      <AnnouncementBanner
-        className="career-transition-grant-capacity-notice border-t"
-        label="A note on timing"
-        dismissible={false}
-      >
-        Many team members are relocating to San Francisco over the next few
-        weeks. Applications are open as usual, but reviews will be slower than
-        normal until early July. Thanks for your patience!
-      </AnnouncementBanner>
       <WhatThisIsForSection />
       <ExpectationsSection />
       <NextStepsSection />


### PR DESCRIPTION
## Summary

- `/programs/career-transition-grant` expectations section: **Monthly / Check-in** ("Every month, a more structured conversation to review progress and discuss what support you need.") → **Ongoing / Check-ins** ("Structured conversations throughout your grant to review progress and plan next steps.") — we're moving away from promising a fixed monthly cadence as active grantee numbers grow.
- Grant report line: dropped "short (1-2 page)" so it reads "A summary of what you achieved during the grant and what you will be doing next."
- Removed the "A note on timing" `AnnouncementBanner` from `/programs/career-transition-grant` and `/programs/advising` — it said reviews would be slower "until early July", which has passed.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (`--max-warnings=0`)
- [x] `npx vitest run` — 1110 passed (129 files), run twice for stability
- [x] Eyeballed both routes on local dev; verified new copy renders, banners gone, no new console errors

## Screenshots
<img width="2560" height="1600" alt="after-ctg-desktop" src="https://github.com/user-attachments/assets/57781e59-921e-4f04-998d-0538ff312c43" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)