### PR TITLE
[fix] Add startupProbe to website deployments to fix prod crash loop

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -31,6 +31,15 @@ const WEBSITE_HEALTH_CHECK = {
   failureThreshold: 3,
 };
 
+// startupProbe gates readiness/liveness until the app responds once, so a slow cold start
+// (seen in prod: pod took >30s to come up) doesn't get misread as a liveness failure and
+// killed before it ever gets a chance to pass. Same budget as bluedot-login's startupProbe.
+const WEBSITE_STARTUP_PROBE = {
+  httpGet: { path: '/api/health', port: WEBSITE_TARGET_PORT },
+  periodSeconds: 10,
+  failureThreshold: 18,
+};
+
 const MCP_AGGREGATOR_HOST = 'mcp.k8s.bluedot.org';
 const MCP_ASHBY_HOST = 'mcp-ashby.k8s.bluedot.org';
 const MCP_GOOGLE_HOST = 'mcp-google.k8s.bluedot.org';
@@ -160,6 +169,7 @@ export const services: ServiceDefinition[] = [
           { name: 'EMAIL_CHANGE_TOKEN_SECRET', valueFrom: envVarSources.emailChangeTokenSecret },
           { name: 'NOTION_API_TOKEN', valueFrom: envVarSources.notionApiToken },
         ],
+        startupProbe: WEBSITE_STARTUP_PROBE,
         readinessProbe: WEBSITE_HEALTH_CHECK,
         livenessProbe: WEBSITE_HEALTH_CHECK,
       }],
@@ -193,6 +203,7 @@ export const services: ServiceDefinition[] = [
           { name: 'EMAIL_CHANGE_TOKEN_SECRET', valueFrom: envVarSources.emailChangeTokenSecret },
           { name: 'NOTION_API_TOKEN', valueFrom: envVarSources.notionApiToken },
         ],
+        startupProbe: WEBSITE_STARTUP_PROBE,
         readinessProbe: WEBSITE_HEALTH_CHECK,
         livenessProbe: WEBSITE_HEALTH_CHECK,
       }],


### PR DESCRIPTION
## What

Hotfix for the prod CD failure caused by #2868 (merged as `d2d97852b`).

## What happened

Merging #2868 crash-looped `bluedot-website-production-deployment` in prod: [CD run](https://github.com/bluedotimpact/bluedot/actions/runs/31396060959/job/93480742080). The container terminated every 30s exactly (`periodSeconds: 10 × failureThreshold: 3`) — the new `livenessProbe` had no grace period, so a pod that took longer than 30s to come up got killed and restarted before it ever passed, resetting the clock each cycle. Pulumi gave up after its 10-minute rollout timeout.

**No user-facing outage**: `bluedot.org` served `200` throughout (old pod kept serving — k8s `maxUnavailable` rounds to 0 at `replicas: 1`, so it never got torn down). `bluedot.org/api/health` returned `404` the whole time, confirming the new image never went live. The rollout itself just never completed, and any future push to master will hit the same failure until this merges.

## Fix

Add a `startupProbe` — same pattern `bluedot-login` already uses in this file. It gates readiness/liveness until the app responds once, with its own generous budget (180s), so a slow cold start (whatever the actual cause — cold boot, node contention) doesn't get misread as a liveness failure and killed prematurely.

## Testing

- `npx tsc --noEmit` (apps/infra) — clean
- `npx eslint src/k8s/serviceDefinitions.ts` — clean
- Can't fully reproduce prod cold-start timing locally; this needs to go through staging→prod CD to confirm the rollout completes cleanly this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
