### PR TITLE
[chore] infra: set memory request on k8up backup/prune jobs

### DIFF
--- a/apps/infra/src/k8s/backups.ts
+++ b/apps/infra/src/k8s/backups.ts
@@ -144,6 +144,12 @@ NAMESPACES_TO_BACKUP.forEach((namespace) => {
       podConfigRef: {
         name: 'podconfig',
       },
+      // No limit: nothing alerts on a failed backup, so a silent OOM is worse than the overuse.
+      resourceRequirementsTemplate: {
+        requests: {
+          memory: '256Mi',
+        },
+      },
     },
   }, { provider, dependsOn: [gcsSecret, resticPasswordSecret, podConfig, k8upOperator] });
 });


### PR DESCRIPTION
# Description

I'm working through setting [these memory limits](https://github.com/bluedotimpact/bluedot/issues/2934) in batches, starting with the simplest/lowest risk. [Batch 1](https://github.com/bluedotimpact/bluedot/pull/2940), [2](https://github.com/bluedotimpact/bluedot/pull/2941), [3](https://github.com/bluedotimpact/bluedot/pull/2942) and [4](https://github.com/bluedotimpact/bluedot/pull/2943) went out without issue. This is the k8up backup and prune jobs, which run nightly at ~4am and don't touch any user-facing path.

Request only (256Mi), no limit: nothing currently alerts on a failed backup, so a loud node-level OOM once a day is preferable to silently losing backups.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2934

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories