### PR TITLE
[feat] Port website-proxy redirects + /u/ proxy into next.config.js for Render

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -1,9 +1,43 @@
 const { withSentryConfig } = require('@sentry/nextjs');
 const { withDefaultBlueDotNextConfig } = require('@bluedot/ui/src/default-config/next');
 
+// Shortlinks previously handled by apps/website-proxy nginx, ported here so the
+// image is self-sufficient on Render (no nginx in front of bluedot.org).
+// nginx returned 301s, so these use statusCode: 301 rather than permanent (308).
+const proxyPortedRedirects = [
+  {
+    source: '/:path*',
+    has: [{ type: 'host', value: 'www.bluedot.org' }],
+    destination: 'https://bluedot.org/:path*',
+    statusCode: 301,
+  },
+  ...[
+    ['/intro-to-tai', '/courses/intro-to-tai'],
+    ['/writing', '/courses/writing'],
+    ['/alignment', '/courses/alignment'],
+    ['/alignment-fast-track', '/courses/alignment'],
+    ['/governance', '/courses/governance'],
+    ['/governance-fast-track', '/courses/governance'],
+    ['/economics-of-tai', '/courses/economics-of-tai'],
+    ['/economics-of-tai-fast-track', '/courses/economics-of-tai'],
+    ['/pandemics', '/courses/biosecurity'],
+    ['/courses/pandemics', '/courses/biosecurity'],
+    ['/careers', '/join-us'],
+    ['/careers/swe-contractor', '/join-us/swe-contractor'],
+    ['/careers/ai-safety-teaching-fellow', '/join-us/ai-safety-teaching-fellow'],
+    ['/ai-alignment-curriculum', '/courses/alignment'],
+    ['/ai-governance-curriculum', '/courses/governance'],
+    ['/alignment-course-details', '/courses/alignment'],
+    ['/governance-course-details', '/courses/governance'],
+    ['/alignment-insession-readings', '/courses/alignment'],
+    ['/alignment-201-curriculum', '/courses/alignment-201'],
+  ].map(([source, destination]) => ({ source, destination, statusCode: 301 })),
+];
+
 const baseConfig = withDefaultBlueDotNextConfig({
   async redirects() {
     return [
+      ...proxyPortedRedirects,
       {
         source: '/company-information',
         destination: '/contact',
@@ -118,6 +152,19 @@ const baseConfig = withDefaultBlueDotNextConfig({
         source: '/settings/account',
         destination: '/account',
         statusCode: 301,
+      },
+    ];
+  },
+  async rewrites() {
+    return [
+      // Legacy uploads server (old bluedot.org box), still referenced by the AISF/BSF
+      // sites; also ported from the website-proxy nginx config. nginx sent
+      // `Host: bluedot.org` and SNI `bluedot.org` to this upstream; Next.js's rewrite
+      // proxy instead sends Host/SNI for the bare IP, which may break the upstream's
+      // TLS cert validation or vhost matching — verify /u/ paths after deploy.
+      {
+        source: '/u/:path*',
+        destination: 'https://45.76.132.116/u/:path*',
       },
     ];
   },


### PR DESCRIPTION
# Description

Part of the 2026-08-19/20 incident recovery. bluedot.org is temporarily served from Render, which bypasses the `apps/website-proxy` nginx layer — so every shortlink handled there is currently **404ing in production** (verified live: `/governance`, `/alignment-fast-track`, `/pandemics`, `/careers` all 404; these are referenced from course materials, emails, and YouTube descriptions).

This ports into `next.config.js`:
- The bluedot.org shortlink redirect table from `nginx.template.conf` (301s, matching nginx's status code)
- The `www.bluedot.org` → `bluedot.org` host redirect
- The `/u/` legacy-uploads proxy (old bluedot.org box, still referenced by the AISF/BSF sites)

Not ported (intentionally): the aisafetyfundamentals.com / biosecurityfundamentals.com legacy-domain redirects — those domains still point at the k8s proxy, which handles them fine.

## Impact on k8s serving

None: nginx in `website-proxy` matches these paths before they reach Next.js, so the ported rules are shadowed duplication there. They only take effect where the Next.js app is the front door (Render).

## Post-merge checklist

- [ ] Confirm Render redeploys from master (or trigger manually) — the fix only lands when Render rebuilds
- [ ] Verify shortlinks live: `curl -sI https://bluedot.org/governance` should 301 to `/courses/governance`
- [ ] Verify `/u/` paths still work — nginx sent `Host: bluedot.org` to the upstream's bare IP; Next's rewrite proxy sends the IP as Host/SNI, which may break TLS/vhost matching on that box (flagged in code comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
