### PR TITLE
Silence the same-page navigation alert

### DIFF
--- a/apps/website/src/lib/clientErrorIgnoreList.test.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.test.ts
@@ -40,6 +40,9 @@ describe('shouldIgnoreClientError', () => {
     'detectLanguage is not a function. (In \'r().i18n.detectLanguage(o)\', \'r().i18n.detectLanguage\' is undefined)',
     'func sseError not found',
     'can\'t access property "includes", args.site.enabledFeatures is undefined',
+    'Invariant: attempted to hard navigate to the same URL /',
+    'Invariant: attempted to hard navigate to the same URL /some/random/page-123',
+    'Invariant: attempted to hard navigate to the same URL /courses/anything/1/1',
   ])('ignores noise beyond Sentry (verified third-party/benign): %s', (message) => {
     expect(shouldIgnoreClientError(message)).toBe(true);
   });
@@ -52,7 +55,7 @@ describe('shouldIgnoreClientError', () => {
     'TypeError: Cannot call a class as a function',
     'TimeoutError: operation timed out',
     'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
-    'Invariant: attempted to hard navigate to the same URL /courses/agi-strategy',
+    'Invariant: attempted to hard navigate to /other-page',
     'Failed to fetch',
     'NetworkError when attempting to fetch resource.',
     'TypeError: undefined is not an object (evaluating \'args.site.enabledFeatures\')',

--- a/apps/website/src/lib/clientErrorIgnoreList.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.ts
@@ -42,6 +42,8 @@ const BEYOND_SENTRY_PATTERNS: RegExp[] = [
   /evaluating 'n\.standardselectors/i, // Minified extension code
   /webkit\.messagehandlers/i, // iOS webview bridge
   /can't access property "includes", args\.site\.enabledfeatures is undefined/i, // Privacy-extension read
+  // Next.js guard for same-page clicks. The user is already there.
+  /attempted to hard navigate to the same url/i,
 ];
 
 const IGNORED_MESSAGE_PATTERNS: RegExp[] = [...SENTRY_MIRRORED_PATTERNS, ...BEYOND_SENTRY_PATTERNS];


### PR DESCRIPTION

# Description

Dozens of alerts in `#update_client-errors` come from a Next.js guardrail, not a bug. It fires when someone navigates to the page they are already on, like clicking Courses while on `/courses`. The user is already where they want to be, so there is nothing to fix. This silences the exact message so we only get paged for navigations that actually break.

It quiets errors like these (all from `#update_client-errors`):

- `website: Client error (unhandledrejection): Invariant: attempted to hard navigate to the same URL /courses/agi-strategy/1/1 <https://bluedot.org/courses/agi-strategy/1/1>` (dozens more across `/`, `/courses`, `/grants/rapid`, `/join-us`, and other slugs)

The pattern matches that Next.js wording wherever it appears, and only Next.js writes this sentence. Fixing every `router.push` would touch a lot of code for nothing. Tests prove the message stays silent on any path while real errors still report. This only stops paging us in slack.

## Issue

Fixes us getting paged when someone clicks a link to the page they are already on.

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist, N/A, no UI changes
- [x] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories, N/A, no UI changes

## Screenshot

N/A, no visual changes.
