### PR TITLE
[feat] infra: raise inotify limits on every node via a DaemonSet

### DIFF
--- a/apps/infra/src/k8s/index.ts
+++ b/apps/infra/src/k8s/index.ts
@@ -4,5 +4,6 @@ import './postgres';
 import './certManager';
 import './observability';
 import './pvc';
+import './inotifyPatch';
 import './services';
 import './backups';

--- a/apps/infra/src/k8s/inotifyPatch.ts
+++ b/apps/infra/src/k8s/inotifyPatch.ts
@@ -23,7 +23,7 @@ new k8s.apps.v1.DaemonSet('node-sysctl', {
         priorityClassName: 'system-node-critical',
         initContainers: [{
           name: 'apply',
-          image: 'busybox:1.36',
+          image: 'busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662',
           command: ['sh', '-euc', [
             `printf '%s\\n' ${settings.map((s) => `'${s}'`).join(' ')} > /host/etc/sysctl.d/99-bluedot-inotify.conf`,
             `sysctl -w ${settings.join(' ')}`,

--- a/apps/infra/src/k8s/inotifyPatch.ts
+++ b/apps/infra/src/k8s/inotifyPatch.ts
@@ -1,0 +1,44 @@
+import * as k8s from '@pulumi/kubernetes';
+import { provider } from './provider';
+
+// VKE nodes ship with kernel-default inotify limits (max_user_instances=128), which the
+// pods on a node exhaust ("failed to create fsnotify watcher: too many open files").
+// Vultr has no node-level config hook, so raise them from a DaemonSet instead: the
+// drop-in file survives reboots, `sysctl -w` applies them immediately.
+const inotifySysctls = {
+  'fs.inotify.max_user_instances': 8192,
+  'fs.inotify.max_user_watches': 1048576,
+};
+
+const settings = Object.entries(inotifySysctls).map(([k, v]) => `${k}=${v}`);
+
+new k8s.apps.v1.DaemonSet('node-sysctl', {
+  metadata: { name: 'node-sysctl', namespace: 'kube-system' },
+  spec: {
+    selector: { matchLabels: { app: 'node-sysctl' } },
+    template: {
+      metadata: { labels: { app: 'node-sysctl' } },
+      spec: {
+        tolerations: [{ operator: 'Exists' }],
+        priorityClassName: 'system-node-critical',
+        initContainers: [{
+          name: 'apply',
+          image: 'busybox:1.36',
+          command: ['sh', '-euc', [
+            `printf '%s\\n' ${settings.map((s) => `'${s}'`).join(' ')} > /host/etc/sysctl.d/99-bluedot-inotify.conf`,
+            `sysctl -w ${settings.join(' ')}`,
+          ].join('\n')],
+          securityContext: { privileged: true },
+          volumeMounts: [{ name: 'sysctl-d', mountPath: '/host/etc/sysctl.d' }],
+        }],
+        // A DaemonSet pod has to keep running, so park on the pause image after the init container.
+        containers: [{
+          name: 'pause',
+          image: 'registry.k8s.io/pause:3.10',
+          resources: { requests: { cpu: '1m', memory: '8Mi' }, limits: { memory: '16Mi' } },
+        }],
+        volumes: [{ name: 'sysctl-d', hostPath: { path: '/etc/sysctl.d', type: 'DirectoryOrCreate' } }],
+      },
+    },
+  },
+}, { provider });


### PR DESCRIPTION
# Description

See comment:
```
// VKE nodes ship with kernel-default inotify limits (max_user_instances=128), which the
// pods on a node exhaust ("failed to create fsnotify watcher: too many open files").
// Vultr has no node-level config hook, so raise them from a DaemonSet instead: the
// drop-in file survives reboots, `sysctl -w` applies them immediately.
```

This low limit was discovered during the recent outage (see e.g. #2917), and potentially contributed to the cluster failing to recover fully from crashes.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories