### PR TITLE
[fix] meet: move page/API tests out of src/pages

### DIFF
--- a/apps/meet/src/__tests__/pages/api/status.test.ts
+++ b/apps/meet/src/__tests__/pages/api/status.test.ts
@@ -2,7 +2,7 @@
 import { type NextApiRequest, type NextApiResponse } from 'next';
 import { createMocks } from 'node-mocks-http';
 import { describe, expect, test } from 'vitest';
-import handle from './status';
+import handle from '../../../pages/api/status';
 
 describe('/api/status', () => {
   test('returns an online status', async () => {

--- a/apps/meet/src/__tests__/pages/record-attendance.test.tsx
+++ b/apps/meet/src/__tests__/pages/record-attendance.test.tsx
@@ -3,8 +3,8 @@ import {
   describe, expect, test, vi,
 } from 'vitest';
 import { AxiosError } from 'axios';
-import { mockApi } from '../__tests__/testUtils';
-import RecordAttendance from './record-attendance';
+import { mockApi } from '../testUtils';
+import RecordAttendance from '../../pages/record-attendance';
 
 vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams('groupDiscussionId=recDiscussion&participantId=recParticipant'),


### PR DESCRIPTION
# Description

#2959 added `record-attendance.test.tsx` under `src/pages/`, which broke the build (`next build` tries to treat it as a page). This moves it to `src/__tests__/pages/`, adopting the pattern from `apps/website`. It also moves `api/status.test.ts` the same way since it was being built and exposed as a real `/api/status.test` route.

## Issue

N/A

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories