### PR TITLE
[fix] Render programmes as separate list rows

### DIFF
--- a/apps/website/src/__tests__/pages/programs.test.tsx
+++ b/apps/website/src/__tests__/pages/programs.test.tsx
@@ -56,6 +56,16 @@ const mockPrograms = [
     order: '3',
   },
   {
+    id: 'rec-context-week',
+    name: 'Context Week',
+    status: 'Active',
+    description: 'A four-day residential programme for people who want to understand the AI safety field and decide where they could contribute.',
+    applicationForm: 'https://example.com/context-week',
+    category: 'Explore',
+    slug: 'context-week',
+    order: '4',
+  },
+  {
     id: 'rec-incubator',
     name: 'Incubator week',
     status: 'Active',
@@ -63,14 +73,14 @@ const mockPrograms = [
     applicationForm: 'https://example.com/incubator',
     category: 'Found',
     slug: 'incubator-week',
-    order: '4',
+    order: '5',
   },
 ];
 
 beforeEach(() => {
   (useRouter as unknown as Mock).mockReturnValue(mockRouter);
   server.use(
-    trpcMsw.programs.getInPerson.query(() => mockPrograms.filter((program) => program.slug === 'incubator-week')),
+    trpcMsw.programs.getInPerson.query(() => mockPrograms.filter((program) => ['context-week', 'incubator-week'].includes(program.slug))),
     trpcMsw.programs.getGrants.query(() => []),
     trpcMsw.courses.getAll.query(() => []),
   );
@@ -81,7 +91,11 @@ describe('ProgramsPage', () => {
     render(<ProgramsPage />, { wrapper: TrpcProvider });
 
     await waitFor(() => {
-      expect(screen.getByText('Incubator week', { selector: 'p' })).toBeInTheDocument();
+      const contextWeekTitle = screen.getByText('Context Week', { selector: 'p' });
+      const incubatorWeekTitle = screen.getByText('Incubator week', { selector: 'p' });
+
+      expect(screen.getByText('A four-day residential programme for people who want to understand the AI safety field and decide where they could contribute.')).toBeInTheDocument();
+      expect(contextWeekTitle.closest('li')).not.toBe(incubatorWeekTitle.closest('li'));
       expect(screen.getByText('AI Security Bootcamp', { selector: 'p' })).toBeInTheDocument();
       expect(screen.queryByText('Rapid grant', { selector: 'p' })).not.toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'Explore courses instead' })).toBeInTheDocument();

--- a/apps/website/src/components/PageListRow.tsx
+++ b/apps/website/src/components/PageListRow.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { Children } from 'react';
 import clsx from 'clsx';
 import Link from 'next/link';
 import { CTALinkOrButton, H3 } from '@bluedot/ui';
@@ -146,12 +147,12 @@ export const PageListRow: React.FC<PageListRowProps> = ({
 
 export type PageListGroupProps = {
   label?: string;
-  children: React.ReactNode[];
+  children: React.ReactNode;
   className?: string;
 };
 
 export const PageListGroup: React.FC<PageListGroupProps> = ({ label, children, className }) => {
-  const items = children.filter(Boolean);
+  const items = Children.toArray(children);
 
   if (items.length === 0) {
     return null;


### PR DESCRIPTION
# Description

Fixes the in-person programmes list when more than one internal programme is active. Context Week and Incubator Week now render as separate list items, each with its own description, spacing, divider, and CTA.

### Why it broke

`ProgramsList` passes the array returned by `programs.map(...)` alongside the fixed AI Security Bootcamp row to `PageListGroup`. `PageListGroup` previously filtered its top-level `children` array directly. This left the mapped programme rows nested inside one array, so React rendered Context Week and Incubator Week inside the same `<li>`.

The bug became visible when Context Week was added as a second active in-person programme. `React.Children.toArray(children)` now normalises the nested children before `PageListGroup` wraps each row in an `<li>`.

## Issue

Reported in Slack by Dewi Erwan. No GitHub issue.

## Developer checklist

- [x] Front-end code follows the Component Accessibility Checklist; the rendered elements and interaction behaviour are unchanged
- [x] Added a happy-path regression test with two internal programmes
- [x] Considered a Storybook change; the existing component story does not need a new variant because the regression is structural and covered by the page test

## Testing

- `npm test -- src/__tests__/pages/programs.test.tsx`
- `npx eslint src/components/PageListRow.tsx src/__tests__/pages/programs.test.tsx --report-unused-disable-directives --max-warnings=0`
- `npm run typecheck`

## Screenshot

The reported state showed Context Week and Incubator Week sharing one row. An after screenshot is not included because this branch has not been deployed; the regression test asserts that their nearest `<li>` elements are different.
