### PR TITLE
[feat] Rename Modal noClickaway to isDismissable and cover ESC and drag-to-dismiss

### DIFF
--- a/apps/website/src/components/courses/AddParticipantModal.tsx
+++ b/apps/website/src/components/courses/AddParticipantModal.tsx
@@ -31,7 +31,7 @@ const AddParticipantModal: React.FC<AddParticipantModalProps> = ({ meetPersonId,
       desktopHeaderClassName="h-[73px] py-0 px-6 mb-0 border-b border-gray-200"
       bottomDrawerOnMobile
       ariaLabel="Add a participant"
-      noClickaway
+      isDismissable={false}
     >
       <div className="w-full max-w-[480px] flex flex-col gap-4 pt-0 sm:pt-5 -mb-4">
         <p className="text-size-xs leading-normal text-bluedot-navy/60">

--- a/apps/website/src/components/courses/ParticipantFeedbackModal.tsx
+++ b/apps/website/src/components/courses/ParticipantFeedbackModal.tsx
@@ -91,7 +91,7 @@ const ParticipantFeedbackModal: React.FC<ParticipantFeedbackModalProps> = ({ mee
       desktopHeaderClassName="h-[73px] py-0 px-6 mb-0 border-b border-gray-200"
       bottomDrawerOnMobile
       ariaLabel="Participant feedback"
-      noClickaway
+      isDismissable={false}
     >
       <div className="w-full max-w-modal pt-4">
         {savePeerFeedback.isError && <ErrorSection error={savePeerFeedback.error} />}

--- a/libraries/ui/src/BottomDrawerModal.tsx
+++ b/libraries/ui/src/BottomDrawerModal.tsx
@@ -189,6 +189,12 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
                     handleClose();
                   }
                 }}
+                onDragTransitionEnd={() => {
+                  // Release momentum can glide the sheet below the open position after onDragEnd has run
+                  if (!isDismissable && y.get() > initialOpenY.current) {
+                    animate(y, initialOpenY.current, { duration: 0.3, ease: [0.32, 0.72, 0, 1] });
+                  }
+                }}
               >
                 <div className="h-full flex flex-col rounded-t-[24px] overflow-hidden">
                   {/* Header Section with Drag Handle */}

--- a/libraries/ui/src/BottomDrawerModal.tsx
+++ b/libraries/ui/src/BottomDrawerModal.tsx
@@ -39,7 +39,7 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
   initialSize,
   children,
   ariaLabel,
-  noClickaway,
+  isDismissable = true,
   centerTitle,
 }) => {
   const [isDragging, setIsDragging] = useState(false);
@@ -59,6 +59,7 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
 
   // Always start from closed position, the useEffect below will animate to an open position if needed
   const y = useMotionValue(closedY);
+  const openY = useRef(halfOpenY);
 
   // Reset on modal state changes
   const prevIsOpen = useRef<boolean | null>(null);
@@ -80,6 +81,7 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
         // Use the larger y value (less expansion) = min height
         const targetY = initialSize === 'fit-screen' ? halfOpenY : Math.max(halfOpenY, contentBasedY);
 
+        openY.current = targetY;
         animate(y, targetY, { duration: 0.3, ease: [0.32, 0.72, 0, 1] });
       });
     } else {
@@ -102,7 +104,7 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
   }, [y, isFullyExpanded]);
 
   const handleClose = () => {
-    if (!isClosing) {
+    if (isDismissable && !isClosing) {
       setIsClosing(true);
       animate(y, closedY, {
         duration: 0.3,
@@ -116,7 +118,9 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
 
   return (
     <ModalOverlay
-      isDismissable={!noClickaway}
+      isDismissable={isDismissable}
+      // react-aria's isDismissable only covers outside interaction, not the escape key
+      isKeyboardDismissDisabled={!isDismissable}
       isOpen={isOpen}
       onOpenChange={(open) => !open && handleClose()}
       className="fixed inset-0 z-60 flex min-h-full items-center justify-center"
@@ -131,7 +135,7 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.3 }}
-                onClick={noClickaway ? undefined : handleClose}
+                onClick={isDismissable ? handleClose : undefined}
               />
               {/* Modal Container */}
               <motion.div
@@ -173,7 +177,11 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
                   const closeThreshold = closedY * CLOSE_POSITION_THRESHOLD;
 
                   if (velocity > CLOSE_VELOCITY_THRESHOLD || currentY > closeThreshold) {
-                    handleClose();
+                    if (isDismissable) {
+                      handleClose();
+                    } else {
+                      animate(y, openY.current, { duration: 0.3, ease: [0.32, 0.72, 0, 1] });
+                    }
                   }
                 }}
               >

--- a/libraries/ui/src/BottomDrawerModal.tsx
+++ b/libraries/ui/src/BottomDrawerModal.tsx
@@ -176,12 +176,17 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
                   const currentY = y.get();
                   const closeThreshold = closedY * CLOSE_POSITION_THRESHOLD;
 
-                  if (velocity > CLOSE_VELOCITY_THRESHOLD || currentY > closeThreshold) {
-                    if (isDismissable) {
-                      handleClose();
-                    } else {
+                  if (!isDismissable) {
+                    // Any downward drag snaps back, otherwise the sheet can be parked off-screen with no way to recover
+                    if (currentY > openY.current) {
                       animate(y, openY.current, { duration: 0.3, ease: [0.32, 0.72, 0, 1] });
                     }
+
+                    return;
+                  }
+
+                  if (velocity > CLOSE_VELOCITY_THRESHOLD || currentY > closeThreshold) {
+                    handleClose();
                   }
                 }}
               >

--- a/libraries/ui/src/BottomDrawerModal.tsx
+++ b/libraries/ui/src/BottomDrawerModal.tsx
@@ -59,7 +59,7 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
 
   // Always start from closed position, the useEffect below will animate to an open position if needed
   const y = useMotionValue(closedY);
-  const openY = useRef(halfOpenY);
+  const initialOpenY = useRef(halfOpenY);
 
   // Reset on modal state changes
   const prevIsOpen = useRef<boolean | null>(null);
@@ -81,7 +81,7 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
         // Use the larger y value (less expansion) = min height
         const targetY = initialSize === 'fit-screen' ? halfOpenY : Math.max(halfOpenY, contentBasedY);
 
-        openY.current = targetY;
+        initialOpenY.current = targetY;
         animate(y, targetY, { duration: 0.3, ease: [0.32, 0.72, 0, 1] });
       });
     } else {
@@ -178,8 +178,8 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
 
                   if (!isDismissable) {
                     // Any downward drag snaps back, otherwise the sheet can be parked off-screen with no way to recover
-                    if (currentY > openY.current) {
-                      animate(y, openY.current, { duration: 0.3, ease: [0.32, 0.72, 0, 1] });
+                    if (currentY > initialOpenY.current) {
+                      animate(y, initialOpenY.current, { duration: 0.3, ease: [0.32, 0.72, 0, 1] });
                     }
 
                     return;

--- a/libraries/ui/src/Modal.stories.tsx
+++ b/libraries/ui/src/Modal.stories.tsx
@@ -153,7 +153,8 @@ export const NotDismissable: Story = {
                 and (on mobile) dragging the drawer down won't close this modal.
               </p>
               <p className="mb-4">
-                It can still be closed with the close button, or programmatically by setting <code>isOpen</code> to false:
+                On desktop the header close button still works, but the mobile bottom drawer has no built-in
+                close button — supply your own, or close it programmatically by setting <code>isOpen</code> to false:
               </p>
               <CTALinkOrButton onClick={() => setIsOpen(false)}>Close programmatically</CTALinkOrButton>
             </div>

--- a/libraries/ui/src/Modal.stories.tsx
+++ b/libraries/ui/src/Modal.stories.tsx
@@ -132,6 +132,40 @@ export const CustomTitle: Story = {
   },
 };
 
+export const NotDismissable: Story = {
+  render() {
+    const NotDismissableDemo = () => {
+      const [isOpen, setIsOpen] = useState(false);
+
+      return (
+        <div>
+          <CTALinkOrButton onClick={() => setIsOpen(true)}>Open Non-dismissable Modal</CTALinkOrButton>
+          <Modal
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            title="Deleting your account"
+            bottomDrawerOnMobile
+            isDismissable={false}
+          >
+            <div className="max-w-[600px]">
+              <p className="mb-4">
+                With <code>isDismissable={'{false}'}</code>, clicking the backdrop, pressing escape
+                and (on mobile) dragging the drawer down won't close this modal.
+              </p>
+              <p className="mb-4">
+                It can still be closed with the close button, or programmatically by setting <code>isOpen</code> to false:
+              </p>
+              <CTALinkOrButton onClick={() => setIsOpen(false)}>Close programmatically</CTALinkOrButton>
+            </div>
+          </Modal>
+        </div>
+      );
+    };
+
+    return <NotDismissableDemo />;
+  },
+};
+
 export const BottomDrawerOnMobile: Story = {
   render() {
     const BottomDrawerOnMobileDemo = () => {

--- a/libraries/ui/src/Modal.test.tsx
+++ b/libraries/ui/src/Modal.test.tsx
@@ -88,6 +88,13 @@ describe('Modal', () => {
       expect(screen.getByText('Content')).toBeInTheDocument();
     });
 
+    // Documented in the isDismissable JSDoc: consumers must render their own close control
+    test('has no built-in close control when isDismissable is false', () => {
+      render(<Modal isOpen setIsOpen={vi.fn()} title="Title" bottomDrawerOnMobile isDismissable={false}>Content</Modal>);
+
+      expect(screen.queryByRole('button', { name: /close|dismiss/i })).not.toBeInTheDocument();
+    });
+
     test('can still be closed programmatically when isDismissable is false', async () => {
       const { rerender } = render(<Modal isOpen setIsOpen={vi.fn()} title="Title" bottomDrawerOnMobile isDismissable={false}>Content</Modal>);
       rerender(<Modal isOpen={false} setIsOpen={vi.fn()} title="Title" bottomDrawerOnMobile isDismissable={false}>Content</Modal>);

--- a/libraries/ui/src/Modal.test.tsx
+++ b/libraries/ui/src/Modal.test.tsx
@@ -1,0 +1,102 @@
+import {
+  render, screen, fireEvent, waitFor,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  describe, test, expect, vi, beforeEach,
+} from 'vitest';
+import { Modal } from './Modal';
+import { useAboveBreakpoint } from './hooks/useBreakpoint';
+
+vi.mock('./hooks/useBreakpoint', async () => {
+  const actual = await vi.importActual('./hooks/useBreakpoint');
+  return {
+    ...actual,
+    useAboveBreakpoint: vi.fn(),
+  };
+});
+
+const mockUseAboveBreakpoint = vi.mocked(useAboveBreakpoint);
+
+const pressEscape = () => {
+  fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape', code: 'Escape' });
+};
+
+describe('Modal', () => {
+  describe('desktop', () => {
+    beforeEach(() => {
+      mockUseAboveBreakpoint.mockReturnValue(true);
+    });
+
+    test('is dismissable by default', () => {
+      const setIsOpen = vi.fn();
+      render(<Modal isOpen setIsOpen={setIsOpen} title="Title">Content</Modal>);
+
+      pressEscape();
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+    });
+
+    test('cannot be dismissed with escape when isDismissable is false', () => {
+      const setIsOpen = vi.fn();
+      render(<Modal isOpen setIsOpen={setIsOpen} title="Title" isDismissable={false}>Content</Modal>);
+
+      pressEscape();
+
+      expect(setIsOpen).not.toHaveBeenCalled();
+      expect(screen.getByText('Content')).toBeInTheDocument();
+    });
+
+    test('close button still works when isDismissable is false', () => {
+      const setIsOpen = vi.fn();
+      render(<Modal isOpen setIsOpen={setIsOpen} title="Title" isDismissable={false}>Content</Modal>);
+
+      fireEvent.click(screen.getByLabelText('Close'));
+
+      expect(setIsOpen).toHaveBeenCalledWith(false);
+    });
+
+    test('can still be closed programmatically when isDismissable is false', () => {
+      const { rerender } = render(<Modal isOpen setIsOpen={vi.fn()} title="Title" isDismissable={false}>Content</Modal>);
+      rerender(<Modal isOpen={false} setIsOpen={vi.fn()} title="Title" isDismissable={false}>Content</Modal>);
+
+      expect(screen.queryByText('Content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('mobile bottom drawer', () => {
+    beforeEach(() => {
+      mockUseAboveBreakpoint.mockReturnValue(false);
+    });
+
+    test('is dismissable by default', async () => {
+      render(<Modal isOpen setIsOpen={vi.fn()} title="Title" bottomDrawerOnMobile>Content</Modal>);
+
+      pressEscape();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Content')).not.toBeInTheDocument();
+      });
+    });
+
+    test('cannot be dismissed with escape when isDismissable is false', () => {
+      const setIsOpen = vi.fn();
+      render(<Modal isOpen setIsOpen={setIsOpen} title="Title" bottomDrawerOnMobile isDismissable={false}>Content</Modal>);
+
+      pressEscape();
+
+      expect(setIsOpen).not.toHaveBeenCalled();
+      expect(screen.getByText('Content')).toBeInTheDocument();
+    });
+
+    test('can still be closed programmatically when isDismissable is false', async () => {
+      const { rerender } = render(<Modal isOpen setIsOpen={vi.fn()} title="Title" bottomDrawerOnMobile isDismissable={false}>Content</Modal>);
+      rerender(<Modal isOpen={false} setIsOpen={vi.fn()} title="Title" bottomDrawerOnMobile isDismissable={false}>Content</Modal>);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Content')).not.toBeInTheDocument();
+      });
+      // No orphaned overlay left behind blocking the page
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/libraries/ui/src/Modal.tsx
+++ b/libraries/ui/src/Modal.tsx
@@ -21,7 +21,11 @@ export type ModalProps = {
   desktopHeaderClassName?: string;
   /** ariaLabel for case where `title` is not a string, otherwise prefer leaving blank (`title` will be used) */
   ariaLabel?: string;
-  /** When false, the user can't dismiss the modal via the escape key, clicking outside it, or (on mobile) dragging it down. The close button and closing it programmatically still work. */
+  /**
+   * When false, the user can't dismiss the modal via the escape key, clicking outside it, or (on mobile) dragging it down.
+   * Closing it programmatically always works, as does the desktop header close button. The mobile bottom drawer has no
+   * built-in close button, so render your own close/cancel control in `children` when using it.
+   */
   isDismissable?: boolean;
   centerTitle?: boolean;
 };

--- a/libraries/ui/src/Modal.tsx
+++ b/libraries/ui/src/Modal.tsx
@@ -21,7 +21,8 @@ export type ModalProps = {
   desktopHeaderClassName?: string;
   /** ariaLabel for case where `title` is not a string, otherwise prefer leaving blank (`title` will be used) */
   ariaLabel?: string;
-  noClickaway?: boolean;
+  /** When false, the user can't dismiss the modal via the escape key, clicking outside it, or (on mobile) dragging it down. The close button and closing it programmatically still work. */
+  isDismissable?: boolean;
   centerTitle?: boolean;
 };
 
@@ -32,12 +33,14 @@ const DesktopModal: React.FC<Omit<ModalProps, 'bottomDrawerOnMobile'>> = ({
   children,
   desktopHeaderClassName,
   ariaLabel,
-  noClickaway,
+  isDismissable = true,
   centerTitle,
 }) => {
   return (
     <ModalOverlay
-      isDismissable={!noClickaway}
+      isDismissable={isDismissable}
+      // react-aria's isDismissable only covers outside interaction, not the escape key
+      isKeyboardDismissDisabled={!isDismissable}
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       className="fixed inset-0 z-60 overflow-y-auto bg-black/25 flex min-h-full items-center justify-center p-4 backdrop-blur-xs"
@@ -68,7 +71,7 @@ export const Modal: React.FC<ModalProps> = ({
   bottomDrawerOnMobile = false,
   desktopHeaderClassName,
   ariaLabel,
-  noClickaway,
+  isDismissable,
   centerTitle,
 }) => {
   const isDesktop = useAboveBreakpoint(breakpoints.md);
@@ -82,14 +85,14 @@ export const Modal: React.FC<ModalProps> = ({
 
   if (shouldUseMobileDrawer) {
     return (
-      <BottomDrawerModal isOpen={isOpen} setIsOpen={setIsOpen} title={title} initialSize="fit-screen" ariaLabel={ariaLabel} noClickaway={noClickaway} centerTitle={centerTitle}>
+      <BottomDrawerModal isOpen={isOpen} setIsOpen={setIsOpen} title={title} initialSize="fit-screen" ariaLabel={ariaLabel} isDismissable={isDismissable} centerTitle={centerTitle}>
         {children}
       </BottomDrawerModal>
     );
   }
 
   return (
-    <DesktopModal isOpen={isOpen} setIsOpen={setIsOpen} title={title} ariaLabel={ariaLabel} desktopHeaderClassName={desktopHeaderClassName} noClickaway={noClickaway} centerTitle={centerTitle}>
+    <DesktopModal isOpen={isOpen} setIsOpen={setIsOpen} title={title} ariaLabel={ariaLabel} desktopHeaderClassName={desktopHeaderClassName} isDismissable={isDismissable} centerTitle={centerTitle}>
       {children}
     </DesktopModal>
   );

--- a/libraries/ui/src/Modal.tsx
+++ b/libraries/ui/src/Modal.tsx
@@ -21,11 +21,6 @@ export type ModalProps = {
   desktopHeaderClassName?: string;
   /** ariaLabel for case where `title` is not a string, otherwise prefer leaving blank (`title` will be used) */
   ariaLabel?: string;
-  /**
-   * When false, the user can't dismiss the modal via the escape key, clicking outside it, or (on mobile) dragging it down.
-   * Closing it programmatically always works, as does the desktop header close button. The mobile bottom drawer has no
-   * built-in close button, so render your own close/cancel control in `children` when using it.
-   */
   isDismissable?: boolean;
   centerTitle?: boolean;
 };


### PR DESCRIPTION
# Description

From the issue:

> There is a flag noClickaway on Modal which is supposed to prevent you from accidentally clicking away during high stakes actions. It works on actual clickaways, but you can still close the modal in these ways:
> - Desktop (or technically mobile): Pressing ESC
> - Mobile: Drag to dismiss

This adds handling of these two cases, renaming `noClickaway` to `isDismissable`. It also fixes an edge case where the modal could get stuck just off the screen (it now snaps back).

You can try this out in [storybook](https://bluedot-storybook-preview-pr-2865.onrender.com/?path=/story/ui-modal--not-dismissable).

## Issue

Fixes #2862

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories