### PR TITLE
[feat] db: add utmCampaign and utmContent to self_serve_course_registration

### DIFF
--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -1382,6 +1382,14 @@ export const selfServeCourseRegistrationTable = pgAirtable('self_serve_course_re
       pgColumn: text(),
       airtableId: 'fldMCr1ReFdYRj9NP',
     },
+    utmCampaign: {
+      pgColumn: text(),
+      airtableId: 'flduva81z6bP5lkJU',
+    },
+    utmContent: {
+      pgColumn: text(),
+      airtableId: 'flddYe9YzHyjBMe5g',
+    },
     createdAt: {
       pgColumn: text(),
       airtableId: 'fldRiPmXA2UB9M9j5',


### PR DESCRIPTION
# Description

Adds `utmCampaign` and `utmContent` columns to `selfServeCourseRegistrationTable`, mapping the new "UTM campaign" and "UTM content" fields in the Self-serve course registrations Airtable table.

## Issue

Follow-up to #2924

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories