### PR TITLE
Return 404 instead of 500 for unknown course slugs

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -209,7 +209,7 @@ async function getUnitWithChunks(courseSlug: string, unitNumber: string) {
 
   const unit = units.find((u) => Number(u.unitNumber) === Number(unitNumber));
   if (!unit) {
-    throw new Error('NOT_FOUND');
+    throw new TRPCError({ code: 'NOT_FOUND', message: `Unit ${unitNumber} not found for course "${courseSlug}".` });
   }
 
   const allUnitChunks = await getActiveChunksByUnit(units);

--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -3,6 +3,7 @@ import {
   chunkTable, eq, type Exercise, exerciseTable, inArray, type UnitResource, unitResourceTable,
 } from '@bluedot/db';
 import { ProgressDots, useAuthStore, useLatestUtmParams } from '@bluedot/ui';
+import { TRPCError } from '@trpc/server';
 import { type GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -170,7 +171,7 @@ export const getServerSideProps: GetServerSideProps<CourseUnitChunkPageProps> = 
       },
     };
   } catch (error) {
-    if (error instanceof Error && error.message === 'NOT_FOUND') {
+    if (error instanceof TRPCError && error.code === 'NOT_FOUND') {
       return { notFound: true };
     }
 

--- a/apps/website/src/pages/courses/[courseSlug]/congratulations.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/congratulations.tsx
@@ -1,6 +1,7 @@
 import { type Unit } from '@bluedot/db';
 import { ErrorView } from '@bluedot/ui/src/ErrorView';
 import { ProgressDots } from '@bluedot/ui';
+import { TRPCError } from '@trpc/server';
 import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import CourseCompletionSection from '../../../components/courses/CourseCompletionSection';
@@ -93,7 +94,7 @@ export const getServerSideProps: GetServerSideProps<CongratulationsPageProps> = 
       },
     };
   } catch (error) {
-    if (error instanceof Error && error.message.includes('NOT_FOUND')) {
+    if (error instanceof TRPCError && error.code === 'NOT_FOUND') {
       return { notFound: true };
     }
 

--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -63,7 +63,6 @@ describe('courses.getBySlug', () => {
     expect(result.units).toEqual([]);
   });
 
-  // db.get() throws on zero rows, which previously surfaced as a 500 instead of a 404 (gh-2882).
   test('throws NOT_FOUND for an unknown slug', async () => {
     const promise = caller.courses.getBySlug({ courseSlug: 'does-not-exist' });
 

--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -69,6 +69,20 @@ describe('courses.getBySlug', () => {
     await expect(promise).rejects.toBeInstanceOf(TRPCError);
     await expect(promise).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
+
+  // Slugs are hand-authored in Airtable with no uniqueness constraint; a collision must fail
+  // loudly rather than render an arbitrary one of the matching courses.
+  test('throws INTERNAL_SERVER_ERROR when two courses share a slug', async () => {
+    await testDb.insert(courseTable, {
+      id: 'course-dupe-1', slug: 'dupe', title: 'dupe 1', shortDescription: 'd', units: [], status: 'Active',
+    });
+    await testDb.insert(courseTable, {
+      id: 'course-dupe-2', slug: 'dupe', title: 'dupe 2', shortDescription: 'd', units: [], status: 'Active',
+    });
+
+    await expect(caller.courses.getBySlug({ courseSlug: 'dupe' }))
+      .rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+  });
 });
 
 // Cases mirror real course-builder data shapes (see gh-2544 prod inspection): most chunks carry no

--- a/apps/website/src/server/routers/courses.test.ts
+++ b/apps/website/src/server/routers/courses.test.ts
@@ -5,6 +5,7 @@ import {
   exerciseTable,
   unitTable,
 } from '@bluedot/db';
+import { TRPCError } from '@trpc/server';
 import { describe, expect, test } from 'vitest';
 import {
   createCaller,
@@ -51,6 +52,25 @@ const seedChunk = (id: string, unitId: string, opts: {
   });
 
 const seedExercise = (id: string, status = 'Core') => testDb.insert(exerciseTable, { id, status });
+
+describe('courses.getBySlug', () => {
+  test('returns the course for a known slug', async () => {
+    await seedCourse('known');
+
+    const result = await caller.courses.getBySlug({ courseSlug: 'known' });
+
+    expect(result.course.slug).toBe('known');
+    expect(result.units).toEqual([]);
+  });
+
+  // db.get() throws on zero rows, which previously surfaced as a 500 instead of a 404 (gh-2882).
+  test('throws NOT_FOUND for an unknown slug', async () => {
+    const promise = caller.courses.getBySlug({ courseSlug: 'does-not-exist' });
+
+    await expect(promise).rejects.toBeInstanceOf(TRPCError);
+    await expect(promise).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
 
 // Cases mirror real course-builder data shapes (see gh-2544 prod inspection): most chunks carry no
 // estimatedTime; some chunkExercises reference inactive exercises; alignment/pandemics use
@@ -120,6 +140,11 @@ describe('courses.getCurriculumMetadata', () => {
         unitId: 'e-empty', unitNumber: '3', duration: null, exerciseCount: 0,
       },
     ]);
+  });
+
+  test('throws NOT_FOUND for an unknown slug', async () => {
+    await expect(caller.courses.getCurriculumMetadata({ courseSlug: 'does-not-exist' }))
+      .rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   test('a course with no active units returns an empty array', async () => {

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -65,12 +65,21 @@ export type CourseProgress = inferRouterOutputs<typeof coursesRouter>['getCourse
  * Fetches course data and its associated units by course slug.
  * This function is shared between the tRPC procedure below and getStaticProps/getServerSideProps when needed.
  */
-export async function getCourseData(courseSlug: string) {
-  const course = await db.getFirst(courseTable, { filter: { slug: courseSlug }, sortBy: 'slug' });
+export async function getCourseBySlugOrThrow(courseSlug: string) {
+  const courses = await db.scan(courseTable, { slug: courseSlug });
 
-  if (!course) {
+  if (courses.length === 0) {
     throw new TRPCError({ code: 'NOT_FOUND', message: `Course with slug "${courseSlug}" not found.` });
   }
+  if (courses.length > 1) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `Multiple courses found for slug "${courseSlug}"` });
+  }
+
+  return courses[0]!;
+}
+
+export async function getCourseData(courseSlug: string) {
+  const course = await getCourseBySlugOrThrow(courseSlug);
 
   // Get units for this course with active status, then sort by unit number
   const allUnitsWithAllChunks = await db.scan(unitTable, { courseSlug, unitStatus: 'Active' });
@@ -228,10 +237,7 @@ export const coursesRouter = router({
       courseSlug: z.string().min(1),
     }))
     .query(async ({ input: { courseSlug } }) => {
-      const course = await db.getFirst(courseTable, { filter: { slug: courseSlug }, sortBy: 'slug' });
-      if (!course) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: `Course "${courseSlug}" not found` });
-      }
+      await getCourseBySlugOrThrow(courseSlug);
 
       // 1. Fetch data
       const allUnits = await db.scan(unitTable, { courseSlug, unitStatus: 'Active' });

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -61,10 +61,6 @@ export type CourseAndUnits = inferRouterOutputs<typeof coursesRouter>['getBySlug
 export type CurriculumMetadata = inferRouterOutputs<typeof coursesRouter>['getCurriculumMetadata'];
 export type CourseProgress = inferRouterOutputs<typeof coursesRouter>['getCourseProgress'];
 
-/**
- * Fetches course data and its associated units by course slug.
- * This function is shared between the tRPC procedure below and getStaticProps/getServerSideProps when needed.
- */
 export async function getCourseBySlugOrThrow(courseSlug: string) {
   const courses = await db.scan(courseTable, { slug: courseSlug });
 
@@ -79,6 +75,10 @@ export async function getCourseBySlugOrThrow(courseSlug: string) {
   return courses[0]!;
 }
 
+/**
+ * Fetches course data and its associated units by course slug.
+ * This function is shared between the tRPC procedure below and getStaticProps/getServerSideProps when needed.
+ */
 export async function getCourseData(courseSlug: string) {
   const course = await getCourseBySlugOrThrow(courseSlug);
 

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -71,6 +71,7 @@ export async function getCourseBySlugOrThrow(courseSlug: string) {
   if (courses.length === 0) {
     throw new TRPCError({ code: 'NOT_FOUND', message: `Course with slug "${courseSlug}" not found.` });
   }
+
   if (courses.length > 1) {
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `Multiple courses found for slug "${courseSlug}"` });
   }

--- a/apps/website/src/server/routers/courses.ts
+++ b/apps/website/src/server/routers/courses.ts
@@ -66,7 +66,7 @@ export type CourseProgress = inferRouterOutputs<typeof coursesRouter>['getCourse
  * This function is shared between the tRPC procedure below and getStaticProps/getServerSideProps when needed.
  */
 export async function getCourseData(courseSlug: string) {
-  const course = await db.get(courseTable, { slug: courseSlug });
+  const course = await db.getFirst(courseTable, { filter: { slug: courseSlug }, sortBy: 'slug' });
 
   if (!course) {
     throw new TRPCError({ code: 'NOT_FOUND', message: `Course with slug "${courseSlug}" not found.` });
@@ -228,7 +228,7 @@ export const coursesRouter = router({
       courseSlug: z.string().min(1),
     }))
     .query(async ({ input: { courseSlug } }) => {
-      const course = await db.get(courseTable, { slug: courseSlug });
+      const course = await db.getFirst(courseTable, { filter: { slug: courseSlug }, sortBy: 'slug' });
       if (!course) {
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course "${courseSlug}" not found` });
       }

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -343,7 +343,7 @@ describe('exercises.getGroupExerciseResponses', () => {
     await expect(caller.exercises.getGroupExerciseResponses({
       courseSlug: 'nonexistent-course',
       exerciseId: 'ex-1',
-    })).rejects.toThrow('Course not found');
+    })).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   test('returns null when registration has roundStatus "Past"', async () => {

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -5,7 +5,6 @@ import {
   asc,
   COURSE_ROLE,
   courseRegistrationTable,
-  courseTable,
   desc,
   eq,
   exerciseResponsePgTable,
@@ -26,6 +25,7 @@ import {
   getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
 } from '../trpc';
 import { issueFoaiCertificateIfComplete } from './certificates';
+import { getCourseBySlugOrThrow } from './courses';
 
 export const exercisesRouter = router({
   getExercise: publicProcedure
@@ -121,13 +121,7 @@ export const exercisesRouter = router({
     }))
     .query(async ({ input, ctx }) => {
       // 1. Find course
-      const course = await db.getFirst(courseTable, {
-        filter: { slug: input.courseSlug },
-        sortBy: 'slug',
-      });
-      if (!course) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${input.courseSlug}` });
-      }
+      const course = await getCourseBySlugOrThrow(input.courseSlug);
 
       const user = await getUserFromAuthOrThrow(ctx.auth);
 

--- a/apps/website/src/server/routers/group-discussions.test.ts
+++ b/apps/website/src/server/routers/group-discussions.test.ts
@@ -26,6 +26,11 @@ beforeEach(async () => {
 });
 
 describe('groupDiscussions.getByCourseSlug', () => {
+  test('throws NOT_FOUND for an unknown course slug', async () => {
+    await expect(caller.groupDiscussions.getByCourseSlug({ courseSlug: 'does-not-exist' }))
+      .rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
   test('uses expected facilitator discussion ids when indirect round linkage misses the upcoming session', async () => {
     const futureStartTimeSecs = Math.floor(Date.now() / 1000) + (7 * 24 * 60 * 60);
     const futureEndTimeSecs = futureStartTimeSecs + (60 * 60);

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -91,7 +91,7 @@ export const groupDiscussionsRouter = router({
   getByCourseSlug: protectedProcedure
     .input(z.object({ courseSlug: z.string().min(1) }))
     .query(async ({ ctx, input: { courseSlug } }) => {
-      const course = await db.get(courseTable, { slug: courseSlug });
+      const course = await db.getFirst(courseTable, { filter: { slug: courseSlug }, sortBy: 'slug' });
       if (!course) {
         throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${courseSlug}` });
       }

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -1,7 +1,6 @@
 import {
   and,
   courseRegistrationTable,
-  courseTable,
   eq,
   groupDiscussionTable,
   groupTable,
@@ -20,6 +19,7 @@ import { TRPCError, type inferRouterOutputs } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
 import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
+import { getCourseBySlugOrThrow } from './courses';
 import {
   getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
 } from '../trpc';
@@ -91,10 +91,7 @@ export const groupDiscussionsRouter = router({
   getByCourseSlug: protectedProcedure
     .input(z.object({ courseSlug: z.string().min(1) }))
     .query(async ({ ctx, input: { courseSlug } }) => {
-      const course = await db.getFirst(courseTable, { filter: { slug: courseSlug }, sortBy: 'slug' });
-      if (!course) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: `Course not found for slug: ${courseSlug}` });
-      }
+      const course = await getCourseBySlugOrThrow(courseSlug);
 
       const user = await getUserFromAuthOrThrow(ctx.auth);
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Visiting a course URL with a slug that doesn't exist (e.g. /courses/does-not-exist) returned a 500 error page. It now returns a proper 404. Same for unit pages, the congratulations page, and the group discussions endpoint under an unknown course.

`db.get()` was throwing an `AirtableTsError` when no records match, so guards would fail and the error would propagate up as `INTERNAL_SERVER_ERROR` (tRPC) or unhandled SSR exception (pages), producing the 500s in Sentry.

## Changes

New helper - getCourseBySlugOrThrow(courseSlug) in courses.ts:

const courses = await db.scan(courseTable, { slug: courseSlug });
// 0 rows  → TRPCError NOT_FOUND        (the 404 this PR is about)
// >1 rows → TRPCError INTERNAL_SERVER_ERROR (data-integrity failure, loud)
// 1 row   → returned

Why scan + trichotomy rather than getFirst: slugs are hand-authored in Airtable with no uniqueness constraint anywhere in the sync path. getFirst silently returns an arbitrary row on a slug collision - a quiet wrong-data failure. The old db.get threw loudly on >1; the helper keeps that protection but as a typed TRPCError, so the 0-row case is distinguishable as a 404 instead of being swallowed into a generic 500.

Call sites moved to the helper (all previously had the dead-guard pattern or an equivalent silent-collision getFirst):

- courses.ts — getCourseData (feeds tRPC getBySlug + three pages' SSR/SSG)
- courses.ts — getCurriculumMetadata (existence check only; bare await)
- group-discussions.ts — getByCourseSlug
- exercises.ts — getGroupExerciseResponses

Intentionally untouched:
- index.tsx course page: bare catch-all already returns notFound: true.
- certificates.ts:88: looks up the course by id from an already-validated registration, so a throw there is genuinely exceptional, not a user-input 404.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2882
