### PR TITLE
Silence old-Safari regex errors from third-party scripts

### DIFF
--- a/apps/website/src/lib/clientErrorIgnoreList.test.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.test.ts
@@ -43,6 +43,7 @@ describe('shouldIgnoreClientError', () => {
     'Invariant: attempted to hard navigate to the same URL /',
     'Invariant: attempted to hard navigate to the same URL /some/random/page-123',
     'Invariant: attempted to hard navigate to the same URL /courses/anything/1/1',
+    'SyntaxError: Invalid regular expression: invalid group specifier name',
   ])('ignores noise beyond Sentry (verified third-party/benign): %s', (message) => {
     expect(shouldIgnoreClientError(message)).toBe(true);
   });
@@ -60,7 +61,7 @@ describe('shouldIgnoreClientError', () => {
     'NetworkError when attempting to fetch resource.',
     'TypeError: undefined is not an object (evaluating \'args.site.enabledFeatures\')',
     'args.site is undefined',
-    'SyntaxError: Invalid regular expression: invalid group specifier name',
+    'Invalid regular expression: missing /',
     'Failed to get base schema: Status: 429. Data: {}',
     'The service is temporarily unavailable. Please retry shortly.',
   ])('keeps real errors: %s', (message) => {

--- a/apps/website/src/lib/clientErrorIgnoreList.ts
+++ b/apps/website/src/lib/clientErrorIgnoreList.ts
@@ -44,6 +44,9 @@ const BEYOND_SENTRY_PATTERNS: RegExp[] = [
   /can't access property "includes", args\.site\.enabledfeatures is undefined/i, // Privacy-extension read
   // Next.js guard for same-page clicks. The user is already there.
   /attempted to hard navigate to the same url/i,
+  // Old Safari regex failure. Our case is fixed on the GFM branch;
+  // the rest is third-party.
+  /invalid group specifier name/i,
 ];
 
 const IGNORED_MESSAGE_PATTERNS: RegExp[] = [...SENTRY_MIRRORED_PATTERNS, ...BEYOND_SENTRY_PATTERNS];


### PR DESCRIPTION

# Description

This silences a dozen old-Safari alerts that page us. They come from old Safari failing to parse a modern regex fragment. I fixed our own instance of this (a lookbehind in the Markdown pipeline) on the `fix/gfm-autolink-safari` branch. With our instance fixed, the rest our third party scripts and so we still nee dto silence it as well.
It quiets errors like these (all from `#update_client-errors`):

- `website: Client error (window.onerror): SyntaxError: Invalid regular expression: invalid group specifier name` (over a dozen)

The pattern matches that phrase wherever it appears. 

## Issue

Fixes us getting paged for old-Safari regex failures in third-party scripts.

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist, N/A, no UI changes
- [x] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories, N/A, no UI changes

## Screenshot

N/A, no visual changes.
