### PR TITLE
Filter browser noise out of `#update_client-errors`

### DIFF
--- a/apps/website/src/lib/clientErrorIgnoreList.test.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.test.ts
@@ -56,6 +56,7 @@ describe('shouldIgnoreClientError', () => {
     'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
     'Invariant: attempted to hard navigate to the same URL /courses/agi-strategy',
     'Failed to fetch',
+    'NetworkError when attempting to fetch resource.',
     'SyntaxError: Invalid regular expression: invalid group specifier name',
     'Failed to get base schema: Status: 429. Data: {}',
     'The service is temporarily unavailable. Please retry shortly.',

--- a/apps/website/src/lib/clientErrorIgnoreList.test.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.test.ts
@@ -39,8 +39,6 @@ describe('shouldIgnoreClientError', () => {
     'No Listener: tabs:outgoing.message.ready',
     'detectLanguage is not a function. (In \'r().i18n.detectLanguage(o)\', \'r().i18n.detectLanguage\' is undefined)',
     'func sseError not found',
-    'TypeError: undefined is not an object (evaluating \'args.site.enabledFeatures\')',
-    'args.site is undefined',
     'can\'t access property "includes", args.site.enabledFeatures is undefined',
   ])('ignores noise beyond Sentry (verified third-party/benign): %s', (message) => {
     expect(shouldIgnoreClientError(message)).toBe(true);
@@ -57,6 +55,8 @@ describe('shouldIgnoreClientError', () => {
     'Invariant: attempted to hard navigate to the same URL /courses/agi-strategy',
     'Failed to fetch',
     'NetworkError when attempting to fetch resource.',
+    'TypeError: undefined is not an object (evaluating \'args.site.enabledFeatures\')',
+    'args.site is undefined',
     'SyntaxError: Invalid regular expression: invalid group specifier name',
     'Failed to get base schema: Status: 429. Data: {}',
     'The service is temporarily unavailable. Please retry shortly.',

--- a/apps/website/src/lib/clientErrorIgnoreList.test.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { shouldIgnoreClientError } from './clientErrorIgnoreList';
+
+describe('shouldIgnoreClientError', () => {
+  it.each([
+    'Failed to connect to MetaMask',
+    'Talisman extension has not been configured yet. Please continue with onboarding.',
+    'Object Not Found Matching Id:4, MethodName:update, ParamCount:4',
+    'Failed to fetch (login.bluedot.org)',
+    'Failed to fetch (cdp-eu.customer.io)',
+    'Failed to fetch (ad.doubleclick.net)',
+  ])('ignores noise mirrored from Sentry ignoreErrors: %s', (message) => {
+    expect(shouldIgnoreClientError(message)).toBe(true);
+  });
+
+  it.each([
+    'Script error.',
+    'Script error',
+    'ResizeObserver loop completed with undelivered notifications.',
+    'TypeError: undefined is not an object (evaluating \'window.ethereum.selectedAddress = undefined\')',
+    'TypeError: undefined is not an object (evaluating \'window.__firefox__.reader\')',
+    'ReferenceError: Can\'t find variable: __firefox__',
+    'Uncaught TypeError: Cannot read properties of undefined (reading \'onMessage\')',
+    'Cannot read properties of undefined (reading \'M_ID\')',
+    'Load failed (login.bluedot.org)',
+    'NetworkError when attempting to fetch resource. (login.bluedot.org)',
+    'Error: Zotero Connector: Failed to send message i18n.getStrings to background page. It may be dead.',
+    'Uncaught TypeError: Cannot redefine property: ethereum',
+    'TypeError: undefined is not an object (evaluating \'n.standardSelectors\')',
+    'ReferenceError: Can\'t find variable: DarkReader',
+    'ReferenceError: jQuery is not defined',
+    'Uncaught Error: Error invoking postMessage: Java object is gone',
+    'Error: WKWebView API client did not respond to this postMessage',
+    'TypeError: undefined is not an object (evaluating \'window.__firefox__.refresh_youtube_quality_E271671A9AFE46918663CBBADA360527\')',
+    'TypeError: undefined is not an object (evaluating \'window.webkit.messageHandlers.scrollEventHandler.postMessage\')',
+    'TypeError: undefined is not an object (evaluating \'top.webkit.messageHandlers.foregroundToBackground.postMessage\')',
+    'Window message "chrome: call method" timed out.',
+    'Uncaught (in promise) TypeError: Cannot read properties of undefined (reading \'runtime.sendMessage\')',
+    'No Listener: tabs:outgoing.message.ready',
+    'detectLanguage is not a function. (In \'r().i18n.detectLanguage(o)\', \'r().i18n.detectLanguage\' is undefined)',
+    'func sseError not found',
+    'TypeError: undefined is not an object (evaluating \'args.site.enabledFeatures\')',
+    'args.site is undefined',
+    'can\'t access property "includes", args.site.enabledFeatures is undefined',
+  ])('ignores noise beyond Sentry (verified third-party/benign): %s', (message) => {
+    expect(shouldIgnoreClientError(message)).toBe(true);
+  });
+
+  it.each([
+    'Cannot read properties of undefined (reading \'title\')',
+    'Cannot read properties of undefined (reading \'courseId\')',
+    'can\'t access property "title", b is undefined',
+    'A network error occurred.',
+    'TypeError: Cannot call a class as a function',
+    'TimeoutError: operation timed out',
+    'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
+    'Invariant: attempted to hard navigate to the same URL /courses/agi-strategy',
+    'Failed to fetch',
+    'SyntaxError: Invalid regular expression: invalid group specifier name',
+    'Failed to get base schema: Status: 429. Data: {}',
+    'The service is temporarily unavailable. Please retry shortly.',
+  ])('keeps real errors: %s', (message) => {
+    expect(shouldIgnoreClientError(message)).toBe(false);
+  });
+});

--- a/apps/website/src/lib/clientErrorIgnoreList.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.ts
@@ -37,7 +37,6 @@ const BEYOND_SENTRY_PATTERNS: RegExp[] = [
   /detectlanguage is not a function/i, // Translation extension
   /func sseerror not found/i, // Missing marketing-tag callback
   /enabledfeatures.*undefined/i, // Extension config object
-  /args\.site/i, // Extension config object
   /^window message ".+" timed out\.?$/i, // Timed-out extension call
   /evaluating 'window\.ethereum/i, // Wallet selectedAddress fight
   /evaluating 'n\.standardselectors/i, // Minified extension code

--- a/apps/website/src/lib/clientErrorIgnoreList.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.ts
@@ -1,6 +1,7 @@
 /**
  * Messages too noisy for the #update_client-errors Slack channel.
- * Checked before reporting; matching messages stay in Sentry only.
+ * Checked before reporting. Mirrored patterns are dropped by Sentry too.
+ * The rest stay in Sentry, just out of Slack.
  */
 
 export const SENTRY_MIRRORED_PATTERNS: RegExp[] = [
@@ -26,7 +27,7 @@ const BEYOND_SENTRY_PATTERNS: RegExp[] = [
   /no listener: tabs:/i, // Extension tabs API
   /reading 'm_id'/i, // Email scanner artifact
   /load failed \(.+\)$/i, // Safari's phrasing of the fetch rule
-  /networkerror when attempting to fetch resource/i, // Firefox's phrasing of the fetch rule
+  /networkerror when attempting to fetch resource\. \(.+\)$/i, // Firefox's phrasing of the fetch rule, wrapped form only
   /zotero connector/i, // Zotero extension
   /wkwebview api client/i, // In-app browsers
   /java object is gone/i, // Old Android webview

--- a/apps/website/src/lib/clientErrorIgnoreList.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.ts
@@ -1,0 +1,51 @@
+/**
+ * Messages too noisy for the #update_client-errors Slack channel.
+ * Checked before reporting; matching messages stay in Sentry only.
+ */
+
+export const SENTRY_MIRRORED_PATTERNS: RegExp[] = [
+  // Same as Sentry `ignoreErrors` in `src/instrumentation-client.ts`.
+  /failed to connect to metamask/i,
+  /talisman extension has not been configured/i,
+  /object not found matching id:\d+, methodname:/i, // Outlook SafeLinks scanner
+  // Extension-wrapped fetch appends "(hostname)". Native fetch never does,
+  // so this can't match our code. Covers ad, analytics, and auth hosts:
+  // a real outage shows server-side, and these reports can't tell an
+  // outage from an adblocker or dropped connection.
+  /^failed to fetch \(.+\)$/i,
+];
+
+const BEYOND_SENTRY_PATTERNS: RegExp[] = [
+  // Not in Sentry's list. Each names its source.
+  /^script error\.?$/i, // Other sites' errors arrive blank
+  /resizeobserver loop/i, // Harmless browser warning
+  /cannot redefine property: ethereum/i, // Wallet extensions fighting
+  /__firefox__/i, // Firefox internals
+  /reading 'onmessage'/i, // Extension messaging
+  /runtime\.sendmessage/i, // Extension messaging
+  /no listener: tabs:/i, // Extension tabs API
+  /reading 'm_id'/i, // Email scanner artifact
+  /load failed \(.+\)$/i, // Safari's phrasing of the fetch rule
+  /networkerror when attempting to fetch resource/i, // Firefox's phrasing of the fetch rule
+  /zotero connector/i, // Zotero extension
+  /wkwebview api client/i, // In-app browsers
+  /java object is gone/i, // Old Android webview
+  /can't find variable: darkreader/i, // DarkReader extension
+  /jquery is not defined/i, // We don't use jQuery
+  /chrome: call method/i, // Timed-out extension call
+  /detectlanguage is not a function/i, // Translation extension
+  /func sseerror not found/i, // Missing marketing-tag callback
+  /enabledfeatures.*undefined/i, // Extension config object
+  /args\.site/i, // Extension config object
+  /^window message ".+" timed out\.?$/i, // Timed-out extension call
+  /evaluating 'window\.ethereum/i, // Wallet selectedAddress fight
+  /evaluating 'n\.standardselectors/i, // Minified extension code
+  /webkit\.messagehandlers/i, // iOS webview bridge
+  /can't access property "includes", args\.site\.enabledfeatures is undefined/i, // Privacy-extension read
+];
+
+const IGNORED_MESSAGE_PATTERNS: RegExp[] = [...SENTRY_MIRRORED_PATTERNS, ...BEYOND_SENTRY_PATTERNS];
+
+export function shouldIgnoreClientError(message: string): boolean {
+  return IGNORED_MESSAGE_PATTERNS.some((pattern) => pattern.test(message.trim()));
+}

--- a/apps/website/src/lib/reportClientError.test.ts
+++ b/apps/website/src/lib/reportClientError.test.ts
@@ -27,7 +27,8 @@ describe('Sentry parity', () => {
   test('every mirrored pattern exists in instrumentation-client.ts ignoreErrors', () => {
     const dirname = path.dirname(fileURLToPath(import.meta.url));
     const src = fs.readFileSync(path.resolve(dirname, '..', 'instrumentation-client.ts'), 'utf8');
-    const block = src.slice(src.indexOf('ignoreErrors'));
+    const start = src.indexOf('ignoreErrors');
+    const block = src.slice(start, src.indexOf('denyUrls', start));
     for (const pattern of SENTRY_MIRRORED_PATTERNS) {
       expect(block.toLowerCase()).toContain(pattern.source.toLowerCase());
     }

--- a/apps/website/src/lib/reportClientError.test.ts
+++ b/apps/website/src/lib/reportClientError.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  describe, expect, test, vi, beforeEach,
+} from 'vitest';
+import { shouldIgnoreClientError, SENTRY_MIRRORED_PATTERNS } from './clientErrorIgnoreList';
+import { reportClientError } from './reportClientError';
+
+describe('reportClientError wiring', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+  });
+
+  test('does not post denylisted noise', () => {
+    reportClientError({ message: 'Script error.' }, 'window.onerror');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('posts real errors', () => {
+    reportClientError({ message: 'wiring-probe-unique-error-42' }, 'window.onerror');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Sentry parity', () => {
+  test('every mirrored pattern exists in instrumentation-client.ts ignoreErrors', () => {
+    const dirname = path.dirname(fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(dirname, '..', 'instrumentation-client.ts'), 'utf8');
+    const block = src.slice(src.indexOf('ignoreErrors'));
+    for (const pattern of SENTRY_MIRRORED_PATTERNS) {
+      expect(block.toLowerCase()).toContain(pattern.source.toLowerCase());
+    }
+  });
+
+  test('denylist matches the documented third-party messages', () => {
+    expect(shouldIgnoreClientError('No Listener: tabs:outgoing.message.ready')).toBe(true);
+  });
+});

--- a/apps/website/src/lib/reportClientError.ts
+++ b/apps/website/src/lib/reportClientError.ts
@@ -1,3 +1,5 @@
+import { shouldIgnoreClientError } from './clientErrorIgnoreList';
+
 const reported = new Set<string>();
 
 export function reportClientError(
@@ -6,6 +8,7 @@ export function reportClientError(
 ) {
   try {
     if (typeof window === 'undefined') return;
+    if (shouldIgnoreClientError(error.message)) return;
 
     const key = `${source}:${error.message}`;
     if (reported.has(key)) return;


### PR DESCRIPTION

# Description

`#update_client-errors` is ~85% noise, so real bugs are easy to miss. Sentry filters these out, but the Slack pipeline had zero filtering. This adds a shared denylist that filters the noise before reporting, so we actually get notified of real errors.

It quiets errors like these (all from `#update_client-errors`):

- `website: Client error (window.onerror): Script error.` (hundreds)
- `website: Client error (unhandledrejection): Failed to connect to MetaMask` (dozens)
- `website: Client error (unhandledrejection): Failed to fetch (ad.doubleclick.net)` (dozens more across ad and tracking hosts)
- `website: Client error (window.onerror): ResizeObserver loop completed with undelivered notifications.` (dozens)
- `website: Client error (window.onerror): TypeError: undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')` (dozens)

I mirrored Sentry's `ignoreErrors` for the most part. The rest are messages I checked and confirmed come from extensions and third-party scripts, not our code (details per pattern in code comments). Real errors still report, including errorboundary crashes like the title and courseId ones. Tests prove noise stays silent and real errors still report. I generally match what Sentry reports. This only stops paging us in slack.

## Issue

Fixes us getting spammed with non errors.

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist, N/A, no UI changes
- [x] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories, N/A, no UI changes

## Screenshot

N/A, no visual changes.
