### PR TITLE
Provision 2nd k8s node, cap loki cache

### DIFF
--- a/apps/infra/src/k8s/observability.ts
+++ b/apps/infra/src/k8s/observability.ts
@@ -326,6 +326,16 @@ new k8s.helm.v3.Release('loki', {
         },
       },
     },
+    // The chart defaults allocate 8GiB to the chunks cache and 1GiB to the results cache
+    // (memcached requests/limits are set to 1.2x these values), which committed ~11GiB of a
+    // 16GiB node to log caches alone. Cap them at sizes that leave headroom for everything
+    // else; these are pure read-through caches, so the only cost is slower Loki queries.
+    chunksCache: {
+      allocatedMemory: 1024,
+    },
+    resultsCache: {
+      allocatedMemory: 256,
+    },
     // Disable things we don't need
     selfMonitoring: {
       enabled: false,

--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -27,7 +27,7 @@ export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
 new vultr.KubernetesNodePools('vke-node-pool-main', {
   clusterId: k8sCluster.id,
   label: 'main-node-pool',
-  nodeQuantity: 1,
+  nodeQuantity: 2,
   // https://api.vultr.com/v2/plans
   plan: 'vhf-4c-16gb',
   autoScaler: false,


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Part of the 2026-08-19/20 production incident. The single-node VKE cluster suffered repeated hard resets; the instance main-node-pool-f1af172060bd was eventually proven to be power-cycled externally every ~2 min (Vultr ticket open). The website and meet were temporarily moved to Render; Keycloak/auth was down ~19h.

1. Second node (main-node-pool-f20f7012c7cc) restored ingress, login, monitoring and currently stable
2. Capped cache memory: helm chart defaults committed ~11GiB of a 16GiB node to log caches alone (memcached requests/limits = 1.2× these values)
