### PR TITLE
[chore] infra: set memory request/limit on pg-sync-service

### DIFF
--- a/apps/infra/src/k8s/serviceDefinitions.ts
+++ b/apps/infra/src/k8s/serviceDefinitions.ts
@@ -470,6 +470,14 @@ export const services: ServiceDefinition[] = [
           { name: 'SENTRY_DSN', value: PG_SYNC_SENTRY_DSN },
           { name: 'SENTRY_ENVIRONMENT', value: 'production' },
         ],
+        resources: {
+          requests: {
+            memory: '400Mi',
+          },
+          limits: {
+            memory: '2000Mi',
+          },
+        },
       }],
     },
   },


### PR DESCRIPTION
# Description

I'm working through setting [these memory limits](https://github.com/bluedotimpact/bluedot/issues/2934) in batches, starting with the simplest/lowest risk. [Batch 1](https://github.com/bluedotimpact/bluedot/pull/2940), [2](https://github.com/bluedotimpact/bluedot/pull/2941), [3](https://github.com/bluedotimpact/bluedot/pull/2942), [4](https://github.com/bluedotimpact/bluedot/pull/2943) and the [k8up jobs](https://github.com/bluedotimpact/bluedot/pull/2947) went out without issue.

This sets pg-sync-service to 400Mi / 2000Mi. The request is sized to a full sync's peak (386Mi, from the 202k-record sync on 27 Aug) rather than to steady state, which sits around 80Mi. The limit is deliberately high because the service could be prone to unbounded memory usage (because it's throughput scales with the amount of data in Airtable)

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2934

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories