### PR TITLE
[fix] Update alumni count from 8,000+ to 10,000+

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/about.test.tsx.snap
@@ -628,7 +628,7 @@ exports[`AboutPage > should render correctly 1`] = `
         <p
           class="bluedot-p not-prose"
         >
-          Those reading groups evolved into the BlueDot courses. We've trained over 7,000 people in AI safety, governance and biosecurity, and hundreds of our graduates now work at Anthropic, DeepMind, and UK AISI.
+          Those reading groups evolved into the BlueDot courses. We've trained over 10,000 people in AI safety, governance and biosecurity, and hundreds of our graduates now work at Anthropic, DeepMind, and UK AISI.
         </p>
         <p
           class="bluedot-p not-prose"

--- a/apps/website/src/__tests__/pages/index.test.tsx
+++ b/apps/website/src/__tests__/pages/index.test.tsx
@@ -76,8 +76,8 @@ describe('HomePage testimonials', () => {
     </TrpcProvider>);
 
     expect(document.title).toBe('BlueDot Impact | Have a positive impact on the trajectory of AI');
-    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Free online courses, grants, and intensive in-person programs from the leading talent accelerator for beneficial AI and societal resilience. Join 7,000+ alumni and start today.');
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe('Free online courses, grants, and intensive in-person programs from the leading talent accelerator for beneficial AI and societal resilience. Join 10,000+ alumni and start today.');
     expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe('BlueDot Impact | Have a positive impact on the trajectory of AI');
-    expect(document.querySelector('meta[name="twitter:description"]')?.getAttribute('content')).toBe('Free online courses, grants, and intensive in-person programs from the leading talent accelerator for beneficial AI and societal resilience. Join 7,000+ alumni and start today.');
+    expect(document.querySelector('meta[name="twitter:description"]')?.getAttribute('content')).toBe('Free online courses, grants, and intensive in-person programs from the leading talent accelerator for beneficial AI and societal resilience. Join 10,000+ alumni and start today.');
   });
 });

--- a/apps/website/src/components/about/IntroSection.tsx
+++ b/apps/website/src/components/about/IntroSection.tsx
@@ -6,7 +6,7 @@ const IntroSection = () => {
       <H3 className="mb-6">Who we are</H3>
       <div className="intro-section__text-container flex flex-col gap-5">
         <P>In 2021, a handful of us at Cambridge wanted to work on AI safety, but couldn&apos;t find where to start. Important ideas and arguments were scattered across the internet. There were no courses, no career paths, and few people to talk to. So we started running reading groups.</P>
-        <P>Those reading groups evolved into the BlueDot courses. We&apos;ve trained over 7,000 people in AI safety, governance and biosecurity, and hundreds of our graduates now work at Anthropic, DeepMind, and UK AISI.</P>
+        <P>Those reading groups evolved into the BlueDot courses. We&apos;ve trained over 10,000 people in AI safety, governance and biosecurity, and hundreds of our graduates now work at Anthropic, DeepMind, and UK AISI.</P>
         <P>But training alone isn&apos;t enough. We give out grants to support career transitions, and we help exceptional people land impactful roles or start new organisations. Our goal isn&apos;t just to educate people, it&apos;s to get them working on the most important problems.</P>
         <P>The gap between how fast AI is advancing and how fast the safety and security workforce is growing is the most dangerous mismatch of our time. We&apos;re a small team based in San Francisco and London working as fast as we can to close it.</P>
       </div>

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -17,7 +17,7 @@ type CourseCompletionSectionProps = {
   className?: string;
 };
 
-const COMMUNITY_SIZE_LABEL = '8,000+ professionals';
+const COMMUNITY_SIZE_LABEL = '10,000+ professionals';
 
 const AVATAR_IMAGES = [
   '/images/graduates/adam.webp',

--- a/apps/website/src/components/grants/grantPrograms.tsx
+++ b/apps/website/src/components/grants/grantPrograms.tsx
@@ -207,12 +207,12 @@ export const GRANT_PROGRAM_SECTIONS: Record<ConfigurableGrantProgramSlug, GrantP
         question: 'Who is BlueDot Impact?',
         answer: (
           <>
-            We&apos;re a nonprofit based in San Francisco. Since 2022, we&apos;ve trained over 8,000 people. Our courses are the main entry point into the AI safety field, with alumni now working at OpenAI, Anthropic, DeepMind, the UK AI Safety Institute, and many more.
+            We&apos;re a nonprofit based in San Francisco. Since 2022, we&apos;ve trained over 10,000 people. Our courses are the main entry point into the AI safety field, with alumni now working at OpenAI, Anthropic, DeepMind, the UK AI Safety Institute, and many more.
             <br /><br />
             Incubator Week is our program for the most entrepreneurial participants — the ones ready to build the startups the world needs.
           </>
         ),
-        answerText: 'We\'re a nonprofit based in San Francisco. Since 2022, we\'ve trained over 8,000 people. Our courses are the main entry point into the AI safety field, with alumni now working at OpenAI, Anthropic, DeepMind, the UK AI Safety Institute, and many more. Incubator Week is our program for the most entrepreneurial participants — the ones ready to build the startups the world needs.',
+        answerText: 'We\'re a nonprofit based in San Francisco. Since 2022, we\'ve trained over 10,000 people. Our courses are the main entry point into the AI safety field, with alumni now working at OpenAI, Anthropic, DeepMind, the UK AI Safety Institute, and many more. Incubator Week is our program for the most entrepreneurial participants — the ones ready to build the startups the world needs.',
       },
     ],
   },

--- a/apps/website/src/components/homepage/StorySection.tsx
+++ b/apps/website/src/components/homepage/StorySection.tsx
@@ -16,7 +16,7 @@ const StorySection = () => {
             </P>
 
             <P className="bd-md:text-size-md leading-relaxed text-bluedot-navy/80 mb-0">
-              Since 2022, we've trained over 7,000 professionals worldwide, from technical staff at frontier AI labs to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M to date.
+              Since 2022, we've trained over 10,000 professionals worldwide, from technical staff at frontier AI labs to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M to date.
             </P>
           </div>
 

--- a/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/HomeHeroContent.test.tsx.snap
@@ -534,7 +534,7 @@ exports[`HomeHeroContent > renders as expected 1`] = `
               <p
                 class="bluedot-p not-prose whitespace-nowrap flex-shrink-0"
               >
-                Our 8,000+ alumni work at
+                Our 10,000+ alumni work at
               </p>
               <div
                 class="w-full sm:flex-1 inline-flex flex-nowrap overflow-hidden [mask-image:_linear-gradient(90deg,transparent_0,_black_12.63%,_black_80.26%,transparent_100%)]"

--- a/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
+++ b/apps/website/src/components/homepage/__snapshots__/StorySection.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`StorySection > renders default as expected 1`] = `
           <p
             class="bluedot-p not-prose bd-md:text-size-md leading-relaxed text-bluedot-navy/80 mb-0"
           >
-            Since 2022, we've trained over 7,000 professionals worldwide, from technical staff at frontier AI labs to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M to date.
+            Since 2022, we've trained over 10,000 professionals worldwide, from technical staff at frontier AI labs to government policymakers. Our alumni work on critical challenges at organisations like Anthropic, Google DeepMind, and the UK's AI Security Institute. We're a small team, and we've raised $35M to date.
           </p>
         </div>
         <a

--- a/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
+++ b/apps/website/src/components/incubator-week/AboutBlueDotSection.tsx
@@ -19,7 +19,7 @@ const AboutBlueDotSection = ({
       <div className="w-full max-w-prose flex flex-col gap-6">
         <H3>About BlueDot</H3>
         <P>
-          BlueDot Impact is a nonprofit building the workforce and organisations needed to safely navigate AGI. We&apos;ve raised over $35M and trained over 8,000 people since 2022.
+          BlueDot Impact is a nonprofit building the workforce and organisations needed to safely navigate AGI. We&apos;ve raised over $35M and trained over 10,000 people since 2022.
         </P>
         {contactEmail && (
           <P className="text-bluedot-navy/80">

--- a/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
+++ b/apps/website/src/components/lander/__snapshots__/AgiStrategyLander.test.tsx.snap
@@ -774,7 +774,7 @@ exports[`AgiStrategyLander > renders the complete page correctly (snapshot) 1`] 
               <p
                 class="bluedot-p not-prose"
               >
-                BlueDot has 7,000+ alumni, with many now working at Anthropic, DeepMind, UK AISI, and dozens of organisations working on a safe transition to advanced AI. You'll meet people in the field who can open doors for you and pressure-test your thinking.
+                BlueDot has 10,000+ alumni, with many now working at Anthropic, DeepMind, UK AISI, and dozens of organisations working on a safe transition to advanced AI. You'll meet people in the field who can open doors for you and pressure-test your thinking.
               </p>
             </div>
           </div>

--- a/apps/website/src/components/lander/components/CourseBenefitsTextSection.stories.tsx
+++ b/apps/website/src/components/lander/components/CourseBenefitsTextSection.stories.tsx
@@ -62,7 +62,7 @@ export const WithParagraphs: Story = {
     title: 'How BlueDot supports you beyond the course',
     paragraphs: [
       'FAIGC is one course in a wider BlueDot pipeline. During the course, we learn enough about participants to point them toward what makes sense next. Outside BlueDot, that often means introductions to hiring managers at AI safety organisations or fellowship leads.',
-      'The AGI Strategy Course is the upstream prerequisite; jurisdiction- and domain-specific courses are in development. About 8,000 alumni are in our Slack — job openings and policy debates come through daily.',
+      'The AGI Strategy Course is the upstream prerequisite; jurisdiction- and domain-specific courses are in development. About 10,000 alumni are in our Slack — job openings and policy debates come through daily.',
     ],
   },
 };

--- a/apps/website/src/components/lander/components/CourseBenefitsTextSection.stories.tsx
+++ b/apps/website/src/components/lander/components/CourseBenefitsTextSection.stories.tsx
@@ -50,7 +50,7 @@ export const Default: Story = {
       },
       {
         heading: 'A community of builders',
-        body: 'BlueDot has 7,000+ alumni, with many now working at Anthropic, DeepMind, UK AISI, and dozens of organisations working on a safe transition to advanced AI. You\'ll meet people in the field who can open doors for you and pressure-test your thinking.',
+        body: 'BlueDot has 10,000+ alumni, with many now working at Anthropic, DeepMind, UK AISI, and dozens of organisations working on a safe transition to advanced AI. You\'ll meet people in the field who can open doors for you and pressure-test your thinking.',
       },
     ],
   },

--- a/apps/website/src/components/lander/components/GraduateSection.tsx
+++ b/apps/website/src/components/lander/components/GraduateSection.tsx
@@ -37,7 +37,7 @@ const GraduateSection = () => {
         <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-5 w-full max-w-[1200px] 2xl:max-w-none">
           {/* Text */}
           <P className="whitespace-nowrap flex-shrink-0">
-            Our 8,000+ alumni work at
+            Our 10,000+ alumni work at
           </P>
 
           {/* Logos with scrolling */}

--- a/apps/website/src/components/lander/course-content/AgiStrategyContent.tsx
+++ b/apps/website/src/components/lander/course-content/AgiStrategyContent.tsx
@@ -54,7 +54,7 @@ export const createAgiStrategyContent = (
       },
       {
         heading: 'A community of builders',
-        body: 'BlueDot has 7,000+ alumni, with many now working at Anthropic, DeepMind, UK AISI, and dozens of organisations working on a safe transition to advanced AI. You\'ll meet people in the field who can open doors for you and pressure-test your thinking.',
+        body: 'BlueDot has 10,000+ alumni, with many now working at Anthropic, DeepMind, UK AISI, and dozens of organisations working on a safe transition to advanced AI. You\'ll meet people in the field who can open doors for you and pressure-test your thinking.',
       },
     ],
   },

--- a/apps/website/src/components/lander/course-content/AiGovernanceContent.tsx
+++ b/apps/website/src/components/lander/course-content/AiGovernanceContent.tsx
@@ -98,7 +98,7 @@ export const createAiGovernanceContent = (
           {' '}
           <a href="/courses/agi-strategy" className={externalLinkClassName}>AGI Strategy Course</a>
           {' '}
-          is the upstream prerequisite; jurisdiction- and domain-specific courses are in development. About 8,000 alumni are in our Slack - job openings and policy debates come through daily.
+          is the upstream prerequisite; jurisdiction- and domain-specific courses are in development. About 10,000 alumni are in our Slack - job openings and policy debates come through daily.
         </>
       ),
     ],

--- a/apps/website/src/components/lander/course-content/FutureOfAiContent.tsx
+++ b/apps/website/src/components/lander/course-content/FutureOfAiContent.tsx
@@ -139,10 +139,10 @@ export const createFutureOfAiContent = (
         question: 'Who is BlueDot Impact?',
         answer: (
           <>
-            We're the world's leading talent accelerator for beneficial AI and societal resilience. Since 2022, we've trained 6,000+ people. Our courses are the main entry point into the AI safety field. We're a small team. We've raised $34M in total, including $25M in 2025.
+            We're the world's leading talent accelerator for beneficial AI and societal resilience. Since 2022, we've trained 10,000+ people. Our courses are the main entry point into the AI safety field. We're a small team. We've raised $34M in total, including $25M in 2025.
           </>
         ),
-        answerText: 'We\'re the world\'s leading talent accelerator for beneficial AI and societal resilience. Since 2022, we\'ve trained 6,000+ people. Our courses are the main entry point into the AI safety field. We\'re a small team. We\'ve raised $34M in total, including $25M in 2025.',
+        answerText: 'We\'re the world\'s leading talent accelerator for beneficial AI and societal resilience. Since 2022, we\'ve trained 10,000+ people. Our courses are the main entry point into the AI safety field. We\'re a small team. We\'ve raised $34M in total, including $25M in 2025.',
       },
     ],
   },

--- a/apps/website/src/components/lander/course-content/TechnicalAiSafetyContent.tsx
+++ b/apps/website/src/components/lander/course-content/TechnicalAiSafetyContent.tsx
@@ -231,14 +231,14 @@ export const createTechnicalAiSafetyContent = (
         question: 'Who is BlueDot Impact?',
         answer: (
           <>
-            We're a London-based startup. Since 2022, we've trained 7,000+ people, with 100s now working on making AI go well.
+            We're a London-based startup. Since 2022, we've trained 10,000+ people, with 100s now working on making AI go well.
             <br /><br />
             Our courses are the main entry point into the AI safety field.
             <br /><br />
             We're an intense 4-person team. We've raised $35M in total, including $25M in 2025.
           </>
         ),
-        answerText: 'We\'re a London-based startup. Since 2022, we\'ve trained 7,000+ people, with 100s now working on making AI go well. Our courses are the main entry point into the AI safety field. We\'re an intense 4-person team. We\'ve raised $35M in total, including $25M in 2025.',
+        answerText: 'We\'re a London-based startup. Since 2022, we\'ve trained 10,000+ people, with 100s now working on making AI go well. Our courses are the main entry point into the AI safety field. We\'re an intense 4-person team. We\'ve raised $35M in total, including $25M in 2025.',
       },
     ],
   },

--- a/apps/website/src/components/lander/course-content/TechnicalAiSafetyProjectContent.tsx
+++ b/apps/website/src/components/lander/course-content/TechnicalAiSafetyProjectContent.tsx
@@ -145,14 +145,14 @@ export const createTechnicalAiSafetyProjectContent = (
         question: 'Who is BlueDot Impact?',
         answer: (
           <>
-            We're a London-based startup. Since 2022, we've trained 7,000+ people, with 100s now working on making AI go well.
+            We're a London-based startup. Since 2022, we've trained 10,000+ people, with 100s now working on making AI go well.
             <br /><br />
             Our courses are the main entry point into the AI safety field.
             <br /><br />
             We're an intense 7-person team. We've raised $35M in total, including $25M in 2025.
           </>
         ),
-        answerText: 'We\'re a London-based startup. Since 2022, we\'ve trained 7,000+ people, with 100s now working on making AI go well. Our courses are the main entry point into the AI safety field. We\'re an intense 7-person team. We\'ve raised $35M in total, including $25M in 2025.',
+        answerText: 'We\'re a London-based startup. Since 2022, we\'ve trained 10,000+ people, with 100s now working on making AI go well. Our courses are the main entry point into the AI safety field. We\'re an intense 7-person team. We\'ve raised $35M in total, including $25M in 2025.',
       },
     ],
   },

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -10,7 +10,7 @@ import { trpc } from '../utils/trpc';
 import { linkPreviewMetaTags, LINK_PREVIEW_FALLBACK_IMAGE_URL } from '../lib/linkPreviewMetaTags';
 
 const META_TITLE = 'BlueDot Impact | Have a positive impact on the trajectory of AI';
-const META_DESCRIPTION = 'Free online courses, grants, and intensive in-person programs from the leading talent accelerator for beneficial AI and societal resilience. Join 7,000+ alumni and start today.';
+const META_DESCRIPTION = 'Free online courses, grants, and intensive in-person programs from the leading talent accelerator for beneficial AI and societal resilience. Join 10,000+ alumni and start today.';
 
 const HomePage = () => {
   const { data: dbTestimonials } = trpc.testimonials.getCommunityMembers.useQuery();


### PR DESCRIPTION
## Summary

- Updates the alumni/trained-people count from 8,000+ to 10,000+ everywhere it appears in website copy:
  - Homepage + lander logo bar (`GraduateSection`): "Our 10,000+ alumni work at"
  - Course congratulations page (`CourseCompletionSection`): "10,000+ professionals"
  - Grants FAQ (`grantPrograms`): "trained over 10,000 people" (×2)
  - Incubator Week about section (`AboutBlueDotSection`): "trained over 10,000 people"
  - AI Governance lander + matching story (`AiGovernanceContent`, `CourseBenefitsTextSection.stories`): "About 10,000 alumni are in our Slack"
- Updated the `HomeHeroContent` snapshot to match.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (--max-warnings=0)
- [x] `npx vitest run` × 2 — 1231 passed (140 files), both runs
- [x] Eyeballed on local dev: `/`, `/courses/ai-governance`, `/programs/incubator-week`

## Screenshots

_paste WebP_

🤖 Generated with [Claude Code](https://claude.com/claude-code)