### PR TITLE
[fix] grant page not showing grants rewarded

### DIFF
--- a/apps/website/src/server/routers/grants.test.ts
+++ b/apps/website/src/server/routers/grants.test.ts
@@ -273,10 +273,10 @@ describe('grants.getRapidGrantStats', () => {
 });
 
 describe('grants.getCareerTransitionGrantStats', () => {
-  test('counts and sums only Approved + Agreement signed; averages every decided row including same-day (0) decisions', async () => {
-    // Granted (Approved + Agreement signed) — counted in count + totalAmountUsd.
-    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 80000, status: 'Agreement signed', timeToDecisionDays: 10 });
-    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 60000, status: 'Approved', timeToDecisionDays: 20 });
+  test('counts and sums only approved grants; averages every decided row including same-day (0) decisions', async () => {
+    // "Approve" is the granted status from the applications table.
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 80000, status: 'Approve', timeToDecisionDays: 10 });
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 60000, status: 'Approve', timeToDecisionDays: 20 });
     // Rejected — excluded from count/total, but its decision time still feeds avg.
     await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 0, status: 'Rejected', timeToDecisionDays: 6 });
     // Same-day decision (0 days) — a real decided row, included in the avg.
@@ -292,7 +292,7 @@ describe('grants.getCareerTransitionGrantStats', () => {
   });
 
   test('returns null avg when no rows have been decided', async () => {
-    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 50000, status: 'Agreement signed', timeToDecisionDays: null });
+    await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: 50000, status: 'Approve', timeToDecisionDays: null });
     await testDb.insert(careerTransitionGrantApplicationTable, { grantAmountUsd: null, status: 'TODO', timeToDecisionDays: null });
 
     const caller = createCaller();

--- a/apps/website/src/server/routers/grants.ts
+++ b/apps/website/src/server/routers/grants.ts
@@ -201,7 +201,7 @@ export const grantsRouter = router({
   // [*] Time to decision formula has resolved to a number, same-day 0s included).
   getCareerTransitionGrantStats: publicProcedure.query(async (): Promise<CareerTransitionGrantStats> => {
     const all = await db.scan(careerTransitionGrantApplicationTable);
-    const granted = all.filter((g) => g.status === 'Approved' || g.status === 'Agreement signed');
+    const granted = all.filter((g) => g.status === 'Approve');
     return {
       count: granted.length,
       totalAmountUsd: granted.reduce((sum, g) => sum + (g.grantAmountUsd ?? 0), 0),


### PR DESCRIPTION
# Description

Fix the Career Transition Grant totals.

The production data uses `Approve` for awarded grants. The code checked for `Approved` and `Agreement signed`, so the page showed zero grants and zero funding. This change uses the current `Approve` value and updates the tests.

## Issue

Not linked to an issue but Sam called it out on slack

## Developer checklist

- [x] Front-end code follows the [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist). No front-end component changed.
- [x] Considered snapshot and happy-path tests. Updated the focused router tests.
- [x] Considered Storybook stories. No component changed.

## Screenshot

| View | Before | After |
|---|---|---|
| Desktop | <img width="1512" height="784" alt="image" src="https://github.com/user-attachments/assets/83331aa9-3efc-4ab3-9313-e5a486e5cbb1" /> | 
<img width="1512" height="784" alt="image" src="https://github.com/user-attachments/assets/6425afd0-a378-4052-a44a-1cf91c0fb5c4" />
 |
