### PR TITLE
[chore] infra: set memory requests/limits on website-production, website-proxy, meet, availability

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -153,6 +153,11 @@ export const services: ServiceDefinition[] = [
       containers: [{
         name: 'bluedot-website-proxy',
         image: 'ghcr.io/bluedotimpact/bluedot-website-proxy:latest',
+        resources: {
+          requests: {
+            memory: '16Mi',
+          },
+        },
       }],
     },
     hosts: ['website-proxy.k8s.bluedot.org', 'www.bluedot.org', 'bluedot.org', 'www.aisafetyfundamentals.com', 'aisafetyfundamentals.com', 'www.biosecurityfundamentals.com', 'biosecurityfundamentals.com', 'course.bluedot.org', 'course.aisafetyfundamentals.com', 'course.biosecurityfundamentals.com'],
@@ -227,6 +232,11 @@ export const services: ServiceDefinition[] = [
         ],
         readinessProbe: WEBSITE_HEALTH_CHECK,
         livenessProbe: WEBSITE_HEALTH_CHECK,
+        resources: {
+          requests: {
+            memory: '1Gi',
+          },
+        },
       }],
     },
     hosts: ['website-production.k8s.bluedot.org'],
@@ -308,6 +318,11 @@ export const services: ServiceDefinition[] = [
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
         ],
+        resources: {
+          requests: {
+            memory: '128Mi',
+          },
+        },
       }],
     },
     hosts: ['meet.bluedot.org'],
@@ -324,6 +339,14 @@ export const services: ServiceDefinition[] = [
           { name: 'ALERTS_SLACK_CHANNEL_ID', value: ALERTS_SLACK_CHANNEL_ID },
           { name: 'ALERTS_SLACK_BOT_TOKEN', valueFrom: envVarSources.alertsSlackBotToken },
         ],
+        resources: {
+          requests: {
+            memory: '128Mi',
+          },
+          limits: {
+            memory: '1Gi',
+          },
+        },
       }],
     },
     hosts: ['availability.bluedot.org'],


### PR DESCRIPTION
# Description

I'm working through setting [these memory limits](https://github.com/bluedotimpact/bluedot/issues/2934) in batches, starting with the simplest/lowest risk. [Batch 1](https://github.com/bluedotimpact/bluedot/pull/2940), [2](https://github.com/bluedotimpact/bluedot/pull/2941) and [3](https://github.com/bluedotimpact/bluedot/pull/2942) went out without issue. This is batch 4, the remaining ones where a deployment doesn't cause any downtime of the service.

Full list of services:
- bluedot-website-production: 1Gi / no limit
- bluedot-website-proxy: 16Mi / no limit
- bluedot-meet: 128Mi / no limit
- bluedot-availability: 128Mi / 1Gi

The remaining services after this need more care:
- login (safe in principle, but it's a critical service so worth handling separately)
- keycloak-pg (will cause a small amount of downtime in the login service when it restarts)
- pg-sync-service
- k8up backup + prune jobs (could fail silently and break backups if it OOMs)
- prometheus (will wipe the last 10d of prometheus metrics, which are useful for reviewing this set of changes)

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2934

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
