### PR TITLE
Forward utm_campaign and utm_content to the application form

### DIFF
--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -118,7 +118,7 @@ export default function CourseCompletionSection({
   }
 
   if (showEnrollmentCTA) {
-    const applicationUrlWithUtm = buildApplicationUrl(application.applicationUrl, latestUtmParams.utm_source);
+    const applicationUrlWithUtm = buildApplicationUrl(application.applicationUrl, latestUtmParams);
 
     const info = COURSE_INFORMATION_DETAILS[courseSlug];
     const accentColor = COURSE_CONFIG[courseSlug]?.accentColor;

--- a/apps/website/src/components/courses/CourseSchedule.tsx
+++ b/apps/website/src/components/courses/CourseSchedule.tsx
@@ -218,7 +218,7 @@ const CourseScheduleCard = ({ course }: CourseScheduleCardProps) => {
   const { data: rounds, isLoading: roundsLoading } = trpc.courseRounds.getRoundsForCourse.useQuery({ courseSlug: course.slug });
   const { latestUtmParams } = useLatestUtmParams();
 
-  const applicationUrlWithUtm = buildApplicationUrl(course.applyUrl, latestUtmParams.utm_source);
+  const applicationUrlWithUtm = buildApplicationUrl(course.applyUrl, latestUtmParams);
 
   const hasIntense = rounds?.intense && rounds.intense.length > 0;
   const hasPartTime = rounds?.partTime && rounds.partTime.length > 0;

--- a/apps/website/src/components/grants/useGrantApplicationUrl.ts
+++ b/apps/website/src/components/grants/useGrantApplicationUrl.ts
@@ -10,5 +10,5 @@ export const useGrantApplicationUrl = (program: ConfigurableGrantProgramSlug): s
   const applicationUrl = data?.applicationForm;
   if (!applicationUrl) return undefined;
 
-  return buildApplicationUrl(applicationUrl, latestUtmParams.utm_source);
+  return buildApplicationUrl(applicationUrl, latestUtmParams);
 };

--- a/apps/website/src/components/lander/CourseLander.tsx
+++ b/apps/website/src/components/lander/CourseLander.tsx
@@ -107,7 +107,7 @@ const CourseLander = ({
 }: CourseLanderProps) => {
   const { latestUtmParams } = useLatestUtmParams();
 
-  const applicationUrlWithUtm = buildApplicationUrl(baseApplicationUrl, latestUtmParams.utm_source);
+  const applicationUrlWithUtm = buildApplicationUrl(baseApplicationUrl, latestUtmParams);
 
   const content = createContentFor(applicationUrlWithUtm, courseSlug);
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/apps/website/src/components/my-courses/useCourseListRow.tsx
+++ b/apps/website/src/components/my-courses/useCourseListRow.tsx
@@ -151,7 +151,7 @@ export type UseCourseActionsResult = {
 
 export const useCourseListRow = (row: CourseListRowProps): UseCourseActionsResult => {
   const { latestUtmParams } = useLatestUtmParams();
-  const derived = deriveCourseRowState(row, latestUtmParams.utm_source);
+  const derived = deriveCourseRowState(row, latestUtmParams);
   const modals = useCourseModals({
     courseSlug: row.course.slug,
     courseRegistrationId: row.courseRegistration.id,
@@ -201,7 +201,7 @@ type CourseRowDerivedState = {
   slackUrl: string | null;
 };
 
-const deriveCourseRowState = (row: CourseListRowProps, utmSource: string | undefined): CourseRowDerivedState => {
+const deriveCourseRowState = (row: CourseListRowProps, latestUtmParams: Record<string, string>): CourseRowDerivedState => {
   const {
     course, courseRegistration, group, meetPersonId, attendedDiscussionIds,
     hasSubmittedFeedback, isDroppedOut, isDeferred,
@@ -215,7 +215,7 @@ const deriveCourseRowState = (row: CourseListRowProps, utmSource: string | undef
   const certificateUrl = courseRegistration.certificateId
     ? addQueryParam(ROUTES.certification.url, 'id', courseRegistration.certificateId)
     : `/courses/${course.slug}`;
-  const applyAgainUrl = buildApplicationUrl(course.applyUrl, utmSource) || `/courses/${course.slug}`;
+  const applyAgainUrl = buildApplicationUrl(course.applyUrl, latestUtmParams) || `/courses/${course.slug}`;
   const slackUrl = group?.slackChannelId ? buildGroupSlackChannelUrl(group.slackChannelId) : null;
   const docUrl = group?.discussionDoc ?? null;
 

--- a/apps/website/src/lib/utils.test.ts
+++ b/apps/website/src/lib/utils.test.ts
@@ -328,17 +328,35 @@ describe('buildApplicationUrl', () => {
   });
 
   it('returns empty string for null / undefined / empty base URL', () => {
-    expect(buildApplicationUrl(null, 'twitter')).toBe('');
-    expect(buildApplicationUrl(undefined, 'twitter')).toBe('');
-    expect(buildApplicationUrl('', 'twitter')).toBe('');
+    expect(buildApplicationUrl(null, { utm_source: 'twitter' })).toBe('');
+    expect(buildApplicationUrl(undefined, { utm_source: 'twitter' })).toBe('');
+    expect(buildApplicationUrl('', { utm_source: 'twitter' })).toBe('');
   });
 
-  it('returns base URL unchanged when neither UTM source nor session ID is available', () => {
+  it('returns base URL unchanged when neither UTM params nor session ID are available', () => {
     expect(buildApplicationUrl('https://example.com/apply', null)).toBe('https://example.com/apply');
+    expect(buildApplicationUrl('https://example.com/apply', {})).toBe('https://example.com/apply');
   });
 
-  it('appends prefill_Source when UTM source is provided', () => {
-    expect(buildApplicationUrl('https://example.com/apply', 'twitter')).toBe('https://example.com/apply?prefill_Source=twitter');
+  it('appends prefill_Source when only utm_source is provided', () => {
+    expect(buildApplicationUrl('https://example.com/apply', { utm_source: 'twitter' })).toBe('https://example.com/apply?prefill_Source=twitter');
+  });
+
+  it('appends prefill_Campaign and prefill_Content when utm_campaign and utm_content are provided', () => {
+    expect(buildApplicationUrl('https://example.com/apply', { utm_source: 'twitter', utm_campaign: 'spring-launch', utm_content: 'video-ad' }))
+      .toBe('https://example.com/apply?prefill_Source=twitter&prefill_Campaign=spring-launch&prefill_Content=video-ad');
+  });
+
+  it('omits prefill params for absent or empty UTM params', () => {
+    expect(buildApplicationUrl('https://example.com/apply', { utm_campaign: 'spring-launch' }))
+      .toBe('https://example.com/apply?prefill_Campaign=spring-launch');
+    expect(buildApplicationUrl('https://example.com/apply', { utm_source: 'twitter', utm_campaign: '' }))
+      .toBe('https://example.com/apply?prefill_Source=twitter');
+  });
+
+  it('does not forward UTM params without a prefill field (e.g. utm_medium, utm_term)', () => {
+    expect(buildApplicationUrl('https://example.com/apply', { utm_medium: 'cpc', utm_term: 'ai+safety' }))
+      .toBe('https://example.com/apply');
   });
 
   it('appends prefill_PostHog Session ID (URL-encoded) when session is available', () => {
@@ -349,12 +367,12 @@ describe('buildApplicationUrl', () => {
 
   it('appends both UTM source and PostHog session ID when both are present', () => {
     mockGetSessionId.mockReturnValue('sess-123');
-    expect(buildApplicationUrl('https://example.com/apply', 'twitter'))
+    expect(buildApplicationUrl('https://example.com/apply', { utm_source: 'twitter' }))
       .toBe('https://example.com/apply?prefill_Source=twitter&prefill_PostHog%20Session%20ID=sess-123');
   });
 
   it('preserves existing query params', () => {
-    expect(buildApplicationUrl('https://example.com/apply?foo=bar', 'twitter'))
+    expect(buildApplicationUrl('https://example.com/apply?foo=bar', { utm_source: 'twitter' }))
       .toBe('https://example.com/apply?foo=bar&prefill_Source=twitter');
   });
 

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -188,15 +188,28 @@ export function getInitials(name: string): string {
   return chars.join('').toUpperCase();
 }
 
+/** Which UTM params get forwarded to the application form, and as which prefill fields. */
+const UTM_PARAM_TO_PREFILL_FIELD: [utmParam: string, prefillField: string][] = [
+  ['utm_source', 'prefill_Source'],
+  ['utm_campaign', 'prefill_Campaign'],
+  ['utm_content', 'prefill_Content'],
+];
+
 /**
- * Build an application form URL with PostHog session id, anonymous distinct id, and UTM source prefill params.
+ * Build an application form URL with PostHog session id, anonymous distinct id, and UTM prefill
+ * params (utm_source → prefill_Source, utm_campaign → prefill_Campaign, utm_content → prefill_Content).
  */
 export const buildApplicationUrl = (
   baseUrl: string | null | undefined,
-  utmSource: string | null | undefined,
+  utmParams: Record<string, string> | null | undefined,
 ): string => {
   if (!baseUrl) return '';
-  const urlWithUtm = utmSource ? addQueryParam(baseUrl, 'prefill_Source', utmSource) : baseUrl;
+
+  let urlWithUtm = baseUrl;
+  UTM_PARAM_TO_PREFILL_FIELD.forEach(([utmParam, prefillField]) => {
+    const value = utmParams?.[utmParam];
+    if (value) urlWithUtm = addQueryParam(urlWithUtm, prefillField, value);
+  });
 
   // new URL() requires an absolute URL; skip relative paths (e.g. internal nav links)
   if (!urlWithUtm.startsWith('http://') && !urlWithUtm.startsWith('https://')) return urlWithUtm;

--- a/apps/website/src/pages/courses/[courseSlug]/index.tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/index.tsx
@@ -234,7 +234,7 @@ const ExternalCoursePage = ({ courseData, courseOgImage }: { courseData: CourseA
 
 const StandardCoursePage = ({ courseData, courseOgImage }: { courseData: CourseAndUnits; courseOgImage: string }) => {
   const { latestUtmParams } = useLatestUtmParams();
-  const registerInterestUrlWithUtm = buildApplicationUrl(registerInterestUrl, latestUtmParams.utm_source);
+  const registerInterestUrlWithUtm = buildApplicationUrl(registerInterestUrl, latestUtmParams);
 
   if (!courseData.course) {
     return null;


### PR DESCRIPTION
## Problem

The Campaign and Content columns on Course registration in Airtable are empty on all applications. The site captures all five UTM params via `useLatestUtmParams`, but `buildApplicationUrl` only forwards `utm_source` to the MiniExtensions application form (as `prefill_Source`), so `utm_campaign` and `utm_content` are dropped.

These columns were historically populated by a Google Tag Manager tag (per the Airtable field description, last reviewed 2024-04-18), which the current prefill-URL flow replaced, wiring up only Source. We verified today (2026-08-26) with a test submission that the MiniExtensions form still accepts `prefill_Campaign` and `prefill_Content` and that both Airtable columns are populated from them.

## Change

- `buildApplicationUrl` now takes the full UTM params record (`Record<string, string> | null | undefined`) instead of just the source string, and forwards `utm_source` → `prefill_Source`, `utm_campaign` → `prefill_Campaign`, `utm_content` → `prefill_Content` (each only when non-empty). PostHog session/distinct id prefills, the %20 space-encoding workaround, and the relative-URL early return are unchanged.
- Updated all six call sites to pass `latestUtmParams` instead of `latestUtmParams.utm_source`.
- Updated `utils.test.ts` for the new signature and added cases: campaign+content forwarded when present, omitted when absent or empty, source-only unchanged, and utm_medium/utm_term not forwarded.

## Testing

- `vitest --run src/lib/utils.test.ts` in apps/website: 41 tests passed.
- `tsc --noEmit` and `eslint --max-warnings=0` on the changed files: clean.
- Not tested against the live form from this branch; the prefill params themselves were verified manually as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)