### PR TITLE
[fix] Trigger Render with the exact image tag after the k8s deploy pushes it

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -294,18 +294,13 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-  render:
-    # meet.bluedot.org is temporarily served from Render after the Aug 2026 Vultr
-    # node outage (#2917, #2918), so master deploys must also trigger Render.
-    # Deliberately independent of `cd`: Render should succeed independently of
-    # whether the k8s deployment succeeds. Remove if we move traffic back to k8s.
-    needs: ci
-    if: ${{ github.ref == 'refs/heads/master' && contains(fromJson(needs.ci.outputs.affected_deployable_apps || '[]'), '@bluedot/meet') }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: {}
-    steps:
+      # meet.bluedot.org is temporarily served from Render after the Aug 2026 Vultr
+      # node outage (#2917, #2918), so master deploys must also trigger Render.
+      # Deliberately independent of the cluster deployment: Render should succeed
+      # independently of whether the k8s deployment succeeds. Remove if we move
+      # traffic back to k8s.
       - name: Trigger Render deploy
+        if: ${{ always() && matrix.app == '@bluedot/meet' }}
         env:
           HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_URL_MEET }}
         run: |
@@ -313,4 +308,5 @@ jobs:
             echo "no Render deploy hook configured, skipping"
             exit 0
           fi
-          curl -fsS --connect-timeout 10 --max-time 60 "${HOOK}&ref=${{ github.sha }}"
+          curl -fsS --connect-timeout 10 --max-time 60 "$HOOK"
+

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -78,21 +78,6 @@ jobs:
               await sleep(pollIntervalMs);
             }
 
-      # bluedot.org is temporarily served from Render after the Aug 2026 Vultr
-      # node outage (#2917, #2918), so releases must also trigger Render.
-      # Deliberately independent of the cluster deployment: Render should succeed
-      # independently of whether the k8s deployment succeeds. Remove if we move
-      # traffic back to k8s.
-      - name: Trigger Render deploy
-        env:
-          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_URL_WEBSITE }}
-        run: |
-          if [[ -z "$HOOK" ]]; then
-            echo "no Render deploy hook configured, skipping"
-            exit 0
-          fi
-          curl -fsS --connect-timeout 10 --max-time 60 "${HOOK}&ref=${{ github.sha }}"
-
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v5
 
@@ -155,3 +140,19 @@ jobs:
         run: npm run deploy:multistage:production --workspace apps/website
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      # bluedot.org is temporarily served from Render after the Aug 2026 Vultr
+      # node outage (#2917, #2918), so releases must also trigger Render.
+      # Deliberately independent of the cluster deployment: Render should succeed
+      # independently of whether the k8s deployment succeeds. Remove if we move
+      # traffic back to k8s.
+      - name: Trigger Render deploy
+        if: ${{ always() }}
+        env:
+          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_URL_WEBSITE }}
+        run: |
+          if [[ -z "$HOOK" ]]; then
+            echo "no Render deploy hook configured, skipping"
+            exit 0
+          fi
+          curl -fsS --connect-timeout 10 --max-time 60 "$HOOK"


### PR DESCRIPTION
## Description

The previous (#2919) attempt didn't work because it was trying to deploy a specific git SHA, when the Render deployments are based on built images instead. I realised that deploying a specific SHA or image isn't actually necessary, because the earlier steps of the deployment set the correct version as `:latest`, so this is a simplified version that just pings the hook (using `always()` to make it work even if earlier steps fail).

## Issue

N/A

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories