### PR TITLE
[chore] Trigger Render deploys for website + meet from GitHub workflows

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -293,3 +293,23 @@ jobs:
         run: npm run deploy:cd --workspace ${{ matrix.app }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+  render:
+    # meet.bluedot.org is temporarily served from Render after the Aug 2026 Vultr
+    # node outage (#2917, #2918), so master deploys must also trigger Render.
+    # Deliberately independent of `cd`: Render should succeed independently of
+    # whether the k8s deployment succeeds. Remove if we move traffic back to k8s.
+    needs: ci
+    if: ${{ github.ref == 'refs/heads/master' && contains(needs.ci.outputs.affected_deployable_apps, '@bluedot/meet') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger Render deploy
+        env:
+          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_URL_MEET }}
+        run: |
+          if [[ -z "$HOOK" ]]; then
+            echo "no Render deploy hook configured, skipping"
+            exit 0
+          fi
+          curl -fsS "${HOOK}&ref=${{ github.sha }}"

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -300,9 +300,10 @@ jobs:
     # Deliberately independent of `cd`: Render should succeed independently of
     # whether the k8s deployment succeeds. Remove if we move traffic back to k8s.
     needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && contains(needs.ci.outputs.affected_deployable_apps, '@bluedot/meet') }}
+    if: ${{ github.ref == 'refs/heads/master' && contains(fromJson(needs.ci.outputs.affected_deployable_apps || '[]'), '@bluedot/meet') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Trigger Render deploy
         env:
@@ -312,4 +313,4 @@ jobs:
             echo "no Render deploy hook configured, skipping"
             exit 0
           fi
-          curl -fsS "${HOOK}&ref=${{ github.sha }}"
+          curl -fsS --connect-timeout 10 --max-time 60 "${HOOK}&ref=${{ github.sha }}"

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -78,6 +78,21 @@ jobs:
               await sleep(pollIntervalMs);
             }
 
+      # bluedot.org is temporarily served from Render after the Aug 2026 Vultr
+      # node outage (#2917, #2918), so releases must also trigger Render.
+      # Deliberately independent of the cluster deployment: Render should succeed
+      # independently of whether the k8s deployment succeeds. Remove if we move
+      # traffic back to k8s.
+      - name: Trigger Render deploy
+        env:
+          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_URL_WEBSITE }}
+        run: |
+          if [[ -z "$HOOK" ]]; then
+            echo "no Render deploy hook configured, skipping"
+            exit 0
+          fi
+          curl -fsS "${HOOK}&ref=${{ github.sha }}"
+
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v5
 

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -91,7 +91,7 @@ jobs:
             echo "no Render deploy hook configured, skipping"
             exit 0
           fi
-          curl -fsS "${HOOK}&ref=${{ github.sha }}"
+          curl -fsS --connect-timeout 10 --max-time 60 "${HOOK}&ref=${{ github.sha }}"
 
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v5


### PR DESCRIPTION
# Description

Currently the meet and website apps are being served from Render, but are not deployed automatically. This PR triggers a deploy via the same workflows, and at the same git SHAs as the k8s system, so we can develop as normal while it's in place.

I've set the secrets via the `gh` CLI. We should remember to remove them if and when we roll this back.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories