### PR TITLE
Send ErrorBoundary crashes to Sentry and keep them in Slack

### DIFF
--- a/apps/website/src/components/ErrorBoundary.test.tsx
+++ b/apps/website/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,71 @@
+import type React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  describe, expect, test, vi, beforeEach,
+} from 'vitest';
+import * as Sentry from '@sentry/nextjs';
+import { ErrorBoundary } from './ErrorBoundary';
+import { reportClientError } from '../lib/reportClientError';
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../lib/reportClientError', () => ({
+  reportClientError: vi.fn(),
+}));
+
+const Boom = (): React.ReactNode => {
+  throw new Error('Cannot read properties of undefined (reading \'title\')');
+};
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  test('forwards caught render errors to both Sentry and the Slack pipeline', () => {
+    render(<ErrorBoundary>
+      <Boom />
+    </ErrorBoundary>);
+
+    expect(screen.getAllByText(/Cannot read properties of undefined/).length).toBeGreaterThan(0);
+    expect(vi.mocked(reportClientError)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Cannot read properties of undefined (reading \'title\')' }),
+      'errorboundary',
+    );
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Cannot read properties of undefined (reading \'title\')' }),
+      expect.objectContaining({ contexts: expect.objectContaining({ react: expect.anything() }) }),
+    );
+  });
+
+  test('still sends the Slack report when Sentry throws', () => {
+    vi.mocked(Sentry.captureException).mockImplementationOnce(() => {
+      throw new Error('Sentry down');
+    });
+    render(<ErrorBoundary>
+      <Boom />
+    </ErrorBoundary>);
+
+    expect(vi.mocked(reportClientError)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Cannot read properties of undefined (reading \'title\')' }),
+      'errorboundary',
+    );
+  });
+
+  test('forwards the error identity and component stack', () => {
+    render(<ErrorBoundary>
+      <Boom />
+    </ErrorBoundary>);
+
+    const sentryCall = vi.mocked(Sentry.captureException).mock.calls[0];
+    expect(sentryCall[0]).toBeInstanceOf(Error);
+    expect(sentryCall[0].message).toBe('Cannot read properties of undefined (reading \'title\')');
+    const contexts = sentryCall[1]?.contexts as { react?: { componentStack?: unknown } } | undefined;
+    expect(typeof contexts?.react?.componentStack).toBe('string');
+    expect(contexts?.react?.componentStack as string).toContain('Boom');
+  });
+});

--- a/apps/website/src/components/ErrorBoundary.test.tsx
+++ b/apps/website/src/components/ErrorBoundary.test.tsx
@@ -61,10 +61,10 @@ describe('ErrorBoundary', () => {
       <Boom />
     </ErrorBoundary>);
 
-    const sentryCall = vi.mocked(Sentry.captureException).mock.calls[0];
+    const sentryCall = vi.mocked(Sentry.captureException).mock.calls[0]!;
     expect(sentryCall[0]).toBeInstanceOf(Error);
-    expect(sentryCall[0].message).toBe('Cannot read properties of undefined (reading \'title\')');
-    const contexts = sentryCall[1]?.contexts as { react?: { componentStack?: unknown } } | undefined;
+    expect((sentryCall[0] as Error).message).toBe('Cannot read properties of undefined (reading \'title\')');
+    const contexts = (sentryCall[1] as { contexts?: { react?: { componentStack?: unknown } } } | undefined)?.contexts;
     expect(typeof contexts?.react?.componentStack).toBe('string');
     expect(contexts?.react?.componentStack as string).toContain('Boom');
   });

--- a/apps/website/src/components/ErrorBoundary.tsx
+++ b/apps/website/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as Sentry from '@sentry/nextjs';
 import { ErrorSection, Section } from '@bluedot/ui';
 import { reportClientError } from '../lib/reportClientError';
 
@@ -15,6 +16,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // Slack first, so a Sentry failure can never swallow the report.
     reportClientError(
       {
         message: error.message,
@@ -23,6 +25,17 @@ export class ErrorBoundary extends React.Component<Props, State> {
       },
       'errorboundary',
     );
+    // Without this, Sentry never sees these crashes. They don't reach window.onerror.
+    // Guarded: a Sentry failure must never break the boundary or swallow the Slack report.
+    try {
+      Sentry.captureException(error, {
+        contexts: {
+          react: { componentStack: errorInfo.componentStack ?? undefined },
+        },
+      });
+    } catch {
+      // Slack already went out above, so there is nothing left to do.
+    }
   }
 
   render() {


### PR DESCRIPTION

# Description

ErrorBoundary crashes only reach Slack and never reach Sentry, so they never get grouped, counted, or source-mapped. This forwards them to Sentry with the React component stack attached, so the next crash shows up as a Sentry issue with real file and line numbers.

`#update_client-errors` shows dozens of `website: Client error (errorboundary): Cannot read properties of undefined (reading 'title')`, plus a couple of `website: Client error (errorboundary): Cannot read properties of undefined (reading 'courseId')`. 

Now `componentDidCatch` calls `Sentry.captureException` with the component stack, alongside the unchanged Slack report. 

## Issue

Fixes ErrorBoundary crashes skipping Sentry.

## Developer checklist

- [x] Front-end code follows Component Accessibility Checklist, N/A, no UI changes
- [x] Considered having snapshot tests and/or happy path functional tests
- [ ] Considered adding Storybook stories, N/A, no UI changes

## Screenshot

N/A, no visual changes.
