### PR TITLE
[fix] claude.yml: pin model, unbreaking @claude bot

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
+          # The action's default model (claude-sonnet-4-20250514) was retired and now
+          # 404s, making every @claude invocation fail. Pin a current model explicitly.
+          model: claude-sonnet-5
+
           # Allow Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Context

Every `@claude` invocation in this repo currently fails within seconds. Example from [PR #2873](https://github.com/bluedotimpact/bluedot/pull/2873): the bot posts "Claude encountered an error" and the [job log](https://github.com/bluedotimpact/bluedot/actions/runs/31414024178) shows:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}}
```

## Cause

`.github/workflows/claude.yml` uses `anthropics/claude-code-action@beta` without a `model:` input. The action's default, `claude-sonnet-4-20250514`, has been retired by Anthropic and the API now returns 404 for it.

## Fix

Pin a current model explicitly: `model: claude-sonnet-5` (current Sonnet alias). One-line change, no other behaviour altered.

## Verification

- YAML parses cleanly (js-yaml).
- Workflow-only change — no app code, so no test suite affected.
- Note: the bot cannot review its own fix. `issue_comment` workflows run from the workflow file on the default branch, so `@claude review` on this PR would still use the broken master copy and 404. The real test is the first `@claude` trigger on any PR after this merges — I'll re-run it on PR #2873 then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)