### PR TITLE
[feat] website: forward utm_campaign and utm_content to FoAI self-serve registrations

### DIFF
--- a/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
+++ b/apps/website/src/pages/courses/[courseSlug]/[unitNumber]/[[...chunkNumber]].tsx
@@ -85,10 +85,15 @@ const CourseUnitChunkPage = ({
     // FoAI course only: If we're logged in, ensures a course registration is recorded
     const shouldRecordCourseRegistration = auth && (unit.courseId === FOAI_COURSE_ID);
     if (shouldRecordCourseRegistration && !isUtmLoading && !isEnsureExistsPending) {
-      createCourseRegistrationMutation({ courseId: unit.courseId, source: latestUtmParams.utm_source });
+      createCourseRegistrationMutation({
+        courseId: unit.courseId,
+        source: latestUtmParams.utm_source,
+        utmCampaign: latestUtmParams.utm_campaign,
+        utmContent: latestUtmParams.utm_content,
+      });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- isEnsureExistsPending intentionally excluded to avoid re-fire loop
-  }, [auth, unit.courseId, latestUtmParams.utm_source, createCourseRegistrationMutation, isUtmLoading]);
+  }, [auth, unit.courseId, latestUtmParams.utm_source, latestUtmParams.utm_campaign, latestUtmParams.utm_content, createCourseRegistrationMutation, isUtmLoading]);
 
   useEffect(() => {
     if (chunks && (chunkIndex < 0 || chunkIndex >= chunks.length)) {

--- a/apps/website/src/server/routers/self-serve-course-registrations.test.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.test.ts
@@ -1,5 +1,8 @@
-import { selfServeCourseRegistrationTable } from '@bluedot/db';
-import { describe, expect, test } from 'vitest';
+import { applicationsCourseTable, selfServeCourseRegistrationTable } from '@bluedot/db';
+import {
+  describe, expect, test, vi,
+} from 'vitest';
+import db from '../../lib/api/db';
 import {
   createCaller, seedLoggedInUser, setupTestDb, testAuthContextLoggedIn, testAuthContextLoggedOut, testDb,
 } from '../../__tests__/dbTestUtils';
@@ -46,6 +49,39 @@ describe('selfServeCourseRegistrations.ensureExists', () => {
       .rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
-  // The full "creates a new FOAI registration" path isn't unit-testable: the insert omits `courseId`
-  // (a notNull lookup column the pg test schema rejects, populated by Airtable in prod).
+  test('writes the UTM params onto a new registration', async () => {
+    await seedLoggedInUser();
+    await testDb.insert(applicationsCourseTable, { id: 'app-course-foai', courseBuilderId: FOAI_COURSE_ID });
+    // The real insert can't run here: it omits `courseId`, a notNull lookup column populated by Airtable in prod
+    const insertSpy = vi.spyOn(db, 'insert').mockResolvedValue({ id: 'ss-new' } as never);
+
+    await createCaller(testAuthContextLoggedIn).selfServeCourseRegistrations.ensureExists({
+      courseId: FOAI_COURSE_ID,
+      source: 'newsletter',
+      utmCampaign: 'spring-launch',
+      utmContent: 'hero-cta',
+    });
+
+    expect(insertSpy).toHaveBeenCalledWith(selfServeCourseRegistrationTable, expect.objectContaining({
+      source: 'newsletter',
+      utmCampaign: 'spring-launch',
+      utmContent: 'hero-cta',
+    }));
+    insertSpy.mockRestore();
+  });
+
+  test('writes nulls when no UTM params are supplied', async () => {
+    await seedLoggedInUser();
+    await testDb.insert(applicationsCourseTable, { id: 'app-course-foai', courseBuilderId: FOAI_COURSE_ID });
+    const insertSpy = vi.spyOn(db, 'insert').mockResolvedValue({ id: 'ss-new' } as never);
+
+    await createCaller(testAuthContextLoggedIn).selfServeCourseRegistrations.ensureExists({ courseId: FOAI_COURSE_ID });
+
+    expect(insertSpy).toHaveBeenCalledWith(selfServeCourseRegistrationTable, expect.objectContaining({
+      source: null,
+      utmCampaign: null,
+      utmContent: null,
+    }));
+    insertSpy.mockRestore();
+  });
 });

--- a/apps/website/src/server/routers/self-serve-course-registrations.ts
+++ b/apps/website/src/server/routers/self-serve-course-registrations.ts
@@ -8,9 +8,17 @@ import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 
 export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
-  .input(z.object({ courseId: z.string(), source: z.string().trim().max(255).optional() }))
+  .input(z.object({
+    courseId: z.string(),
+    // `source` is "UTM source", just like utmContent/utmCampaign; name format is different for backwards compatibility
+    source: z.string().trim().max(255).optional(),
+    utmCampaign: z.string().trim().max(255).optional(),
+    utmContent: z.string().trim().max(255).optional(),
+  }))
   .mutation(async ({ ctx, input }) => {
-    const { courseId, source } = input;
+    const {
+      courseId, source, utmCampaign, utmContent,
+    } = input;
 
     if (courseId !== FOAI_COURSE_ID) {
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'Only the Future of AI course supports self-serve registration' });
@@ -39,6 +47,8 @@ export const ensureSelfServeRegistrationExistsProcedure = protectedProcedure
       userId: user.id,
       courseApplicationsBaseId: applicationsCourse.id,
       source: source ?? null,
+      utmCampaign: utmCampaign ?? null,
+      utmContent: utmContent ?? null,
       createdAt: new Date().toISOString(),
     });
   });


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Populated the `utmCampaign` and `utmContent` fields in line with the rule used for `source` (UTM source)

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Follow-up to #2924, to make FoAI behave the same as facilitated courses

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories