### PR TITLE
[fix] Refine Context Week page copy

### DIFF
--- a/apps/website/src/__tests__/pages/context-week.test.tsx
+++ b/apps/website/src/__tests__/pages/context-week.test.tsx
@@ -65,7 +65,6 @@ describe('ContextWeekProgramPage', () => {
     expect(screen.getByRole('heading', { name: 'Programme' })).toBeInTheDocument();
     expect(screen.getByText(/The detailed schedule is still being developed/)).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'After Context Week' })).toBeInTheDocument();
-    expect(screen.getByText(/about ten hours of reading/)).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getAllByRole('link', { name: 'Apply to Context Week' })).toHaveLength(2);

--- a/apps/website/src/components/context-week/OverviewSection.tsx
+++ b/apps/website/src/components/context-week/OverviewSection.tsx
@@ -19,8 +19,7 @@ const OverviewSection = () => {
         </P>
         <P className="text-bluedot-navy/80">
           Participants arrive on August 30. Programming runs from August 31 to September 3,
-          and participants depart on September 4. Before arriving, participants complete
-          about ten hours of reading selected by the programme team.
+          and participants depart on September 4.
         </P>
       </div>
     </section>

--- a/apps/website/src/components/context-week/ParticipantOutputsSection.tsx
+++ b/apps/website/src/components/context-week/ParticipantOutputsSection.tsx
@@ -16,11 +16,6 @@ const ParticipantOutputsSection = () => {
           applications, conversations, further reading, or project work. They may make a
           decision during the week or leave knowing what they still need to learn.
         </P>
-        <P className="text-bluedot-navy/80">
-          BlueDot will assess participants&apos; knowledge before and after the programme and
-          contact them 90 days later to ask what they did next. The evaluation will also look
-          for overconfidence and pressure to agree with the group.
-        </P>
       </div>
     </section>
   );


### PR DESCRIPTION
# Description

Updates the Context Week page to match the current public programme copy:

- removes the sentence requiring about ten hours of advance reading
- removes the paragraph describing BlueDot's post-programme evaluation

Follow-up to #2909.

## Developer checklist

- [x] Front-end accessibility is unchanged
- [x] Updated the page test for the removed preparation sentence
- [x] A Storybook story is not needed for these copy removals

## Testing

- `npm test -- src/__tests__/pages/context-week.test.tsx`
- `npm run typecheck`

## Screenshot

Not included. These changes only remove copy from the existing page.
