### PR TITLE
[chore] infra: set memory requests/limits on observability stack (prometheus-operator, +7 more)

### DIFF
--- a/apps/infra/src/k8s/observability.ts
+++ b/apps/infra/src/k8s/observability.ts
@@ -83,7 +83,35 @@ const kubePrometheus = new k8s.helm.v3.Release('kube-prometheus', {
     alertmanager: {
       enabled: false,
     },
+    prometheusOperator: {
+      resources: {
+        requests: {
+          memory: '64Mi',
+        },
+        limits: {
+          memory: '192Mi',
+        },
+      },
+    },
+    'kube-state-metrics': {
+      resources: {
+        requests: {
+          memory: '64Mi',
+        },
+        limits: {
+          memory: '256Mi',
+        },
+      },
+    },
     grafana: {
+      resources: {
+        requests: {
+          memory: '256Mi',
+        },
+        limits: {
+          memory: '1Gi',
+        },
+      },
       env: {
         GF_DATABASE_TYPE: 'postgres',
         GF_DATABASE_HOST: getConnectionDetails(grafanaPg).host,
@@ -164,6 +192,14 @@ new k8s.helm.v3.Release('opentelemetry-collector', {
     },
     command: {
       name: 'otelcol-contrib',
+    },
+    resources: {
+      requests: {
+        memory: '128Mi',
+      },
+      limits: {
+        memory: '512Mi',
+      },
     },
     presets: {
       // Collect logs from Kubernetes containers
@@ -309,8 +345,24 @@ new k8s.helm.v3.Release('loki', {
     deploymentMode: 'SingleBinary',
     singleBinary: {
       replicas: 1,
+      resources: {
+        requests: {
+          memory: '512Mi',
+        },
+        limits: {
+          memory: '1500Mi',
+        },
+      },
     },
     gateway: {
+      resources: {
+        requests: {
+          memory: '24Mi',
+        },
+        limits: {
+          memory: '96Mi',
+        },
+      },
       // Partial fix for https://github.com/bluedotimpact/bluedot/issues/1170 , the default anti-affinity
       // rules were preventing deployment on our single node cluster (because pods can't be scheduled on
       // separate nodes)

--- a/apps/infra/src/k8s/postgres.ts
+++ b/apps/infra/src/k8s/postgres.ts
@@ -47,6 +47,14 @@ export const grafanaPg = new k8s.apiextensions.CustomResource('grafana-pg', {
     storage: {
       size: '5Gi',
     },
+    resources: {
+      requests: {
+        memory: '128Mi',
+      },
+      limits: {
+        memory: '1Gi',
+      },
+    },
   },
 }, { provider, dependsOn: [cloudNativePg] });
 

--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -461,6 +461,7 @@ export const services: ServiceDefinition[] = [
           { name: 'MINIO_ROOT_USER', value: 'root' },
           { name: 'MINIO_ROOT_PASSWORD', valueFrom: envVarSources.minioRootPassword },
           { name: 'MINIO_BROWSER', value: 'false' },
+          { name: 'GOMEMLIMIT', value: '1200MiB' },
         ],
         volumeMounts: [
           {
@@ -472,6 +473,14 @@ export const services: ServiceDefinition[] = [
           httpGet: {
             path: '/minio/health/ready',
             port: 8080,
+          },
+        },
+        resources: {
+          requests: {
+            memory: '512Mi',
+          },
+          limits: {
+            memory: '1500Mi',
           },
         },
       }],


### PR DESCRIPTION
# Description

I'm working through setting [these memory limits](https://github.com/bluedotimpact/bluedot/issues/2934) in batches, starting with the simplest/lowest risk. [Batch 1](https://github.com/bluedotimpact/bluedot/pull/2940) and [2](https://github.com/bluedotimpact/bluedot/pull/2941) went out without issue. This is batch 3, all still low risk, and focused on the observability stack.

Full list of services:
- prometheus-operator: 64Mi / 192Mi
- kube-state-metrics: 64Mi / 256Mi
- grafana: 256Mi / 1Gi
- loki-gateway: 24Mi / 96Mi
- opentelemetry-collector: 128Mi / 512Mi
- loki: 512Mi / 1500Mi
- grafana-pg: 128Mi / 1Gi
- minio: 512Mi / 1500Mi, plus `GOMEMLIMIT=1200MiB`

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2934

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories


