### PR TITLE
[chore] infra: return VKE main node pool to a single node

### DIFF
--- a/apps/infra/src/vultr/vke.ts
+++ b/apps/infra/src/vultr/vke.ts
@@ -27,7 +27,7 @@ export const k8sCluster = new vultr.Kubernetes('vke-cluster', {
 new vultr.KubernetesNodePools('vke-node-pool-main', {
   clusterId: k8sCluster.id,
   label: 'main-node-pool',
-  nodeQuantity: 2,
+  nodeQuantity: 1,
   // https://api.vultr.com/v2/plans
   plan: 'vhf-4c-16gb',
   autoScaler: false,


### PR DESCRIPTION
# Description

#2917 added a second node as an emergency drain target during the 19-20 Aug outage. The old node was drained and has been empty (except DaemonSets) since 20 Aug, I'm now removing it.

This PR puts `nodeQuantity` back to 1. Vultr doesn't document which node it removes on a scale-down, so I'll delete the old node by hand first, and this PR should be a no-op when it deploys.

Runbook:
- [x] Delete node `acd2bfeb-cdad-4ae3-b68d-bbda5d50478e` in the [Vultr console](https://console.vultr.com/kubernetes/manage/?id=83dad468-420e-4bdb-a5da-5b5395b22bdc#subsnodes)
- [x] `cd apps/infra && PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi refresh --stack prod` so Pulumi state sees quantity 1. Don't run any other `pulumi up` before merging this, it would scale back to 2 (read: merge it quickly after)
- [x] Merge this PR (first check that `pulumi preview` on this branch is a no-op)

Unblocks #2936

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2935

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories