### PR TITLE
Delete dead code after Dewi

### DIFF
--- a/apps/website/src/pages/grants/agi-strategy-fund.tsx
+++ b/apps/website/src/pages/grants/agi-strategy-fund.tsx
@@ -1,1 +1,0 @@
-export { default } from '../grants';

--- a/apps/website/src/pages/grants/bridge.tsx
+++ b/apps/website/src/pages/grants/bridge.tsx
@@ -1,1 +1,0 @@
-export { default } from '../grants';

--- a/apps/website/src/pages/programs/career-transition-grant.tsx
+++ b/apps/website/src/pages/programs/career-transition-grant.tsx
@@ -1,1 +1,0 @@
-export { default, getStaticProps } from '../grants/career-transition';

--- a/apps/website/src/pages/programs/rapid-grants.tsx
+++ b/apps/website/src/pages/programs/rapid-grants.tsx
@@ -1,1 +1,0 @@
-export { default, getStaticProps } from '../grants/rapid';


### PR DESCRIPTION
# Description

This PR removes four redundant Next.js page wrappers left after PR #2891 moved the grant pages and added permanent redirects.

The deleted files are:

`apps/website/src/pages/grants/agi-strategy-fund.tsx`

`apps/website/src/pages/grants/bridge.tsx`

`apps/website/src/pages/programs/career-transition-grant.tsx`

`apps/website/src/pages/programs/rapid-grants.tsx`

The redirects remain in `apps/website/next.config.js`. The old URLs still redirect to the canonical pages, so this does not change the user experience. No source or test files import the deleted wrappers.

## Issue

Related to PR #2891. No separate issue is linked.

## Developer checklist

- [x] Front end code follows the [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist). No rendered front end code changed.
- [x] Considered having snapshot tests and/or happy path functional tests. Existing route tests and the full test suite pass. No new test is needed for deleting unused wrappers.
- [x] Considered adding Storybook stories. No visual component changed, so a new story is not needed.

## Screenshot

This change does not change the rendered pages, so screenshots are not applicable.

| 📸 | Before | After |
|---------|---|---|
| 📱 | Not applicable | Not applicable |
| 🖥️ | Not applicable | Not applicable |
