### PR TITLE
[chore] infra: set memory request/limit on prometheus

### DIFF
--- a/apps/infra/src/k8s/observability.ts
+++ b/apps/infra/src/k8s/observability.ts
@@ -103,6 +103,18 @@ const kubePrometheus = new k8s.helm.v3.Release('kube-prometheus', {
         },
       },
     },
+    prometheus: {
+      prometheusSpec: {
+        resources: {
+          requests: {
+            memory: '400Mi',
+          },
+          limits: {
+            memory: '1500Mi',
+          },
+        },
+      },
+    },
     grafana: {
       resources: {
         requests: {


### PR DESCRIPTION
# Description

I'm working through setting [these memory limits](https://github.com/bluedotimpact/bluedot/issues/2934) in batches, starting with the simplest/lowest risk. [Batch 1](https://github.com/bluedotimpact/bluedot/pull/2940), [2](https://github.com/bluedotimpact/bluedot/pull/2941), [3](https://github.com/bluedotimpact/bluedot/pull/2942), [4](https://github.com/bluedotimpact/bluedot/pull/2943) and the [k8up jobs](https://github.com/bluedotimpact/bluedot/pull/2947) went out without issue. This is the last one, prometheus. I'm doing this restarting prometheus wipes metrics history (up to the 10d retention), and it's useful for checking the other ones deploy correctly.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2934

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories