### PR TITLE
[fix] Nav: keep hamburger menu until 1280px to stop link squeeze

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`AboutPage > should render correctly 1`] = `
               class="flex items-center"
             >
               <div
-                class="mobile-nav-links lg:hidden"
+                class="mobile-nav-links xl:hidden"
               >
                 <button
                   class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn text-white [&_svg]:text-white"
@@ -56,7 +56,7 @@ exports[`AboutPage > should render correctly 1`] = `
                   class="mobile-nav-links__drawer absolute top-[60px] lg:top-[76px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-all duration-300 ease-in-out bg-white max-h-0 opacity-0 pb-0 pointer-events-none overflow-hidden"
                 >
                   <div
-                    class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
+                    class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 xl:hidden"
                     role="presentation"
                   >
                     <div
@@ -302,7 +302,7 @@ exports[`AboutPage > should render correctly 1`] = `
               class="flex items-center gap-12"
             >
               <div
-                class="nav-links flex gap-9 [&>*]:w-fit hidden lg:flex"
+                class="nav-links flex gap-9 [&>*]:w-fit hidden xl:flex"
               >
                 <div
                   class="nav-dropdown"

--- a/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/join-us.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
               class="flex items-center"
             >
               <div
-                class="mobile-nav-links lg:hidden"
+                class="mobile-nav-links xl:hidden"
               >
                 <button
                   class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn text-white [&_svg]:text-white"
@@ -56,7 +56,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
                   class="mobile-nav-links__drawer absolute top-[60px] lg:top-[76px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-all duration-300 ease-in-out bg-white max-h-0 opacity-0 pb-0 pointer-events-none overflow-hidden"
                 >
                   <div
-                    class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
+                    class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 xl:hidden"
                     role="presentation"
                   >
                     <div
@@ -302,7 +302,7 @@ exports[`JoinUsPage > should render correctly 1`] = `
               class="flex items-center gap-12"
             >
               <div
-                class="nav-links flex gap-9 [&>*]:w-fit hidden lg:flex"
+                class="nav-links flex gap-9 [&>*]:w-fit hidden xl:flex"
               >
                 <div
                   class="nav-dropdown"

--- a/apps/website/src/components/Nav/Nav.tsx
+++ b/apps/website/src/components/Nav/Nav.tsx
@@ -38,7 +38,7 @@ export const Nav: React.FC<NavProps> = ({ variant: variantProp }) => {
 
   // Handle viewport breakpoint changes to reset dropdown states on mobile/desktop transitions
   useEffect(() => {
-    const mediaQuery = window.matchMedia('(min-width: 1024px)');
+    const mediaQuery = window.matchMedia('(min-width: 1280px)');
 
     const handleBreakpointChange = () => {
       setExpandedSections({

--- a/apps/website/src/components/Nav/_DesktopNavLinks.tsx
+++ b/apps/website/src/components/Nav/_DesktopNavLinks.tsx
@@ -15,7 +15,7 @@ export const DesktopNavLinks: React.FC<{
       expandedSections={expandedSections}
       updateExpandedSections={updateExpandedSections}
       onColoredBackground={onColoredBackground}
-      className="hidden lg:flex"
+      className="hidden xl:flex"
     />
   );
 };

--- a/apps/website/src/components/Nav/_MobileNavLinks.tsx
+++ b/apps/website/src/components/Nav/_MobileNavLinks.tsx
@@ -54,7 +54,7 @@ export const MobileNavLinks: React.FC<{
   };
 
   return (
-    <div ref={mobileNavRef} className={`${MOBILE_NAV_CLASS} lg:hidden`}>
+    <div ref={mobileNavRef} className={`${MOBILE_NAV_CLASS} xl:hidden`}>
       <IconButton
         open={expandedSections.mobileNav}
         Icon={<HamburgerIcon />}
@@ -66,7 +66,7 @@ export const MobileNavLinks: React.FC<{
       />
       <div className={clsx('mobile-nav-links__drawer', DRAWER_CLASSES(expandedSections.mobileNav))}>
         <div
-          className="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
+          className="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 xl:hidden"
           onClick={(e) => {
             // Close mobile nav when any link is clicked
             if ((e.target as HTMLElement).tagName === 'A') {

--- a/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/apps/website/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Nav > renders with courses 1`] = `
           class="flex items-center"
         >
           <div
-            class="mobile-nav-links lg:hidden"
+            class="mobile-nav-links xl:hidden"
           >
             <button
               class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn"
@@ -52,7 +52,7 @@ exports[`Nav > renders with courses 1`] = `
               class="mobile-nav-links__drawer absolute top-[60px] lg:top-[76px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-all duration-300 ease-in-out bg-white max-h-0 opacity-0 pb-0 pointer-events-none overflow-hidden"
             >
               <div
-                class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
+                class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 xl:hidden"
                 role="presentation"
               >
                 <div
@@ -318,7 +318,7 @@ exports[`Nav > renders with courses 1`] = `
           class="flex items-center gap-12"
         >
           <div
-            class="nav-links flex gap-9 [&>*]:w-fit hidden lg:flex"
+            class="nav-links flex gap-9 [&>*]:w-fit hidden xl:flex"
           >
             <div
               class="nav-dropdown"

--- a/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`HomeHeroContent > renders as expected 1`] = `
             class="flex items-center"
           >
             <div
-              class="mobile-nav-links lg:hidden"
+              class="mobile-nav-links xl:hidden"
             >
               <button
                 class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn text-white [&_svg]:text-white"
@@ -55,7 +55,7 @@ exports[`HomeHeroContent > renders as expected 1`] = `
                 class="mobile-nav-links__drawer absolute top-[60px] lg:top-[76px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-all duration-300 ease-in-out bg-white max-h-0 opacity-0 pb-0 pointer-events-none overflow-hidden"
               >
                 <div
-                  class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
+                  class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 xl:hidden"
                   role="presentation"
                 >
                   <div
@@ -275,7 +275,7 @@ exports[`HomeHeroContent > renders as expected 1`] = `
             class="flex items-center gap-12"
           >
             <div
-              class="nav-links flex gap-9 [&>*]:w-fit hidden lg:flex"
+              class="nav-links flex gap-9 [&>*]:w-fit hidden xl:flex"
             >
               <div
                 class="nav-dropdown"

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             class="flex items-center"
           >
             <div
-              class="mobile-nav-links lg:hidden"
+              class="mobile-nav-links xl:hidden"
             >
               <button
                 class="icon-button size-[32px] flex items-center justify-center hover:cursor-pointer mobile-nav-links__btn text-white [&_svg]:text-white"
@@ -119,7 +119,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
                 class="mobile-nav-links__drawer absolute top-[60px] lg:top-[76px] left-0 w-full lg:-left-spacing-x lg:w-[calc(100%+(var(--spacing-x)*2))] px-spacing-x transition-all duration-300 ease-in-out bg-white max-h-0 opacity-0 pb-0 pointer-events-none overflow-hidden"
               >
                 <div
-                  class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 lg:hidden"
+                  class="mobile-nav-links__drawer-content flex flex-col grow font-medium pb-8 pt-2 xl:hidden"
                   role="presentation"
                 >
                   <div
@@ -339,7 +339,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
             class="flex items-center gap-12"
           >
             <div
-              class="nav-links flex gap-9 [&>*]:w-fit hidden lg:flex"
+              class="nav-links flex gap-9 [&>*]:w-fit hidden xl:flex"
             >
               <div
                 class="nav-dropdown"


### PR DESCRIPTION
## Summary

- The desktop nav switches on at `lg` (1024px), but its contents (logo + 6 links + CTAs) need ~1064px and only ~928px is available at that width — so between 1024px and ~1170px the links got crushed and "Join us" wrapped onto two lines. Likely appeared when the Programs dropdown was added.
- Fix: keep the hamburger menu until `xl` (1280px), where the full nav fits with ~56px slack. Adding future nav items won't silently re-break the tablet band.
- Changes: `_DesktopNavLinks.tsx` (`lg:flex` → `xl:flex`), `_MobileNavLinks.tsx` (`lg:hidden` → `xl:hidden` ×2), `Nav.tsx` (dropdown-reset media query 1024px → 1280px), plus 5 snapshot updates containing only these class swaps.

Note: with any nav dropdown/drawer open, the white sheet extends ~80px past the viewport and the page can be nudged sideways. This is identical on production today (shared `DRAWER_CLASSES` behaviour), so it's intentionally left out of scope here.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (`--max-warnings=0`)
- [x] `npx vitest run` ×2 — 1135 passed (131 files), snapshot diffs are purely `lg:` → `xl:`
- [x] Playwright: hamburger + working drawer at 1100px/1150px, full single-line nav at 1280px, homepage (transparent nav) verified
- [x] Eyeballed in local dev by Li-Lian

## Screenshots
<img width="1150" height="800" alt="nav-after-1150" src="https://github.com/user-attachments/assets/838961a1-95f4-4c37-9892-4c5ae65b8f9e" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)