### PR TITLE
Remove deletion request notification via customer.io

### DIFF
--- a/apps/website/src/lib/api/customerio.ts
+++ b/apps/website/src/lib/api/customerio.ts
@@ -162,27 +162,6 @@ export async function sendEmailChangeVerification({ oldEmail, newEmail, confirmU
   }
 }
 
-export async function sendAccountDeletionRequestedNotice({ email }: { email: string }): Promise<void> {
-  const res = await fetch(`${CIO_API_BASE}/send/email`, {
-    method: 'POST',
-    headers: { ...appHeaders(), 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      to: normaliseEmail(email),
-      identifiers: { email: normaliseEmail(email) },
-      send_to_unsubscribed: true,
-      from: 'BlueDot Impact <team@bluedot.org>',
-      subject: 'Account deletion requested',
-      body: [
-        '<p>A request was made to delete your BlueDot Impact account. Your account, including any course records, will be deleted shortly.</p>',
-        '<p>If this was not intended, reply to this email so we can help.</p>',
-      ].join('\n'),
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`customer.io account deletion notice send failed: HTTP ${res.status}`);
-  }
-}
-
 export async function sendEmailChangeRequestedNotice({ oldEmail, newEmail }: { oldEmail: string; newEmail: string }): Promise<void> {
   const safeOldEmail = escapeHtml(normaliseEmail(oldEmail));
   const safeNewEmail = escapeHtml(normaliseEmail(newEmail));

--- a/apps/website/src/server/routers/deletion-requests.test.ts
+++ b/apps/website/src/server/routers/deletion-requests.test.ts
@@ -374,28 +374,11 @@ describe('deletionRequests.adminRequestAccountDeletion', () => {
       .rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
-  test('sends a confirmation email to the account being deleted', async () => {
+  test('does not email the account through customer.io', async () => {
     await makeAdmin();
 
     await createCaller(testAuthContextLoggedIn).deletionRequests.adminRequestAccountDeletion({ userId: SUBJECT.id });
 
-    await vi.waitFor(() => expect(cioEmailSends).toEqual([{ to: SUBJECT.email, subject: 'Account deletion requested' }]));
-  });
-
-  test('still creates the request when the confirmation email fails, and alerts', async () => {
-    await makeAdmin();
-    vi.stubGlobal('fetch', vi.fn(async (input: string, init?: RequestInit) => {
-      if (init?.method === 'POST' && new URL(input).pathname === '/v1/send/email') {
-        return new Response('nope', { status: 500 });
-      }
-
-      return fakeCio(input, init);
-    }));
-
-    const { request } = await createCaller(testAuthContextLoggedIn).deletionRequests.adminRequestAccountDeletion({ userId: SUBJECT.id });
-
-    expect(request).toMatchObject({ userId: SUBJECT.id, status: 'Pending' });
-    await vi.waitFor(() => expect(vi.mocked(slackAlert).mock.calls[0]?.[1]?.[0]).toContain('confirmation notice'));
     expect(cioEmailSends).toEqual([]);
   });
 
@@ -490,7 +473,7 @@ describe('deletionRequests.userRequestAccountDeletion', () => {
       initiatedByRole: 'User',
       initiatedBy: ['test-user'],
     });
-    await vi.waitFor(() => expect(cioEmailSends).toEqual([{ to: 'test@example.com', subject: 'Account deletion requested' }]));
+    expect(cioEmailSends).toEqual([]);
   });
 
   test('blocks the request while impersonating another user', async () => {

--- a/apps/website/src/server/routers/deletion-requests.ts
+++ b/apps/website/src/server/routers/deletion-requests.ts
@@ -14,11 +14,8 @@ import {
 } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import { logger } from '@bluedot/ui/src/api';
-import { slackAlert } from '@bluedot/utils/src/slackNotifications';
 import z from 'zod';
 import db from '../../lib/api/db';
-import env from '../../lib/api/env';
-import { sendAccountDeletionRequestedNotice } from '../../lib/api/customerio';
 import { DELETION_REQUEST_STATUS } from '../../lib/constants';
 import { runAccountDeletion } from '../../lib/api/accountDeletion';
 import { normaliseEmail, verifyPublicToken } from '../../lib/api/utils';
@@ -89,9 +86,6 @@ export const deletionRequestsRouter = router({
         requestedAt: new Date().toISOString(),
       });
 
-      sendAccountDeletionRequestedNotice({ email: subject.email })
-        .catch((error: unknown) => slackAlert(env, [`[AccountDeletion] confirmation notice for deletion request ${request.id} failed: ${error instanceof Error ? error.message : String(error)}`]));
-
       logger.info(`[AccountDeletion] deletion request ${request.id} created for user ${subject.id} by admin ${initiator.email}`);
 
       return { request, isRetry: false };
@@ -134,9 +128,6 @@ export const deletionRequestsRouter = router({
       initiatedBy: [subject.id],
       requestedAt: new Date().toISOString(),
     });
-
-    sendAccountDeletionRequestedNotice({ email: subject.email })
-      .catch((error: unknown) => slackAlert(env, [`[AccountDeletion] confirmation notice for deletion request ${request.id} failed: ${error instanceof Error ? error.message : String(error)}`]));
 
     logger.info(`[AccountDeletion] deletion request ${request.id} created for user ${subject.id} by ${subject.email}`);
 


### PR DESCRIPTION
# Description

Previously this deletion request notice would leave a stub profile in customer.io, which could make it so the user who just deleted their account receives broadcast emails in future (probably not what they want).

I have replaced this with a Gmail step in the [automation](https://airtable.com/appnJbsG1eWbAdEvf/wflyrP2PiE5A51RZL/wacWlL97KUzUswu0C) that send a notification after we process a deletion request. This needs to be deployed at the same time as turning that on so there is no time where no notification is sent (doesn't need to be exact, requests are ~1/day)

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2911

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories