### PR TITLE
[fix] Make groupDiscussion.endDateTime nullable to stop sync warning spam

### DIFF
--- a/apps/meet/src/pages/api/public/meeting-participants.ts
+++ b/apps/meet/src/pages/api/public/meeting-participants.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import createHttpError from 'http-errors';
 import {
   groupTable, groupDiscussionTable, isDiscussionFacilitator, isDiscussionParticipant, meetPersonTable, zoomAccountTable,
+  type GroupDiscussion,
 } from '@bluedot/db';
 import { makeApiRoute } from '../../../lib/api/makeApiRoute';
 import db from '../../../lib/api/db';
@@ -57,7 +58,7 @@ export default makeApiRoute({
   const groupDiscussions = await db.scan(groupDiscussionTable, { group: body.groupId });
 
   const groupDiscussionsWithDistance = groupDiscussions
-    .filter((groupDiscussion) => !!groupDiscussion.startDateTime && !!groupDiscussion.endDateTime)
+    .filter((groupDiscussion): groupDiscussion is GroupDiscussion & { endDateTime: number } => !!groupDiscussion.startDateTime && !!groupDiscussion.endDateTime)
     .map((groupDiscussion) => ({
       groupDiscussion,
       distance: Math.abs((Date.now() / 1000) - (groupDiscussion.startDateTime)),

--- a/apps/website/src/__tests__/pages/api/calendar/discussions/[discussionId].test.ts
+++ b/apps/website/src/__tests__/pages/api/calendar/discussions/[discussionId].test.ts
@@ -134,6 +134,35 @@ describe('calendar discussion download api', () => {
     expect(res.json).toHaveBeenCalledWith({ error: 'You do not have access to this discussion' });
   });
 
+  it('returns 409 when the discussion has no end time', async () => {
+    const { req, res } = createMockReqRes();
+
+    vi.mocked(loginPresets.keycloak.verifyAndDecodeToken).mockResolvedValue(mockAuth);
+    vi.mocked(db.getFirst).mockResolvedValue({ id: 'user-ash', email: 'ash@example.com' } as never);
+    vi.mocked(db.get).mockResolvedValueOnce({
+      ...createMockGroupDiscussion({
+        id: 'discussion-1',
+        participantsExpected: ['meet-person-1'],
+      }),
+      endDateTime: null,
+    } as never);
+    vi.mocked(db.scan)
+      .mockResolvedValueOnce([createMockMeetPerson({
+        id: 'meet-person-1',
+        userId: 'user-ash',
+        applicationsBaseRecordId: 'course-registration-1',
+      })])
+      .mockResolvedValueOnce([createMockCourseRegistration({
+        id: 'course-registration-1',
+        userId: 'user-ash',
+      })]);
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Discussion does not have an end time yet' });
+  });
+
   it('returns a calendar file for an attached user', async () => {
     const { req, res } = createMockReqRes();
 

--- a/apps/website/src/__tests__/testUtils.ts
+++ b/apps/website/src/__tests__/testUtils.ts
@@ -4,7 +4,6 @@ import type {
   CourseRegistration,
   Exercise,
   Group,
-  GroupDiscussion,
   MeetPerson,
   Program,
   ResourceCompletion,
@@ -13,6 +12,7 @@ import type {
 } from '@bluedot/db';
 import { RESOURCE_FEEDBACK } from '@bluedot/db/src/schema';
 import { render, type RenderResult } from '@testing-library/react';
+import type { GroupDiscussionWithEnd } from '../lib/group-discussions/utils';
 import type { CourseRound } from '../server/routers/course-rounds';
 
 // Re-export from libraries/ui for convenience
@@ -221,7 +221,7 @@ export const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
   ...overrides,
 });
 
-export const createMockGroupDiscussion = (overrides: Partial<GroupDiscussion> = {}): GroupDiscussion => ({
+export const createMockGroupDiscussion = (overrides: Partial<GroupDiscussionWithEnd> = {}): GroupDiscussionWithEnd => ({
   activityDoc: null,
   attendees: [],
   autoNumberId: 1,

--- a/apps/website/src/components/courses/GroupDiscussionBanner.tsx
+++ b/apps/website/src/components/courses/GroupDiscussionBanner.tsx
@@ -1,4 +1,4 @@
-import type { GroupDiscussion, Unit } from '@bluedot/db';
+import type { Unit } from '@bluedot/db';
 import {
   CTALinkOrButton, OverflowMenu, useCurrentTimeMs, type OverflowMenuItemProps,
 } from '@bluedot/ui';
@@ -9,7 +9,7 @@ import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { FaCopy } from 'react-icons/fa6';
 import { IoAdd } from 'react-icons/io5';
-import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
+import { getDiscussionTimeState, type GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import { buildCourseUnitUrl, buildGroupSlackChannelUrl, formatDateTimeRelative } from '../../lib/utils';
 import { trpc } from '../../utils/trpc';
 import {
@@ -47,7 +47,7 @@ export type ButtonOrMenuItem = {
 
 type GroupDiscussionBannerProps = {
   unit: Unit;
-  groupDiscussion: GroupDiscussion;
+  groupDiscussion: GroupDiscussionWithEnd;
   userRole?: 'participant' | 'facilitator';
   hostKeyForFacilitators?: string;
 };

--- a/apps/website/src/components/my-courses/CourseListRow.tsx
+++ b/apps/website/src/components/my-courses/CourseListRow.tsx
@@ -1,5 +1,5 @@
 import type {
-  Course, CourseRegistration, Group, GroupDiscussion, Unit,
+  Course, CourseRegistration, Group, Unit,
 } from '@bluedot/db';
 import {
   Eyebrow, H3, OverflowMenu, Tooltip,
@@ -8,6 +8,7 @@ import { Fragment, type ReactNode } from 'react';
 import { ChevronRightIcon } from '../icons';
 import { COURSE_CONFIG } from '../../lib/constants';
 import { COURSE_COLORS, type CourseColorSlug } from '../../lib/courseColors';
+import type { GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import { formatMonthAndDay, parseWeekFromRoundName } from '../../lib/utils';
 import DiscussionList from './DiscussionList';
 import { classifyCourseRegistration, useCourseListRow } from './useCourseListRow';
@@ -34,7 +35,7 @@ type CommonRowProps = {
   group: Group | null;
   meetPersonId: string | null;
   roundId: string | null;
-  discussions: GroupDiscussion[];
+  discussions: GroupDiscussionWithEnd[];
   attendedDiscussionIds: string[];
   units: Record<string, Unit>;
   roundStartDate: string | null;

--- a/apps/website/src/components/my-courses/DiscussionList.tsx
+++ b/apps/website/src/components/my-courses/DiscussionList.tsx
@@ -1,18 +1,19 @@
-import type { GroupDiscussion, Unit } from '@bluedot/db';
+import type { Unit } from '@bluedot/db';
+import type { GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import type { SwitchType } from '../courses/GroupSwitchModal';
 import DiscussionListRow, { type DiscussionListRowMode } from './DiscussionListRow';
 
 type DiscussionListProps = {
   mode?: DiscussionListRowMode;
-  discussions: GroupDiscussion[];
+  discussions: GroupDiscussionWithEnd[];
   units: Record<string, Unit>;
   attendedDiscussionIds: string[];
   courseSlug: string;
   canReschedule: boolean;
   rescheduleEligibleUnits: string[];
   onClickReschedule: (props: { unitNumber: string | null; switchType: SwitchType }) => void;
-  onClickFacilitatorReschedule?: (discussion: GroupDiscussion) => void;
-  onClickFacilitatorAssignSubstitute?: (discussion: GroupDiscussion) => void;
+  onClickFacilitatorReschedule?: (discussion: GroupDiscussionWithEnd) => void;
+  onClickFacilitatorAssignSubstitute?: (discussion: GroupDiscussionWithEnd) => void;
   onClickViewAttendees?: () => void;
 };
 

--- a/apps/website/src/components/my-courses/DiscussionListRow.stories.tsx
+++ b/apps/website/src/components/my-courses/DiscussionListRow.stories.tsx
@@ -1,4 +1,5 @@
-import type { GroupDiscussion, Unit } from '@bluedot/db';
+import type { Unit } from '@bluedot/db';
+import type { GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import type { Meta, StoryObj } from '@storybook/react';
 import DiscussionListRow from './DiscussionListRow';
 
@@ -7,15 +8,15 @@ import DiscussionListRow from './DiscussionListRow';
 const nowSec = Math.floor(Date.now() / 1000);
 const HOUR = 60 * 60;
 
-const baseDiscussion: GroupDiscussion = {
+const baseDiscussion: GroupDiscussionWithEnd = {
   id: 'disc-1',
   startDateTime: nowSec + 2 * HOUR,
   endDateTime: nowSec + 3 * HOUR,
   unitNumber: 4,
   zoomLink: 'https://zoom.us/j/000',
-} as unknown as GroupDiscussion;
+} as unknown as GroupDiscussionWithEnd;
 
-const at = (offsets: { start: number; end: number }): GroupDiscussion => ({
+const at = (offsets: { start: number; end: number }): GroupDiscussionWithEnd => ({
   ...baseDiscussion,
   startDateTime: nowSec + offsets.start,
   endDateTime: nowSec + offsets.end,
@@ -54,10 +55,10 @@ const soon = at({ start: 10 * 60, end: 70 * 60 });
 const live = at({ start: -10 * 60, end: 50 * 60 });
 const past = at({ start: -2 * HOUR, end: -HOUR });
 
-const upcomingFac = { ...upcoming, participantsExpected: ['mp-a', 'mp-b', 'mp-c', 'mp-d', 'mp-e', 'mp-f', 'mp-g', 'mp-h'] } as GroupDiscussion;
-const soonFac = { ...soon, participantsExpected: ['mp-a', 'mp-b', 'mp-c', 'mp-d', 'mp-e', 'mp-f', 'mp-g', 'mp-h'] } as GroupDiscussion;
-const liveFac = { ...live, participantsExpected: ['mp-a', 'mp-b', 'mp-c', 'mp-d', 'mp-e', 'mp-f', 'mp-g', 'mp-h'] } as GroupDiscussion;
-const pastFac = { ...past, participantsExpected: ['mp-a', 'mp-b', 'mp-c', 'mp-d', 'mp-e', 'mp-f', 'mp-g', 'mp-h'] } as GroupDiscussion;
+const upcomingFac = { ...upcoming, participantsExpected: ['mp-a', 'mp-b', 'mp-c', 'mp-d', 'mp-e', 'mp-f', 'mp-g', 'mp-h'] } as GroupDiscussionWithEnd;
+const soonFac = { ...soon, participantsExpected: ['mp-a', 'mp-b', 'mp-c', 'mp-d', 'mp-e', 'mp-f', 'mp-g', 'mp-h'] } as GroupDiscussionWithEnd;
+const liveFac = { ...live, participantsExpected: ['mp-a', 'mp-b', 'mp-c', 'mp-d', 'mp-e', 'mp-f', 'mp-g', 'mp-h'] } as GroupDiscussionWithEnd;
+const pastFac = { ...past, participantsExpected: ['mp-a', 'mp-b', 'mp-c', 'mp-d', 'mp-e', 'mp-f', 'mp-g', 'mp-h'] } as GroupDiscussionWithEnd;
 
 const facBaseArgs = {
   ...baseArgs,

--- a/apps/website/src/components/my-courses/DiscussionListRow.test.tsx
+++ b/apps/website/src/components/my-courses/DiscussionListRow.test.tsx
@@ -5,8 +5,9 @@ import {
   render, screen, fireEvent, waitFor,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import type { GroupDiscussion, Unit } from '@bluedot/db';
+import type { Unit } from '@bluedot/db';
 import { createMockGroupDiscussion } from '../../__tests__/testUtils';
+import type { GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import DiscussionListRow from './DiscussionListRow';
 import * as downloadModule from '../../lib/downloadCalendarFile';
 
@@ -34,8 +35,8 @@ const unit = {
  */
 const propsForStatus = (
   status: DisplayStatus,
-  discussion: GroupDiscussion = baseDiscussion,
-): { discussion: GroupDiscussion; isAttended: boolean } => {
+  discussion: GroupDiscussionWithEnd = baseDiscussion,
+): { discussion: GroupDiscussionWithEnd; isAttended: boolean } => {
   switch (status) {
     case 'upcoming':
       return { discussion: { ...discussion, startDateTime: NOW_SEC + 2 * HOUR, endDateTime: NOW_SEC + 3 * HOUR }, isAttended: false };
@@ -57,7 +58,7 @@ const renderRow = ({
   ...overrides
 }: {
   status?: DisplayStatus;
-  discussion?: GroupDiscussion;
+  discussion?: GroupDiscussionWithEnd;
   unit?: Unit | null;
   canReschedule?: boolean;
   onReschedule?: () => void;
@@ -161,14 +162,14 @@ describe('DiscussionListRow', () => {
     });
 
     test('hidden on live without zoomLink', () => {
-      const noZoom = { ...baseDiscussion, zoomLink: null } as GroupDiscussion;
+      const noZoom = { ...baseDiscussion, zoomLink: null } as GroupDiscussionWithEnd;
       renderRow({ status: 'live', discussion: noZoom });
       expect(screen.queryByRole('link', { name: 'Join now' })).toBeNull();
     });
   });
 
   test('title falls back to "Discussion" plain text when unit and unitNumber are missing', () => {
-    const noUnitDiscussion = { ...baseDiscussion, unitNumber: null } as GroupDiscussion;
+    const noUnitDiscussion = { ...baseDiscussion, unitNumber: null } as GroupDiscussionWithEnd;
     const { container } = renderRow({ unit: null, discussion: noUnitDiscussion });
     // Title is rendered as text, not as a link, when there's no unit number to link to.
     expect(screen.getByText('Discussion').tagName).toBe('P');
@@ -211,7 +212,7 @@ describe('DiscussionListRow', () => {
   });
 
   describe('facilitator mode', () => {
-    const withAttendees = (n: number): GroupDiscussion => ({
+    const withAttendees = (n: number): GroupDiscussionWithEnd => ({
       ...baseDiscussion,
       participantsExpected: Array.from({ length: n }, (_, i) => `p-${i}`),
     });
@@ -224,9 +225,9 @@ describe('DiscussionListRow', () => {
       onClickViewAttendees = () => {},
     }: {
       status?: DisplayStatus;
-      discussion?: GroupDiscussion;
-      onClickFacilitatorReschedule?: (d: GroupDiscussion) => void;
-      onClickFacilitatorAssignSubstitute?: (d: GroupDiscussion) => void;
+      discussion?: GroupDiscussionWithEnd;
+      onClickFacilitatorReschedule?: (d: GroupDiscussionWithEnd) => void;
+      onClickFacilitatorAssignSubstitute?: (d: GroupDiscussionWithEnd) => void;
       onClickViewAttendees?: () => void;
     } = {}) => {
       const statusProps = propsForStatus(status, discussion);
@@ -268,7 +269,7 @@ describe('DiscussionListRow', () => {
     });
 
     test('live without a zoom link: no "Join now" link', () => {
-      const noZoom = { ...baseDiscussion, zoomLink: null } as GroupDiscussion;
+      const noZoom = { ...baseDiscussion, zoomLink: null } as GroupDiscussionWithEnd;
       renderFacRow({ status: 'live', discussion: noZoom });
       expect(screen.queryByRole('link', { name: 'Join now' })).toBeNull();
     });

--- a/apps/website/src/components/my-courses/DiscussionListRow.tsx
+++ b/apps/website/src/components/my-courses/DiscussionListRow.tsx
@@ -1,6 +1,7 @@
 import { OverflowMenu, type OverflowMenuItemProps } from '@bluedot/ui';
-import type { GroupDiscussion, Unit } from '@bluedot/db';
+import type { Unit } from '@bluedot/db';
 import { type ReactNode } from 'react';
+import type { GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import { formatDateMonthAndDay, formatTime12HourClock } from '../../lib/utils';
 import LiveBadge from './LiveBadge';
 import { useDiscussionActions } from './useDiscussionActions';
@@ -23,14 +24,14 @@ export type CourseAction = {
 
 export type DiscussionListRowProps = {
   mode?: DiscussionListRowMode;
-  discussion: GroupDiscussion;
+  discussion: GroupDiscussionWithEnd;
   unit: Unit | null;
   courseSlug: string;
   isAttended: boolean;
   canReschedule: boolean;
   onReschedule: () => void;
-  onClickFacilitatorReschedule?: (discussion: GroupDiscussion) => void;
-  onClickFacilitatorAssignSubstitute?: (discussion: GroupDiscussion) => void;
+  onClickFacilitatorReschedule?: (discussion: GroupDiscussionWithEnd) => void;
+  onClickFacilitatorAssignSubstitute?: (discussion: GroupDiscussionWithEnd) => void;
   onClickViewAttendees?: () => void;
 };
 

--- a/apps/website/src/components/my-courses/NextDiscussionCard.tsx
+++ b/apps/website/src/components/my-courses/NextDiscussionCard.tsx
@@ -17,8 +17,8 @@ const formatEyebrow = (prefix: string, unitNumber: string | undefined): string =
   return `${prefix.toUpperCase()}: ${unitText}`;
 };
 
-const formatDatetimeLabel = (startSec: number, endSec: number) =>
-  `${formatDateMonthAndDay(startSec)}, ${formatTime12HourClock(startSec)} - ${formatTime12HourClock(endSec)}`;
+const formatDatetimeLabel = (startSec: number, endSec: number | null) =>
+  `${formatDateMonthAndDay(startSec)}, ${formatTime12HourClock(startSec)}${endSec !== null ? ` - ${formatTime12HourClock(endSec)}` : ''}`;
 
 // Fixed square badge slot: shows the calendar date, or the LIVE indicator (same dimensions) when live.
 const CalendarBadge = ({ month, day, isLive }: { month: string; day: number; isLive: boolean }) => (

--- a/apps/website/src/components/my-courses/NextDiscussionCard.tsx
+++ b/apps/website/src/components/my-courses/NextDiscussionCard.tsx
@@ -1,7 +1,7 @@
-import type { Group, GroupDiscussion, Unit } from '@bluedot/db';
+import type { Group, Unit } from '@bluedot/db';
 import { CTALinkOrButton, H3, useCurrentTimeMs } from '@bluedot/ui';
 import { useState, type ReactNode } from 'react';
-import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
+import { getDiscussionTimeState, type GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import { buildCourseUnitUrl, formatDateMonthAndDay, formatTime12HourClock } from '../../lib/utils';
 import FacilitatorSwitchModal from '../courses/FacilitatorSwitchModal';
 import GroupSwitchModal from '../courses/GroupSwitchModal';
@@ -17,8 +17,8 @@ const formatEyebrow = (prefix: string, unitNumber: string | undefined): string =
   return `${prefix.toUpperCase()}: ${unitText}`;
 };
 
-const formatDatetimeLabel = (startSec: number, endSec: number | null) =>
-  `${formatDateMonthAndDay(startSec)}, ${formatTime12HourClock(startSec)}${endSec !== null ? ` - ${formatTime12HourClock(endSec)}` : ''}`;
+const formatDatetimeLabel = (startSec: number, endSec: number) =>
+  `${formatDateMonthAndDay(startSec)}, ${formatTime12HourClock(startSec)} - ${formatTime12HourClock(endSec)}`;
 
 // Fixed square badge slot: shows the calendar date, or the LIVE indicator (same dimensions) when live.
 const CalendarBadge = ({ month, day, isLive }: { month: string; day: number; isLive: boolean }) => (
@@ -44,7 +44,7 @@ export type NextDiscussionCardProps = {
   mode?: NextDiscussionCardMode;
   courseSlug: string;
   courseTitle: string;
-  discussion: GroupDiscussion;
+  discussion: GroupDiscussionWithEnd;
   unit: Unit | null;
   group?: Group | null;
   facilitatorSubtitle?: string | null;

--- a/apps/website/src/components/my-courses/useCourseListRow.tsx
+++ b/apps/website/src/components/my-courses/useCourseListRow.tsx
@@ -1,11 +1,11 @@
 import {
   CTALinkOrButton, addQueryParam, useLatestUtmParams, type OverflowMenuItemProps,
 } from '@bluedot/ui';
-import type { GroupDiscussion } from '@bluedot/db';
 import { Fragment, type ReactNode } from 'react';
 import { FaCheck, FaLock } from 'react-icons/fa6';
 import { IoBan } from 'react-icons/io5';
 import { FOAI_COURSE_SLUG } from '../../lib/constants';
+import type { GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import { ROUTES } from '../../lib/routes';
 import { buildApplicationUrl, buildGroupSlackChannelUrl, getActionPlanUrl } from '../../lib/utils';
 import { buildAvailabilityFormUrl, type SwitchType } from '../courses/GroupSwitchModal';
@@ -62,7 +62,7 @@ const sortByFinalDiscussionDesc = (courses: CourseListRowProps[]): CourseListRow
     const attendedSet = new Set(c.attendedDiscussionIds);
 
     const openTimes = c.discussions
-      .filter((d) => !attendedSet.has(d.id) && d.endDateTime !== null && d.endDateTime >= nowSec)
+      .filter((d) => !attendedSet.has(d.id) && d.endDateTime >= nowSec)
       .map((d) => d.startDateTime);
 
     if (openTimes.length > 0) {
@@ -133,8 +133,8 @@ export const bucketCoursesByTab = (
 
 export type ModalCallbacks = {
   onClickReschedule: (input: { unitNumber: string | null; switchType: SwitchType }) => void;
-  onClickFacilitatorReschedule: (discussion: GroupDiscussion) => void;
-  onClickFacilitatorAssignSubstitute: (discussion: GroupDiscussion) => void;
+  onClickFacilitatorReschedule: (discussion: GroupDiscussionWithEnd) => void;
+  onClickFacilitatorAssignSubstitute: (discussion: GroupDiscussionWithEnd) => void;
   onClickViewAttendees: (() => void) | undefined;
 };
 

--- a/apps/website/src/components/my-courses/useCourseListRow.tsx
+++ b/apps/website/src/components/my-courses/useCourseListRow.tsx
@@ -62,7 +62,7 @@ const sortByFinalDiscussionDesc = (courses: CourseListRowProps[]): CourseListRow
     const attendedSet = new Set(c.attendedDiscussionIds);
 
     const openTimes = c.discussions
-      .filter((d) => !attendedSet.has(d.id) && d.endDateTime >= nowSec)
+      .filter((d) => !attendedSet.has(d.id) && d.endDateTime !== null && d.endDateTime >= nowSec)
       .map((d) => d.startDateTime);
 
     if (openTimes.length > 0) {

--- a/apps/website/src/components/my-courses/useDiscussionActions.tsx
+++ b/apps/website/src/components/my-courses/useDiscussionActions.tsx
@@ -1,12 +1,11 @@
 import {
   CTALinkOrButton, useCurrentTimeMs, type OverflowMenuItemProps,
 } from '@bluedot/ui';
-import type { GroupDiscussion } from '@bluedot/db';
 import { Fragment, useState, type ReactNode } from 'react';
 import { FaCheck } from 'react-icons/fa6';
 import { IoBan, IoCheckmark } from 'react-icons/io5';
 import { downloadDiscussionCalendarFile } from '../../lib/downloadCalendarFile';
-import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
+import { getDiscussionTimeState, type GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import type { CourseAction, DiscussionListRowProps } from './DiscussionListRow';
 
 export type DiscussionStatus = 'upcoming' | 'soon' | 'live' | 'attended' | 'absent';
@@ -62,7 +61,7 @@ export const useDiscussionActions = (input: DiscussionListRowProps): UseDiscussi
   };
 };
 
-const deriveStatus = (discussion: GroupDiscussion, isAttended: boolean, currentTimeMs: number): DiscussionStatus => {
+const deriveStatus = (discussion: GroupDiscussionWithEnd, isAttended: boolean, currentTimeMs: number): DiscussionStatus => {
   const timeState = getDiscussionTimeState({ discussion, currentTimeMs });
   // Live wins over attended: suppress the Attended pill while a discussion is in progress so
   // users can't read off "you're counted as attended" the moment they click Join.

--- a/apps/website/src/lib/group-discussions/utils.ts
+++ b/apps/website/src/lib/group-discussions/utils.ts
@@ -17,9 +17,8 @@ export function getDiscussionTimeState({
   currentTimeMs: number;
 }) {
   const startMs = discussion.startDateTime * 1000;
-  const endMs = discussion.endDateTime * 1000;
 
-  if (currentTimeMs > endMs) {
+  if (discussion.endDateTime === null || currentTimeMs > discussion.endDateTime * 1000) {
     return 'ended';
   }
 

--- a/apps/website/src/lib/group-discussions/utils.ts
+++ b/apps/website/src/lib/group-discussions/utils.ts
@@ -1,5 +1,10 @@
 import { type GroupDiscussion } from '@bluedot/db';
 
+// Discussions can be bulk-created without an end time; server boundaries filter those out so the UI only sees scheduled ones.
+export type GroupDiscussionWithEnd = GroupDiscussion & { endDateTime: number };
+
+export const hasEndDateTime = (d: GroupDiscussion): d is GroupDiscussionWithEnd => d.endDateTime !== null;
+
 const ONE_HOUR_MS = 3_600_000;
 
 /**
@@ -13,12 +18,13 @@ export function getDiscussionTimeState({
   discussion,
   currentTimeMs,
 }: {
-  discussion: Pick<GroupDiscussion, 'startDateTime' | 'endDateTime'>;
+  discussion: Pick<GroupDiscussionWithEnd, 'startDateTime' | 'endDateTime'>;
   currentTimeMs: number;
 }) {
   const startMs = discussion.startDateTime * 1000;
+  const endMs = discussion.endDateTime * 1000;
 
-  if (discussion.endDateTime === null || currentTimeMs > discussion.endDateTime * 1000) {
+  if (currentTimeMs > endMs) {
     return 'ended';
   }
 

--- a/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
+++ b/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
@@ -104,7 +104,7 @@ export default makeApiRoute({
     unitTitle: unit?.title,
     unitFallback: discussion.unitFallback,
     startDateTime: discussion.startDateTime,
-    endDateTime: discussion.endDateTime,
+    endDateTime: discussion.endDateTime ?? discussion.startDateTime + 60 * 60,
     zoomLink: discussion.zoomLink,
     activityDoc: discussion.activityDoc,
   });

--- a/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
+++ b/apps/website/src/pages/api/calendar/discussions/[discussionId].ts
@@ -87,6 +87,10 @@ export default makeApiRoute({
     throw new createHttpError.Forbidden('You do not have access to this discussion');
   }
 
+  if (discussion.endDateTime === null) {
+    throw new createHttpError.Conflict('Discussion does not have an end time yet');
+  }
+
   const unit = discussion.courseBuilderUnitRecordId
     ? await db.get(unitTable, { id: discussion.courseBuilderUnitRecordId })
     : null;
@@ -104,7 +108,7 @@ export default makeApiRoute({
     unitTitle: unit?.title,
     unitFallback: discussion.unitFallback,
     startDateTime: discussion.startDateTime,
-    endDateTime: discussion.endDateTime ?? discussion.startDateTime + 60 * 60,
+    endDateTime: discussion.endDateTime,
     zoomLink: discussion.zoomLink,
     activityDoc: discussion.activityDoc,
   });

--- a/apps/website/src/server/routers/facilitators.ts
+++ b/apps/website/src/server/routers/facilitators.ts
@@ -20,6 +20,7 @@ import {
 import { TRPCError } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
+import { hasEndDateTime } from '../../lib/group-discussions/utils';
 import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 import { getFieldOptions } from '../airtableFieldOptions';
 
@@ -160,11 +161,12 @@ export const facilitatorRouter = router({
       const user = await getUserFromAuthOrThrow(ctx.auth);
       const facilitator = await getFacilitator(roundId, user.id);
 
-      const groupDiscussions = await db.pg
+      const groupDiscussions = (await db.pg
         .select()
         .from(groupDiscussionTable.pg)
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        .where(and(inArray(groupDiscussionTable.pg.id, facilitator.expectedDiscussionsFacilitator || [])));
+        .where(and(inArray(groupDiscussionTable.pg.id, facilitator.expectedDiscussionsFacilitator || []))))
+        .filter(hasEndDateTime);
 
       const groups = await db.pg
         .select()

--- a/apps/website/src/server/routers/group-discussions.ts
+++ b/apps/website/src/server/routers/group-discussions.ts
@@ -18,7 +18,7 @@ import { logger } from '@bluedot/ui/src/api';
 import { TRPCError, type inferRouterOutputs } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
-import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
+import { getDiscussionTimeState, hasEndDateTime } from '../../lib/group-discussions/utils';
 import { getCourseBySlugOrThrow } from './courses';
 import {
   getUserFromAuthOrThrow, protectedProcedure, publicProcedure, router,
@@ -36,12 +36,12 @@ export const groupDiscussionsRouter = router({
         return { discussions: [] };
       }
 
-      const discussions = await db.scan(groupDiscussionTable, {
+      const allDiscussions = await db.scan(groupDiscussionTable, {
         OR: discussionIds.map((id) => ({ id })),
       });
 
-      if (discussions.length !== discussionIds.length) {
-        const foundIds = new Set(discussions.map((d) => d.id));
+      if (allDiscussions.length !== discussionIds.length) {
+        const foundIds = new Set(allDiscussions.map((d) => d.id));
         const missingIds = discussionIds.filter((id) => !foundIds.has(id));
         logger.error(`Some group discussions not found for the provided IDs: ${missingIds.join(', ')}`);
         throw new TRPCError({
@@ -50,6 +50,7 @@ export const groupDiscussionsRouter = router({
         });
       }
 
+      const discussions = allDiscussions.filter(hasEndDateTime);
       const groupIds = [...new Set(discussions.map((d) => d.group))];
       const unitIds = [...new Set(discussions.map((d) => d.courseBuilderUnitRecordId).filter((id): id is string => !!id))];
 
@@ -156,11 +157,12 @@ export const groupDiscussionsRouter = router({
 
       // Query discussions through both the direct expected-discussion linkage and the
       // round-based fallback so the course hub stays aligned with the settings page.
-      const groupDiscussions = await db.pg
+      const groupDiscussions = (await db.pg
         .select()
         .from(groupDiscussionTable.pg)
         .where(discussionConditions.length === 1 ? discussionConditions[0]! : or(...discussionConditions))
-        .orderBy(groupDiscussionTable.pg.startDateTime);
+        .orderBy(groupDiscussionTable.pg.startDateTime))
+        .filter(hasEndDateTime);
 
       const dedupedDiscussions = groupDiscussions.filter((discussion, index, discussions) => discussions.findIndex((d) => d.id === discussion.id) === index);
 

--- a/apps/website/src/server/routers/group-switching.ts
+++ b/apps/website/src/server/routers/group-switching.ts
@@ -6,18 +6,17 @@ import {
   groupSwitchingTable,
   groupTable, inArray, isDiscussionFacilitator, isDiscussionParticipant, meetPersonTable, roundTable,
   type Group,
-  type GroupDiscussion,
 } from '@bluedot/db';
 import { TRPCError, type inferRouterOutputs } from '@trpc/server';
 import z from 'zod';
 import db from '../../lib/api/db';
-import { getDiscussionTimeState } from '../../lib/group-discussions/utils';
+import { getDiscussionTimeState, hasEndDateTime, type GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 
 export type DiscussionsAvailable = inferRouterOutputs<typeof groupSwitchingRouter>['discussionsAvailable'];
 
 type DiscussionsByUnit = Record<string, {
-  discussion: GroupDiscussion;
+  discussion: GroupDiscussionWithEnd;
   spotsLeftIfKnown: number | null;
   userIsParticipant: boolean;
   groupName: string;
@@ -29,7 +28,7 @@ export function calculateGroupAvailability({
   maxParticipants,
   participantId,
 }: {
-  groupDiscussions: GroupDiscussion[];
+  groupDiscussions: GroupDiscussionWithEnd[];
   groups: Group[];
   maxParticipants: number | null | undefined;
   participantId: string;
@@ -157,7 +156,7 @@ export function getAvailableGroupsAndDiscussions({
   maxParticipants,
 }: {
   allGroupsInRound: Group[];
-  allGroupDiscussionsInRound: GroupDiscussion[];
+  allGroupDiscussionsInRound: GroupDiscussionWithEnd[];
   participantId: string;
   participantHumanOpinion: string | null;
   maxParticipants: number | null | undefined;
@@ -199,7 +198,7 @@ export const groupSwitchingRouter = router({
 
       const [allGroupsInRound, allGroupDiscussionsInRound] = await Promise.all([
         db.scan(groupTable, { round: roundId }),
-        db.scan(groupDiscussionTable, { round: roundId }),
+        db.scan(groupDiscussionTable, { round: roundId }).then((rows) => rows.filter(hasEndDateTime)),
       ]);
 
       const result = getAvailableGroupsAndDiscussions({
@@ -374,7 +373,7 @@ export const groupSwitchingRouter = router({
         if (newGroup && !isManualRequest && typeof maxParticipants === 'number') {
           // Calculate spots left based on the minimum spots across all discussions in the group
           // This matches the logic in available.ts
-          const groupDiscussions = await db.scan(groupDiscussionTable, { group: newGroup.id });
+          const groupDiscussions = (await db.scan(groupDiscussionTable, { group: newGroup.id })).filter(hasEndDateTime);
           const spotsLeftIfKnownValues = groupDiscussions
             .map((d) => Math.max(0, maxParticipants - d.participantsExpected.filter((pId) => pId !== participantId).length))
             .filter((v) => typeof v === 'number');

--- a/apps/website/src/server/routers/my-bluedot.test.ts
+++ b/apps/website/src/server/routers/my-bluedot.test.ts
@@ -144,6 +144,66 @@ describe('myCoursesPage.getOverview', () => {
     expect(result.courses.map((c) => c.course.slug)).toEqual(['participant-course']);
   });
 
+  test('discussions without an end time are excluded from the response', async () => {
+    await testDb.insert(courseTable, {
+      id: 'course-1',
+      slug: 'course-1',
+      title: 'Course 1',
+      shortDescription: 'c',
+      units: [],
+      status: 'Active',
+    });
+    await testDb.insert(courseRegistrationTable, {
+      id: 'reg-1',
+      email: CALLER_EMAIL,
+      userId: 'test-user',
+      courseId: 'course-1',
+      decision: 'Accept',
+      role: 'Participant',
+      roundStatus: 'Active',
+    });
+    await testDb.insert(meetPersonTable, {
+      id: 'mp-1',
+      userId: 'test-user',
+      applicationsBaseRecordId: 'reg-1',
+      round: 'round-1',
+      role: 'Participant',
+      groupsAsParticipant: ['group-1'],
+      expectedDiscussionsParticipant: ['disc-no-end', 'disc-scheduled'],
+    });
+    await testDb.insert(groupTable, {
+      id: 'group-1',
+      groupName: 'Group 1',
+      round: 'round-1',
+      participants: ['mp-1'],
+    });
+
+    // Sooner, but bulk-created without an end time — must not surface anywhere.
+    await testDb.insert(groupDiscussionTable, {
+      id: 'disc-no-end',
+      group: 'group-1',
+      round: 'round-1',
+      startDateTime: inOneWeek,
+      endDateTime: null,
+      facilitators: [],
+      participantsExpected: ['mp-1'],
+    });
+    await testDb.insert(groupDiscussionTable, {
+      id: 'disc-scheduled',
+      group: 'group-1',
+      round: 'round-1',
+      startDateTime: inOneMonth,
+      endDateTime: inOneMonth + 60 * 60,
+      facilitators: [],
+      participantsExpected: ['mp-1'],
+    });
+
+    const result = await caller.myBluedot.myCoursesPage();
+
+    expect(result.courses[0]?.discussions.map((d) => d.id)).toEqual(['disc-scheduled']);
+    expect(result.nextDiscussion?.discussion.id).toBe('disc-scheduled');
+  });
+
   test('dropped-out registrations do not contribute discussions to nextDiscussion', async () => {
     // User is dropped from course-dropped (dropoutTable entry, decision still 'Accept').
     // The Airtable lookup field expectedDiscussionsParticipant still references their

--- a/apps/website/src/server/routers/my-bluedot.ts
+++ b/apps/website/src/server/routers/my-bluedot.ts
@@ -377,7 +377,7 @@ export const myBluedotRouter = router({
     // "Next" includes a discussion that's started but not yet ended (i.e. live now)
     const nowSec = Math.floor(Date.now() / 1000);
     const soonest = discussions
-      .filter((d) => d.endDateTime > nowSec)
+      .filter((d) => d.endDateTime !== null && d.endDateTime > nowSec)
       .sort((a, b) => a.startDateTime - b.startDateTime)
       .find((d) => courseByDiscussionId.has(d.id));
 
@@ -516,7 +516,7 @@ export const myBluedotRouter = router({
       .flatMap((row) => {
         if (!row.group) return [];
         if (row.isDroppedOut && !row.isDeferred) return [];
-        const soonest = row.discussions.find((d) => d.endDateTime > nowSec);
+        const soonest = row.discussions.find((d) => d.endDateTime !== null && d.endDateTime > nowSec);
         if (!soonest) return [];
 
         const unit = soonest.courseBuilderUnitRecordId ? unitById.get(soonest.courseBuilderUnitRecordId) ?? null : null;

--- a/apps/website/src/server/routers/my-bluedot.ts
+++ b/apps/website/src/server/routers/my-bluedot.ts
@@ -24,6 +24,7 @@ import {
 import z from 'zod';
 import type { FacilitatorRowProps, ParticipantRowProps } from '../../components/my-courses/CourseListRow';
 import db from '../../lib/api/db';
+import { hasEndDateTime, type GroupDiscussionWithEnd } from '../../lib/group-discussions/utils';
 import { FOAI_COURSE_ID } from '../../lib/constants';
 import { parseWeekFromRoundName, unique } from '../../lib/utils';
 import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
@@ -234,7 +235,8 @@ export const myBluedotRouter = router({
           .select()
           .from(groupDiscussionTable.pg)
           .where(inArray(groupDiscussionTable.pg.id, allExpectedDiscussionIds))
-        : Promise.resolve([] as GroupDiscussion[]),
+          .then((rows) => rows.filter(hasEndDateTime))
+        : Promise.resolve([] as GroupDiscussionWithEnd[]),
       fetchApplicationsRoundsByIds(allRoundIds),
     ]);
 
@@ -246,8 +248,9 @@ export const myBluedotRouter = router({
         ? db.pg.select().from(groupTable.pg).where(inArray(groupTable.pg.round, meetPersonRoundIds)) as Promise<Group[]>
         : Promise.resolve([] as Group[]),
       meetPersonRoundIds.length > 0
-        ? db.pg.select().from(groupDiscussionTable.pg).where(inArray(groupDiscussionTable.pg.round, meetPersonRoundIds)) as Promise<GroupDiscussion[]>
-        : Promise.resolve([] as GroupDiscussion[]),
+        ? (db.pg.select().from(groupDiscussionTable.pg).where(inArray(groupDiscussionTable.pg.round, meetPersonRoundIds)) as Promise<GroupDiscussion[]>)
+          .then((rows) => rows.filter(hasEndDateTime))
+        : Promise.resolve([] as GroupDiscussionWithEnd[]),
       meetPersonRoundIds.length > 0
         ? db.pg
           .select({ id: roundTable.pg.id, maxParticipantsPerGroup: roundTable.pg.maxParticipantsPerGroup })
@@ -298,7 +301,7 @@ export const myBluedotRouter = router({
       const expectedIds = meetPerson?.expectedDiscussionsParticipant ?? [];
       const courseDiscussions = expectedIds
         .map((id) => discussionById.get(id))
-        .filter((d): d is GroupDiscussion => !!d)
+        .filter((d): d is GroupDiscussionWithEnd => !!d)
         .sort((a, b) => a.startDateTime - b.startDateTime);
 
       const courseUnits: Record<string, Unit> = {};
@@ -377,14 +380,14 @@ export const myBluedotRouter = router({
     // "Next" includes a discussion that's started but not yet ended (i.e. live now)
     const nowSec = Math.floor(Date.now() / 1000);
     const soonest = discussions
-      .filter((d) => d.endDateTime !== null && d.endDateTime > nowSec)
+      .filter((d) => d.endDateTime > nowSec)
       .sort((a, b) => a.startDateTime - b.startDateTime)
       .find((d) => courseByDiscussionId.has(d.id));
 
     let nextDiscussion: {
       courseSlug: string;
       courseTitle: string;
-      discussion: GroupDiscussion;
+      discussion: GroupDiscussionWithEnd;
       unit: Unit | null;
       group: Group | null;
     } | null = null;
@@ -439,8 +442,9 @@ export const myBluedotRouter = router({
         ? db.pg.select().from(groupTable.pg).where(inArray(groupTable.pg.round, meetPersonRoundIds)) as Promise<Group[]>
         : Promise.resolve([] as Group[]),
       expectedDiscussionIds.length > 0
-        ? db.pg.select().from(groupDiscussionTable.pg).where(inArray(groupDiscussionTable.pg.id, expectedDiscussionIds)) as Promise<GroupDiscussion[]>
-        : Promise.resolve([] as GroupDiscussion[]),
+        ? (db.pg.select().from(groupDiscussionTable.pg).where(inArray(groupDiscussionTable.pg.id, expectedDiscussionIds)) as Promise<GroupDiscussion[]>)
+          .then((rows) => rows.filter(hasEndDateTime))
+        : Promise.resolve([] as GroupDiscussionWithEnd[]),
       fetchApplicationsRoundsByIds(unique(courseRegistrations.map((cr) => cr.roundId))),
     ]);
 
@@ -491,7 +495,7 @@ export const myBluedotRouter = router({
       return groupsForCr.map((group): FacilitatorRowProps => {
         const groupDiscussions = (meetPerson.expectedDiscussionsFacilitator ?? [])
           .map((id) => discussionById.get(id))
-          .filter((d): d is GroupDiscussion => !!d && d.group === group.id)
+          .filter((d): d is GroupDiscussionWithEnd => !!d && d.group === group.id)
           .sort((a, b) => a.startDateTime - b.startDateTime);
 
         const courseUnits: Record<string, Unit> = {};
@@ -516,7 +520,7 @@ export const myBluedotRouter = router({
       .flatMap((row) => {
         if (!row.group) return [];
         if (row.isDroppedOut && !row.isDeferred) return [];
-        const soonest = row.discussions.find((d) => d.endDateTime !== null && d.endDateTime > nowSec);
+        const soonest = row.discussions.find((d) => d.endDateTime > nowSec);
         if (!soonest) return [];
 
         const unit = soonest.courseBuilderUnitRecordId ? unitById.get(soonest.courseBuilderUnitRecordId) ?? null : null;

--- a/libraries/computed-posthog-events/src/definitions.ts
+++ b/libraries/computed-posthog-events/src/definitions.ts
@@ -84,7 +84,7 @@ const calculateDiscussionAttendanceEvents = async (
   const events: Event[] = [];
   for (const d of discussions) {
     // absent only materialises once a discussion has comfortably ended; attended emits as soon as recorded.
-    const hasEnded = d.endDateTime * 1000 <= nowMs - FIFTEEN_MINUTES_MS;
+    const hasEnded = d.endDateTime !== null && d.endDateTime * 1000 <= nowMs - FIFTEEN_MINUTES_MS;
     if (kind === 'absent' && !hasEnded) continue;
 
     const attendedSet = new Set(d.attendees ?? []);

--- a/libraries/db/src/schema.ts
+++ b/libraries/db/src/schema.ts
@@ -319,7 +319,7 @@ export const groupDiscussionTable = pgAirtable('group_discussion', {
       airtableId: 'flduTqIxS6OEHNr4H',
     },
     endDateTime: {
-      pgColumn: numeric({ mode: 'number' }).notNull(),
+      pgColumn: numeric({ mode: 'number' }),
       airtableId: 'flda1ONwG37ROVo8e',
     },
     group: {


### PR DESCRIPTION
# Description

This field is often temporarily null while people are setting up new cohorts, and this causes spam alerts from pg-sync-service trying to coerce the value.

We plan to ban `notNull` eventually for any field that syncs from Airtable (#2081), so this is in line with that direction.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

N/A (cleaning up spam alerts)

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories