### PR TITLE
[refactor] website: factor admin page guard into withAdminGuard HoC

### DIFF
--- a/apps/website/src/components/admin/withAdminGuard.test.tsx
+++ b/apps/website/src/components/admin/withAdminGuard.test.tsx
@@ -1,0 +1,70 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { userTable } from '@bluedot/db';
+import {
+  beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import { withAdminGuard } from './withAdminGuard';
+import {
+  createTrpcDbProvider, setupTestDb, testAuthContextLoggedIn, testDb,
+} from '../../__tests__/dbTestUtils';
+
+const routerReplace = vi.fn();
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {},
+    replace: routerReplace,
+  }),
+}));
+
+const ctxFor = (sub: string) => ({
+  ...testAuthContextLoggedIn,
+  auth: { ...testAuthContextLoggedIn.auth!, sub },
+});
+
+const GuardedPage = withAdminGuard(() => <p>Admin only content</p>);
+
+describe('withAdminGuard', () => {
+  setupTestDb();
+
+  beforeEach(() => {
+    routerReplace.mockClear();
+  });
+
+  const renderGuard = (sub: string) => render(
+    <GuardedPage />,
+    { wrapper: createTrpcDbProvider(ctxFor(sub)) },
+  );
+
+  test('shows progress dots while the admin check is pending', () => {
+    const { container } = renderGuard('admin-sub');
+
+    expect(container.querySelector('.progress-dots')).toBeInTheDocument();
+    expect(screen.queryByText('Admin only content')).not.toBeInTheDocument();
+  });
+
+  test('renders children for an admin', async () => {
+    await testDb.insert(userTable, {
+      id: 'admin-id', email: 'admin@example.com', name: 'Admin', isAdmin: true, keycloakIdentifier: 'admin-sub',
+    });
+
+    renderGuard('admin-sub');
+
+    expect(await screen.findByText('Admin only content')).toBeInTheDocument();
+    expect(routerReplace).not.toHaveBeenCalled();
+  });
+
+  test('redirects a non-admin to /404 without rendering children', async () => {
+    await testDb.insert(userTable, {
+      id: 'regular-id', email: 'regular@example.com', name: 'Regular', keycloakIdentifier: 'regular-sub',
+    });
+
+    renderGuard('regular-sub');
+
+    await waitFor(() => {
+      expect(routerReplace).toHaveBeenCalledWith('/404');
+    });
+    expect(screen.queryByText('Admin only content')).not.toBeInTheDocument();
+  });
+});

--- a/apps/website/src/components/admin/withAdminGuard.tsx
+++ b/apps/website/src/components/admin/withAdminGuard.tsx
@@ -1,0 +1,19 @@
+import { ProgressDots } from '@bluedot/ui';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { trpc } from '../../utils/trpc';
+
+export const withAdminGuard = (Component: React.FC): React.FC => {
+  return () => {
+    const router = useRouter();
+    const accessQuery = trpc.admin.isUserAdmin.useQuery(undefined, { retry: false });
+    const isAdmin = accessQuery.data === true;
+    const shouldShow404 = accessQuery.data === false;
+
+    useEffect(() => {
+      if (shouldShow404) router.replace('/404');
+    }, [shouldShow404, router]);
+
+    return isAdmin ? <Component /> : <ProgressDots className="py-8" />;
+  };
+};

--- a/apps/website/src/pages/admin/change-email.tsx
+++ b/apps/website/src/pages/admin/change-email.tsx
@@ -1,9 +1,9 @@
 import {
-  Breadcrumbs, CTALinkOrButton, Input, P, ProgressDots, Section,
+  Breadcrumbs, CTALinkOrButton, Input, P, Section,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { withAdminGuard } from '../../components/admin/withAdminGuard';
 import { UserSearchModal } from '../../components/admin/UserSearchModal';
 import { ROUTES } from '../../lib/routes';
 import type { UserSearchResult } from '../../server/routers/admin';
@@ -11,15 +11,7 @@ import { trpc } from '../../utils/trpc';
 
 const CURRENT_ROUTE = ROUTES.adminChangeEmail;
 
-const AdminChangeEmail = () => {
-  const router = useRouter();
-  const accessQuery = trpc.admin.isUserAdmin.useQuery(undefined, { retry: false });
-  const isAdmin = accessQuery.data === true;
-  const shouldShow404 = accessQuery.data === false;
-  useEffect(() => {
-    if (shouldShow404) router.replace('/404');
-  }, [shouldShow404, router]);
-
+const AdminChangeEmail = withAdminGuard(() => {
   const [isSelectUserModalOpen, setIsSelectUserModalOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(null);
   const [newEmail, setNewEmail] = useState('');
@@ -38,30 +30,13 @@ const AdminChangeEmail = () => {
     requestMutation.mutate({ userId: selectedUser.id, newEmail: newEmail.trim() });
   };
 
-  const header = (
-    <>
+  return (
+    <div>
       <Head>
         <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
         <meta name="robots" content="noindex" />
       </Head>
       <Breadcrumbs route={CURRENT_ROUTE} />
-    </>
-  );
-
-  if (!isAdmin) {
-    return (
-      <div>
-        {header}
-        <Section className="min-h-[50vh]">
-          <ProgressDots className="py-8" />
-        </Section>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      {header}
       <Section className="min-h-[50vh]">
         <div className="flex flex-col gap-6 max-w-prose">
           <P>
@@ -138,6 +113,6 @@ const AdminChangeEmail = () => {
       />
     </div>
   );
-};
+});
 
 export default AdminChangeEmail;

--- a/apps/website/src/pages/admin/deletion-requests.tsx
+++ b/apps/website/src/pages/admin/deletion-requests.tsx
@@ -2,8 +2,8 @@ import {
   Breadcrumbs, CTALinkOrButton, ProgressDots, Section,
 } from '@bluedot/ui';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { withAdminGuard } from '../../components/admin/withAdminGuard';
 import { UserSearchModal } from '../../components/admin/UserSearchModal';
 import DeleteAccountModal from '../../components/settings/DeleteAccountModal';
 import { ROUTES } from '../../lib/routes';
@@ -12,48 +12,21 @@ import { trpc } from '../../utils/trpc';
 
 const CURRENT_ROUTE = ROUTES.adminDeletionRequests;
 
-const AdminDeletionRequests = () => {
-  const router = useRouter();
-
-  const accessQuery = trpc.admin.isUserAdmin.useQuery(undefined, { retry: false });
-  const isAdmin = accessQuery.data === true;
-  const shouldShow404 = accessQuery.data === false;
-
-  useEffect(() => {
-    if (shouldShow404) router.replace('/404');
-  }, [shouldShow404, router]);
-
+const AdminDeletionRequests = withAdminGuard(() => {
   const [isSelectUserModalOpen, setIsSelectUserModalOpen] = useState(false);
   const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(null);
 
-  const requestsQuery = trpc.deletionRequests.list.useQuery(undefined, { enabled: isAdmin, refetchInterval: 15_000 });
+  const requestsQuery = trpc.deletionRequests.list.useQuery(undefined, { refetchInterval: 15_000 });
   const { refetch: refetchRequests } = requestsQuery;
 
-  const header = (
-    <>
+  return (
+    <div>
       <Head>
         <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
         <meta name="robots" content="noindex" />
       </Head>
       <Breadcrumbs route={CURRENT_ROUTE} />
-    </>
-  );
-
-  if (!isAdmin) {
-    return (
-      <div>
-        {header}
-        <Section className="min-h-[50vh]">
-          <ProgressDots className="py-8" />
-        </Section>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      {header}
       <Section className="min-h-[50vh]">
         <div className="flex flex-col gap-6 max-w-prose">
           <div className="container-lined p-4 flex flex-col gap-1">
@@ -127,6 +100,6 @@ const AdminDeletionRequests = () => {
       )}
     </div>
   );
-};
+});
 
 export default AdminDeletionRequests;

--- a/apps/website/src/pages/admin/exercises.tsx
+++ b/apps/website/src/pages/admin/exercises.tsx
@@ -7,6 +7,7 @@ import {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 import { RiSearchLine } from 'react-icons/ri';
+import { withAdminGuard } from '../../components/admin/withAdminGuard';
 import { UserSearchModal } from '../../components/admin/UserSearchModal';
 import MarkdownExtendedRenderer from '../../components/courses/MarkdownExtendedRenderer';
 import { ROUTES } from '../../lib/routes';
@@ -37,17 +38,9 @@ const writeUrlParams = (changes: Record<string, string | undefined>) => {
   window.history.replaceState(window.history.state, '', url);
 };
 
-const AdminUserExerciseResponses = () => {
+const AdminUserExerciseResponses = withAdminGuard(() => {
   const router = useRouter();
   const userId = typeof router.query.userId === 'string' ? router.query.userId : undefined;
-
-  // Page-level admin gate. Until this resolves we render ProgressDots; on `false` we redirect to /404.
-  const accessQuery = trpc.admin.isUserAdmin.useQuery(undefined, { retry: false });
-  const isAdmin = accessQuery.data === true;
-  const shouldShow404 = accessQuery.data === false;
-  useEffect(() => {
-    if (shouldShow404) router.replace('/404');
-  }, [shouldShow404, router]);
 
   const [courseId, setCourseIdState] = useState<string | undefined>(undefined);
   const [includeInProgress, setIncludeInProgressState] = useState<boolean>(false);
@@ -75,7 +68,7 @@ const AdminUserExerciseResponses = () => {
 
   const metaQuery = trpc.admin.getUserExerciseResponsesMetaInfo.useQuery(
     { userId: userId ?? '' },
-    { enabled: !!userId && isAdmin, retry: false },
+    { enabled: !!userId, retry: false },
   );
 
   const exerciseResponseQuery = trpc.admin.getUserExerciseResponses.useInfiniteQuery(
@@ -83,7 +76,7 @@ const AdminUserExerciseResponses = () => {
       userId: userId ?? '', courseId, includeInProgress, search: search || undefined, limit: PAGE_SIZE,
     },
     {
-      enabled: !!userId && isAdmin,
+      enabled: !!userId,
       getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
       initialCursor: 0,
       retry: false,
@@ -128,30 +121,13 @@ const AdminUserExerciseResponses = () => {
     );
   };
 
-  const renderHeader = () => (
-    <>
+  return (
+    <div>
       <Head>
         <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
         <meta name="robots" content="noindex" />
       </Head>
       <Breadcrumbs route={CURRENT_ROUTE} />
-    </>
-  );
-
-  if (!isAdmin) {
-    return (
-      <div>
-        {renderHeader()}
-        <Section>
-          <ProgressDots className="py-8" />
-        </Section>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      {renderHeader()}
       <Section>
         {metaQuery.error && <ErrorSection error={metaQuery.error} />}
         <div className="flex flex-col md:flex-row gap-6">
@@ -255,7 +231,7 @@ const AdminUserExerciseResponses = () => {
       />
     </div>
   );
-};
+});
 
 const ResponseCard = ({
   response, exercise, unit, chunkPosition, exercisePosition,

--- a/apps/website/src/pages/admin/index.tsx
+++ b/apps/website/src/pages/admin/index.tsx
@@ -1,59 +1,42 @@
-import { Breadcrumbs, ProgressDots, Section } from '@bluedot/ui';
+import { Breadcrumbs, Section } from '@bluedot/ui';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { withAdminGuard } from '../../components/admin/withAdminGuard';
 import { ROUTES } from '../../lib/routes';
-import { trpc } from '../../utils/trpc';
 
 const CURRENT_ROUTE = ROUTES.admin;
 
-const AdminHome = () => {
-  const router = useRouter();
-  const accessQuery = trpc.admin.isUserAdmin.useQuery(undefined, { retry: false });
-  const isAdmin = accessQuery.data === true;
-  const shouldShow404 = accessQuery.data === false;
-
-  useEffect(() => {
-    if (shouldShow404) router.replace('/404');
-  }, [shouldShow404, router]);
-
-  return (
-    <div>
-      <Head>
-        <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
-        <meta name="robots" content="noindex" />
-      </Head>
-      <Breadcrumbs route={CURRENT_ROUTE} />
-      <Section className="min-h-[50vh]">
-        {isAdmin ? (
-          <ul className="list-disc list-inside flex flex-col gap-2">
-            <li>
-              <a href={ROUTES.adminSyncDashboard.url} className="text-bluedot-normal underline hover:opacity-80">
-                {ROUTES.adminSyncDashboard.title}
-              </a>
-            </li>
-            <li>
-              <a href={ROUTES.adminUserExerciseResponses.url} className="text-bluedot-normal underline hover:opacity-80">
-                {ROUTES.adminUserExerciseResponses.title}
-              </a>
-            </li>
-            <li>
-              <a href={ROUTES.adminChangeEmail.url} className="text-bluedot-normal underline hover:opacity-80">
-                {ROUTES.adminChangeEmail.title}
-              </a>
-            </li>
-            <li>
-              <a href={ROUTES.adminDeletionRequests.url} className="text-bluedot-normal underline hover:opacity-80">
-                {ROUTES.adminDeletionRequests.title}
-              </a>
-            </li>
-          </ul>
-        ) : (
-          <ProgressDots className="py-8" />
-        )}
-      </Section>
-    </div>
-  );
-};
+const AdminHome = withAdminGuard(() => (
+  <div>
+    <Head>
+      <title>{`${CURRENT_ROUTE.title} | BlueDot Impact`}</title>
+      <meta name="robots" content="noindex" />
+    </Head>
+    <Breadcrumbs route={CURRENT_ROUTE} />
+    <Section className="min-h-[50vh]">
+      <ul className="list-disc list-inside flex flex-col gap-2">
+        <li>
+          <a href={ROUTES.adminSyncDashboard.url} className="text-bluedot-normal underline hover:opacity-80">
+            {ROUTES.adminSyncDashboard.title}
+          </a>
+        </li>
+        <li>
+          <a href={ROUTES.adminUserExerciseResponses.url} className="text-bluedot-normal underline hover:opacity-80">
+            {ROUTES.adminUserExerciseResponses.title}
+          </a>
+        </li>
+        <li>
+          <a href={ROUTES.adminChangeEmail.url} className="text-bluedot-normal underline hover:opacity-80">
+            {ROUTES.adminChangeEmail.title}
+          </a>
+        </li>
+        <li>
+          <a href={ROUTES.adminDeletionRequests.url} className="text-bluedot-normal underline hover:opacity-80">
+            {ROUTES.adminDeletionRequests.title}
+          </a>
+        </li>
+      </ul>
+    </Section>
+  </div>
+));
 
 export default AdminHome;


### PR DESCRIPTION
# Description

We had repeated admin-guarding logic across all the admin pages. This adds a `withAdminGuard` higher order component, modelled after `withAuth` to guard the pages.

## Issue

Fixes #2861

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

## Screenshot

_No visual change_