### PR TITLE
[fix] Withdrawing a pending application no longer creates a Drop out …

### DIFF
--- a/apps/website/src/server/routers/dropout.test.ts
+++ b/apps/website/src/server/routers/dropout.test.ts
@@ -1,4 +1,6 @@
-import { applicationsRoundTable, courseRegistrationTable, eq } from '@bluedot/db';
+import {
+  applicationsRoundTable, courseRegistrationTable, dropoutTable, eq,
+} from '@bluedot/db';
 import {
   beforeEach, describe, expect, test,
 } from 'vitest';
@@ -16,6 +18,8 @@ beforeEach(async () => {
   await testDb.insert(applicationsRoundTable, { id: 'round-2', courseId: 'course-1' });
   await testDb.insert(applicationsRoundTable, { id: 'round-other-course', courseId: 'course-2' });
 });
+
+const getDropouts = async () => testDb.pg.select().from(dropoutTable.pg);
 
 const getDecision = async (id: string) => {
   const [reg] = await testDb.pg
@@ -56,32 +60,38 @@ describe('dropout.dropoutOrDeferral', () => {
     })).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
-  test('lets a facilitator withdraw before acceptance (decision = null) and sets decision to Withdrawn', async () => {
+  test('lets a facilitator withdraw before acceptance (decision = null) without creating a Drop out record', async () => {
     await insertRegistration({ role: 'Facilitator', decision: null });
 
     const result = await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
       applicantId: 'reg-1', type: 'Drop out',
     });
-    expect(result).toBeTruthy();
+    expect(result).toBeNull();
     expect(await getDecision('reg-1')).toBe('Withdrawn');
+    expect(await getDropouts()).toHaveLength(0);
   });
 
-  test('sets decision to Withdrawn when a participant withdraws a pre-decision application', async () => {
+  test('withdraws a pre-decision participant application without creating a Drop out record', async () => {
     await insertRegistration({ role: 'Participant', decision: null });
 
-    await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
+    const result = await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
       applicantId: 'reg-1', type: 'Drop out',
     });
+    expect(result).toBeNull();
     expect(await getDecision('reg-1')).toBe('Withdrawn');
+    expect(await getDropouts()).toHaveLength(0);
   });
 
-  test('leaves the decision untouched when dropping out post-decision', async () => {
+  test('creates a Drop out record and leaves the decision untouched when dropping out post-decision', async () => {
     await insertRegistration({ role: 'Participant', decision: 'Accept' });
 
     await createCaller(testAuthContextLoggedIn).dropout.dropoutOrDeferral({
       applicantId: 'reg-1', type: 'Drop out',
     });
     expect(await getDecision('reg-1')).toBe('Accept');
+    const dropouts = await getDropouts();
+    expect(dropouts).toHaveLength(1);
+    expect(dropouts[0]).toMatchObject({ applicantId: ['reg-1'], type: 'Drop out' });
   });
 
   test('lets a participant defer once accepted', async () => {

--- a/apps/website/src/server/routers/dropout.ts
+++ b/apps/website/src/server/routers/dropout.ts
@@ -106,6 +106,16 @@ export const dropoutRouter = router({
         }
       }
 
+      // A pre-decision "Drop out" is an application withdrawal, not a course drop-out: the
+      // registration moves to "Withdrawn" so it's no longer evaluated (and potentially accepted)
+      // in review, and no Drop out record is created. Drop out records drive the drop-out
+      // confirmation email and Slack alert automations, and would keep marking the person as
+      // dropped out if the application is later re-accepted.
+      if (type === 'Drop out' && courseRegistration.decision === null) {
+        await db.update(courseRegistrationTable, { id: applicantId, decision: 'Withdrawn' });
+        return null;
+      }
+
       const dropout = await db.insert(dropoutTable, {
         applicantId: [applicantId],
         reason: reason ?? null,
@@ -113,11 +123,6 @@ export const dropoutRouter = router({
         newRoundId: type === 'Deferral' && newRoundId ? [newRoundId] : null,
         oldRoundId: type === 'Deferral' && oldRoundId ? [oldRoundId] : null,
       });
-
-      // A pre-decision application moves to "Withdrawn" so it's no longer evaluated (and potentially accepted) in review.
-      if (type === 'Drop out' && courseRegistration.decision === null) {
-        await db.update(courseRegistrationTable, { id: applicantId, decision: 'Withdrawn' });
-      }
 
       return dropout;
     }),


### PR DESCRIPTION
…record

Withdrawal is not a course drop-out: the registration's Withdrawn decision fully captures it. The Drop out record only fed drop-out emails/alerts with wrong-for-withdrawal copy, and stayed behind marking the person as dropped out if the application was later re-accepted (James Newport, Aug 2026).

# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->



## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #

## Developer checklist

- [ ] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [ ] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->

## Screenshot
<!-- If this PR results in visual changes -->

| 📸 | Before | After |
|---------|---|---|
| 📱  | <!-- **Mobile** before --> | <!-- **Mobile** after --> |
| 🖥️ | <!-- **Desktop** before --> | <!-- **Desktop** after --> |
