### PR TITLE
[chore] infra: set memory requests/limits (room, editor, +6 more)

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -184,6 +184,14 @@ export const services: ServiceDefinition[] = [
         ],
         readinessProbe: WEBSITE_HEALTH_CHECK,
         livenessProbe: WEBSITE_HEALTH_CHECK,
+        resources: {
+          requests: {
+            memory: '256Mi',
+          },
+          limits: {
+            memory: '1500Mi',
+          },
+        },
       }],
     },
     hosts: ['website-staging.k8s.bluedot.org'],
@@ -256,6 +264,14 @@ export const services: ServiceDefinition[] = [
           { name: 'WEBSITE_ASSETS_BUCKET_ACCESS_KEY_ID', value: websiteAssetsBucket.readWriteUser.name },
           { name: 'WEBSITE_ASSETS_BUCKET_SECRET_ACCESS_KEY', value: websiteAssetsBucket.readWriteUser.secret },
         ],
+        resources: {
+          requests: {
+            memory: '256Mi',
+          },
+          limits: {
+            memory: '512Mi',
+          },
+        },
       }],
     },
     hosts: ['editor.k8s.bluedot.org'],
@@ -266,6 +282,14 @@ export const services: ServiceDefinition[] = [
       containers: [{
         name: 'bluedot-posthog-proxy',
         image: 'ghcr.io/bluedotimpact/bluedot-posthog-proxy:latest',
+        resources: {
+          requests: {
+            memory: '16Mi',
+          },
+          limits: {
+            memory: '128Mi',
+          },
+        },
       }],
     },
     hosts: ['analytics.k8s.bluedot.org'],
@@ -315,6 +339,14 @@ export const services: ServiceDefinition[] = [
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
         ],
+        resources: {
+          requests: {
+            memory: '128Mi',
+          },
+          limits: {
+            memory: '512Mi',
+          },
+        },
       }],
     },
     hosts: ['room.bluedot.org'],
@@ -333,6 +365,14 @@ export const services: ServiceDefinition[] = [
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
         ],
+        resources: {
+          requests: {
+            memory: '256Mi',
+          },
+          limits: {
+            memory: '1Gi',
+          },
+        },
       }],
     },
     hosts: ['course-demos.k8s.bluedot.org'],
@@ -349,6 +389,14 @@ export const services: ServiceDefinition[] = [
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
         ],
+        resources: {
+          requests: {
+            memory: '256Mi',
+          },
+          limits: {
+            memory: '512Mi',
+          },
+        },
       }],
     },
     hosts: ['speed-review.k8s.bluedot.org'],
@@ -504,6 +552,14 @@ export const services: ServiceDefinition[] = [
           name: 'mcp-data-volume',
           mountPath: '/app/data',
         }],
+        resources: {
+          requests: {
+            memory: '128Mi',
+          },
+          limits: {
+            memory: '1Gi',
+          },
+        },
       }],
       volumes: [{
         name: 'mcp-data-volume',
@@ -542,6 +598,14 @@ export const services: ServiceDefinition[] = [
           name: 'mcp-data-volume',
           mountPath: '/app/data',
         }],
+        resources: {
+          requests: {
+            memory: '64Mi',
+          },
+          limits: {
+            memory: '1Gi',
+          },
+        },
       }],
       volumes: [{
         name: 'mcp-data-volume',


### PR DESCRIPTION
# Description

I'm working through setting [these memory limits](https://github.com/bluedotimpact/bluedot/issues/2934) in batches, starting with the simplest/lowest risk. [Batch 1](https://github.com/bluedotimpact/bluedot/pull/2940) (4 services) went out without issue, this is batch 2 (8 services this time)

Full list of services:
- bluedot-room: 128Mi / 512Mi
- bluedot-editor: 256Mi / 512Mi
- bluedot-speed-review: 256Mi / 512Mi
- bluedot-course-demos: 256Mi / 1Gi
- bluedot-mcp-ashby: 64Mi / 1Gi
- bluedot-mcp-google-workspace: 128Mi / 1Gi
- bluedot-posthog-proxy: 16Mi / 128Mi
- bluedot-website (staging): 256Mi / 1500Mi

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2934

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories