### PR TITLE
Count autosaved free-text answers toward FoAI certificate eligibility

### DIFF
--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -440,4 +440,50 @@ describe('issueFoaiCertificateIfComplete', () => {
       .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
     expect(selfServe?.certificateId).toBe('ss-1');
   });
+
+  test('counts an autosaved non-empty free-text response as complete even without completedAt', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-1', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-text', courseId: FOAI_COURSE_ID, status: 'Core', type: 'Free text', title: 'Text', exerciseNumber: '1',
+    });
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'resp-text', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-text', response: 'my typed answer', completedAt: null,
+    });
+
+    expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(true);
+
+    const [selfServe] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
+      .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-1'));
+    expect(selfServe?.certificateId).toBe('ss-1');
+  });
+
+  test('does not count a whitespace-only free-text response without completedAt', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-1', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-text', courseId: FOAI_COURSE_ID, status: 'Core', type: 'Free text', title: 'Text', exerciseNumber: '1',
+    });
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'resp-text', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-text', response: '  \n ', completedAt: null,
+    });
+
+    expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(false);
+  });
+
+  test('does not count a multiple-choice response without completedAt (wrong answer)', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-1', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-mc', courseId: FOAI_COURSE_ID, status: 'Core', type: 'Multiple choice', title: 'MC', exerciseNumber: '1',
+    });
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'resp-mc', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-mc', response: 'Wrong option', completedAt: null,
+    });
+
+    expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(false);
+  });
 });

--- a/apps/website/src/server/routers/certificates.test.ts
+++ b/apps/website/src/server/routers/certificates.test.ts
@@ -473,6 +473,25 @@ describe('issueFoaiCertificateIfComplete', () => {
     expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(false);
   });
 
+  test('judges by the latest response row when duplicates exist: cleared latest answer blocks the certificate', async () => {
+    await testDb.insert(selfServeCourseRegistrationTable, {
+      id: 'ss-1', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-text', courseId: FOAI_COURSE_ID, status: 'Core', type: 'Free text', title: 'Text', exerciseNumber: '1',
+    });
+    // Older duplicate row: substantive answer, explicitly completed
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'resp-old', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-text', response: 'my typed answer', completedAt: '2026-01-01T00:00:00.000Z', createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    // Latest row: answer cleared, not completed
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'resp-new', userId: [FOAI_USER_ID], exerciseId: 'foai-ex-text', response: '', completedAt: null, createdAt: '2026-01-02T00:00:00.000Z',
+    });
+
+    expect(await issueFoaiCertificateIfComplete(FOAI_USER_ID)).toBe(false);
+  });
+
   test('does not count a multiple-choice response without completedAt (wrong answer)', async () => {
     await testDb.insert(selfServeCourseRegistrationTable, {
       id: 'ss-1', userId: FOAI_USER_ID, courseId: FOAI_COURSE_ID, createdAt: '2026-01-01T00:00:00.000Z',

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -4,6 +4,7 @@ import {
   COURSE_ROLE,
   courseRegistrationTable,
   courseTable,
+  desc,
   eq,
   exerciseResponsePgTable,
   exerciseTable,
@@ -36,25 +37,33 @@ async function areAllFoaiExercisesComplete(userId: string): Promise<boolean> {
   }
 
   // Scope the response scan to FoAI exercises so we don't pull every response this user has ever
-  // submitted (across all courses) just to check FoAI completion.
-  const exerciseResponses = await db.pg
-    .select()
+  // submitted (across all courses) just to check FoAI completion. Concurrent autosaves can leave
+  // duplicate rows per exercise, so take only the latest row per exercise — the one
+  // getExerciseResponse shows the learner.
+  const latestResponses = await db.pg
+    .selectDistinctOn([exerciseResponsePgTable.pg.exerciseId])
     .from(exerciseResponsePgTable.pg)
-    .where(and(
-      arrayContains(exerciseResponsePgTable.pg.userId, [userId]),
-      inArray(exerciseResponsePgTable.pg.exerciseId, requiredExercises.map((e) => e.id)),
-    ));
+    .where(
+      and(
+        arrayContains(exerciseResponsePgTable.pg.userId, [userId]),
+        inArray(
+          exerciseResponsePgTable.pg.exerciseId,
+          requiredExercises.map((e) => e.id),
+        ),
+      ),
+    )
+    .orderBy(exerciseResponsePgTable.pg.exerciseId, desc(exerciseResponsePgTable.pg.createdAt));
+
+  const responseByExerciseId = new Map(latestResponses.map((resp) => [resp.exerciseId, resp]));
 
   // Free-text answers autosave with completedAt null unless the learner clicks "Complete", so a
   // typed answer counts for the certificate even without the explicit click.
-  const freeTextExerciseIds = new Set(requiredExercises
-    .filter((exercise) => exercise.type === 'Free text')
-    .map((exercise) => exercise.id));
-  const completedExerciseIds = new Set(exerciseResponses
-    .filter((resp) => resp.completedAt != null
-      || (freeTextExerciseIds.has(resp.exerciseId) && resp.response.trim().length > 0))
-    .map((resp) => resp.exerciseId));
-  return requiredExercises.every((exercise) => completedExerciseIds.has(exercise.id));
+  return requiredExercises.every((exercise) => {
+    const resp = responseByExerciseId.get(exercise.id);
+    return (
+      resp != null && (resp.completedAt != null || (exercise.type === 'Free text' && resp.response.trim().length > 0))
+    );
+  });
 }
 
 export async function issueFoaiCertificateIfComplete(userId: string): Promise<boolean> {

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -25,7 +25,7 @@ import { hasUpcomingRoundsForCourseId } from './course-rounds';
 
 async function areAllFoaiExercisesComplete(userId: string): Promise<boolean> {
   const requiredExercises = await db.pg
-    .select({ id: exerciseTable.pg.id })
+    .select({ id: exerciseTable.pg.id, type: exerciseTable.pg.type })
     .from(exerciseTable.pg)
     .where(and(
       eq(exerciseTable.pg.courseId, FOAI_COURSE_ID),
@@ -45,8 +45,14 @@ async function areAllFoaiExercisesComplete(userId: string): Promise<boolean> {
       inArray(exerciseResponsePgTable.pg.exerciseId, requiredExercises.map((e) => e.id)),
     ));
 
+  // Free-text answers autosave with completedAt null unless the learner clicks "Complete", so a
+  // typed answer counts for the certificate even without the explicit click.
+  const freeTextExerciseIds = new Set(requiredExercises
+    .filter((exercise) => exercise.type === 'Free text')
+    .map((exercise) => exercise.id));
   const completedExerciseIds = new Set(exerciseResponses
-    .filter((resp) => resp.completedAt != null)
+    .filter((resp) => resp.completedAt != null
+      || (freeTextExerciseIds.has(resp.exerciseId) && resp.response.trim().length > 0))
     .map((resp) => resp.exerciseId));
   return requiredExercises.every((exercise) => completedExerciseIds.has(exercise.id));
 }

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -81,7 +81,11 @@ export async function issueFoaiCertificateIfComplete(userId: string): Promise<bo
   const certificateCreatedAt = Math.floor(Date.now() / 1000);
   const certificateId = selfServeRegistration.id;
 
-  await db.update(selfServeCourseRegistrationTable, { id: selfServeRegistration.id, certificateId, certificateCreatedAt });
+  await db.update(selfServeCourseRegistrationTable, {
+    id: selfServeRegistration.id,
+    certificateId,
+    certificateCreatedAt,
+  });
 
   return true;
 }
@@ -89,7 +93,10 @@ export async function issueFoaiCertificateIfComplete(userId: string): Promise<bo
 export type CertificateData = inferRouterOutputs<AppRouter>['certificates']['getStatus'];
 
 export async function getCertificateData(certificateId: string) {
-  const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' });
+  const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
+    filter: { certificateId },
+    sortBy: 'createdAt',
+  });
   const facilitatedRegistration = await db.getFirst(courseRegistrationTable, { filter: { certificateId } });
 
   const registration = selfServeRegistration ?? facilitatedRegistration;
@@ -162,7 +169,10 @@ export const certificatesRouter = router({
     .query(async ({ ctx, input: { certificateId } }) => {
       const user = await getUserFromAuthOrThrow(ctx.auth);
 
-      const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, { filter: { certificateId }, sortBy: 'createdAt' });
+      const selfServeRegistration = await db.getFirst(selfServeCourseRegistrationTable, {
+        filter: { certificateId },
+        sortBy: 'createdAt',
+      });
       const facilitatedRegistration = await db.getFirst(courseRegistrationTable, { filter: { certificateId } });
 
       const registration = selfServeRegistration ?? facilitatedRegistration;
@@ -241,8 +251,7 @@ export const certificatesRouter = router({
         : null;
       const sevenDaysFromNow = Date.now() + 7 * ONE_DAY_MS;
       const isLastDiscussionSoonOrPassed
-        = round?.lastDiscussionDate != null
-          && new Date(round.lastDiscussionDate).getTime() <= sevenDaysFromNow;
+        = round?.lastDiscussionDate != null && new Date(round.lastDiscussionDate).getTime() <= sevenDaysFromNow;
 
       if (!hasAttendedEnough) {
         return {

--- a/apps/website/src/server/routers/certificates.ts
+++ b/apps/website/src/server/routers/certificates.ts
@@ -43,15 +43,13 @@ async function areAllFoaiExercisesComplete(userId: string): Promise<boolean> {
   const latestResponses = await db.pg
     .selectDistinctOn([exerciseResponsePgTable.pg.exerciseId])
     .from(exerciseResponsePgTable.pg)
-    .where(
-      and(
-        arrayContains(exerciseResponsePgTable.pg.userId, [userId]),
-        inArray(
-          exerciseResponsePgTable.pg.exerciseId,
-          requiredExercises.map((e) => e.id),
-        ),
+    .where(and(
+      arrayContains(exerciseResponsePgTable.pg.userId, [userId]),
+      inArray(
+        exerciseResponsePgTable.pg.exerciseId,
+        requiredExercises.map((e) => e.id),
       ),
-    )
+    ))
     .orderBy(exerciseResponsePgTable.pg.exerciseId, desc(exerciseResponsePgTable.pg.createdAt));
 
   const responseByExerciseId = new Map(latestResponses.map((resp) => [resp.exerciseId, resp]));

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -222,6 +222,28 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
     expect(reg?.certificateCreatedAt).toBeGreaterThanOrEqual(before);
   });
 
+  test('auto-issues on an autosave (completed undefined) when the typed free-text answer is the last missing piece', async () => {
+    await seedFoaiRegistration();
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
+    });
+    await testDb.insert(exerciseTable, {
+      id: 'foai-ex-2', courseId: FOAI_COURSE_ID, status: 'Core', type: 'Free text', title: 'Ex 2', exerciseNumber: '2',
+    });
+    await testDb.pg.insert(exerciseResponsePgTable.pg).values({
+      id: 'resp-1', userId: ['test-user'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+    });
+
+    const result = await caller.exercises.saveExerciseResponse({
+      exerciseId: 'foai-ex-2',
+      response: 'typed but never marked complete',
+    });
+
+    expect(result.certificateIssued).toBe(true);
+    const reg = await getSelfServeFoai();
+    expect(reg?.certificateId).toBe('ss-foai');
+  });
+
   test('does not auto-issue when other FOAI exercises remain incomplete', async () => {
     await seedFoaiRegistration();
     await testDb.insert(exerciseTable, {

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -240,6 +240,7 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
     });
 
     expect(result.certificateIssued).toBe(true);
+    expect(result.completedAt).toBeNull(); // Autosave stays incomplete
     const reg = await getSelfServeFoai();
     expect(reg?.certificateId).toBe('ss-foai');
   });

--- a/apps/website/src/server/routers/exercises.test.ts
+++ b/apps/website/src/server/routers/exercises.test.ts
@@ -17,7 +17,8 @@ import {
   createCaller,
   seedLoggedInUser,
   setupTestDb,
-  testAuthContextLoggedIn, testDb,
+  testAuthContextLoggedIn,
+  testDb,
 } from '../../__tests__/dbTestUtils';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 
@@ -191,7 +192,9 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
   }
 
   const getSelfServeFoai = async () => {
-    const [row] = await testDb.pg.select().from(selfServeCourseRegistrationTable.pg)
+    const [row] = await testDb.pg
+      .select()
+      .from(selfServeCourseRegistrationTable.pg)
       .where(eq(selfServeCourseRegistrationTable.pg.id, 'ss-foai'));
     return row;
   };
@@ -199,13 +202,25 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
   test('auto-issues a certificate when the final FOAI exercise is completed', async () => {
     await seedFoaiRegistration();
     await testDb.insert(exerciseTable, {
-      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Reading reflection', exerciseNumber: '1',
+      id: 'foai-ex-1',
+      courseId: FOAI_COURSE_ID,
+      status: 'Core',
+      title: 'Reading reflection',
+      exerciseNumber: '1',
     });
     await testDb.insert(exerciseTable, {
-      id: 'foai-ex-2', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Action plan', exerciseNumber: '2',
+      id: 'foai-ex-2',
+      courseId: FOAI_COURSE_ID,
+      status: 'Core',
+      title: 'Action plan',
+      exerciseNumber: '2',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', userId: ['test-user'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1',
+      userId: ['test-user'],
+      exerciseId: 'foai-ex-1',
+      response: 'done',
+      completedAt: '2026-01-01',
     });
 
     const before = Math.floor(Date.now() / 1000);
@@ -225,13 +240,26 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
   test('auto-issues on an autosave (completed undefined) when the typed free-text answer is the last missing piece', async () => {
     await seedFoaiRegistration();
     await testDb.insert(exerciseTable, {
-      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
+      id: 'foai-ex-1',
+      courseId: FOAI_COURSE_ID,
+      status: 'Core',
+      title: 'Ex 1',
+      exerciseNumber: '1',
     });
     await testDb.insert(exerciseTable, {
-      id: 'foai-ex-2', courseId: FOAI_COURSE_ID, status: 'Core', type: 'Free text', title: 'Ex 2', exerciseNumber: '2',
+      id: 'foai-ex-2',
+      courseId: FOAI_COURSE_ID,
+      status: 'Core',
+      type: 'Free text',
+      title: 'Ex 2',
+      exerciseNumber: '2',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', userId: ['test-user'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1',
+      userId: ['test-user'],
+      exerciseId: 'foai-ex-1',
+      response: 'done',
+      completedAt: '2026-01-01',
     });
 
     const result = await caller.exercises.saveExerciseResponse({
@@ -248,10 +276,18 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
   test('does not auto-issue when other FOAI exercises remain incomplete', async () => {
     await seedFoaiRegistration();
     await testDb.insert(exerciseTable, {
-      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
+      id: 'foai-ex-1',
+      courseId: FOAI_COURSE_ID,
+      status: 'Core',
+      title: 'Ex 1',
+      exerciseNumber: '1',
     });
     await testDb.insert(exerciseTable, {
-      id: 'foai-ex-2', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 2', exerciseNumber: '2',
+      id: 'foai-ex-2',
+      courseId: FOAI_COURSE_ID,
+      status: 'Core',
+      title: 'Ex 2',
+      exerciseNumber: '2',
     });
 
     const result = await caller.exercises.saveExerciseResponse({
@@ -267,10 +303,18 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
 
   test('does not auto-issue for non-FOAI courses', async () => {
     await testDb.insert(courseRegistrationTable, {
-      id: 'reg-other', email: CALLER_EMAIL, userId: 'test-user', courseId: 'rec-other', decision: 'Accept',
+      id: 'reg-other',
+      email: CALLER_EMAIL,
+      userId: 'test-user',
+      courseId: 'rec-other',
+      decision: 'Accept',
     });
     await testDb.insert(exerciseTable, {
-      id: 'other-ex-1', courseId: 'rec-other', status: 'Core', title: 'Other', exerciseNumber: '1',
+      id: 'other-ex-1',
+      courseId: 'rec-other',
+      status: 'Core',
+      title: 'Other',
+      exerciseNumber: '1',
     });
 
     const result = await caller.exercises.saveExerciseResponse({
@@ -293,7 +337,11 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
       certificateCreatedAt: 1700000000,
     });
     await testDb.insert(exerciseTable, {
-      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
+      id: 'foai-ex-1',
+      courseId: FOAI_COURSE_ID,
+      status: 'Core',
+      title: 'Ex 1',
+      exerciseNumber: '1',
     });
 
     const result = await caller.exercises.saveExerciseResponse({
@@ -310,10 +358,18 @@ describe('exercises.saveExerciseResponse — FOAI auto-certificate', () => {
   test('does not auto-issue when completed is false (un-marking)', async () => {
     await seedFoaiRegistration();
     await testDb.insert(exerciseTable, {
-      id: 'foai-ex-1', courseId: FOAI_COURSE_ID, status: 'Core', title: 'Ex 1', exerciseNumber: '1',
+      id: 'foai-ex-1',
+      courseId: FOAI_COURSE_ID,
+      status: 'Core',
+      title: 'Ex 1',
+      exerciseNumber: '1',
     });
     await testDb.pg.insert(exerciseResponsePgTable.pg).values({
-      id: 'resp-1', userId: ['test-user'], exerciseId: 'foai-ex-1', response: 'done', completedAt: '2026-01-01',
+      id: 'resp-1',
+      userId: ['test-user'],
+      exerciseId: 'foai-ex-1',
+      response: 'done',
+      completedAt: '2026-01-01',
     });
 
     const result = await caller.exercises.saveExerciseResponse({
@@ -336,7 +392,10 @@ describe('exercises.getExerciseResponse', () => {
 
   test('returns response scoped to the current user', async () => {
     await testDb.insert(userTable, {
-      id: 'user-other', email: 'other@example.com', name: 'Other User', keycloakIdentifier: 'other-sub',
+      id: 'user-other',
+      email: 'other@example.com',
+      name: 'Other User',
+      keycloakIdentifier: 'other-sub',
     });
 
     await caller.exercises.saveExerciseResponse({
@@ -465,7 +524,9 @@ describe('exercises.getGroupExerciseResponses', () => {
       role: 'Facilitator',
     });
     await testDb.insert(meetPersonTable, {
-      id: 'meet-participant', userId: 'up-user', name: 'Alice',
+      id: 'meet-participant',
+      userId: 'up-user',
+      name: 'Alice',
     });
     await testDb.insert(groupTable, {
       id: 'group-1',
@@ -609,9 +670,15 @@ describe('exercises.getGroupExerciseResponses', () => {
   });
 
   // Registration + facilitator meetPerson + a one-participant group, suffixed so multiple rounds can coexist
-  async function seedFacilitatorRound(suffix: string, {
-    roundStatus = 'Active', roundTitle, roundStartDate, groupNumber = 1,
-  }: { roundStatus?: string; roundTitle?: string; roundStartDate?: string; groupNumber?: number } = {}) {
+  async function seedFacilitatorRound(
+    suffix: string,
+    {
+      roundStatus = 'Active',
+      roundTitle,
+      roundStartDate,
+      groupNumber = 1,
+    }: { roundStatus?: string; roundTitle?: string; roundStartDate?: string; groupNumber?: number } = {},
+  ) {
     await testDb.insert(courseRegistrationTable, {
       id: `reg-${suffix}`,
       email: CALLER_EMAIL,
@@ -632,7 +699,9 @@ describe('exercises.getGroupExerciseResponses', () => {
       round: `round-${suffix}`,
     });
     await testDb.insert(meetPersonTable, {
-      id: `meet-participant-${suffix}`, userId: `user-${suffix}`, name: `Participant ${suffix}`,
+      id: `meet-participant-${suffix}`,
+      userId: `user-${suffix}`,
+      name: `Participant ${suffix}`,
     });
     await testDb.insert(groupTable, {
       id: `group-${suffix}`,
@@ -646,8 +715,14 @@ describe('exercises.getGroupExerciseResponses', () => {
 
   test('returns groups from all active rounds, newest round first by start date', async () => {
     await seedCourse();
-    await seedFacilitatorRound('old', { roundTitle: 'Course (2026 Jun W23) - Part-time', roundStartDate: '2026-06-01T00:00:00.000Z' });
-    await seedFacilitatorRound('new', { roundTitle: 'Course (2026 Jul W28) - Part-time', roundStartDate: '2026-07-06T00:00:00.000Z' });
+    await seedFacilitatorRound('old', {
+      roundTitle: 'Course (2026 Jun W23) - Part-time',
+      roundStartDate: '2026-06-01T00:00:00.000Z',
+    });
+    await seedFacilitatorRound('new', {
+      roundTitle: 'Course (2026 Jul W28) - Part-time',
+      roundStartDate: '2026-07-06T00:00:00.000Z',
+    });
 
     const result = await caller.exercises.getGroupExerciseResponses({
       courseSlug: 'test-course',
@@ -655,7 +730,10 @@ describe('exercises.getGroupExerciseResponses', () => {
     });
 
     expect(result!.groups.map((g) => g.id)).toEqual(['group-new', 'group-old']);
-    expect(result!.groups.map((g) => g.roundName)).toEqual(['Course (2026 Jul W28) - Part-time', 'Course (2026 Jun W23) - Part-time']);
+    expect(result!.groups.map((g) => g.roundName)).toEqual([
+      'Course (2026 Jul W28) - Part-time',
+      'Course (2026 Jun W23) - Part-time',
+    ]);
     expect(result!.groups.map((g) => g.groupNumber)).toEqual([1, 1]);
   });
 
@@ -677,10 +755,18 @@ describe('exercises.getGroupExerciseResponses', () => {
     await seedCourse();
     await seedFacilitatorRound('r1', { groupNumber: 2 });
     await testDb.insert(groupTable, {
-      id: 'group-b', round: 'round-r1', groupNumber: 10, facilitator: ['meet-facilitator-r1'], participants: ['meet-participant-r1'],
+      id: 'group-b',
+      round: 'round-r1',
+      groupNumber: 10,
+      facilitator: ['meet-facilitator-r1'],
+      participants: ['meet-participant-r1'],
     });
     await testDb.insert(groupTable, {
-      id: 'group-a', round: 'round-r1', groupNumber: 1, facilitator: ['meet-facilitator-r1'], participants: ['meet-participant-r1'],
+      id: 'group-a',
+      round: 'round-r1',
+      groupNumber: 1,
+      facilitator: ['meet-facilitator-r1'],
+      participants: ['meet-participant-r1'],
     });
 
     const result = await caller.exercises.getGroupExerciseResponses({

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -106,11 +106,12 @@ export const exercisesRouter = router({
           })
           .returning();
 
-      if (!exerciseResponse) throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to save exercise response' });
+      if (!exerciseResponse) {
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to save exercise response' });
+      }
 
-      const certificateIssued = exercise?.courseId === FOAI_COURSE_ID
-        ? await issueFoaiCertificateIfComplete(user.id)
-        : false;
+      const certificateIssued
+        = exercise?.courseId === FOAI_COURSE_ID ? await issueFoaiCertificateIfComplete(user.id) : false;
 
       return { ...exerciseResponse, certificateIssued };
     }),
@@ -153,7 +154,10 @@ export const exercisesRouter = router({
         .select({ id: meetPersonTable.pg.id })
         .from(meetPersonTable.pg)
         .where(and(
-          inArray(meetPersonTable.pg.applicationsBaseRecordId, courseRegistrations.map((r) => r.id)),
+          inArray(
+            meetPersonTable.pg.applicationsBaseRecordId,
+            courseRegistrations.map((r) => r.id),
+          ),
           eq(meetPersonTable.pg.role, COURSE_ROLE.FACILITATOR),
         ));
       if (facilitatorMeetPersons.length === 0) {
@@ -182,17 +186,18 @@ export const exercisesRouter = router({
       }
 
       const roundIds = [...new Set(groups.map((g) => g.round).filter((r): r is string => r != null))];
-      const rounds = roundIds.length > 0
-        ? await db.pg
-          .select({ id: roundTable.pg.id, title: roundTable.pg.title, startDate: roundTable.pg.startDate })
-          .from(roundTable.pg)
-          .where(inArray(roundTable.pg.id, roundIds))
-        : [];
+      const rounds
+        = roundIds.length > 0
+          ? await db.pg
+            .select({ id: roundTable.pg.id, title: roundTable.pg.title, startDate: roundTable.pg.startDate })
+            .from(roundTable.pg)
+            .where(inArray(roundTable.pg.id, roundIds))
+          : [];
       const roundById = new Map(rounds.map((r) => [r.id, r]));
 
       // Newest round first (groups of the same round contiguous, even if two rounds share a start
       // date); the SQL groupNumber ordering is the stable within-round tiebreak
-      const startDateOf = (round: string | null) => (round ? roundById.get(round)?.startDate ?? '' : '');
+      const startDateOf = (round: string | null) => (round ? (roundById.get(round)?.startDate ?? '') : '');
       const sortedGroups = [...groups].sort((a, b) => {
         const byStartDate = startDateOf(b.round).localeCompare(startDateOf(a.round));
         if (byStartDate !== 0) return byStartDate;
@@ -255,7 +260,7 @@ export const exercisesRouter = router({
           id: g.id,
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           name: g.groupName || 'Unnamed group',
-          roundName: g.round ? roundById.get(g.round)?.title ?? null : null,
+          roundName: g.round ? (roundById.get(g.round)?.title ?? null) : null,
           groupNumber: g.groupNumber,
           totalParticipants: groupParticipantIds.length,
           responses,

--- a/apps/website/src/server/routers/exercises.ts
+++ b/apps/website/src/server/routers/exercises.ts
@@ -66,10 +66,11 @@ export const exercisesRouter = router({
         completedAt = null;
       } // else undefined = "don't change"
 
+      // Fetch the exercise on every save, not just explicit completions: a typed free-text answer
+      // alone can satisfy FoAI certificate eligibility, so autosaves (completed undefined) must
+      // also attempt issuance.
       const [exercise, user] = await Promise.all([
-        input.completed === true
-          ? db.getFirst(exerciseTable, { filter: { id: input.exerciseId }, sortBy: 'id' })
-          : Promise.resolve(undefined),
+        db.getFirst(exerciseTable, { filter: { id: input.exerciseId }, sortBy: 'id' }),
         getUserFromAuthOrThrow(ctx.auth),
       ]);
 


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Learners who typed answers to all FoAI core exercises but never clicked the "Complete" button were silently blocked from receiving their certificate. After this change, a typed (non-empty) free-text answer counts toward certificate eligibility, whether or not the learner clicked 'Complete'.

Changes:

`areAllFoaiExercisesComplete` in `certificates.ts` previously required `completedAt != null` on every core exercise response. They now check for this or that there is a response at all.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2495
