### PR TITLE
Deferral flow: add guard to check round belongs to course

### DIFF
--- a/apps/website/src/server/routers/dropout.test.ts
+++ b/apps/website/src/server/routers/dropout.test.ts
@@ -151,6 +151,17 @@ describe('dropout.dropoutOrDeferral', () => {
     })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
+  test('fails closed when the current round cannot be resolved, instead of trusting the course link', async () => {
+    // Registration claims a round that has no row in pg (deleted / not synced). Falling back to
+    // the course link here would reopen the wrong-course hole for exactly the records where the
+    // link is least trustworthy.
+    await insertRegistration({ role: 'Participant', decision: 'Accept', roundId: 'round-missing' });
+
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-2',
+    })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
   test('rejects a deferral when the course cannot be determined', async () => {
     await insertRegistration({
       role: 'Participant', decision: 'Accept', courseId: '', roundId: null,

--- a/apps/website/src/server/routers/dropout.test.ts
+++ b/apps/website/src/server/routers/dropout.test.ts
@@ -162,6 +162,18 @@ describe('dropout.dropoutOrDeferral', () => {
     })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
+  test('fails closed when the current round has no course, instead of trusting the course link', async () => {
+    await testDb.insert(applicationsRoundTable, { id: 'round-no-course', courseId: null });
+    await testDb.insert(applicationsRoundTable, { id: 'round-stale-link-course', courseId: 'course-stale' });
+    await insertRegistration({
+      role: 'Participant', decision: 'Accept', courseId: 'course-stale', roundId: 'round-no-course',
+    });
+
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-stale-link-course',
+    })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
   test('rejects a deferral when the course cannot be determined', async () => {
     await insertRegistration({
       role: 'Participant', decision: 'Accept', courseId: '', roundId: null,

--- a/apps/website/src/server/routers/dropout.test.ts
+++ b/apps/website/src/server/routers/dropout.test.ts
@@ -1,4 +1,4 @@
-import { courseRegistrationTable, eq } from '@bluedot/db';
+import { applicationsRoundTable, courseRegistrationTable, eq } from '@bluedot/db';
 import {
   beforeEach, describe, expect, test,
 } from 'vitest';
@@ -9,8 +9,12 @@ import {
 setupTestDb();
 
 // The authenticated user's row is assumed to exist by the userId-scoped routes.
+// Deferral targets are validated against rounds, so seed the rounds referenced by tests.
 beforeEach(async () => {
   await seedLoggedInUser();
+  await testDb.insert(applicationsRoundTable, { id: 'round-1', courseId: 'course-1' });
+  await testDb.insert(applicationsRoundTable, { id: 'round-2', courseId: 'course-1' });
+  await testDb.insert(applicationsRoundTable, { id: 'round-other-course', courseId: 'course-2' });
 });
 
 const getDecision = async (id: string) => {
@@ -96,5 +100,64 @@ describe('dropout.dropoutOrDeferral', () => {
     await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
       applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-2',
     })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  test('rejects a deferral to a round of a different course', async () => {
+    await insertRegistration({ role: 'Participant', decision: 'Accept' });
+
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-other-course',
+    })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  test('rejects a deferral to a round that does not exist', async () => {
+    await insertRegistration({ role: 'Participant', decision: 'Accept' });
+
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-nonexistent',
+    })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  test('validates against the current round\'s course, not a stale registration course link', async () => {
+    // Registration's course link disagrees with its round: the round's course wins.
+    await insertRegistration({ role: 'Participant', decision: 'Accept', courseId: 'course-stale' });
+
+    // Same course as the current round: allowed despite the stale link.
+    const result = await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-2',
+    });
+    expect(result).toBeTruthy();
+
+    // Matching the stale link but not the round's course: rejected.
+    await testDb.insert(applicationsRoundTable, { id: 'round-stale-course', courseId: 'course-stale' });
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-stale-course',
+    })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  test('falls back to the registration course link when there is no current round', async () => {
+    await insertRegistration({ role: 'Participant', decision: 'Accept', roundId: null });
+
+    const result = await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-2',
+    });
+    expect(result).toBeTruthy();
+
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-2', email: 'test@example.com', userId: 'test-user', courseId: 'course-2', decision: 'Accept', roundId: null,
+    });
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-2', type: 'Deferral', newRoundId: 'round-2',
+    })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  test('rejects a deferral when the course cannot be determined', async () => {
+    await insertRegistration({
+      role: 'Participant', decision: 'Accept', courseId: '', roundId: null,
+    });
+
+    await expect(createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+      applicantId: 'reg-1', type: 'Deferral', newRoundId: 'round-2',
+    })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 });

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -99,8 +99,6 @@ export const dropoutRouter = router({
         }
 
         const expectedCourseId = oldRound?.courseId ?? courseRegistration.courseId;
-        // The falsy check also covers '': on the not-null registration column, an empty Airtable
-        // link syncs as '' rather than null.
         if (!expectedCourseId || newRound.courseId !== expectedCourseId) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: 'The selected round belongs to a different course. Please refresh the page and try again.' });
         }

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -1,5 +1,5 @@
 import {
-  arrayOverlaps, COURSE_ROLE, courseRegistrationTable, dropoutTable, eq,
+  applicationsRoundTable, arrayOverlaps, COURSE_ROLE, courseRegistrationTable, dropoutTable, eq,
 } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import z from 'zod';
@@ -85,6 +85,26 @@ export const dropoutRouter = router({
       }
 
       const oldRoundId = courseRegistration.roundId ?? null;
+
+      // The registration's course link and its round's course are maintained independently in
+      // Airtable and can disagree (#2792). The round is the participant's actual enrolment, so
+      // validate the deferral target against the current round's course.
+      if (type === 'Deferral' && newRoundId) {
+        const [oldRound, newRound] = await Promise.all([
+          oldRoundId ? db.getFirst(applicationsRoundTable, { sortBy: 'id', filter: { id: oldRoundId } }) : null,
+          db.getFirst(applicationsRoundTable, { sortBy: 'id', filter: { id: newRoundId } }),
+        ]);
+        if (!newRound) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'The selected round was not found.' });
+        }
+
+        const expectedCourseId = oldRound?.courseId ?? courseRegistration.courseId;
+        // The falsy check also covers '': on the not-null registration column, an empty Airtable
+        // link syncs as '' rather than null.
+        if (!expectedCourseId || newRound.courseId !== expectedCourseId) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: 'The selected round belongs to a different course. Please refresh the page and try again.' });
+        }
+      }
 
       const dropout = await db.insert(dropoutTable, {
         applicantId: [applicantId],

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -98,7 +98,9 @@ export const dropoutRouter = router({
           throw new TRPCError({ code: 'NOT_FOUND', message: 'The selected round was not found.' });
         }
 
-        const expectedCourseId = oldRound?.courseId ?? courseRegistration.courseId;
+        // Only round-less registrations fall back to the course link; an unresolvable round fails
+        // closed. The falsy check also covers '' (how an empty link syncs on not-null columns).
+        const expectedCourseId = oldRoundId ? oldRound?.courseId : courseRegistration.courseId;
         if (!expectedCourseId || newRound.courseId !== expectedCourseId) {
           throw new TRPCError({ code: 'BAD_REQUEST', message: 'The selected round belongs to a different course. Please refresh the page and try again.' });
         }


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Protect the deferral procedure by ensuring that the new round belongs to the correct course. A participant using the deferral flow could be silently moved to a different course: the deferral modal scopes its round picker by the registration's course link, and the server accepted any `newRoundId` without checking it. When a registration's course link and its Round disagree in Airtable (they're maintained independently and ~60 prod records had diverged), the modal offered wrong-course rounds and the server wrote them through.

Changes:

- Deferral request throws if the target round doesn't exist
- Deferral request throws if course doesn't match current round's course

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Part of #2792

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

