### PR TITLE
Refresh Career Transition Grants page

### DIFF
--- a/apps/website/src/components/career-transition-grant/ApplicationPreviewSection.tsx
+++ b/apps/website/src/components/career-transition-grant/ApplicationPreviewSection.tsx
@@ -1,0 +1,52 @@
+import { H3, P } from '@bluedot/ui';
+import { PiCaretDown } from 'react-icons/pi';
+
+const PREPARATION_ITEMS = [
+  {
+    title: 'Recent evidence',
+    body: 'Examples of relevant action, achievement or momentum that help us understand what you can do.',
+  },
+  {
+    title: 'Accessible work samples',
+    body: 'Links to your strongest relevant work, or an explanation of the analogous evidence we should consider.',
+  },
+  {
+    title: 'Milestones',
+    body: 'The outputs, tests and decision points you expect during the transition.',
+  },
+  {
+    title: 'Theory of change',
+    body: 'How the proposed work could ultimately contribute to reducing catastrophic risks from advanced AI or biological threats.',
+  },
+  {
+    title: 'A simple budget',
+    body: 'The amount and duration you are requesting, what it covers and what the funding would change.',
+  },
+];
+
+const ApplicationPreviewSection = () => {
+  return (
+    <section className="section section-body career-transition-grant-application-preview-section bg-color-canvas">
+      <div className="w-full flex flex-col gap-6">
+        <H3>Application preview</H3>
+        <P className="max-w-3xl">The application takes around 45 minutes. You can prepare the main evidence before you begin.</P>
+        <details className="group overflow-hidden rounded-xl border border-bluedot-navy/10 bg-white">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-6 px-6 py-5 font-semibold text-bluedot-navy [&::-webkit-details-marker]:hidden">
+            What to prepare
+            <PiCaretDown aria-hidden className="size-5 shrink-0 transition-transform group-open:rotate-180" />
+          </summary>
+          <ul className="grid grid-cols-1 gap-5 border-t border-bluedot-navy/10 px-6 py-6 bd-md:grid-cols-2">
+            {PREPARATION_ITEMS.map((item) => (
+              <li key={item.title} className="flex flex-col gap-1">
+                <strong className="text-size-sm text-bluedot-navy">{item.title}</strong>
+                <P className="text-bluedot-navy/80">{item.body}</P>
+              </li>
+            ))}
+          </ul>
+        </details>
+      </div>
+    </section>
+  );
+};
+
+export default ApplicationPreviewSection;

--- a/apps/website/src/components/career-transition-grant/CareerTransitionGrantContent.test.tsx
+++ b/apps/website/src/components/career-transition-grant/CareerTransitionGrantContent.test.tsx
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+import GrantFaqSection from '../grants/sections/GrantFaqSection';
+import ApplicationPreviewSection from './ApplicationPreviewSection';
+import ExpectationsSection from './ExpectationsSection';
+import NextStepsSection from './NextStepsSection';
+import WhatThisIsForSection from './WhatThisIsForSection';
+import WhatWeLookForSection from './WhatWeLookForSection';
+import WhatYouReceiveSection from './WhatYouReceiveSection';
+
+describe('Career Transition Grant content', () => {
+  test('presents the transition thesis, evidence criteria, support, expectations, and evaluation stages', () => {
+    render(<>
+      <WhatThisIsForSection />
+      <WhatWeLookForSection />
+      <WhatYouReceiveSection />
+      <ExpectationsSection />
+      <ApplicationPreviewSection />
+      <NextStepsSection />
+    </>);
+
+    expect(screen.getByRole('heading', { name: 'What this is for' })).toBeInTheDocument();
+    expect(screen.getByText(/defined period working full-time on a transition/i)).toBeInTheDocument();
+    expect(screen.queryByText(/upskilling, exploring opportunities, building your network/i)).not.toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: 'What we look for' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Evidence that you are already moving' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'A grant that meaningfully improves the path' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Clear thinking under uncertainty' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'A credible connection to catastrophic-risk reduction' })).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: 'Funding' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Targeted connections' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Regular progress updates' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Structured check-ins' })).toBeInTheDocument();
+
+    expect(screen.getByText('What to prepare').closest('details')).toBeInTheDocument();
+    expect(screen.getByText('Accessible work samples')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'We determine the right route' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'We review the relevant evidence' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'We interview selected applicants' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'We decide and set up the grant' })).toBeInTheDocument();
+  });
+
+  test('answers the revised applicant-routing questions', async () => {
+    const user = userEvent.setup();
+    render(<GrantFaqSection program="career-transition-grant" />);
+
+    expect(screen.getByRole('button', { name: 'Who should apply?' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Who is eligible?' })).not.toBeInTheDocument();
+
+    await act(async () => user.click(screen.getByRole('button', { name: 'Do I need to be unable to transition without funding?' })));
+    expect(screen.getByText(/do not require the transition to be literally impossible/i)).toBeVisible();
+
+    await act(async () => user.click(screen.getByRole('button', { name: 'Should I apply to Rapid Grants instead?' })));
+    expect(screen.getByText(/concrete project with specific costs/i)).toBeVisible();
+  });
+});

--- a/apps/website/src/components/career-transition-grant/ExpectationsSection.tsx
+++ b/apps/website/src/components/career-transition-grant/ExpectationsSection.tsx
@@ -9,18 +9,18 @@ const EXPECTATIONS = [
   },
   {
     cadence: 'Weekly',
-    title: 'Progress updates',
-    body: 'Short async updates to your BlueDot point of contact on what you did, who you talked to, what you learned, and how your thinking is evolving.',
+    title: 'Regular progress updates',
+    body: 'Brief updates on what you produced, what evidence you gathered, what changed in your thinking, progress against milestones and any decisions you need to make.',
   },
   {
     cadence: 'Ongoing',
-    title: 'Check-ins',
-    body: 'Structured conversations throughout your grant to review progress and plan next steps.',
+    title: 'Structured check-ins',
+    body: 'Conversations with your BlueDot point of contact to assess progress, revisit important assumptions and decide whether to continue, change or narrow the plan.',
   },
   {
     cadence: 'At the end',
-    title: 'Grant report',
-    body: 'A summary of what you achieved during the grant and what you will be doing next.',
+    title: 'Grant-end and follow-up reporting',
+    body: 'A short report covering what you produced, what you learned, how your plans changed and what you will do next. We may also ask for a brief follow-up after the grant so we can improve future funding decisions.',
   },
 ];
 

--- a/apps/website/src/components/career-transition-grant/NextStepsSection.stories.tsx
+++ b/apps/website/src/components/career-transition-grant/NextStepsSection.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: 'Three-step "What happens next" timeline rendered on the /career-transition-grant page. The steps are hard-coded — change copy in `NextStepsSection.tsx`.',
+        component: 'Five-step "What happens next" timeline rendered on the /career-transition-grant page. The steps are hard-coded — change copy in `NextStepsSection.tsx`.',
       },
     },
   },

--- a/apps/website/src/components/career-transition-grant/NextStepsSection.tsx
+++ b/apps/website/src/components/career-transition-grant/NextStepsSection.tsx
@@ -3,15 +3,23 @@ import { H3, H4, P } from '@bluedot/ui';
 const NEXT_STEPS = [
   {
     title: 'You apply',
-    body: 'Fill in the application form. It takes around 45 minutes.',
+    body: 'Complete the application form. It takes around 45 minutes and asks about your recent work, proposed transition, theory of change, milestones and funding request.',
   },
   {
-    title: 'We review and book a call',
-    body: 'If we want to talk or need more information, we schedule a call to discuss next steps.',
+    title: 'We determine the right route',
+    body: 'We first assess whether the request is a good fit for a Career Transition Grant or whether another funding route would be more appropriate.',
   },
   {
-    title: 'Grant starts',
-    body: 'Once approved, we set up the grant within a few days so you can start right away.',
+    title: 'We review the relevant evidence',
+    body: 'If the application is promising, we may review your work sample, ask a focused follow-up question, seek expert input or contact a reference. We only request additional information when it could materially affect our decision.',
+  },
+  {
+    title: 'We interview selected applicants',
+    body: 'Interviews focus on the most important remaining questions about your plan, reasoning and ability to execute.',
+  },
+  {
+    title: 'We decide and set up the grant',
+    body: 'If approved, we agree the amount, duration and any relevant milestones, then arrange payment so you can begin.',
   },
 ];
 
@@ -21,7 +29,7 @@ const NextStepsSection = () => {
       <div className="w-full flex flex-col gap-6">
         <H3>What happens next</H3>
 
-        <ol className="grid gap-8 bd-md:gap-6 grid-cols-1 bd-md:grid-cols-3">
+        <ol className="grid gap-8 bd-md:gap-6 grid-cols-1 bd-md:grid-cols-2 min-[1120px]:grid-cols-3">
           {NEXT_STEPS.map((step, index) => (
             <li key={step.title} className="flex flex-col gap-3">
               <span

--- a/apps/website/src/components/career-transition-grant/WhatThisIsForSection.tsx
+++ b/apps/website/src/components/career-transition-grant/WhatThisIsForSection.tsx
@@ -1,26 +1,11 @@
-import { H3, H4, P } from '@bluedot/ui';
-import {
-  PiCompass,
-  PiHandshake,
-  PiUsersThree,
-} from 'react-icons/pi';
+import { H3, P } from '@bluedot/ui';
 
-const SUPPORT_CARDS = [
-  {
-    icon: PiHandshake,
-    title: 'Introductions',
-    description: 'Warm intros to relevant people in the field so you can talk to the right people faster.',
-  },
-  {
-    icon: PiCompass,
-    title: 'Advising',
-    description: 'Regular check-ins with your BlueDot point of contact to pressure-test your thinking and unblock you.',
-  },
-  {
-    icon: PiUsersThree,
-    title: 'Community',
-    description: 'Connection to others making similar transitions so you are not figuring this out alone.',
-  },
+const EXAMPLE_USES = [
+  'Produce research, policy work, technical work or another substantial output',
+  'Build evidence that you can contribute at a higher level',
+  'Test an uncertain but potentially high-impact career path',
+  'Address a specific skill or experience bottleneck',
+  'Move into a role or establish a sustained independent contribution',
 ];
 
 const WhatThisIsForSection = () => {
@@ -29,29 +14,20 @@ const WhatThisIsForSection = () => {
       <div className="w-full flex flex-col gap-6">
         <H3>What this is for</H3>
 
-        <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-5 max-w-4xl">
           <P>
-            BlueDot&apos;s career transition grant supports you to work full-time on impactful AI safety work. It enables you to fully focus on upskilling, exploring opportunities, building your network, and figuring out where you can have the most impact.
+            Career Transition Grants support people who are ready to spend a defined period working full-time on a transition into impactful AI safety or biosecurity work.
           </P>
-          <P>Alongside funding, you also get:</P>
-        </div>
-
-        <div className="pt-2 grid gap-8 grid-cols-1 bd-md:grid-cols-3">
-          {SUPPORT_CARDS.map(({ icon: Icon, title, description }) => (
-            <div key={title} className="flex flex-col gap-5">
-              <div className="size-14 rounded-lg flex items-center justify-center flex-shrink-0 bg-bluedot-lighter/40">
-                <Icon className="text-bluedot-navy" size={28} />
-              </div>
-              <div className="flex flex-col gap-2">
-                <H4>
-                  {title}
-                </H4>
-                <P className="text-bluedot-navy/80">
-                  {description}
-                </P>
-              </div>
-            </div>
-          ))}
+          <P>You might use the grant to:</P>
+          <ul className="flex flex-col gap-3 pl-6 list-disc text-size-sm leading-relaxed text-bluedot-navy/80">
+            {EXAMPLE_USES.map((item) => <li key={item}>{item}</li>)}
+          </ul>
+          <P>
+            We expect plans to change. What matters is that you can make progress, learn from evidence and produce something valuable even if your original path does not work.
+          </P>
+          <P>
+            This program is primarily for personal, full-time transitions. If your main request is to fund a discrete project, event or organisational activity, another BlueDot funding route may be a better fit. You can still apply if you are unsure—we will help route the request.
+          </P>
         </div>
       </div>
     </section>

--- a/apps/website/src/components/career-transition-grant/WhatWeLookForSection.tsx
+++ b/apps/website/src/components/career-transition-grant/WhatWeLookForSection.tsx
@@ -1,0 +1,47 @@
+import { H3, H4, P } from '@bluedot/ui';
+
+const CRITERIA = [
+  {
+    title: 'Evidence that you are already moving',
+    body: (
+      <>
+        <P>We look for concrete recent action—not only an intention to enter the field. This might include research, writing, technical work, policy work, organising, professional achievements or strong analogous work.</P>
+        <P>You do not need a conventional AI safety background, but we need enough evidence to judge your ability to carry out the proposed transition.</P>
+      </>
+    ),
+  },
+  {
+    title: 'A grant that meaningfully improves the path',
+    body: <P>Your transition does not need to be impossible without BlueDot. We want to understand what funding would change: its timing, focus, ambition, quality or likelihood of happening.</P>,
+  },
+  {
+    title: 'Clear thinking under uncertainty',
+    body: <P>Career plans rarely work exactly as expected. We look for people who can prioritise, identify important uncertainties, notice when an approach is failing and adapt without losing sight of the ultimate goal.</P>,
+  },
+  {
+    title: 'A credible connection to catastrophic-risk reduction',
+    body: <P>We fund transitions where success could plausibly contribute to reducing catastrophic risks from advanced AI or biological threats. We want to understand the causal connection between the work you plan to do and the outcomes it could ultimately affect.</P>,
+  },
+];
+
+const WhatWeLookForSection = () => {
+  return (
+    <section className="section section-body career-transition-grant-criteria-section bg-color-canvas">
+      <div className="w-full flex flex-col gap-8">
+        <H3>What we look for</H3>
+        <div className="grid grid-cols-1 gap-5 bd-md:grid-cols-2">
+          {CRITERIA.map((criterion) => (
+            <article key={criterion.title} className="flex flex-col gap-3 rounded-xl border border-bluedot-navy/10 bg-white p-6">
+              <H4>{criterion.title}</H4>
+              <div className="flex flex-col gap-3 text-bluedot-navy/80">
+                {criterion.body}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WhatWeLookForSection;

--- a/apps/website/src/components/career-transition-grant/WhatYouReceiveSection.tsx
+++ b/apps/website/src/components/career-transition-grant/WhatYouReceiveSection.tsx
@@ -1,0 +1,55 @@
+import { H3, H4, P } from '@bluedot/ui';
+import {
+  PiCompass,
+  PiCurrencyDollar,
+  PiHandshake,
+  PiUsersThree,
+} from 'react-icons/pi';
+
+const SUPPORT_CARDS = [
+  {
+    icon: PiCurrencyDollar,
+    title: 'Funding',
+    description: 'A fellowship grant that allows you to focus full-time on the transition.',
+  },
+  {
+    icon: PiCompass,
+    title: 'Advising',
+    description: 'Structured check-ins to review evidence, pressure-test decisions and adapt the plan when circumstances change.',
+  },
+  {
+    icon: PiHandshake,
+    title: 'Targeted connections',
+    description: 'Where useful and where we can help, we may introduce you to people who can provide relevant feedback, expertise or opportunities.',
+  },
+  {
+    icon: PiUsersThree,
+    title: 'Community',
+    description: 'Connection with other people making serious transitions into AI safety and biosecurity.',
+  },
+];
+
+const WhatYouReceiveSection = () => {
+  return (
+    <section className="section section-body career-transition-grant-support-section">
+      <div className="w-full flex flex-col gap-8">
+        <H3>What you receive</H3>
+        <div className="grid gap-8 grid-cols-1 bd-md:grid-cols-2 min-[1120px]:grid-cols-4">
+          {SUPPORT_CARDS.map(({ icon: Icon, title, description }) => (
+            <div key={title} className="flex flex-col gap-5">
+              <div className="size-14 rounded-lg flex items-center justify-center flex-shrink-0 bg-bluedot-lighter/40">
+                <Icon className="text-bluedot-navy" size={28} />
+              </div>
+              <div className="flex flex-col gap-2">
+                <H4>{title}</H4>
+                <P className="text-bluedot-navy/80">{description}</P>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WhatYouReceiveSection;

--- a/apps/website/src/components/grants/grantPrograms.tsx
+++ b/apps/website/src/components/grants/grantPrograms.tsx
@@ -32,8 +32,8 @@ export const GRANT_PROGRAMS: GrantProgramDefinition[] = [
     title: 'Career Transition Grants',
     href: '/programs/career-transition-grant',
     track: 'Funding',
-    goal: 'Support BlueDot graduates to work full-time on impactful AI safety work.',
-    scope: 'Funding plus intros, advising, and community for people ready to go full-time on AI safety.',
+    goal: 'Support people making full-time transitions into work that reduces catastrophic risks from advanced AI or biological threats.',
+    scope: 'Funding, advising, targeted connections, and community for a defined period of evidence-producing personal transition.',
     status: 'Active',
   },
   {
@@ -121,21 +121,39 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
     faqItems: [
       {
         id: 'eligibility',
-        question: 'Who is eligible?',
+        question: 'Who should apply?',
         answer: (
           <>
-            Everyone who's ready to go full-time on AI safety and biosecurity.
-            <br />
-            <br />
-            You're more likely to receive a grant if you're a BlueDot course participant, alumni, facilitator, or active member of the AI safety/biosecurity community.
+            <span className="block mb-3">Apply if you:</span>
+            <span className="block mb-2">• Are ready to work full-time on a personal transition</span>
+            <span className="block mb-2">• Can point to evidence of relevant ability or recent momentum</span>
+            <span className="block mb-2">• Have a plausible plan for producing work, testing a path or moving into a contribution</span>
+            <span className="block mb-2">• Can explain how success could contribute to reducing catastrophic risks from advanced AI or biological threats</span>
+            <span className="block mb-4">• Believe funding would meaningfully improve the transition</span>
+            <span className="block">Applications are open to everyone. Prior participation in a BlueDot course or community is not required.</span>
           </>
         ),
-        answerText: 'Everyone who\'s ready to go full-time on AI safety and biosecurity. You\'re more likely to receive a grant if you\'re a BlueDot course participant, alumni, facilitator, or active member of the AI safety/biosecurity community.',
+        answerText: 'Apply if you are ready to work full-time on a personal transition, can point to evidence of relevant ability or recent momentum, have a plausible plan for producing work, testing a path or moving into a contribution, can explain how success could contribute to reducing catastrophic risks from advanced AI or biological threats, and believe funding would meaningfully improve the transition. Applications are open to everyone. Prior participation in a BlueDot course or community is not required.',
+      },
+      {
+        id: 'funding-need',
+        question: 'Do I need to be unable to transition without funding?',
+        answer: 'No. We do not require the transition to be literally impossible without BlueDot. We do want to understand what funding would change—for example, whether it lets you begin sooner, work full-time, take a more ambitious path or produce stronger evidence before making your next career decision.',
+      },
+      {
+        id: 'work-sample',
+        question: 'Do I need an AI safety work sample?',
+        answer: 'Relevant AI safety or biosecurity work is the most useful evidence, but strong analogous work can also be informative. If you do not yet have a work sample, you may still apply; explain what other evidence we should use to assess your ability.',
+      },
+      {
+        id: 'rapid-grants',
+        question: 'Should I apply to Rapid Grants instead?',
+        answer: 'Rapid Grants are usually a better fit when you have a concrete project with specific costs—such as research, an event, travel, compute or tooling—and need up to $10,000. Career Transition Grants are for a period of full-time personal transition. If you are unsure, apply to the route that seems closest and we can redirect you.',
       },
       {
         id: 'uncertain',
         question: 'Should I apply if I don\'t know exactly how to contribute to AI safety yet?',
-        answer: 'Yes. We do not expect you to have it all figured out. We would rather see a clear-eyed account of what you do not know and a plan for finding out.',
+        answer: 'Yes. We do not expect a fixed career plan or certainty about every step. We do expect a serious hypothesis, a way to test it and a plan that can produce useful work or information even if the original path does not work.',
       },
       {
         id: 'circumstances-change',
@@ -145,20 +163,20 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
       {
         id: 'masters-phd',
         question: 'Will you fund a Master\'s or PhD?',
-        answer: 'Generally, no. For most people, a Master\'s or PhD isn\'t the most direct route to impactful AI safety work. There are exceptions. Mention it in your application if you think yours is one.',
+        answer: 'Generally, no. For most people, a Master\'s or PhD isn\'t the most direct route to impactful AI safety or biosecurity work. There are exceptions. Mention it in your application if you think yours is one.',
       },
       {
         id: 'grant-structure',
         question: 'How is the grant structured?',
         answer: (
           <>
-            The grant is a fellowship grant in support of your AI safety work. It is not a salary or a contract for services. BlueDot is a UK entity, so we don't issue W-2s or 1099s, and the agreement explicitly states there is no employment, worker, or contractor relationship between us.
+            The grant is a fellowship grant in support of your AI safety or biosecurity transition. It is not a salary or a contract for services. BlueDot is a UK entity, so we don't issue W-2s or 1099s, and the agreement explicitly states there is no employment, worker, or contractor relationship between us.
             <br />
             <br />
             We can't give tax advice, so please check the tax implications with a qualified advisor in your country.
           </>
         ),
-        answerText: 'The grant is a fellowship grant in support of your AI safety work. It is not a salary or a contract for services. BlueDot is a UK entity, so we don\'t issue W-2s or 1099s, and the agreement explicitly states there is no employment, worker, or contractor relationship between us. We can\'t give tax advice, so please check the tax implications with a qualified advisor in your country.',
+        answerText: 'The grant is a fellowship grant in support of your AI safety or biosecurity transition. It is not a salary or a contract for services. BlueDot is a UK entity, so we don\'t issue W-2s or 1099s, and the agreement explicitly states there is no employment, worker, or contractor relationship between us. We can\'t give tax advice, so please check the tax implications with a qualified advisor in your country.',
       },
     ],
   },

--- a/apps/website/src/pages/programs/career-transition-grant.tsx
+++ b/apps/website/src/pages/programs/career-transition-grant.tsx
@@ -1,4 +1,5 @@
 import { Breadcrumbs } from '@bluedot/ui';
+import { sendGAEvent } from '@next/third-parties/google';
 import type { GetStaticProps } from 'next';
 import Head from 'next/head';
 import MarketingHero from '../../components/MarketingHero';
@@ -6,7 +7,10 @@ import GrantStatsStrip from '../../components/grants/sections/GrantStatsStrip';
 import GrantFaqSection from '../../components/grants/sections/GrantFaqSection';
 import GrantCta from '../../components/grants/sections/GrantCta';
 import WhatThisIsForSection from '../../components/career-transition-grant/WhatThisIsForSection';
+import WhatWeLookForSection from '../../components/career-transition-grant/WhatWeLookForSection';
+import WhatYouReceiveSection from '../../components/career-transition-grant/WhatYouReceiveSection';
 import ExpectationsSection from '../../components/career-transition-grant/ExpectationsSection';
+import ApplicationPreviewSection from '../../components/career-transition-grant/ApplicationPreviewSection';
 import NextStepsSection from '../../components/career-transition-grant/NextStepsSection';
 import GranteesSection from '../../components/career-transition-grant/GranteesSection';
 import { ROUTES } from '../../lib/routes';
@@ -51,9 +55,20 @@ const CareerTransitionGrantPage = ({ programName, programDescription }: ProgramD
           { label: 'Funding awarded', value: fundingAwardedLabel },
           { label: 'Avg days to decision', value: avgDaysToDecisionLabel },
         ]}
+        secondaryAction={{
+          label: 'Learn about Rapid Grants',
+          url: '/programs/rapid-grants',
+          onClick: () => sendGAEvent('event', 'grant_route_click', {
+            from_program: 'career-transition-grant',
+            to_program: 'rapid-grants',
+          }),
+        }}
       />
       <WhatThisIsForSection />
+      <WhatWeLookForSection />
+      <WhatYouReceiveSection />
       <ExpectationsSection />
+      <ApplicationPreviewSection />
       <NextStepsSection />
       <GranteesSection />
       <GrantFaqSection program="career-transition-grant" />


### PR DESCRIPTION
## Summary

- Reframe Career Transition Grants around defined, full-time transitions that produce evidence and move people towards catastrophic-risk-reduction work
- Add applicant-facing selection criteria, a clearer support offer, and an expandable application preview
- Update grantee expectations, the five-stage evaluation process, program listing copy, and FAQs
- Preserve the existing hero and live statistics strip while adding a tracked route to Rapid Grants for concrete projects

## Why

The page had drifted from the current application and proposed evidence-led evaluation process. The old framing emphasized upskilling, networking, and open-ended exploration, which risked attracting requests that were better suited to another funding route.

This update makes the personal-transition thesis, evidence bar, additionality test, uncertainty handling, and catastrophic-risk connection clearer without publishing the internal decision rubric.

## Validation

- `npm test -- --reporter=dot --silent=passed-only` — 128 test files, 1,108 tests passed
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
- Desktop and mobile visual QA of the hero, live statistics, content sections, application preview, and evaluation steps
