### PR TITLE
[fix] website: remove Facilitator Applications "Active" tab, default to first non-empty tab

### DIFF
--- a/apps/website/src/__tests__/pages/facilitator-applications.test.tsx
+++ b/apps/website/src/__tests__/pages/facilitator-applications.test.tsx
@@ -42,8 +42,8 @@ const application = (overrides: Partial<FacilitatorApplicationListItem>): Facili
   ...overrides,
 });
 
-const renderPage = async (apps: FacilitatorApplicationListItem[], tab = 'active') => {
-  routerQuery = { tab };
+const renderPage = async (apps: FacilitatorApplicationListItem[], tab?: string) => {
+  routerQuery = tab ? { tab } : {};
   server.use(trpcMsw.facilitatorApplications.list.query(() => apps));
   render(<FacilitatorApplicationsPage />, { wrapper: TrpcProvider });
   await screen.findByText(apps[0]!.roundName!);
@@ -109,5 +109,13 @@ describe('FacilitatorApplicationsPage', () => {
     await renderPage([application({ decision: 'Reject', roundStatus: 'Past' })], 'past');
 
     expect(openMenuItems()).toEqual([]);
+  });
+
+  test('without a tab param, defaults to the first non-empty tab', async () => {
+    await renderPage([application({ decision: 'Withdrawn', roundStatus: 'Future' })]);
+
+    expect(screen.queryByRole('button', { name: 'Active' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Past' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Accepted' })).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/apps/website/src/components/facilitator-applications/applicationTabs.test.ts
+++ b/apps/website/src/components/facilitator-applications/applicationTabs.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import type { FacilitatorApplicationListItem } from '../../server/routers/facilitator-applications';
-import { filterByTab, getApplicationStatus, isApplicationTab } from './applicationTabs';
+import {
+  filterByTab, getApplicationStatus, getDefaultTab, isApplicationTab,
+} from './applicationTabs';
 
 const baseApp = (overrides: Partial<FacilitatorApplicationListItem>): FacilitatorApplicationListItem => ({
   id: 'reg-1',
@@ -22,11 +24,12 @@ const baseApp = (overrides: Partial<FacilitatorApplicationListItem>): Facilitato
 
 describe('isApplicationTab', () => {
   test('accepts known tab ids', () => {
-    expect(isApplicationTab('active')).toBe(true);
+    expect(isApplicationTab('accepted')).toBe(true);
     expect(isApplicationTab('past')).toBe(true);
   });
   test('rejects unknown values', () => {
     expect(isApplicationTab('foo')).toBe(false);
+    expect(isApplicationTab('active')).toBe(false);
     expect(isApplicationTab(undefined)).toBe(false);
   });
 });
@@ -65,12 +68,6 @@ describe('filterByTab', () => {
 
   const all = [accepted, pending, activeAccepted, inFlightRejected, pastAccepted, pastRejected, withdrawnFuture];
 
-  test('active excludes withdrawn and rejected (terminal decisions)', () => {
-    expect(filterByTab(all, 'active')
-      .map((a) => a.id)
-      .sort()).toEqual(['a', 'aa', 'p'].sort());
-  });
-
   test('accepted includes only in-flight accepted', () => {
     expect(filterByTab(all, 'accepted')
       .map((a) => a.id)
@@ -85,5 +82,23 @@ describe('filterByTab', () => {
     expect(filterByTab(all, 'past')
       .map((a) => a.id)
       .sort()).toEqual(['ir', 'pa', 'pr', 'wf'].sort());
+  });
+});
+
+describe('getDefaultTab', () => {
+  test('picks the first tab with content, in tab order', () => {
+    expect(getDefaultTab([
+      baseApp({ decision: 'Accept', roundStatus: 'Active' }),
+      baseApp({ decision: null, roundStatus: 'Future' }),
+    ])).toBe('accepted');
+    expect(getDefaultTab([
+      baseApp({ decision: null, roundStatus: 'Future' }),
+      baseApp({ decision: 'Reject', roundStatus: 'Past' }),
+    ])).toBe('pending');
+    expect(getDefaultTab([baseApp({ decision: 'Withdrawn' })])).toBe('past');
+  });
+
+  test('falls back to the first tab when there are no applications', () => {
+    expect(getDefaultTab([])).toBe('accepted');
   });
 });

--- a/apps/website/src/components/facilitator-applications/applicationTabs.ts
+++ b/apps/website/src/components/facilitator-applications/applicationTabs.ts
@@ -1,7 +1,6 @@
 import type { FacilitatorApplicationListItem } from '../../server/routers/facilitator-applications';
 
 export const APPLICATION_TABS = [
-  { id: 'active', label: 'Active' },
   { id: 'accepted', label: 'Accepted' },
   { id: 'pending', label: 'Pending' },
   { id: 'past', label: 'Past' },
@@ -41,8 +40,6 @@ const isInFlight = (a: FacilitatorApplicationListItem): boolean =>
   a.roundStatus === 'Active' || a.roundStatus === 'Future';
 
 const TAB_PREDICATES: Record<ApplicationTab, (a: FacilitatorApplicationListItem) => boolean> = {
-  // In-flight applications still in play (not withdrawn, not rejected — those are terminal).
-  active: (a) => isInFlight(a) && a.decision !== 'Withdrawn' && a.decision !== 'Reject',
   accepted: (a) => isInFlight(a) && a.decision === 'Accept',
   pending: (a) => isInFlight(a) && a.decision == null,
   // Past rounds OR any terminal decision (withdrawn / rejected) regardless of round status.
@@ -53,3 +50,8 @@ export const filterByTab = (
   applications: FacilitatorApplicationListItem[],
   tab: ApplicationTab,
 ): FacilitatorApplicationListItem[] => applications.filter(TAB_PREDICATES[tab]);
+
+export const getDefaultTab = (applications: FacilitatorApplicationListItem[]): ApplicationTab => {
+  const firstNonEmpty = APPLICATION_TABS.find((tab) => applications.some(TAB_PREDICATES[tab.id]));
+  return (firstNonEmpty ?? APPLICATION_TABS[0]).id;
+};

--- a/apps/website/src/pages/facilitator-applications/index.tsx
+++ b/apps/website/src/pages/facilitator-applications/index.tsx
@@ -11,6 +11,7 @@ import {
   APPLICATION_TABS,
   filterByTab,
   getApplicationStatus,
+  getDefaultTab,
   isApplicationTab,
   type ApplicationTab,
 } from '../../components/facilitator-applications/applicationTabs';
@@ -82,10 +83,6 @@ const getApplicationActions = (
 };
 
 const EMPTY_BY_TAB: Record<ApplicationTab, { title: string; description: string }> = {
-  active: {
-    title: 'No active applications',
-    description: 'Applications you submit will appear here.',
-  },
   accepted: {
     title: 'No accepted applications',
     description: 'Accepted applications for upcoming rounds will appear here.',
@@ -103,13 +100,14 @@ const EMPTY_BY_TAB: Record<ApplicationTab, { title: string; description: string 
 const FacilitatorApplicationsPage = () => {
   const router = useRouter();
   const queryTab = router.query.tab;
-  const activeTab: ApplicationTab = isApplicationTab(queryTab) ? queryTab : 'active';
 
   const setActiveTab = (id: ApplicationTab) => {
     router.replace({ pathname: router.pathname, query: { ...router.query, tab: id } }, undefined, { shallow: true });
   };
 
   const { data, isLoading, error } = trpc.facilitatorApplications.list.useQuery();
+
+  const activeTab: ApplicationTab = isApplicationTab(queryTab) ? queryTab : getDefaultTab(data ?? []);
 
   const [showAll, setShowAll] = useState(false);
   const [withdrawingId, setWithdrawingId] = useState<string | null>(null);


### PR DESCRIPTION
# Description

Per [this comment](https://github.com/bluedotimpact/bluedot/issues/2843#issuecomment-5428727283), this tab included a confusing set of applications, and wasn't adding anything over the other three tabs. Also included in this PR is defaulting to the first non-empty tab, which Eleni suggested [here](https://github.com/bluedotimpact/bluedot/pull/2929#pullrequestreview-5055307034).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2843

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | <img width="3024" height="1392" alt="Screenshot 2026-08-31 at 14 36 33" src="https://github.com/user-attachments/assets/b54e70e0-1dd8-4827-b2ec-73f288a1fc90" /> | <img width="3024" height="1392" alt="Screenshot 2026-08-31 at 14 36 10" src="https://github.com/user-attachments/assets/c60babd3-a4ee-4bef-8f34-f408d814dc26" /> |
