### PR TITLE
Fix MDX pages crashing on old Safari

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { withSentryConfig } = require('@sentry/nextjs');
 const { withDefaultBlueDotNextConfig } = require('@bluedot/ui/src/default-config/next');
 
@@ -186,19 +187,35 @@ const baseConfig = withDefaultBlueDotNextConfig({
 });
 
 // withDefaultBlueDotNextConfig is async; withSentryConfig needs the resolved object
-module.exports = async () => withSentryConfig(await baseConfig, {
-  org: 'bluedotimpact',
-  project: 'website',
-  authToken: process.env.SENTRY_AUTH_TOKEN,
-  widenClientFileUpload: true,
-  // Tags our bundled modules as first-party so thirdPartyErrorFilterIntegration
-  // (instrumentation-client.ts) can drop errors thrown solely by extension scripts.
-  applicationKey: 'bluedot-website',
-  tunnelRoute: true,
-  silent: !process.env.CI,
-  webpack: {
-    treeshake: {
-      removeDebugLogging: true,
+module.exports = async () => {
+  const resolved = await baseConfig;
+  const previousWebpack = resolved.webpack;
+  // Old Safari can't parse one regex in our Markdown package (CE-14).
+  // Use our copy without it.
+  resolved.webpack = (webpackConfig, context, ...args) => {
+    webpackConfig.resolve.alias = {
+      ...(webpackConfig.resolve.alias ?? {}),
+      'mdast-util-gfm-autolink-literal': path.resolve(__dirname, 'src/vendor/mdast-util-gfm-autolink-literal.js'),
+    };
+    return previousWebpack
+      ? previousWebpack(webpackConfig, context, ...args)
+      : webpackConfig;
+  };
+
+  return withSentryConfig(resolved, {
+    org: 'bluedotimpact',
+    project: 'website',
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    widenClientFileUpload: true,
+    // Tags our bundled modules as first-party so thirdPartyErrorFilterIntegration
+    // (instrumentation-client.ts) can drop errors thrown solely by extension scripts.
+    applicationKey: 'bluedot-website',
+    tunnelRoute: true,
+    silent: !process.env.CI,
+    webpack: {
+      treeshake: {
+        removeDebugLogging: true,
+      },
     },
-  },
-});
+  });
+};

--- a/apps/website/src/components/courses/MarkdownExtendedRenderer.test.tsx
+++ b/apps/website/src/components/courses/MarkdownExtendedRenderer.test.tsx
@@ -133,6 +133,37 @@ describe('MarkdownExtendedRenderer', () => {
       expect(paragraphs[2]?.textContent).toBe('Hello World');
     });
 
+    test('GFM email autolinks still link bare addresses (vendored lookbehind-free pattern)', async () => {
+      const { container } = render(<MarkdownExtendedRenderer>
+        {'Contact us at team@bluedot.org for help'}
+      </MarkdownExtendedRenderer>);
+
+      await waitFor(() => {
+        expect(container.querySelector('a[href="mailto:team@bluedot.org"]')).toBeTruthy();
+      });
+    });
+
+    test('vendored autolink boundary matches upstream: punctuation and symbols link', async () => {
+      const { container } = render(<MarkdownExtendedRenderer>
+        {'(team@bluedot.org) and \u20ACteam@bluedot.org'}
+      </MarkdownExtendedRenderer>);
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('a[href="mailto:team@bluedot.org"]')).toHaveLength(2);
+      });
+    });
+
+    test('vendored slash guard: slashes before @ stay text', async () => {
+      const { container } = render(<MarkdownExtendedRenderer>
+        {'see foo/bar@baz.com today'}
+      </MarkdownExtendedRenderer>);
+
+      await waitFor(() => {
+        expect(container.querySelector('p')).toBeTruthy();
+      });
+      expect(container.querySelector('a[href^="mailto:"]')).toBeNull();
+    });
+
     test('remark-breaks plugin: single newlines create line breaks', async () => {
       const { container } = render(<MarkdownExtendedRenderer>
         {'First line\nSecond line\nThird line'}

--- a/apps/website/src/vendor/mdast-util-gfm-autolink-literal.LICENSE
+++ b/apps/website/src/vendor/mdast-util-gfm-autolink-literal.LICENSE
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2020 Titus Wormer <tituswormer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/apps/website/src/vendor/mdast-util-gfm-autolink-literal.js
+++ b/apps/website/src/vendor/mdast-util-gfm-autolink-literal.js
@@ -1,0 +1,302 @@
+/* eslint-disable -- vendored upstream file, see header below. */
+/**
+ * Vendored from mdast-util-gfm-autolink-literal@2.0.1 (MIT, see
+ * mdast-util-gfm-autolink-literal.LICENSE), loaded instead of the published
+ * file via a webpack/vitest alias.
+ *
+ * Single change vs upstream: the email-autolink pattern's lookbehind is
+ * removed because lookbehind throws a SyntaxError at parse time on
+ * Safari < 16.4, killing every page that renders MDX client-side (CE-14).
+ * The `previous()` runtime guard below enforces the same boundary the
+ * lookbehind did (`^|\s|\p{P}|\p{S}`). Micromark's `unicodePunctuation`
+ * covers symbols too, so behavior is unchanged. Pinned by the renderer
+ * tests.
+ * (Also drops the upstream `// eslint-disable-next-line max-params`, made
+ * redundant by the file-level disable above.)
+ * That this file stays a header plus exactly those two line changes is
+ * enforced by mdast-util-gfm-autolink-literal.test.ts. Read that test
+ * to see the complete delta without diffing 280 lines.
+ *
+ * Future upgrades: copy the new upstream lib/index.js over this file,
+ * re-apply the two changes above, and run the vendor tests. The tests
+ * fail until you do, so this cannot silently rot.
+ */
+/**
+ * @import {RegExpMatchObject, ReplaceFunction} from 'mdast-util-find-and-replace'
+ * @import {CompileContext, Extension as FromMarkdownExtension, Handle as FromMarkdownHandle, Transform as FromMarkdownTransform} from 'mdast-util-from-markdown'
+ * @import {ConstructName, Options as ToMarkdownExtension} from 'mdast-util-to-markdown'
+ * @import {Link, PhrasingContent} from 'mdast'
+ */
+
+import {ccount} from 'ccount'
+import {ok as assert} from 'devlop'
+import {unicodePunctuation, unicodeWhitespace} from 'micromark-util-character'
+import {findAndReplace} from 'mdast-util-find-and-replace'
+
+/** @type {ConstructName} */
+const inConstruct = 'phrasing'
+/** @type {Array<ConstructName>} */
+const notInConstruct = ['autolink', 'link', 'image', 'label']
+
+/**
+ * Create an extension for `mdast-util-from-markdown` to enable GFM autolink
+ * literals in markdown.
+ *
+ * @returns {FromMarkdownExtension}
+ *   Extension for `mdast-util-to-markdown` to enable GFM autolink literals.
+ */
+export function gfmAutolinkLiteralFromMarkdown() {
+  return {
+    transforms: [transformGfmAutolinkLiterals],
+    enter: {
+      literalAutolink: enterLiteralAutolink,
+      literalAutolinkEmail: enterLiteralAutolinkValue,
+      literalAutolinkHttp: enterLiteralAutolinkValue,
+      literalAutolinkWww: enterLiteralAutolinkValue
+    },
+    exit: {
+      literalAutolink: exitLiteralAutolink,
+      literalAutolinkEmail: exitLiteralAutolinkEmail,
+      literalAutolinkHttp: exitLiteralAutolinkHttp,
+      literalAutolinkWww: exitLiteralAutolinkWww
+    }
+  }
+}
+
+/**
+ * Create an extension for `mdast-util-to-markdown` to enable GFM autolink
+ * literals in markdown.
+ *
+ * @returns {ToMarkdownExtension}
+ *   Extension for `mdast-util-to-markdown` to enable GFM autolink literals.
+ */
+export function gfmAutolinkLiteralToMarkdown() {
+  return {
+    unsafe: [
+      {
+        character: '@',
+        before: '[+\\-.\\w]',
+        after: '[\\-.\\w]',
+        inConstruct,
+        notInConstruct
+      },
+      {
+        character: '.',
+        before: '[Ww]',
+        after: '[\\-.\\w]',
+        inConstruct,
+        notInConstruct
+      },
+      {
+        character: ':',
+        before: '[ps]',
+        after: '\\/',
+        inConstruct,
+        notInConstruct
+      }
+    ]
+  }
+}
+
+/**
+ * @this {CompileContext}
+ * @type {FromMarkdownHandle}
+ */
+function enterLiteralAutolink(token) {
+  this.enter({type: 'link', title: null, url: '', children: []}, token)
+}
+
+/**
+ * @this {CompileContext}
+ * @type {FromMarkdownHandle}
+ */
+function enterLiteralAutolinkValue(token) {
+  this.config.enter.autolinkProtocol.call(this, token)
+}
+
+/**
+ * @this {CompileContext}
+ * @type {FromMarkdownHandle}
+ */
+function exitLiteralAutolinkHttp(token) {
+  this.config.exit.autolinkProtocol.call(this, token)
+}
+
+/**
+ * @this {CompileContext}
+ * @type {FromMarkdownHandle}
+ */
+function exitLiteralAutolinkWww(token) {
+  this.config.exit.data.call(this, token)
+  const node = this.stack[this.stack.length - 1]
+  assert(node.type === 'link')
+  node.url = 'http://' + this.sliceSerialize(token)
+}
+
+/**
+ * @this {CompileContext}
+ * @type {FromMarkdownHandle}
+ */
+function exitLiteralAutolinkEmail(token) {
+  this.config.exit.autolinkEmail.call(this, token)
+}
+
+/**
+ * @this {CompileContext}
+ * @type {FromMarkdownHandle}
+ */
+function exitLiteralAutolink(token) {
+  this.exit(token)
+}
+
+/** @type {FromMarkdownTransform} */
+function transformGfmAutolinkLiterals(tree) {
+  findAndReplace(
+    tree,
+    [
+      [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
+      [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmail]
+    ],
+    {ignore: ['link', 'linkReference']}
+  )
+}
+
+/**
+ * @type {ReplaceFunction}
+ * @param {string} _
+ * @param {string} protocol
+ * @param {string} domain
+ * @param {string} path
+ * @param {RegExpMatchObject} match
+ * @returns {Array<PhrasingContent> | Link | false}
+ */
+function findUrl(_, protocol, domain, path, match) {
+  let prefix = ''
+
+  // Not an expected previous character.
+  if (!previous(match)) {
+    return false
+  }
+
+  // Treat `www` as part of the domain.
+  if (/^w/i.test(protocol)) {
+    domain = protocol + domain
+    protocol = ''
+    prefix = 'http://'
+  }
+
+  if (!isCorrectDomain(domain)) {
+    return false
+  }
+
+  const parts = splitUrl(domain + path)
+
+  if (!parts[0]) return false
+
+  /** @type {Link} */
+  const result = {
+    type: 'link',
+    title: null,
+    url: prefix + protocol + parts[0],
+    children: [{type: 'text', value: protocol + parts[0]}]
+  }
+
+  if (parts[1]) {
+    return [result, {type: 'text', value: parts[1]}]
+  }
+
+  return result
+}
+
+/**
+ * @type {ReplaceFunction}
+ * @param {string} _
+ * @param {string} atext
+ * @param {string} label
+ * @param {RegExpMatchObject} match
+ * @returns {Link | false}
+ */
+function findEmail(_, atext, label, match) {
+  if (
+    // Not an expected previous character.
+    !previous(match, true) ||
+    // Label ends in not allowed character.
+    /[-\d_]$/.test(label)
+  ) {
+    return false
+  }
+
+  return {
+    type: 'link',
+    title: null,
+    url: 'mailto:' + atext + '@' + label,
+    children: [{type: 'text', value: atext + '@' + label}]
+  }
+}
+
+/**
+ * @param {string} domain
+ * @returns {boolean}
+ */
+function isCorrectDomain(domain) {
+  const parts = domain.split('.')
+
+  if (
+    parts.length < 2 ||
+    (parts[parts.length - 1] &&
+      (/_/.test(parts[parts.length - 1]) ||
+        !/[a-zA-Z\d]/.test(parts[parts.length - 1]))) ||
+    (parts[parts.length - 2] &&
+      (/_/.test(parts[parts.length - 2]) ||
+        !/[a-zA-Z\d]/.test(parts[parts.length - 2])))
+  ) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * @param {string} url
+ * @returns {[string, string | undefined]}
+ */
+function splitUrl(url) {
+  const trailExec = /[!"&'),.:;<>?\]}]+$/.exec(url)
+
+  if (!trailExec) {
+    return [url, undefined]
+  }
+
+  url = url.slice(0, trailExec.index)
+
+  let trail = trailExec[0]
+  let closingParenIndex = trail.indexOf(')')
+  const openingParens = ccount(url, '(')
+  let closingParens = ccount(url, ')')
+
+  while (closingParenIndex !== -1 && openingParens > closingParens) {
+    url += trail.slice(0, closingParenIndex + 1)
+    trail = trail.slice(closingParenIndex + 1)
+    closingParenIndex = trail.indexOf(')')
+    closingParens++
+  }
+
+  return [url, trail]
+}
+
+/**
+ * @param {RegExpMatchObject} match
+ * @param {boolean | null | undefined} [email=false]
+ * @returns {boolean}
+ */
+function previous(match, email) {
+  const code = match.input.charCodeAt(match.index - 1)
+
+  return (
+    (match.index === 0 ||
+      unicodeWhitespace(code) ||
+      unicodePunctuation(code)) &&
+    // If it’s an email, the previous character should not be a slash.
+    (!email || code !== 47)
+  )
+}

--- a/apps/website/src/vendor/mdast-util-gfm-autolink-literal.test.ts
+++ b/apps/website/src/vendor/mdast-util-gfm-autolink-literal.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const VENDORED_FILE = path.resolve(dirname, 'mdast-util-gfm-autolink-literal.js');
+
+// Byte-for-byte lines. If upstream changes them, this test fails: re-copy the file.
+const UPSTREAM_LINE = String.raw`      [/(?<=^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmail]`;
+const FIXED_LINE = String.raw`      [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmail]`;
+const DROPPED_DIRECTIVE = '// eslint-disable-next-line max-params';
+
+describe('vendored mdast-util-gfm-autolink-literal', () => {
+  test('contains no lookbehind or named-group constructs (Safari < 16.4 parse safety)', () => {
+    const src = fs.readFileSync(VENDORED_FILE, 'utf8');
+    expect(src).not.toMatch(/\(\?<[=!]/);
+    expect(src).not.toMatch(/\(\?<[A-Za-z_]/);
+  });
+
+  test('is upstream 2.0.1 plus the header and exactly two documented line changes', () => {
+    const vendored = fs.readFileSync(VENDORED_FILE, 'utf8').split('\n');
+    // Our header comes first, so the first ' */' line ends it.
+    const headerEnd = vendored.findIndex((line) => line === ' */');
+    expect(headerEnd).toBeGreaterThan(0);
+    const body = vendored.slice(headerEnd + 1).join('\n');
+
+    const require = createRequire(import.meta.url);
+    const installedPath = path.join(
+      path.dirname(require.resolve('mdast-util-gfm-autolink-literal')),
+      'lib/index.js',
+    );
+    const installed = fs.readFileSync(installedPath, 'utf8');
+    expect(installed.split('\n').filter((line) => line === UPSTREAM_LINE)).toHaveLength(1);
+    expect(installed.split('\n').filter((line) => line === DROPPED_DIRECTIVE)).toHaveLength(1);
+
+    const expected = installed
+      .replace(UPSTREAM_LINE, FIXED_LINE)
+      .replace(`${DROPPED_DIRECTIVE}\n`, '');
+    expect(body).toBe(expected);
+  });
+
+  test('production webpack config points at the vendored file', () => {
+    const nextConfig = fs.readFileSync(path.resolve(dirname, '..', '..', 'next.config.js'), 'utf8');
+    expect(nextConfig).toContain('\'mdast-util-gfm-autolink-literal\': path.resolve(__dirname, \'src/vendor/mdast-util-gfm-autolink-literal.js\')');
+  });
+
+  test('vitest mirrors the production alias', () => {
+    const vitestConfig = fs.readFileSync(path.resolve(dirname, '..', '..', 'vitest.config.mjs'), 'utf8');
+    expect(vitestConfig).toContain('\'mdast-util-gfm-autolink-literal\': path.resolve(dirname, \'src/vendor/mdast-util-gfm-autolink-literal.js\')');
+  });
+});

--- a/apps/website/vitest.config.mjs
+++ b/apps/website/vitest.config.mjs
@@ -1,6 +1,16 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { withDefaultBlueDotVitestConfig } from '@bluedot/utils/src/default-config/vitest.mjs';
 
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default withDefaultBlueDotVitestConfig({
+  // Test our copy, not the published package.
+  resolve: {
+    alias: {
+      'mdast-util-gfm-autolink-literal': path.resolve(dirname, 'src/vendor/mdast-util-gfm-autolink-literal.js'),
+    },
+  },
   test: {
     setupFiles: ['./src/test-setup.ts'],
     environmentOptions: {


### PR DESCRIPTION

# Description

Unsure how I feel about this PR and the maintenance load for it.
--
This removes 21 characters so course and job pages load on old Safari. Right now those users get a blank page. Their browser can't parse a lookbehind regex that ships in our Markdown bundle, so the whole page fails before it renders.

It fixes errors like these (all from `#update_client-errors`):

- `website: Client error (window.onerror): SyntaxError: Invalid regular expression: invalid group specifier name` (over a dozen)

The lookbehind sits in `mdast-util-gfm-autolink-literal`, which our Markdown renderer pulls in. I keep a copy of that one file without the lookbehind and point the build at it. Email autolinking works as before. A test pins the boundary matches upstream, punctuation and symbols alike. A test enforces the copy stays a header plus those two documented changes. The production build contains zero lookbehind.

Future upgrades copy the new upstream file over, re-apply the two changes, and run the vendor tests.

## Issue

Fixes course and job pages failing on old Safari.

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist, N/A, no UI changes
- [x] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories, N/A, no UI changes

## Screenshot

N/A, no visual changes.
