### PR TITLE
[fix] speed-review: point round stats at [*] Num offers after accepte…

### DIFF
--- a/apps/speed-review/src/lib/api/airtable.ts
+++ b/apps/speed-review/src/lib/api/airtable.ts
@@ -317,7 +317,7 @@ export const fetchRoundStats = async (roundId: string): Promise<RoundStats> => {
       filterByFormula: `RECORD_ID() = "${roundId}"`,
       returnFieldsByFieldId: 'true',
     },
-    ['fldc3Uc7v3OlWYgzJ', 'fld8fYfDVJHfjbqRj', 'fldF4ORgkl7Fjgs2A'],
+    ['fldc3Uc7v3OlWYgzJ', 'fld8fYfDVJHfjbqRj', 'fldr4KqdjVGrePi6W'],
   );
 
   const fields = records[0]?.fields ?? {};
@@ -326,7 +326,7 @@ export const fetchRoundStats = async (roundId: string): Promise<RoundStats> => {
   return {
     total: n('fldc3Uc7v3OlWYgzJ'),
     evaluated: n('fld8fYfDVJHfjbqRj'),
-    accepted: n('fldF4ORgkl7Fjgs2A'),
+    accepted: n('fldr4KqdjVGrePi6W'),
   };
 };
 


### PR DESCRIPTION
…d-participants field deletion

The Rounds field '[*] Num accepted participants' (fldF4ORgkl7Fjgs2A) was deleted from Airtable, so GET /api/round-stats returned 422 UNKNOWN_FIELD_NAME and the session-complete stats section failed to load. Swap to '[*] Num offers' (fldr4KqdjVGrePi6W), which counts the same Applicants link.

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
