### PR TITLE
[fix] Strip duplicate export default lines from generated demo code

### DIFF
--- a/apps/course-demos/src/__tests__/components/CodeRenderer.test.ts
+++ b/apps/course-demos/src/__tests__/components/CodeRenderer.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { sanitiseCode } from '../../components/CodeRenderer';
+
+describe('sanitiseCode', () => {
+  test('strips a trailing export default line', () => {
+    expect(sanitiseCode('const Component = () => <div />;\n\nexport default Component;\n\n')).toBe('const Component = () => <div />;');
+  });
+
+  test('strips an export default of any identifier, without a semicolon', () => {
+    expect(sanitiseCode('const ComponentList = () => <div />;\nconst Component = () => <ComponentList />;\n\nexport default ComponentList')).toBe('const ComponentList = () => <div />;\nconst Component = () => <ComponentList />;');
+  });
+
+  test('removes only the export default prefix from a declaration, even indented', () => {
+    expect(sanitiseCode('const A = 1;\n  export default function Component() {\n  return <div />;\n}')).toBe('const A = 1;\n  function Component() {\n  return <div />;\n}');
+  });
+
+  test('leaves export default alone when not at the start of a line', () => {
+    expect(sanitiseCode('const s = "export default Component";\nconst Component = () => <div>{s}</div>;')).toBe('const s = "export default Component";\nconst Component = () => <div>{s}</div>;');
+  });
+
+  test('strips markdown code fences', () => {
+    expect(sanitiseCode('```jsx\nconst Component = () => <div />;\n\nexport default Component;\n```')).toBe('const Component = () => <div />;');
+  });
+});

--- a/apps/course-demos/src/components/CodeRenderer.tsx
+++ b/apps/course-demos/src/components/CodeRenderer.tsx
@@ -11,14 +11,21 @@ type CodeRendererProps = {
   hidePreview?: boolean;
 };
 
-// The model is instructed not to wrap output in markdown code fences, but it
-// sometimes ignores that. Strip them so the fenced text doesn't break the render.
-// Written to also handle partial output while the response is still streaming.
-const stripCodeFences = (raw: string): string => {
-  return raw
+export const sanitiseCode = (raw: string): string => {
+  // The model is instructed not to wrap output in markdown code fences, but it
+  // sometimes ignores that. Strip them so the fenced text doesn't break the render.
+  // Written to also handle partial output while the response is still streaming.
+  const stripCodeFences = (code: string) => code
     .trim()
     .replace(/^```\w*\n?/, '')
     .replace(/\n?```\s*$/, '');
+
+  const stripDefaultExport = (code: string) => code
+    .replace(/^\s*export default \w*;?\s*$/gm, '')
+    .replace(/^(\s*)export default /gm, '$1')
+    .trim();
+
+  return stripDefaultExport(stripCodeFences(raw));
 };
 
 export const CodeRenderer: React.FC<CodeRendererProps> = ({ code, height, hidePreview = false }) => {
@@ -27,7 +34,7 @@ export const CodeRenderer: React.FC<CodeRendererProps> = ({ code, height, hidePr
     '/App.js': {
       code: `import React from 'react';
 
-${stripCodeFences(code)}
+${sanitiseCode(code)}
 
 export default function App() {
   return (


### PR DESCRIPTION
# Description

From the issue:

> About 10% of the time, the model behind our [building web applications](https://bluedot.org/courses/future-of-ai/1/1) demo adds an extra `export default Component` which causes a build error. We can strip this out with a regex before running the code to fix this.

This strips any line starting `export default` from the generated code, next to the existing code fence stripping in `CodeRenderer`.

## Issue

Fixes #2914

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories