### PR TITLE
[docs] Meet README: note that the app is temporarily served from Render

### DIFF
--- a/apps/meet/README.md
+++ b/apps/meet/README.md
@@ -12,6 +12,8 @@ This app is deployed onto the K8s cluster as a standard Next.js app in docker. I
 
 To deploy a new version, simply commit to the master branch. GitHub Actions automatically handles CD.
 
+As of August 2026 the app is temporarily being served from Render while we sort out problems with the k8s cluster (see #2919). Deploying works the same way: merging to master deploys to both k8s and Render.
+
 ## How it works
 
 The app presents a user interface where people can join via links like:


### PR DESCRIPTION
# Description

Small README update to say meet is currently served from Render. Also serves as a test of the deploy hooks from #2919, since any change under `apps/meet` should now trigger both the k8s and Render deploys.

## Issue

N/A