### PR TITLE
[chore] Stop triggering Render deploys

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -293,20 +293,3 @@ jobs:
         run: npm run deploy:cd --workspace ${{ matrix.app }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-      # meet.bluedot.org is temporarily served from Render after the Aug 2026 Vultr
-      # node outage (#2917, #2918), so master deploys must also trigger Render.
-      # Deliberately independent of the cluster deployment: Render should succeed
-      # independently of whether the k8s deployment succeeds. Remove if we move
-      # traffic back to k8s.
-      - name: Trigger Render deploy
-        if: ${{ always() && matrix.app == '@bluedot/meet' }}
-        env:
-          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_URL_MEET }}
-        run: |
-          if [[ -z "$HOOK" ]]; then
-            echo "no Render deploy hook configured, skipping"
-            exit 0
-          fi
-          curl -fsS --connect-timeout 10 --max-time 60 "$HOOK"
-

--- a/.github/workflows/website_deploy_production.yaml
+++ b/.github/workflows/website_deploy_production.yaml
@@ -140,19 +140,3 @@ jobs:
         run: npm run deploy:multistage:production --workspace apps/website
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-      # bluedot.org is temporarily served from Render after the Aug 2026 Vultr
-      # node outage (#2917, #2918), so releases must also trigger Render.
-      # Deliberately independent of the cluster deployment: Render should succeed
-      # independently of whether the k8s deployment succeeds. Remove if we move
-      # traffic back to k8s.
-      - name: Trigger Render deploy
-        if: ${{ always() }}
-        env:
-          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_URL_WEBSITE }}
-        run: |
-          if [[ -z "$HOOK" ]]; then
-            echo "no Render deploy hook configured, skipping"
-            exit 0
-          fi
-          curl -fsS --connect-timeout 10 --max-time 60 "$HOOK"

--- a/apps/meet/README.md
+++ b/apps/meet/README.md
@@ -12,8 +12,6 @@ This app is deployed onto the K8s cluster as a standard Next.js app in docker. I
 
 To deploy a new version, simply commit to the master branch. GitHub Actions automatically handles CD.
 
-As of August 2026 the app is temporarily being served from Render while we sort out problems with the k8s cluster (see #2919). Deploying works the same way: merging to master deploys to both k8s and Render.
-
 ## How it works
 
 The app presents a user interface where people can join via links like:


### PR DESCRIPTION
# Description

We're switching back to serving the website and meet apps from the k8s cluster, so we don't need these deploy hooks any more

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2935

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories