### PR TITLE
[feat] Process ordinary account deletion requests

### DIFF
--- a/apps/website/src/lib/api/accountDeletion.ts
+++ b/apps/website/src/lib/api/accountDeletion.ts
@@ -123,8 +123,7 @@ const buildDeletionSteps = ({ userId, keycloakIdentifier, registrationIds, meetP
     throw new Error('userId is null or empty');
   }
 
-  // Rows linked to these ids and nobody else. The overlap check is what keeps `<@` from also matching
-  // every row linked to nobody, which is how an empty Airtable cell syncs.
+  // Rows linked to these ids and nobody else. `arrayContained` on its own would otherwise match `[]` and delete rows with no owner
   const linkedSolelyTo = (column: SQLWrapper, ids: string[]): SQL | 'skip' => (
     ids.length === 0 ? 'skip' : and(arrayOverlaps(column, ids), arrayContained(column, ids))!
   );

--- a/apps/website/src/lib/api/accountDeletion.ts
+++ b/apps/website/src/lib/api/accountDeletion.ts
@@ -1,0 +1,233 @@
+import {
+  arrayContained,
+  arrayContains,
+  courseRegistrationTable,
+  deletionRequestTable,
+  eq,
+  exerciseResponsePgTable,
+  inArray,
+  meetPersonTable,
+  projectSubmissionTable,
+  resourceCompletionPgTable,
+  selfServeCourseRegistrationTable,
+  userTable,
+  type PgAirtableColumnInput,
+  type PgAirtableTable,
+  type SQL,
+} from '@bluedot/db';
+import { TRPCError } from '@trpc/server';
+import { logger } from '@bluedot/ui/src/api';
+import { slackAlert } from '@bluedot/utils/src/slackNotifications';
+import { deleteKeycloakUser, keycloakUserExists } from './keycloak';
+import { CIO_API_BASE, getProfileById, setSubscriptionTopics } from './customerio';
+import db from './db';
+import env from './env';
+import { DELETION_REQUEST_STATUS } from '../constants';
+
+// A newsletter signup is independent of the account, so deletion leaves it subscribed.
+const NEWSLETTER_TOPIC = 'topic_15';
+
+// Error if we try to delete more rows than a single account plausibly owns, to limit
+// the blast radius of a "match all rows" bug
+const MAX_DELETIONS_PER_STEP = 1000;
+
+type DeletionStep = {
+  name: string;
+  /** Deletes everything the step owns and returns how many records were deleted. */
+  run: () => Promise<number>;
+};
+
+export const runAccountDeletion = async (deletionRequestId: string) => {
+  const [request] = await db.scan(deletionRequestTable, { id: deletionRequestId });
+  if (!request) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Deletion request not found' });
+  }
+
+  if (request.status === DELETION_REQUEST_STATUS.completed) {
+    return { status: DELETION_REQUEST_STATUS.completed, steps: [] as { step: string; deleted: number }[] };
+  }
+
+  if (request.status !== DELETION_REQUEST_STATUS.pending && request.status !== DELETION_REQUEST_STATUS.failed) {
+    throw new TRPCError({ code: 'CONFLICT', message: `Deletion request is "${request.status}"` });
+  }
+
+  if (!request.userId) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Deletion request is missing the user id' });
+  }
+
+  const { userId } = request;
+  // Airtable gives back '' rather than null for an empty cell
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const keycloakIdentifier = request.keycloakIdentifier || null;
+
+  // Both anchors are read before anything is deleted, so a retry can still find the dependents.
+  const registrationIds = (await db.pg
+    .select({ id: courseRegistrationTable.pg.id })
+    .from(courseRegistrationTable.pg)
+    .where(eq(courseRegistrationTable.pg.userId, userId))).map((row) => row.id);
+
+  const meetPersonIds = registrationIds.length === 0 ? [] : (await db.pg
+    .select({ id: meetPersonTable.pg.id })
+    .from(meetPersonTable.pg)
+    .where(inArray(meetPersonTable.pg.applicationsBaseRecordId, registrationIds))).map((row) => row.id);
+
+  await db.update(deletionRequestTable, { id: request.id, status: DELETION_REQUEST_STATUS.inProgress });
+
+  const steps: { step: string; deleted: number }[] = [];
+  const summarise = () => steps.map(({ step, deleted }) => `${step} (${deleted})`).join(', ') || 'none';
+
+  for (const step of buildDeletionSteps({
+    userId, keycloakIdentifier, registrationIds, meetPersonIds,
+  })) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const deleted = await step.run();
+      steps.push({ step: step.name, deleted });
+    } catch (error) {
+      // eslint-disable-next-line no-await-in-loop
+      await failDeletionRequest(request.id, `Failed at step "${step.name}": ${error instanceof Error ? error.message : String(error)}. Completed: ${summarise()}`, error);
+    }
+  }
+
+  // Completion promises the email is freed, so check the Airtable user row and the Keycloak login.
+  const survivingUserObjects = await Promise.all([
+    // Use airtableClient directly to check the source of truth
+    db.airtableClient.scan(userTable.airtable, { filterByFormula: `RECORD_ID()='${userId}'` }),
+    keycloakIdentifier === null ? false : keycloakUserExists(keycloakIdentifier),
+  ]).then(([userRecords, keycloakUserSurvives]) => [
+    ...userRecords.map((record) => `user record ${record.id}`),
+    ...(keycloakUserSurvives ? [`Keycloak user ${keycloakIdentifier}`] : []),
+  ]).catch((error: unknown) => failDeletionRequest(request.id, `Failed checking the account is gone: ${error instanceof Error ? error.message : String(error)}. Completed: ${summarise()}`, error));
+
+  if (survivingUserObjects.length > 0) {
+    await failDeletionRequest(request.id, `Failed to free email: ${survivingUserObjects.join(', ')} survived deletion.`);
+  }
+
+  await db.update(deletionRequestTable, {
+    id: request.id,
+    status: DELETION_REQUEST_STATUS.completed,
+    completedAt: new Date().toISOString(),
+  });
+
+  logger.info(`[AccountDeletion] deletion request ${request.id} completed: ${summarise()}`);
+
+  return { status: DELETION_REQUEST_STATUS.completed, steps };
+};
+
+// Bottom-up ordering: everything that hangs off the course records, then the records themselves, then the user row, then Keycloak.
+const buildDeletionSteps = ({ userId, keycloakIdentifier, registrationIds, meetPersonIds }: { userId: string; keycloakIdentifier: string | null; registrationIds: string[]; meetPersonIds: string[] }): DeletionStep[] => {
+  if (!userId) {
+    throw new Error('userId is null or empty');
+  }
+
+  return [
+    {
+    // Keep the customer.io profile, this email may have subscribed to newsletters while logged out
+      name: 'customerio-subscription-topics',
+      run: async () => {
+        const profile = await getProfileById(userId);
+        const cioId = profile?.identifiers?.cio_id;
+        if (cioId === undefined) return 0;
+
+        const res = await fetch(`${CIO_API_BASE}/customers/${encodeURIComponent(cioId)}/subscription_preferences`, {
+          headers: { Authorization: `Bearer ${env.CIO_APP_API_KEY}` },
+        });
+        if (!res.ok) {
+          throw new Error(`Failed to fetch customer.io subscription preferences: HTTP ${res.status}`);
+        }
+
+        // Every topic is subscribed-by-default: unsubscribe whatever the person never explicitly chose.
+        const data = await res.json() as { customer?: { topics?: { id: number; subscribed: boolean }[] } };
+        const rawChosen = profile?.attributes?.cio_subscription_preferences;
+        const chosen = typeof rawChosen === 'string' ? (JSON.parse(rawChosen) as { topics?: Record<string, boolean> }).topics ?? {} : {};
+        const keepNewsletter = profile?.attributes?.anonymous_id !== undefined;
+
+        const topics = (data.customer?.topics ?? [])
+          .filter((topic) => topic.subscribed)
+          .map((topic) => `topic_${topic.id}`)
+          .filter((topic) => chosen[topic] === undefined && !(keepNewsletter && topic === NEWSLETTER_TOPIC));
+        if (topics.length === 0) return 0;
+
+        await setSubscriptionTopics({ cioId, topics: Object.fromEntries(topics.map((topic) => [topic, false])) });
+        return 1;
+      },
+    },
+    deleteMatchingPgRecords({ name: 'exercise-responses', table: exerciseResponsePgTable, sqlCondition: arrayContains(exerciseResponsePgTable.pg.userId, [userId]) }),
+    deleteMatchingPgRecords({ name: 'resource-completions', table: resourceCompletionPgTable, sqlCondition: arrayContains(resourceCompletionPgTable.pg.userId, [userId]) }),
+    deleteMatchingAirtableRecords({ name: 'self-serve-course-registrations', table: selfServeCourseRegistrationTable, sqlCondition: eq(selfServeCourseRegistrationTable.pg.userId, userId) }),
+    // Leave project submissions that have co-authors
+    deleteMatchingAirtableRecords({ name: 'project-submissions', table: projectSubmissionTable, sqlCondition: meetPersonIds.length === 0 ? 'skip' : arrayContained(projectSubmissionTable.pg.participant, meetPersonIds) }),
+    // The Course runner registration and the Course builder registration are syncs of this one, and follow it.
+    // TODO flag facilitator compensation risk in PR
+    deleteMatchingAirtableRecords({ name: 'course-registrations', table: courseRegistrationTable, sqlCondition: registrationIds.length === 0 ? 'skip' : inArray(courseRegistrationTable.pg.id, registrationIds) }),
+    deleteMatchingAirtableRecords({ name: 'user-record', table: userTable, sqlCondition: eq(userTable.pg.id, userId) }),
+    {
+      name: 'keycloak-user',
+      run: async () => {
+        if (keycloakIdentifier === null || !(await keycloakUserExists(keycloakIdentifier))) return 0;
+
+        await deleteKeycloakUser(keycloakIdentifier);
+        return 1;
+      },
+    },
+  ];
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const findIdsToDelete = async (pgTable: any, sqlCondition: SQL | 'skip'): Promise<string[]> => {
+  if (!sqlCondition) {
+    throw new Error('sqlCondition is missing');
+  }
+
+  if (sqlCondition === 'skip') return [];
+
+  // Drizzle cannot infer a select over a still-generic table, hence the cast (same as db.scan).
+  const rows = await (db.pg.select({ id: pgTable.id }).from(pgTable).where(sqlCondition) as Promise<{ id: string }[]>);
+  if (rows.length > MAX_DELETIONS_PER_STEP) {
+    throw new Error(`Matched ${rows.length} records, more than the maximum of ${MAX_DELETIONS_PER_STEP}`);
+  }
+
+  return rows.map((row) => row.id);
+};
+
+const deleteMatchingAirtableRecords = <TName extends string, TColumns extends Record<string, PgAirtableColumnInput>>(
+  { name, table, sqlCondition }: { name: string; table: PgAirtableTable<TName, TColumns>; sqlCondition: SQL | 'skip' },
+): DeletionStep => ({
+  name,
+  run: async () => {
+    const ids = await findIdsToDelete(table.pg, sqlCondition);
+    for (const id of ids) {
+      // eslint-disable-next-line no-await-in-loop
+      await db.remove(table, id);
+    }
+
+    return ids.length;
+  },
+});
+
+const deleteMatchingPgRecords = ({ name, table, sqlCondition }: { name: string; table: typeof exerciseResponsePgTable | typeof resourceCompletionPgTable; sqlCondition: SQL | 'skip' }): DeletionStep => ({
+  name,
+  run: async () => {
+    const ids = await findIdsToDelete(table.pg, sqlCondition);
+    if (ids.length === 0) return 0;
+
+    await db.pg.delete(table.pg).where(inArray(table.pg.id, ids));
+    return ids.length;
+  },
+});
+
+const failDeletionRequest = async (id: string, detail: string, cause?: unknown): Promise<never> => {
+  // If this write also fails the row is stuck "In progress"; the alert says how to unstick it.
+  let markFailedError: Error | null = null;
+  try {
+    await db.update(deletionRequestTable, { id, status: DELETION_REQUEST_STATUS.failed });
+  } catch (error) {
+    markFailedError = error instanceof Error ? error : new Error(String(error));
+  }
+
+  await slackAlert(env, [markFailedError === null
+    ? `[AccountDeletion] deletion request ${id} did not complete. ${detail} Re-firing the endpoint resumes it.`
+    : `[AccountDeletion] deletion request ${id} did not complete, and could not be marked failed (${markFailedError.message}). ${detail} It is stuck "In progress": set its status to "Failed" in Airtable before re-firing the endpoint.`]);
+
+  throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: detail, cause });
+};

--- a/apps/website/src/lib/api/accountDeletion.ts
+++ b/apps/website/src/lib/api/accountDeletion.ts
@@ -157,8 +157,6 @@ const buildDeletionSteps = ({ userId, keycloakIdentifier, registrationIds, meetP
     deleteMatchingAirtableRecords({ name: 'self-serve-course-registrations', table: selfServeCourseRegistrationTable, sqlCondition: eq(selfServeCourseRegistrationTable.pg.userId, userId) }),
     // Leave project submissions that have co-authors
     deleteMatchingAirtableRecords({ name: 'project-submissions', table: projectSubmissionTable, sqlCondition: meetPersonIds.length === 0 ? 'skip' : arrayContained(projectSubmissionTable.pg.participant, meetPersonIds) }),
-    // The Course runner registration and the Course builder registration are syncs of this one, and follow it.
-    // TODO flag facilitator compensation risk in PR
     deleteMatchingAirtableRecords({ name: 'course-registrations', table: courseRegistrationTable, sqlCondition: registrationIds.length === 0 ? 'skip' : inArray(courseRegistrationTable.pg.id, registrationIds) }),
     deleteMatchingAirtableRecords({ name: 'user-record', table: userTable, sqlCondition: eq(userTable.pg.id, userId) }),
     {

--- a/apps/website/src/lib/api/accountDeletion.ts
+++ b/apps/website/src/lib/api/accountDeletion.ts
@@ -219,15 +219,28 @@ const deleteMatchingPgRecords = ({ name, table, sqlCondition }: { name: string; 
 const failDeletionRequest = async (id: string, detail: string, cause?: unknown): Promise<never> => {
   // If this write also fails the row is stuck "In progress"; the alert says how to unstick it.
   let markFailedError: Error | null = null;
+  let completedByAnotherRun = false;
   try {
-    await db.update(deletionRequestTable, { id, status: DELETION_REQUEST_STATUS.failed });
+    // Never downgrade Completed: a concurrent run may have finished the deletion while this one errored.
+    const [request] = await db.scan(deletionRequestTable, { id });
+    completedByAnotherRun = request?.status === DELETION_REQUEST_STATUS.completed;
+    if (!completedByAnotherRun) {
+      await db.update(deletionRequestTable, { id, status: DELETION_REQUEST_STATUS.failed });
+    }
   } catch (error) {
     markFailedError = error instanceof Error ? error : new Error(String(error));
   }
 
-  await slackAlert(env, [markFailedError === null
-    ? `[AccountDeletion] deletion request ${id} did not complete. ${detail} Re-firing the endpoint resumes it.`
-    : `[AccountDeletion] deletion request ${id} did not complete, and could not be marked failed (${markFailedError.message}). ${detail} It is stuck "In progress": set its status to "Failed" in Airtable before re-firing the endpoint.`]);
+  let message: string;
+  if (completedByAnotherRun) {
+    message = `[AccountDeletion] deletion request ${id} errored, but another run already completed it, so it stays "Completed". ${detail}`;
+  } else if (markFailedError === null) {
+    message = `[AccountDeletion] deletion request ${id} did not complete. ${detail} Re-firing the endpoint resumes it.`;
+  } else {
+    message = `[AccountDeletion] deletion request ${id} did not complete, and could not be marked failed (${markFailedError.message}). ${detail} It is stuck "In progress": set its status to "Failed" in Airtable before re-firing the endpoint.`;
+  }
+
+  await slackAlert(env, [message]);
 
   throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: detail, cause });
 };

--- a/apps/website/src/lib/api/accountDeletion.ts
+++ b/apps/website/src/lib/api/accountDeletion.ts
@@ -1,6 +1,8 @@
 import {
+  and,
   arrayContained,
   arrayContains,
+  arrayOverlaps,
   courseRegistrationTable,
   deletionRequestTable,
   eq,
@@ -14,6 +16,7 @@ import {
   type PgAirtableColumnInput,
   type PgAirtableTable,
   type SQL,
+  type SQLWrapper,
 } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import { logger } from '@bluedot/ui/src/api';
@@ -120,6 +123,12 @@ const buildDeletionSteps = ({ userId, keycloakIdentifier, registrationIds, meetP
     throw new Error('userId is null or empty');
   }
 
+  // Rows linked to these ids and nobody else. The overlap check is what keeps `<@` from also matching
+  // every row linked to nobody, which is how an empty Airtable cell syncs.
+  const linkedSolelyTo = (column: SQLWrapper, ids: string[]): SQL | 'skip' => (
+    ids.length === 0 ? 'skip' : and(arrayOverlaps(column, ids), arrayContained(column, ids))!
+  );
+
   return [
     {
     // Keep the customer.io profile, this email may have subscribed to newsletters while logged out
@@ -156,7 +165,7 @@ const buildDeletionSteps = ({ userId, keycloakIdentifier, registrationIds, meetP
     deleteMatchingPgRecords({ name: 'resource-completions', table: resourceCompletionPgTable, sqlCondition: arrayContains(resourceCompletionPgTable.pg.userId, [userId]) }),
     deleteMatchingAirtableRecords({ name: 'self-serve-course-registrations', table: selfServeCourseRegistrationTable, sqlCondition: eq(selfServeCourseRegistrationTable.pg.userId, userId) }),
     // Leave project submissions that have co-authors
-    deleteMatchingAirtableRecords({ name: 'project-submissions', table: projectSubmissionTable, sqlCondition: meetPersonIds.length === 0 ? 'skip' : arrayContained(projectSubmissionTable.pg.participant, meetPersonIds) }),
+    deleteMatchingAirtableRecords({ name: 'project-submissions', table: projectSubmissionTable, sqlCondition: linkedSolelyTo(projectSubmissionTable.pg.participant, meetPersonIds) }),
     deleteMatchingAirtableRecords({ name: 'course-registrations', table: courseRegistrationTable, sqlCondition: registrationIds.length === 0 ? 'skip' : inArray(courseRegistrationTable.pg.id, registrationIds) }),
     deleteMatchingAirtableRecords({ name: 'user-record', table: userTable, sqlCondition: eq(userTable.pg.id, userId) }),
     {

--- a/apps/website/src/lib/api/customerio.ts
+++ b/apps/website/src/lib/api/customerio.ts
@@ -29,7 +29,7 @@ const trackHeaders = () => {
   };
 };
 
-async function getProfileById(userId: string): Promise<CioProfile | null> {
+export async function getProfileById(userId: string): Promise<CioProfile | null> {
   const res = await fetch(`${CIO_API_BASE}/customers/${encodeURIComponent(userId)}/attributes?id_type=id`, { headers: appHeaders() });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`Failed to fetch customer.io profile by id: HTTP ${res.status}`);
@@ -42,6 +42,15 @@ async function searchProfilesByEmail(email: string): Promise<CioProfileSummary[]
   if (!res.ok) throw new Error(`Failed to search customer.io profiles by email: HTTP ${res.status}`);
   const data = await res.json() as { results?: CioProfileSummary[] };
   return data.results ?? [];
+}
+
+export async function setSubscriptionTopics({ cioId, topics }: { cioId: string; topics: Record<string, boolean> }): Promise<void> {
+  const res = await fetch(`${CIO_TRACK_V1_BASE}/customers/cio_${cioId}`, {
+    method: 'PUT',
+    headers: trackHeaders(),
+    body: JSON.stringify({ cio_subscription_preferences: { topics } }),
+  });
+  if (!res.ok) throw new Error(`customer.io subscription topic update failed: HTTP ${res.status}`);
 }
 
 async function identify({ userId, email }: { userId: string; email: string }): Promise<void> {

--- a/apps/website/src/lib/api/keycloak.test.ts
+++ b/apps/website/src/lib/api/keycloak.test.ts
@@ -4,7 +4,9 @@ import { isHttpError } from 'http-errors';
 import {
   describe, it, expect, vi, beforeEach,
 } from 'vitest';
-import { registerPreviewRedirectUri, unlinkStaleGoogleIdentities } from './keycloak';
+import {
+  deleteKeycloakUser, keycloakUserExists, registerPreviewRedirectUri, unlinkStaleGoogleIdentities,
+} from './keycloak';
 
 vi.mock('axios');
 vi.mock('@bluedot/ui/src/api', () => ({
@@ -240,5 +242,54 @@ describe('unlinkStaleGoogleIdentities', () => {
     await unlinkStaleGoogleIdentities('user-sub', 'new@example.com');
 
     expect(unlinkedProviders()).toEqual(['google']);
+  });
+});
+
+describe('deleteKeycloakUser', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedAxios.post.mockResolvedValue(FAKE_TOKEN_RESPONSE);
+  });
+
+  const notFound = () => Object.assign(new Error('Request failed'), {
+    isAxiosError: true,
+    response: { status: 404 },
+  });
+
+  it('deletes the account', async () => {
+    mockedAxios.request.mockResolvedValue({ data: {} });
+
+    await deleteKeycloakUser('user-sub');
+
+    expect(mockedAxios.request).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'delete',
+      url: expect.stringContaining('/users/user-sub'),
+    }));
+  });
+
+  it('treats an account that is already gone as deleted, so a retry does not fail', async () => {
+    mockedAxios.isAxiosError.mockReturnValue(true);
+    mockedAxios.request.mockRejectedValue(notFound());
+
+    await expect(deleteKeycloakUser('user-sub')).resolves.toBeUndefined();
+  });
+
+  it('propagates other failures rather than reporting a deletion that did not happen', async () => {
+    mockedAxios.isAxiosError.mockReturnValue(true);
+    mockedAxios.request.mockRejectedValue(Object.assign(new Error('boom'), {
+      isAxiosError: true,
+      response: { status: 500 },
+    }));
+
+    await expect(deleteKeycloakUser('user-sub')).rejects.toSatisfy(isHttpError);
+  });
+
+  it('reports whether the account still exists', async () => {
+    mockedAxios.request.mockResolvedValue({ data: { id: 'user-sub' } });
+    await expect(keycloakUserExists('user-sub')).resolves.toBe(true);
+
+    mockedAxios.isAxiosError.mockReturnValue(true);
+    mockedAxios.request.mockRejectedValue(notFound());
+    await expect(keycloakUserExists('user-sub')).resolves.toBe(false);
   });
 });

--- a/apps/website/src/lib/api/keycloak.ts
+++ b/apps/website/src/lib/api/keycloak.ts
@@ -172,6 +172,29 @@ export async function updateKeycloakEmail(userSub: string, newEmail: string): Pr
   });
 }
 
+export async function keycloakUserExists(userSub: string): Promise<boolean> {
+  try {
+    await adminRequest({ method: 'get', path: `/users/${userSub}` });
+    return true;
+  } catch (error) {
+    if (createHttpError.isHttpError(error) && error.status === 404) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+export async function deleteKeycloakUser(userSub: string): Promise<void> {
+  try {
+    await adminRequest({ method: 'delete', path: `/users/${userSub}` });
+  } catch (error) {
+    if (!createHttpError.isHttpError(error) || error.status !== 404) {
+      throw error;
+    }
+  }
+}
+
 export type LoginMethods = { hasPassword: boolean; hasGoogleLogin: boolean };
 
 export async function unlinkStaleGoogleIdentities(userSub: string, newEmail: string): Promise<LoginMethods> {

--- a/apps/website/src/server/routers/deletion-requests.test.ts
+++ b/apps/website/src/server/routers/deletion-requests.test.ts
@@ -710,6 +710,27 @@ describe('deletionRequests.executeAccountDeletion', () => {
     expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain(`user record ${SUBJECT.id}`);
   });
 
+  test('does not downgrade a request another run already completed, and says so in the alert', async () => {
+    await seedSubjectData();
+    await seedRequest();
+
+    const remove = testDb.remove.bind(testDb);
+    vi.spyOn(testDb, 'remove').mockImplementation(async (table, recordId) => {
+      if (table === (userTable as never)) {
+        await testDb.update(deletionRequestTable, { id: 'req-1', status: 'Completed' });
+        throw new Error('Airtable rate limit');
+      }
+
+      return remove(table, recordId);
+    });
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+
+    const request = (await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0];
+    expect(request?.status).toBe('Completed');
+    expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain('another run already completed it');
+  });
+
   test('completes for an account with no Keycloak identifier, and never calls Keycloak', async () => {
     await seedSubjectData();
     await seedRequest({ keycloakIdentifier: '' });

--- a/apps/website/src/server/routers/deletion-requests.test.ts
+++ b/apps/website/src/server/routers/deletion-requests.test.ts
@@ -829,6 +829,20 @@ describe('fail-closed: another user\'s records survive even when they look like 
     expect(airtableUserRecords.map((record) => record.id)).toContain('user-decoy');
   });
 
+  test('project submissions nobody is linked to survive', async () => {
+    await seedSubjectData();
+    // An empty Airtable linked-record cell syncs as an empty array, which is contained by every id list
+    await testDb.insert(projectSubmissionTable, { id: 'ps-unlinked', participant: [] });
+    await testDb.pg.insert(projectSubmissionTable.pg).values({ id: 'ps-unset' });
+    await seedRequest();
+
+    const result = await execute('req-1');
+
+    expect(result.status).toBe('Completed');
+    expect(result.steps).toContainEqual({ step: 'project-submissions', deleted: 1 });
+    expect(await pgIdsIn(projectSubmissionTable)).toEqual(['ps-other', 'ps-shared', 'ps-unlinked', 'ps-unset']);
+  });
+
   test('refuses to delete more rows than one account plausibly owns', async () => {
     // One over MAX_DELETIONS_PER_STEP.
     await testDb.pg.insert(exerciseResponsePgTable.pg).values(Array.from({ length: 1001 }, (_, i) => ({

--- a/apps/website/src/server/routers/deletion-requests.test.ts
+++ b/apps/website/src/server/routers/deletion-requests.test.ts
@@ -1,8 +1,23 @@
-import { deletionRequestTable, userTable } from '@bluedot/db';
+import {
+  courseFeedbackTable,
+  courseRegistrationTable,
+  deletionRequestTable,
+  dropoutTable,
+  exerciseResponsePgTable,
+  facilitatorDiscussionSwitchingTable,
+  groupSwitchingTable,
+  meetPersonTable,
+  peerFeedbackTable,
+  projectSubmissionTable,
+  resourceCompletionPgTable,
+  selfServeCourseRegistrationTable,
+  userTable,
+} from '@bluedot/db';
 import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
+import { deleteKeycloakUser, keycloakUserExists } from '../../lib/api/keycloak';
 import {
   createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
@@ -17,10 +32,16 @@ vi.mock('../../lib/api/env', () => ({
     ALERTS_SLACK_BOT_TOKEN: 'fake',
     KEYCLOAK_CLIENT_ID: 'fake',
     KEYCLOAK_CLIENT_SECRET: 'fake',
+    AIRTABLE_AUTOMATION_TOKEN: 'test-token-secret',
     CIO_APP_API_KEY: 'fake-app-key',
     CIO_TRACK_API_KEY: 'fake:track-key',
     VITEST: 'true',
   },
+}));
+
+vi.mock('../../lib/api/keycloak', () => ({
+  deleteKeycloakUser: vi.fn(),
+  keycloakUserExists: vi.fn(),
 }));
 
 vi.mock('@bluedot/utils/src/slackNotifications', () => ({
@@ -29,6 +50,8 @@ vi.mock('@bluedot/utils/src/slackNotifications', () => ({
 
 setupTestDb();
 
+const TEST_TOKEN = 'test-token-secret';
+
 const SUBJECT = {
   id: 'user-subject',
   email: 'subject@example.com',
@@ -36,20 +59,94 @@ const SUBJECT = {
   keycloakIdentifier: 'subject-sub',
 };
 
+const ALL_TOPIC_IDS = [9, 12, 14, 15, 16];
+
+type CioProfile = { cioId: string; id?: string; email: string; attributes: Record<string, string> };
+
+let airtableUserRecords: { id: string }[];
+let userRecordUndeletable: boolean;
+let keycloakUserPresent: boolean;
+let cioProfiles: CioProfile[];
+let cioTopicWrites: { cioId: string; topics: Record<string, boolean> }[];
 let cioEmailSends: { to: string; subject: string }[];
 
+const fakeCio = async (input: string, init?: RequestInit) => {
+  const url = new URL(input);
+  const method = init?.method ?? 'GET';
+  const ok = (body: unknown) => new Response(JSON.stringify(body), { status: 200 });
+
+  const attributesMatch = /^\/v1\/customers\/(.+)\/attributes$/.exec(url.pathname);
+  if (method === 'GET' && attributesMatch && url.searchParams.get('id_type') === 'id') {
+    const profile = cioProfiles.find((p) => p.id === decodeURIComponent(attributesMatch[1]!));
+    return profile
+      ? ok({ customer: { identifiers: { cio_id: profile.cioId, id: profile.id, email: profile.email }, attributes: profile.attributes } })
+      : new Response('{}', { status: 404 });
+  }
+
+  const preferencesMatch = /^\/v1\/customers\/(.+)\/subscription_preferences$/.exec(url.pathname);
+  if (method === 'GET' && preferencesMatch) {
+    const profile = cioProfiles.find((p) => p.cioId === decodeURIComponent(preferencesMatch[1]!));
+    if (!profile) return new Response('{}', { status: 404 });
+    // Every topic is subscribed-by-default: effective state is the default overridden by explicit choices.
+    const raw = profile.attributes.cio_subscription_preferences;
+    const chosen: Record<string, boolean> = raw ? JSON.parse(raw).topics : {};
+    return ok({ customer: { topics: ALL_TOPIC_IDS.map((id) => ({ id, subscribed: chosen[`topic_${id}`] ?? true })) } });
+  }
+
+  if (method === 'POST' && url.pathname === '/v1/send/email') {
+    const payload = JSON.parse(init!.body as string) as { to: string; subject: string };
+    cioEmailSends.push({ to: payload.to, subject: payload.subject });
+    return ok({});
+  }
+
+  const trackMatch = /^\/api\/v1\/customers\/cio_(.+)$/.exec(url.pathname);
+  if (method === 'PUT' && trackMatch) {
+    const cioId = trackMatch[1]!;
+    const profile = cioProfiles.find((p) => p.cioId === cioId)!;
+    const { topics } = JSON.parse(init!.body as string).cio_subscription_preferences as { topics: Record<string, boolean> };
+    cioTopicWrites.push({ cioId, topics });
+    const existing = profile.attributes.cio_subscription_preferences;
+    profile.attributes.cio_subscription_preferences = JSON.stringify({
+      topics: { ...(existing ? JSON.parse(existing).topics : {}), ...topics },
+    });
+    return ok({});
+  }
+
+  throw new Error(`Unexpected fetch: ${method} ${url}`);
+};
+
 beforeEach(async () => {
+  keycloakUserPresent = true;
+  vi.mocked(keycloakUserExists).mockImplementation(async () => keycloakUserPresent);
+  vi.mocked(deleteKeycloakUser).mockImplementation(async () => {
+    keycloakUserPresent = false;
+  });
+
+  cioProfiles = [{
+    cioId: 'cio-subject', id: SUBJECT.id, email: SUBJECT.email, attributes: {},
+  }];
+  cioTopicWrites = [];
   cioEmailSends = [];
-  vi.stubGlobal('fetch', vi.fn(async (input: string, init?: RequestInit) => {
-    const url = new URL(input);
-    if (init?.method === 'POST' && url.pathname === '/v1/send/email') {
-      const payload = JSON.parse(init.body as string) as { to: string; subject: string };
-      cioEmailSends.push({ to: payload.to, subject: payload.subject });
-      return new Response('{}', { status: 200 });
+  vi.stubGlobal('fetch', vi.fn(fakeCio));
+
+  airtableUserRecords = [{ id: SUBJECT.id }, { id: 'test-user' }];
+  userRecordUndeletable = false;
+
+  vi.spyOn(testDb.airtableClient, 'scan').mockImplementation(async (table, params) => {
+    if (table.tableId !== userTable.airtable.tableId) throw new Error(`Unexpected scan of ${table.tableId}`);
+    const formula = params?.filterByFormula;
+    if (formula === undefined) return airtableUserRecords as never;
+    return airtableUserRecords.filter((record) => formula.includes(`RECORD_ID()='${record.id}'`)) as never;
+  });
+
+  const removeFromAirtable = testDb.airtableClient.remove.bind(testDb.airtableClient);
+  vi.spyOn(testDb.airtableClient, 'remove').mockImplementation(async (table, id) => {
+    if (table.tableId === userTable.airtable.tableId && !userRecordUndeletable) {
+      airtableUserRecords = airtableUserRecords.filter((record) => record.id !== id);
     }
 
-    throw new Error(`Unexpected fetch: ${init?.method ?? 'GET'} ${url}`);
-  }));
+    return removeFromAirtable(table, id);
+  });
 
   await seedLoggedInUser();
   await testDb.insert(userTable, SUBJECT);
@@ -62,6 +159,57 @@ afterEach(() => {
 
 const makeAdmin = () => testDb.update(userTable, { id: 'test-user', isAdmin: true });
 
+const seedSubjectData = async () => {
+  await testDb.insert(courseRegistrationTable, {
+    id: 'reg-subject', email: SUBJECT.email, userId: SUBJECT.id, courseId: 'course-1',
+  });
+  // No user link: an undefined state that deletion leaves alone.
+  await testDb.insert(courseRegistrationTable, {
+    id: 'reg-subject-unlinked', email: 'SUBJECT@Example.com', courseId: 'course-1',
+  });
+  await testDb.insert(courseRegistrationTable, {
+    id: 'reg-other', email: 'other@example.com', userId: 'test-user', courseId: 'course-1',
+  });
+  await testDb.insert(meetPersonTable, {
+    id: 'mp-subject', name: 'Subject Person', userId: SUBJECT.id, applicationsBaseRecordId: 'reg-subject',
+  });
+  await testDb.insert(meetPersonTable, {
+    id: 'mp-other', name: 'Other Person', userId: 'test-user', applicationsBaseRecordId: 'reg-other',
+  });
+
+  await testDb.insert(dropoutTable, { id: 'do-subject', applicantId: ['reg-subject'] });
+  await testDb.insert(dropoutTable, { id: 'do-other', applicantId: ['reg-other'] });
+  await testDb.insert(projectSubmissionTable, { id: 'ps-subject', participant: ['mp-subject'] });
+  await testDb.insert(projectSubmissionTable, { id: 'ps-shared', participant: ['mp-subject', 'mp-other'] });
+  await testDb.insert(projectSubmissionTable, { id: 'ps-other', participant: ['mp-other'] });
+  await testDb.insert(courseFeedbackTable, { id: 'cf-subject', person: ['mp-subject'] });
+  await testDb.insert(courseFeedbackTable, { id: 'cf-other', person: ['mp-other'] });
+  await testDb.insert(groupSwitchingTable, { id: 'gs-subject', participant: 'mp-subject' });
+  await testDb.insert(groupSwitchingTable, { id: 'gs-other', participant: 'mp-other' });
+  await testDb.insert(facilitatorDiscussionSwitchingTable, { id: 'fds-subject', facilitator: 'mp-subject' });
+  await testDb.insert(facilitatorDiscussionSwitchingTable, { id: 'fds-other', facilitator: 'mp-other' });
+
+  await testDb.insert(selfServeCourseRegistrationTable, {
+    id: 'ss-subject', userId: SUBJECT.id, courseId: 'course-1',
+  });
+  await testDb.insert(selfServeCourseRegistrationTable, {
+    id: 'ss-other', userId: 'test-user', courseId: 'course-1',
+  });
+
+  await testDb.pg.insert(exerciseResponsePgTable.pg).values([
+    {
+      id: 'er-subject', exerciseId: 'ex-1', response: 'mine', userId: [SUBJECT.id],
+    },
+    {
+      id: 'er-other', exerciseId: 'ex-1', response: 'theirs', userId: ['test-user'],
+    },
+  ]);
+  await testDb.pg.insert(resourceCompletionPgTable.pg).values([
+    { id: 'rc-subject', userId: [SUBJECT.id] },
+    { id: 'rc-other', userId: ['test-user'] },
+  ]);
+};
+
 const seedRequest = (overrides: Record<string, unknown> = {}) => testDb.insert(deletionRequestTable, {
   id: 'req-1',
   email: SUBJECT.email,
@@ -72,6 +220,101 @@ const seedRequest = (overrides: Record<string, unknown> = {}) => testDb.insert(d
   requestedAt: '2026-08-03T00:00:00.000Z',
   ...overrides,
 });
+
+const execute = (deletionRequestId: string, publicToken: string = TEST_TOKEN) => createCaller()
+  .deletionRequests.executeAccountDeletion({ publicToken, deletionRequestId });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const pgIdsIn = async (table: { pg: any }): Promise<string[]> => (await testDb.pg.select().from(table.pg)).map((row) => String(row.id)).sort();
+
+// The database state every completed deletion of the seeded subject must produce, however it got there.
+const expectDeletionEndState = async () => {
+  expect(await pgIdsIn(userTable)).toEqual(['test-user']);
+  expect(await pgIdsIn(courseRegistrationTable)).toEqual(['reg-other', 'reg-subject-unlinked']);
+  expect(await pgIdsIn(exerciseResponsePgTable)).toEqual(['er-other']);
+  expect(await pgIdsIn(resourceCompletionPgTable)).toEqual(['rc-other']);
+  expect(await pgIdsIn(selfServeCourseRegistrationTable)).toEqual(['ss-other']);
+  expect(await pgIdsIn(dropoutTable)).toEqual(['do-other', 'do-subject']);
+  expect(await pgIdsIn(projectSubmissionTable)).toEqual(['ps-other', 'ps-shared']);
+  expect(await pgIdsIn(courseFeedbackTable)).toEqual(['cf-other', 'cf-subject']);
+  expect(await pgIdsIn(groupSwitchingTable)).toEqual(['gs-other', 'gs-subject']);
+  expect(await pgIdsIn(facilitatorDiscussionSwitchingTable)).toEqual(['fds-other', 'fds-subject']);
+  expect(airtableUserRecords.map((record) => record.id)).toEqual(['test-user']);
+  expect(keycloakUserPresent).toBe(false);
+  const request = (await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0];
+  expect(request?.status).toBe('Completed');
+  expect(request?.completedAt).toBeTruthy();
+};
+
+const ALL_STEPS = [
+  'customerio-subscription-topics',
+  'exercise-responses',
+  'resource-completions',
+  'self-serve-course-registrations',
+  'project-submissions',
+  'course-registrations',
+  'user-record',
+  'keycloak-user',
+] as const;
+
+const STEP_AIRTABLE_TABLES = {
+  'self-serve-course-registrations': selfServeCourseRegistrationTable,
+  'project-submissions': projectSubmissionTable,
+  'course-registrations': courseRegistrationTable,
+  'user-record': userTable,
+} as const;
+
+const STEP_PG_TABLES = {
+  'exercise-responses': exerciseResponsePgTable,
+  'resource-completions': resourceCompletionPgTable,
+} as const;
+
+// Makes the named step fail exactly once, through whichever channel it deletes on.
+const armStepFailure = (step: (typeof ALL_STEPS)[number]) => {
+  let fired = false;
+
+  if (step === 'customerio-subscription-topics') {
+    vi.stubGlobal('fetch', vi.fn(async (input: string, init?: RequestInit) => {
+      if (!fired && init?.method === 'PUT') {
+        fired = true;
+        return new Response('nope', { status: 500 });
+      }
+
+      return fakeCio(input, init);
+    }));
+  } else if (step === 'keycloak-user') {
+    vi.mocked(deleteKeycloakUser).mockImplementation(async () => {
+      if (!fired) {
+        fired = true;
+        throw new Error('Keycloak down');
+      }
+
+      keycloakUserPresent = false;
+    });
+  } else if (step in STEP_PG_TABLES) {
+    const target = STEP_PG_TABLES[step as keyof typeof STEP_PG_TABLES].pg;
+    const pgDelete = testDb.pg.delete.bind(testDb.pg);
+    vi.spyOn(testDb.pg, 'delete').mockImplementation(((table: unknown) => {
+      if (!fired && table === target) {
+        fired = true;
+        throw new Error('pg delete failed');
+      }
+
+      return pgDelete(table as never);
+    }) as never);
+  } else {
+    const target = STEP_AIRTABLE_TABLES[step as keyof typeof STEP_AIRTABLE_TABLES];
+    const remove = testDb.remove.bind(testDb);
+    vi.spyOn(testDb, 'remove').mockImplementation(async (table, id) => {
+      if (!fired && table === (target as never)) {
+        fired = true;
+        throw new Error('Airtable rate limit');
+      }
+
+      return remove(table, id);
+    });
+  }
+};
 
 describe('deletionRequests.triggerAccountDeletion', () => {
   test('rejects unauthenticated callers', async () => {
@@ -112,6 +355,18 @@ describe('deletionRequests.triggerAccountDeletion', () => {
     expect(request).toMatchObject({ initiatedByRole: 'Admin', initiatedBy: ['test-user'] });
   });
 
+  test('creating a request deletes nothing on its own', async () => {
+    await seedSubjectData();
+    await makeAdmin();
+
+    await createCaller(testAuthContextLoggedIn).deletionRequests.triggerAccountDeletion({ userId: SUBJECT.id });
+
+    expect(await pgIdsIn(userTable)).toEqual(['test-user', SUBJECT.id]);
+    expect(await pgIdsIn(courseRegistrationTable)).toEqual(['reg-other', 'reg-subject', 'reg-subject-unlinked']);
+    expect(cioTopicWrites).toEqual([]);
+    expect(deleteKeycloakUser).not.toHaveBeenCalled();
+  });
+
   test('throws NOT_FOUND when the admin targets a user that does not exist', async () => {
     await makeAdmin();
 
@@ -129,7 +384,13 @@ describe('deletionRequests.triggerAccountDeletion', () => {
 
   test('still creates the request when the confirmation email fails, and alerts', async () => {
     await makeAdmin();
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 500 })));
+    vi.stubGlobal('fetch', vi.fn(async (input: string, init?: RequestInit) => {
+      if (init?.method === 'POST' && new URL(input).pathname === '/v1/send/email') {
+        return new Response('nope', { status: 500 });
+      }
+
+      return fakeCio(input, init);
+    }));
 
     const { request } = await createCaller(testAuthContextLoggedIn).deletionRequests.triggerAccountDeletion({ userId: SUBJECT.id });
 
@@ -212,5 +473,353 @@ describe('deletionRequests.list', () => {
 
     const rows = await createCaller(testAuthContextLoggedIn).deletionRequests.list();
     expect(rows.map((row) => row.id)).toEqual(['req-admin']);
+  });
+});
+
+describe('deletionRequests.executeAccountDeletion', () => {
+  test('throws UNAUTHORIZED when no token matches (wrong length short-circuits before timingSafeEqual)', async () => {
+    await seedRequest();
+    await expect(execute('req-1', 'wrong')).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    await expect(execute('req-1', 'X'.repeat(TEST_TOKEN.length))).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+    expect(await testDb.getFirst(userTable, { filter: { id: SUBJECT.id } })).not.toBeNull();
+    expect(deleteKeycloakUser).not.toHaveBeenCalled();
+  });
+
+  test('throws NOT_FOUND for an unknown deletion request', async () => {
+    await expect(execute('missing')).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  test('throws BAD_REQUEST for a request missing the identifiers the router always writes', async () => {
+    await seedRequest({
+      id: 'req-ghost', email: '', userId: '', keycloakIdentifier: '',
+    });
+
+    await expect(execute('req-ghost')).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(deleteKeycloakUser).not.toHaveBeenCalled();
+  });
+
+  test('deletes the account, its activity and its course record, in dependents-before-anchors order', async () => {
+    await seedSubjectData();
+    await seedRequest();
+
+    const result = await execute('req-1');
+
+    expect(result.status).toBe('Completed');
+    expect(result.steps).toEqual([
+      { step: 'customerio-subscription-topics', deleted: 1 },
+      { step: 'exercise-responses', deleted: 1 },
+      { step: 'resource-completions', deleted: 1 },
+      { step: 'self-serve-course-registrations', deleted: 1 },
+      { step: 'project-submissions', deleted: 1 },
+      { step: 'course-registrations', deleted: 1 },
+      { step: 'user-record', deleted: 1 },
+      { step: 'keycloak-user', deleted: 1 },
+    ]);
+
+    expect(await pgIdsIn(userTable)).toEqual(['test-user']);
+    expect(await pgIdsIn(exerciseResponsePgTable)).toEqual(['er-other']);
+    expect(await pgIdsIn(resourceCompletionPgTable)).toEqual(['rc-other']);
+    expect(await pgIdsIn(selfServeCourseRegistrationTable)).toEqual(['ss-other']);
+    expect(await pgIdsIn(courseRegistrationTable)).toEqual(['reg-other', 'reg-subject-unlinked']);
+    expect(await pgIdsIn(dropoutTable)).toEqual(['do-other', 'do-subject']);
+    expect(await pgIdsIn(projectSubmissionTable)).toEqual(['ps-other', 'ps-shared']);
+    expect(await pgIdsIn(courseFeedbackTable)).toEqual(['cf-other', 'cf-subject']);
+    expect(await pgIdsIn(groupSwitchingTable)).toEqual(['gs-other', 'gs-subject']);
+    expect(await pgIdsIn(facilitatorDiscussionSwitchingTable)).toEqual(['fds-other', 'fds-subject']);
+
+    expect(cioTopicWrites).toEqual([{
+      cioId: 'cio-subject',
+      topics: {
+        topic_9: false, topic_12: false, topic_14: false, topic_15: false, topic_16: false,
+      },
+    }]);
+
+    expect(deleteKeycloakUser).toHaveBeenCalledWith('subject-sub');
+
+    const request = (await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0];
+    expect(request?.status).toBe('Completed');
+    expect(request?.completedAt).toBeTruthy();
+  });
+
+  test('completes when customer.io has no profile under the user id', async () => {
+    cioProfiles = [];
+    await seedRequest();
+
+    const result = await execute('req-1');
+
+    expect(result.steps[0]).toEqual({ step: 'customerio-subscription-topics', deleted: 0 });
+    expect(cioTopicWrites).toEqual([]);
+  });
+
+  test('leaves the newsletter alone for a profile that signed up through the website form', async () => {
+    cioProfiles[0]!.attributes.anonymous_id = 'anon-123';
+    await seedRequest();
+
+    await execute('req-1');
+
+    expect(cioTopicWrites).toEqual([{
+      cioId: 'cio-subject',
+      topics: {
+        topic_9: false, topic_12: false, topic_14: false, topic_16: false,
+      },
+    }]);
+  });
+
+  test('leaves topics the person explicitly chose, and does not rewrite ones already off', async () => {
+    cioProfiles[0]!.attributes.cio_subscription_preferences = JSON.stringify({ topics: { topic_12: true, topic_14: false } });
+    await seedRequest();
+
+    await execute('req-1');
+
+    expect(cioTopicWrites).toEqual([{
+      cioId: 'cio-subject',
+      topics: { topic_9: false, topic_15: false, topic_16: false },
+    }]);
+  });
+
+  test('unsubscribes the profile customer.io still holds under the person\'s old email', async () => {
+    cioProfiles[0]!.email = 'previous-address@example.com';
+    await seedRequest();
+
+    const result = await execute('req-1');
+
+    expect(result.steps[0]).toEqual({ step: 'customerio-subscription-topics', deleted: 1 });
+    expect(cioTopicWrites).toEqual([{
+      cioId: 'cio-subject',
+      topics: {
+        topic_9: false, topic_12: false, topic_14: false, topic_15: false, topic_16: false,
+      },
+    }]);
+  });
+
+  test('completes even though customer.io has not served the new preferences back yet', async () => {
+    // The write is accepted but reads keep returning the old attributes for a few seconds.
+    vi.stubGlobal('fetch', vi.fn(async (input: string, init?: RequestInit) => (
+      init?.method === 'PUT' ? new Response('{}', { status: 200 }) : fakeCio(input, init))));
+    await seedRequest();
+
+    const result = await execute('req-1');
+
+    expect(result.status).toBe('Completed');
+  });
+
+  test('marks the request failed when customer.io rejects the write', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: string, init?: RequestInit) => (
+      init?.method === 'PUT' ? new Response('nope', { status: 500 }) : fakeCio(input, init))));
+    await seedSubjectData();
+    await seedRequest();
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+
+    const request = (await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0];
+    expect(request?.status).toBe('Failed');
+    expect(await pgIdsIn(userTable)).toEqual(['test-user', SUBJECT.id]);
+    expect(deleteKeycloakUser).not.toHaveBeenCalled();
+  });
+
+  test('deletes the login last, so an earlier failure leaves an account the subject can still sign into', async () => {
+    await seedSubjectData();
+    await seedRequest();
+
+    vi.mocked(deleteKeycloakUser).mockImplementation(async () => {
+      expect(await testDb.getFirst(userTable, { filter: { id: SUBJECT.id } })).toBeNull();
+      keycloakUserPresent = false;
+    });
+
+    await execute('req-1');
+    expect(deleteKeycloakUser).toHaveBeenCalledTimes(1);
+  });
+
+  test('a failure among the dependents leaves the course record standing, so a retry still finds them', async () => {
+    await seedSubjectData();
+    await seedRequest();
+
+    const remove = testDb.remove.bind(testDb);
+    let projectSubmissionRemoveFails = true;
+    vi.spyOn(testDb, 'remove').mockImplementation(async (table, id) => {
+      if (table === (projectSubmissionTable as never) && projectSubmissionRemoveFails) throw new Error('Airtable rate limit');
+      return remove(table, id);
+    });
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+
+    expect(await pgIdsIn(courseRegistrationTable)).toEqual(['reg-other', 'reg-subject', 'reg-subject-unlinked']);
+    expect(await pgIdsIn(meetPersonTable)).toEqual(['mp-other', 'mp-subject']);
+    expect(await pgIdsIn(projectSubmissionTable)).toEqual(['ps-other', 'ps-shared', 'ps-subject']);
+    expect(await pgIdsIn(userTable)).toEqual(['test-user', SUBJECT.id]);
+    expect(deleteKeycloakUser).not.toHaveBeenCalled();
+
+    const request = (await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0];
+    expect(request?.status).toBe('Failed');
+
+    expect(slackAlert).toHaveBeenCalledOnce();
+    expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain('req-1');
+
+    projectSubmissionRemoveFails = false;
+    const retry = await execute('req-1');
+
+    expect(retry.status).toBe('Completed');
+    expect(await pgIdsIn(courseRegistrationTable)).toEqual(['reg-other', 'reg-subject-unlinked']);
+    expect(await pgIdsIn(projectSubmissionTable)).toEqual(['ps-other', 'ps-shared']);
+    expect(await pgIdsIn(userTable)).toEqual(['test-user']);
+  });
+
+  test('fails the request when the Applications user record survives', async () => {
+    await seedSubjectData();
+    await seedRequest();
+
+    userRecordUndeletable = true;
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+
+    const request = (await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0];
+    expect(request?.status).toBe('Failed');
+    expect(slackAlert).toHaveBeenCalledOnce();
+  });
+
+  test('fails the request when the Keycloak user survives', async () => {
+    await seedSubjectData();
+    await seedRequest();
+
+    vi.mocked(deleteKeycloakUser).mockResolvedValue(undefined);
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+
+    const request = (await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0];
+    expect(request?.status).toBe('Failed');
+    expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain('Keycloak user subject-sub');
+  });
+
+  test('alerts that the request needs a manual reset when it cannot be marked failed', async () => {
+    await seedSubjectData();
+    await seedRequest();
+
+    userRecordUndeletable = true;
+
+    const update = testDb.update.bind(testDb);
+    vi.spyOn(testDb, 'update').mockImplementation((table, values) => {
+      if ((values as { status?: string }).status === 'Failed') throw new Error('Airtable write rejected');
+      return update(table, values);
+    });
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+
+    expect(slackAlert).toHaveBeenCalledOnce();
+    expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain('could not be marked failed');
+    expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain(`user record ${SUBJECT.id}`);
+  });
+
+  test('completes for an account with no Keycloak identifier, and never calls Keycloak', async () => {
+    await seedSubjectData();
+    await seedRequest({ keycloakIdentifier: '' });
+
+    const result = await execute('req-1');
+
+    expect(result.status).toBe('Completed');
+    expect(result.steps[result.steps.length - 1]).toEqual({ step: 'keycloak-user', deleted: 0 });
+    expect(keycloakUserExists).not.toHaveBeenCalled();
+    expect(deleteKeycloakUser).not.toHaveBeenCalled();
+    expect(await pgIdsIn(userTable)).toEqual(['test-user']);
+  });
+
+  test('is a no-op once completed', async () => {
+    await seedRequest({ status: 'Completed' });
+
+    const result = await execute('req-1');
+
+    expect(result).toEqual({ status: 'Completed', steps: [] });
+    expect(deleteKeycloakUser).not.toHaveBeenCalled();
+  });
+
+  test('refuses to start a second run while one is in progress', async () => {
+    await seedSubjectData();
+    await seedRequest({ status: 'In progress' });
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    expect(await pgIdsIn(userTable)).toEqual(['test-user', SUBJECT.id]);
+    expect(deleteKeycloakUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('resumability: a one-time failure at any step marks the request failed, and a retry reaches the same end state', () => {
+  test.each(ALL_STEPS)('%s', async (stepName) => {
+    await seedSubjectData();
+    await seedRequest();
+    armStepFailure(stepName);
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+    expect((await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0]?.status).toBe('Failed');
+    expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain(`"${stepName}"`);
+
+    const retry = await execute('req-1');
+
+    expect(retry.status).toBe('Completed');
+    await expectDeletionEndState();
+  });
+});
+
+describe('fail-closed: another user\'s records survive even when they look like the subject\'s', () => {
+  test('a decoy user sharing the subject\'s email keeps every record', async () => {
+    await seedSubjectData();
+    await testDb.insert(userTable, {
+      id: 'user-decoy', email: SUBJECT.email, name: 'Decoy Person', keycloakIdentifier: 'decoy-sub',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-decoy', email: SUBJECT.email, userId: 'user-decoy', courseId: 'course-1',
+    });
+    await testDb.insert(meetPersonTable, {
+      id: 'mp-decoy', name: 'Decoy Person', userId: 'user-decoy', applicationsBaseRecordId: 'reg-decoy',
+    });
+    await testDb.insert(selfServeCourseRegistrationTable, { id: 'ss-decoy', userId: 'user-decoy', courseId: 'course-1' });
+    await testDb.insert(dropoutTable, { id: 'do-decoy', applicantId: ['reg-decoy'] });
+    await testDb.insert(projectSubmissionTable, { id: 'ps-decoy', participant: ['mp-decoy'] });
+    await testDb.insert(courseFeedbackTable, { id: 'cf-decoy', person: ['mp-decoy'] });
+    await testDb.insert(peerFeedbackTable, { id: 'pf-decoy', feedbackRecipient: ['mp-decoy'], courseFeedback: ['cf-decoy'] });
+    await testDb.insert(groupSwitchingTable, { id: 'gs-decoy', participant: 'mp-decoy' });
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values([{
+      id: 'er-decoy', exerciseId: 'ex-1', response: 'decoy', userId: ['user-decoy'],
+    }]);
+    await testDb.pg.insert(resourceCompletionPgTable.pg).values([{ id: 'rc-decoy', userId: ['user-decoy'] }]);
+    airtableUserRecords.push({ id: 'user-decoy' });
+    await seedRequest();
+
+    const result = await execute('req-1');
+
+    expect(result.status).toBe('Completed');
+    const decoySurvivors = [
+      [userTable, 'user-decoy'],
+      [courseRegistrationTable, 'reg-decoy'],
+      [selfServeCourseRegistrationTable, 'ss-decoy'],
+      [dropoutTable, 'do-decoy'],
+      [projectSubmissionTable, 'ps-decoy'],
+      [courseFeedbackTable, 'cf-decoy'],
+      [peerFeedbackTable, 'pf-decoy'],
+      [groupSwitchingTable, 'gs-decoy'],
+      [exerciseResponsePgTable, 'er-decoy'],
+      [resourceCompletionPgTable, 'rc-decoy'],
+    ] as const;
+    for (const [table, id] of decoySurvivors) {
+      // eslint-disable-next-line no-await-in-loop
+      expect(await pgIdsIn(table)).toContain(id);
+    }
+
+    expect(airtableUserRecords.map((record) => record.id)).toContain('user-decoy');
+  });
+
+  test('refuses to delete more rows than one account plausibly owns', async () => {
+    // One over MAX_DELETIONS_PER_STEP.
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values(Array.from({ length: 1001 }, (_, i) => ({
+      id: `er-bulk-${i}`, exerciseId: 'ex-1', response: 'r', userId: [SUBJECT.id],
+    })));
+    await seedRequest();
+
+    await expect(execute('req-1')).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+
+    expect((await testDb.scan(deletionRequestTable, { id: 'req-1' }))[0]?.status).toBe('Failed');
+    expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain('more than the maximum');
+    expect((await pgIdsIn(exerciseResponsePgTable)).length).toBe(1001);
+    expect(await pgIdsIn(userTable)).toEqual(['test-user', SUBJECT.id]);
   });
 });

--- a/apps/website/src/server/routers/deletion-requests.ts
+++ b/apps/website/src/server/routers/deletion-requests.ts
@@ -9,9 +9,10 @@ import db from '../../lib/api/db';
 import env from '../../lib/api/env';
 import { sendAccountDeletionRequestedNotice } from '../../lib/api/customerio';
 import { DELETION_REQUEST_STATUS } from '../../lib/constants';
-import { normaliseEmail } from '../../lib/api/utils';
+import { runAccountDeletion } from '../../lib/api/accountDeletion';
+import { normaliseEmail, verifyPublicToken } from '../../lib/api/utils';
 import {
-  adminProcedure, getUserFromAuthOrThrow, impersonationRealIdentity, router,
+  adminProcedure, getUserFromAuthOrThrow, impersonationRealIdentity, publicProcedure, router,
 } from '../trpc';
 
 export const deletionRequestsRouter = router({
@@ -69,4 +70,15 @@ export const deletionRequestsRouter = router({
     .where(eq(deletionRequestTable.pg.initiatedByRole, 'Admin'))
     .orderBy(desc(deletionRequestTable.pg.requestedAt))
     .limit(100)),
+
+  executeAccountDeletion: publicProcedure
+    .input(z.object({
+      publicToken: z.string().min(1),
+      deletionRequestId: z.string().min(1),
+    }))
+    .mutation(({ input }) => {
+      verifyPublicToken(input.publicToken);
+
+      return runAccountDeletion(input.deletionRequestId);
+    }),
 });

--- a/libraries/db/src/index.ts
+++ b/libraries/db/src/index.ts
@@ -112,6 +112,7 @@ export {
   getPgAirtableFromIds, PgAirtableTable, DeprecationSafePgTable, deprecationSafePgTable, isDeprecationSafeTable,
 } from './lib/db-core';
 export type { DeprecationSafeTable } from './lib/db-core';
+export type { PgAirtableColumnInput } from './lib/typeUtils';
 
 export { AirtableTsError, ErrorType } from 'airtable-ts/dist/AirtableTsError';
 


### PR DESCRIPTION
# Description

Plan from the [Issue](https://github.com/bluedotimpact/bluedot/issues/2567):

> Summary of the architecture I'm planning to go with here:
> 1. The on-site flow will insert a row into a [Deletion requests](https://airtable.com/appnJbsG1eWbAdEvf/tbl0b9zoIUjBPsL84/viwBZSACf21Ua4o2L?blocks=hide) table (similar to drop out/group switching requests)
> 2. This will then be picked up by an Airtable automation which kicks off the actual deletion
> 3. The automation itself pings a `executeAccountDeletion` endpoint on the website (using the [`AIRTABLE_AUTOMATION_TOKEN`](https://github.com/bluedotimpact/bluedot/issues/2808) for authentication)

> And the UI I'm planning to add on the website:
> - A new "Delete accounts" admin page (select user -> confirm modal)
> - The user-facing "Delete account" button as in the screenshots above

This PR sets up the backend processing of ordinary (non-GDPR) deletion requests. The user-facing behaviour I am aiming for when an account is deleted is:
- The email is freed. You are able to change another account to use that email, or create a fresh account with the same email
- If you do create an account with the same email, it starts empty and behaves the same as if you had signed up for the first time
- You stop receiving any communication resulting from you having an account

Things which are notably not included in this:
- Stopping email marketing that _is not_ the result of having an account. Specifically, newsletter signups through the anonymous form (e.g. at the bottom of the [programs page](https://bluedot.org/programs)), which also come through customer.io (so we need to keep the profile alive)
- Deleting data that was not visible to the user in the first place. E.g. groups switching/drop out requests
- Deleting data that is not closely tied to the course hub website, e.g. grant applications

Apart from that, the main decision I made was on the question of **soft deletion** (adding `deletedAt` columns to tables) vs **hard deletion**. I opted for hard deletion, because it simplifies things massively, and we don't have a clear use case for soft deletion (i.e. we don't need low-friction restore/undo). In the case where an account is accidentally deleted, we could bring it back from database backups if absolutely needed.

To do after deploying this:
- [x] Create an Airtable automation "process deletion request", triggered "on record matches conditions ("Pending" status)" in the Deletion requests table, which pings this `executeAccountDeletion` endpoint (edit: created [here](https://airtable.com/appnJbsG1eWbAdEvf/wflyrP2PiE5A51RZL/wachmD0zIcMc7RYuI), just need to turn on once this merges)

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2567

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories