### PR TITLE
[fix] Add website liveness, readiness probes against a Next-handled route

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -19,11 +19,10 @@ const PG_SYNC_SLACK_CHANNEL_ID = 'C0BFEG755PG'; // #update_pg-sync
 // (apps/website/.env.production.template). Not a secret: it's exposed in the browser bundle.
 const POSTHOG_PROJECT_API_KEY = 'phc_NVqRwH6xZ0MiP9I5a9tx3l9zsTWBvMI1YEbvbCOXDcI';
 
-// Shared with the Service's targetPort below so the probe can't silently drift from it.
 const WEBSITE_TARGET_PORT = 8080;
 
-// Hits a Next-handled route, so a build that boots but throws on every request fails the
-// rollout instead of "succeeding". A plain TCP check can't tell those apart.
+// A Next-handled route, so a build that boots but throws on every request fails the
+// rollout instead of "succeeding".
 // Readiness pulls a stalled pod out of rotation; liveness restarts it so single-replica
 // website doesn't stay stuck NotReady until the stall clears on its own.
 const WEBSITE_HEALTH_CHECK = {

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -19,10 +19,15 @@ const PG_SYNC_SLACK_CHANNEL_ID = 'C0BFEG755PG'; // #update_pg-sync
 // (apps/website/.env.production.template). Not a secret: it's exposed in the browser bundle.
 const POSTHOG_PROJECT_API_KEY = 'phc_NVqRwH6xZ0MiP9I5a9tx3l9zsTWBvMI1YEbvbCOXDcI';
 
+// Shared with the Service's targetPort below so the probe can't silently drift from it.
+const WEBSITE_TARGET_PORT = 8080;
+
 // Hits a Next-handled route, so a build that boots but throws on every request fails the
 // rollout instead of "succeeding". A plain TCP check can't tell those apart.
-const WEBSITE_READINESS_PROBE = {
-  httpGet: { path: '/api/health', port: 8080 },
+// Readiness pulls a stalled pod out of rotation; liveness restarts it so single-replica
+// website doesn't stay stuck NotReady until the stall clears on its own.
+const WEBSITE_HEALTH_CHECK = {
+  httpGet: { path: '/api/health', port: WEBSITE_TARGET_PORT },
   periodSeconds: 10,
   failureThreshold: 3,
 };
@@ -156,10 +161,12 @@ export const services: ServiceDefinition[] = [
           { name: 'EMAIL_CHANGE_TOKEN_SECRET', valueFrom: envVarSources.emailChangeTokenSecret },
           { name: 'NOTION_API_TOKEN', valueFrom: envVarSources.notionApiToken },
         ],
-        readinessProbe: WEBSITE_READINESS_PROBE,
+        readinessProbe: WEBSITE_HEALTH_CHECK,
+        livenessProbe: WEBSITE_HEALTH_CHECK,
       }],
     },
     hosts: ['website-staging.k8s.bluedot.org'],
+    targetPort: WEBSITE_TARGET_PORT,
   },
   {
     name: 'bluedot-website-production',
@@ -187,10 +194,12 @@ export const services: ServiceDefinition[] = [
           { name: 'EMAIL_CHANGE_TOKEN_SECRET', valueFrom: envVarSources.emailChangeTokenSecret },
           { name: 'NOTION_API_TOKEN', valueFrom: envVarSources.notionApiToken },
         ],
-        readinessProbe: WEBSITE_READINESS_PROBE,
+        readinessProbe: WEBSITE_HEALTH_CHECK,
+        livenessProbe: WEBSITE_HEALTH_CHECK,
       }],
     },
     hosts: ['website-production.k8s.bluedot.org'],
+    targetPort: WEBSITE_TARGET_PORT,
   },
   {
     name: 'bluedot-storybook',

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -19,6 +19,14 @@ const PG_SYNC_SLACK_CHANNEL_ID = 'C0BFEG755PG'; // #update_pg-sync
 // (apps/website/.env.production.template). Not a secret: it's exposed in the browser bundle.
 const POSTHOG_PROJECT_API_KEY = 'phc_NVqRwH6xZ0MiP9I5a9tx3l9zsTWBvMI1YEbvbCOXDcI';
 
+// Hits a Next-handled route, so a build that boots but throws on every request fails the
+// rollout instead of "succeeding". A plain TCP check can't tell those apart.
+const WEBSITE_READINESS_PROBE = {
+  httpGet: { path: '/api/health', port: 8080 },
+  periodSeconds: 10,
+  failureThreshold: 3,
+};
+
 const MCP_AGGREGATOR_HOST = 'mcp.k8s.bluedot.org';
 const MCP_ASHBY_HOST = 'mcp-ashby.k8s.bluedot.org';
 const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';
@@ -148,6 +156,7 @@ export const services: ServiceDefinition[] = [
           { name: 'EMAIL_CHANGE_TOKEN_SECRET', valueFrom: envVarSources.emailChangeTokenSecret },
           { name: 'NOTION_API_TOKEN', valueFrom: envVarSources.notionApiToken },
         ],
+        readinessProbe: WEBSITE_READINESS_PROBE,
       }],
     },
     hosts: ['website-staging.k8s.bluedot.org'],
@@ -178,6 +187,7 @@ export const services: ServiceDefinition[] = [
           { name: 'EMAIL_CHANGE_TOKEN_SECRET', valueFrom: envVarSources.emailChangeTokenSecret },
           { name: 'NOTION_API_TOKEN', valueFrom: envVarSources.notionApiToken },
         ],
+        readinessProbe: WEBSITE_READINESS_PROBE,
       }],
     },
     hosts: ['website-production.k8s.bluedot.org'],

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -10,8 +10,8 @@ export async function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
-  // Don't protect the login page or its API route
-  if (pathname === '/site-login' || pathname === '/api/site-login') {
+  // Don't protect the login page, its API route, or the k8s readiness probe
+  if (pathname === '/site-login' || pathname === '/api/site-login' || pathname === '/api/health') {
     return NextResponse.next();
   }
 

--- a/apps/website/src/pages/api/health.test.ts
+++ b/apps/website/src/pages/api/health.test.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { describe, it, expect, vi } from 'vitest';
+import {
+  describe, it, expect, vi,
+} from 'vitest';
 import handler from './health';
 
 describe('health', () => {

--- a/apps/website/src/pages/api/health.test.ts
+++ b/apps/website/src/pages/api/health.test.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { describe, it, expect, vi } from 'vitest';
+import handler from './health';
+
+describe('health', () => {
+  it('returns 200 so a booted app passes the readiness probe', () => {
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as NextApiResponse;
+
+    handler({} as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'ok' });
+  });
+});

--- a/apps/website/src/pages/api/health.ts
+++ b/apps/website/src/pages/api/health.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Used by the k8s readiness probe. Deliberately has no external dependencies
+// (db, Airtable): readiness should reflect whether the app can serve requests,
+// not whether upstream systems are up.
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ status: 'ok' });
+}


### PR DESCRIPTION
## What

Adds `/api/health` to the website and points a k8s readiness probe at it, for both staging and production deployments.

## Why

Today's Sentry outage (#2864, reverted in #2866) shipped an image that booted successfully but threw `MODULE_NOT_FOUND` on every request. Because the website has no readiness probe, k8s saw the container as healthy, `kubectl rollout status` reported success, and the deploy "passed" while every page and API route returned a 500. Static files from `public/` kept serving, which made the pod look even healthier.

A probe against a Next-handled route makes that failure mode fail the rollout instead. A TCP-level check wouldn't help here — the server was listening the whole time.

## Notes

- The endpoint deliberately has no database or Airtable dependency. Readiness should mean "this pod can serve requests", not "all upstream systems are up" — otherwise an Airtable blip pulls every pod out of the load balancer.
- Added to the site-gate exemption in `middleware.ts` alongside `/site-login`, so the probe still works if `SITE_ACCESS_PASSWORD` is set.
- No `nginx.template.conf` change needed: the proxy's default `location /` already forwards everything, and the probe hits the pod directly on port 8080.
- `periodSeconds: 10`, `failureThreshold: 3` — a pod has to fail for ~30s before being pulled, which won't flap on a slow first request.

## Verification

- Ran the dev server with `SITE_ACCESS_PASSWORD` set: `/api/health` → `200 {"status":"ok"}`, `/` → `307` to the login page. Confirms the middleware exemption works and the gate is otherwise intact.
- Unit test covers the handler's status and body.
- `tsc --noEmit` and eslint clean for both `apps/website` and `apps/infra`.

Suggested merge order: this first, then #2867 (Sentry reintroduction), so that PR's rollout is actually gated on the app serving traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
