### PR TITLE
[fix] infra: export k8s resource attributes as Prometheus labels from otel-collector

### DIFF
--- a/apps/infra/src/k8s/observability.ts
+++ b/apps/infra/src/k8s/observability.ts
@@ -196,6 +196,9 @@ new k8s.helm.v3.Release('opentelemetry-collector', {
         // Expose metrics for Prometheus
         prometheus: {
           endpoint: '0.0.0.0:8889',
+          // Without this, resource attributes (k8s.pod.name etc.) are dropped and every pod's
+          // kubeletstats series collapses into one
+          resource_to_telemetry_conversion: { enabled: true },
         },
         // Send logs to Loki
         'otlphttp/loki': {


### PR DESCRIPTION
# Description

> // Without this, resource attributes (k8s.pod.name etc.) are dropped and every pod's
> // kubeletstats series collapses into one

This will let us view metrics like `container_memory_working_set_bytes` at a per-pod level, which will make it easier to diagnose memory issues in future

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Related to #2934

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories