### PR TITLE
[feat] Propagate email changes to course registrations

### DIFF
--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -1043,6 +1043,34 @@ describe('users.confirmEmailChange', () => {
     scanSpy.mockRestore();
   });
 
+  test('still updates the remaining registrations and alerts when one update fails', async () => {
+    await seedTarget();
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-a', userId: 'target-id', email: 'old@example.com', courseId: 'course-1',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-b', userId: 'target-id', email: 'old@example.com', courseId: 'course-2',
+    });
+    const realUpdate = db.update.bind(db);
+    const updateSpy = vi.spyOn(db, 'update').mockImplementation((table, data) => {
+      if ((table as unknown) === courseRegistrationTable && (data as { id?: string }).id === 'reg-a') {
+        return Promise.reject(new Error('airtable blip'));
+      }
+
+      return realUpdate(table, data);
+    });
+
+    const result = await anonCaller().users.confirmEmailChange({ token: await mintToken() });
+
+    expect(result.newEmail).toBe('new@example.com');
+    await vi.waitFor(async () => {
+      expect((await testDb.get(courseRegistrationTable, { id: 'reg-b' })).email).toBe('new@example.com');
+      expect(slackAlert).toHaveBeenCalledWith(expect.anything(), [expect.stringContaining('Failed to update 1 registration(s): airtable blip')]);
+    });
+    expect((await testDb.get(courseRegistrationTable, { id: 'reg-a' })).email).toBe('old@example.com');
+    updateSpy.mockRestore();
+  });
+
   test('retries the identity cleanup once and does not alert if the retry succeeds', async () => {
     await seedTarget();
     vi.mocked(unlinkStaleGoogleIdentities)

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -1,4 +1,4 @@
-import { userTable } from '@bluedot/db';
+import { courseRegistrationTable, userTable } from '@bluedot/db';
 import type { TRPCError } from '@trpc/server';
 import { loginPresets } from '@bluedot/ui/src/Login';
 import { slackAlert } from '@bluedot/utils/src/slackNotifications';
@@ -956,6 +956,91 @@ describe('users.confirmEmailChange', () => {
     expect(unlinkStaleGoogleIdentities).toHaveBeenCalledTimes(3);
     expect(slackAlert).toHaveBeenCalledWith(expect.anything(), [expect.stringContaining('Email for user target-id changed successfully to new@example.com, but stale Google identity cleanup failed')]);
     expect((await testDb.get(userTable, { id: 'target-id' })).email).toBe('new@example.com');
+  });
+
+  test('propagates the new email to the user\'s course registrations', async () => {
+    await seedTarget();
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-1', userId: 'target-id', email: 'old@example.com', courseId: 'course-1',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-2', userId: 'target-id', email: 'personal@example.com', courseId: 'course-2',
+    });
+
+    const result = await anonCaller().users.confirmEmailChange({ token: await mintToken() });
+
+    expect(result.newEmail).toBe('new@example.com');
+    await vi.waitFor(async () => {
+      expect((await testDb.get(courseRegistrationTable, { id: 'reg-1' })).email).toBe('new@example.com');
+      expect((await testDb.get(courseRegistrationTable, { id: 'reg-2' })).email).toBe('new@example.com');
+    });
+  });
+
+  test('leaves registrations with an empty email untouched', async () => {
+    await seedTarget();
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-empty', userId: 'target-id', email: '', courseId: 'course-1',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-stale', userId: 'target-id', email: 'old@example.com', courseId: 'course-2',
+    });
+
+    await anonCaller().users.confirmEmailChange({ token: await mintToken() });
+
+    await vi.waitFor(async () => {
+      expect((await testDb.get(courseRegistrationTable, { id: 'reg-stale' })).email).toBe('new@example.com');
+    });
+    expect((await testDb.get(courseRegistrationTable, { id: 'reg-empty' })).email).toBe('');
+  });
+
+  test('leaves other users\' registrations untouched', async () => {
+    await seedTarget();
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-mine', userId: 'target-id', email: 'old@example.com', courseId: 'course-1',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-other', userId: 'other-id', email: 'old@example.com', courseId: 'course-1',
+    });
+
+    await anonCaller().users.confirmEmailChange({ token: await mintToken() });
+
+    await vi.waitFor(async () => {
+      expect((await testDb.get(courseRegistrationTable, { id: 'reg-mine' })).email).toBe('new@example.com');
+    });
+    expect((await testDb.get(courseRegistrationTable, { id: 'reg-other' })).email).toBe('old@example.com');
+  });
+
+  test('does not write to registrations already at the new email', async () => {
+    await seedTarget();
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-current', userId: 'target-id', email: 'new@example.com', courseId: 'course-1',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-stale', userId: 'target-id', email: 'old@example.com', courseId: 'course-2',
+    });
+    const updateSpy = vi.spyOn(db, 'update');
+
+    await anonCaller().users.confirmEmailChange({ token: await mintToken() });
+
+    await vi.waitFor(async () => {
+      expect((await testDb.get(courseRegistrationTable, { id: 'reg-stale' })).email).toBe('new@example.com');
+    });
+    const registrationUpdates = updateSpy.mock.calls.filter(([table]) => (table as unknown) === courseRegistrationTable);
+    expect(registrationUpdates).toEqual([[courseRegistrationTable, { id: 'reg-stale', email: 'new@example.com' }]]);
+    updateSpy.mockRestore();
+  });
+
+  test('succeeds and alerts when the registration propagation fails', async () => {
+    await seedTarget();
+    const scanSpy = vi.spyOn(db, 'scan').mockRejectedValue(new Error('pg down'));
+
+    const result = await anonCaller().users.confirmEmailChange({ token: await mintToken() });
+
+    expect(result.newEmail).toBe('new@example.com');
+    await vi.waitFor(() => {
+      expect(slackAlert).toHaveBeenCalledWith(expect.anything(), [expect.stringContaining('course registration email propagation failed for user target-id: pg down')]);
+    });
+    scanSpy.mockRestore();
   });
 
   test('retries the identity cleanup once and does not alert if the retry succeeds', async () => {

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -1,4 +1,4 @@
-import { sql, userTable } from '@bluedot/db';
+import { courseRegistrationTable, sql, userTable } from '@bluedot/db';
 import { TRPCError } from '@trpc/server';
 import { logger } from '@bluedot/ui/src/api';
 import { loginPresets } from '@bluedot/ui/src/Login';
@@ -103,6 +103,17 @@ async function unlinkStaleGoogleIdentitiesOrAlert(userId: string, keycloakIdenti
     `[EmailChange] Email for user ${userId} changed successfully to ${newEmail}, but stale Google identity cleanup failed after 3 attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}. The old Google account may still be able to sign in. Check the Keycloak user and remove the stale Google identity manually.`,
   ]);
   return { loginMethods: null };
+}
+
+async function propagateEmailToCourseRegistrations(userId: string, newEmail: string): Promise<void> {
+  const registrations = await db.scan(courseRegistrationTable, { userId });
+  for (const registration of registrations) {
+    // Registrations with an empty email are left empty: filling them could wake dormant Airtable automation triggers
+    if (registration.email && normaliseEmail(registration.email) !== newEmail) {
+      // eslint-disable-next-line no-await-in-loop
+      await db.update(courseRegistrationTable, { id: registration.id, email: newEmail });
+    }
+  }
 }
 
 export const usersRouter = router({
@@ -316,6 +327,9 @@ export const usersRouter = router({
 
       updateCustomerIoEmail({ userId: user.id, oldEmail: user.email, newEmail: payload.newEmail })
         .catch((error: unknown) => slackAlert(env, [`[EmailChange] customer.io rename failed for user ${user.id}: ${error instanceof Error ? error.message : String(error)}`]));
+
+      propagateEmailToCourseRegistrations(user.id, payload.newEmail)
+        .catch((error: unknown) => slackAlert(env, [`[EmailChange] course registration email propagation failed for user ${user.id}: ${error instanceof Error ? error.message : String(error)}`]));
 
       return { newEmail: payload.newEmail, ...await unlinkStaleGoogleIdentitiesOrAlert(user.id, user.keycloakIdentifier, payload.newEmail) };
     }),

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -107,12 +107,21 @@ async function unlinkStaleGoogleIdentitiesOrAlert(userId: string, keycloakIdenti
 
 async function propagateEmailToCourseRegistrations(userId: string, newEmail: string): Promise<void> {
   const registrations = await db.scan(courseRegistrationTable, { userId });
+  const errors: unknown[] = [];
   for (const registration of registrations) {
     // Registrations with an empty email are left empty: filling them could wake dormant Airtable automation triggers
     if (registration.email && normaliseEmail(registration.email) !== newEmail) {
-      // eslint-disable-next-line no-await-in-loop
-      await db.update(courseRegistrationTable, { id: registration.id, email: newEmail });
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await db.update(courseRegistrationTable, { id: registration.id, email: newEmail });
+      } catch (error) {
+        errors.push(error);
+      }
     }
+  }
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `Failed to update ${errors.length} registration(s): ${errors.map((e) => (e instanceof Error ? e.message : String(e))).join('; ')}`);
   }
 }
 


### PR DESCRIPTION
# Description

Per #2930, this allows us to simplify a lot of Airtable automations, at the cost of losing fully-normalised emails.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2930

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories