### PR TITLE
[feat] website: One-off migration to backfill `firstName`/`lastName` for existing users

### DIFF
--- a/apps/website/scripts/throwaway/2913-user-name-backfill/README.md
+++ b/apps/website/scripts/throwaway/2913-user-name-backfill/README.md
@@ -8,7 +8,7 @@ For each user missing first or last name:
 
 1. Source: the most recent course registration with both names, else Keycloak (`given_name` / `family_name`), matched by Keycloak sub and then by email. Registration wins ties because it's what they asked to be called on the course.
 2. If the user has a stored `name`, the source must join to it exactly, ignoring only surrounding and repeated whitespace. Users with no source, or whose stored `name` matches no source, are skipped rather than guessed.
-3. First and last name are written from the source. This supersedes the first name that is already in Airtable: `First name` was unused previously and is only set for 45 users (unsure where these come from). `name` is written as the join of the two parts when it was blank or differed only in whitespace, so the three fields always agree.
+3. First and last name are written from the source. This supersedes the first name that is already in Airtable: `First name` was unused previously and is only set for 45 users (unsure where these come from).
 
 ## Running
 
@@ -21,5 +21,3 @@ npx dotenv -e .env.local -- npx tsx scripts/throwaway/2913-user-name-backfill/ba
 # Write to Airtable in batches of 10 at 2.5 req/s (pg-sync-service replicates to Postgres)
 npx dotenv -e .env.local -- npx tsx scripts/throwaway/2913-user-name-backfill/backfill.ts --apply
 ```
-
-Safe to rerun after a failure: the plan is rebuilt from Postgres each time and users with both names set are skipped, so already-written users drop out.

--- a/apps/website/scripts/throwaway/2913-user-name-backfill/README.md
+++ b/apps/website/scripts/throwaway/2913-user-name-backfill/README.md
@@ -4,11 +4,11 @@ One-off script to fill the `First name` / `Last name` fields on the Airtable Use
 
 ## Rules
 
-For each user missing first or last name:
+For each user, the target is a first and last name that join to `name` exactly. Users whose stored fields already match are skipped; otherwise whichever of the three fields differ are written.
 
-1. Source: the most recent course registration with both names, else Keycloak (`given_name` / `family_name`), matched by Keycloak sub and then by email. Registration wins ties because it's what they asked to be called on the course.
-2. If the user has a stored `name`, the source must join to it exactly, ignoring only surrounding and repeated whitespace. Users with no source, or whose stored `name` matches no source, are skipped rather than guessed.
-3. First and last name are written from the source. This supersedes the first name that is already in Airtable: `First name` was unused previously and is only set for 45 users (unsure where these come from).
+1. If `name` is set: take the first/last name from the most recent course registration with both names, else from Keycloak (`given_name` / `family_name`, matched by Keycloak sub and then by email), provided it joins to `name` ignoring only surrounding and repeated whitespace. Registration wins ties because it's what they asked to be called on the course. If no source matches, split `name` on the first space (a single word becomes the first name with an empty last name). This is the same split the facilitator application form has always used to pre-fill its fields.
+2. If `name` is blank: take the first source available, else the existing first/last name, and write `name` as its join. Users with none of these are skipped.
+3. An existing first/last name that doesn't match the target is overwritten. `First name` was unused previously and is only set for 45 users (unsure where these come from).
 
 ## Running
 

--- a/apps/website/scripts/throwaway/2913-user-name-backfill/README.md
+++ b/apps/website/scripts/throwaway/2913-user-name-backfill/README.md
@@ -1,0 +1,25 @@
+# User first/last name backfill (#2913)
+
+One-off script to fill the `First name` / `Last name` fields on the Airtable User table from sources that already hold them separately (Keycloak and course applications). It is written to run once before the first/last name PR merges, and once after to catch any stragglers. The user's combined `name` is always preserved if it exists.
+
+## Rules
+
+For each user missing first or last name:
+
+1. Source: the most recent course registration with both names, else Keycloak (`given_name` / `family_name`), matched by Keycloak sub and then by email. Registration wins ties because it's what they asked to be called on the course.
+2. If the user has a stored `name`, the source must join to it exactly, ignoring only surrounding and repeated whitespace. Users with no source, or whose stored `name` matches no source, are skipped rather than guessed.
+3. First and last name are written from the source. This supersedes the first name that is already in Airtable: `First name` was unused previously and is only set for 45 users (unsure where these come from). `name` is written as the join of the two parts when it was blank or differed only in whitespace, so the three fields always agree.
+
+## Running
+
+From `apps/website`, with `.env.local` holding `PG_URL`, `AIRTABLE_PERSONAL_ACCESS_TOKEN`, `KEYCLOAK_CLIENT_ID` and `KEYCLOAK_CLIENT_SECRET`:
+
+```bash
+# Dry run: prints a summary of what would be written
+npx dotenv -e .env.local -- npx tsx scripts/throwaway/2913-user-name-backfill/backfill.ts
+
+# Write to Airtable in batches of 10 at 2.5 req/s (pg-sync-service replicates to Postgres)
+npx dotenv -e .env.local -- npx tsx scripts/throwaway/2913-user-name-backfill/backfill.ts --apply
+```
+
+Safe to rerun after a failure: the plan is rebuilt from Postgres each time and users with both names set are skipped, so already-written users drop out.

--- a/apps/website/scripts/throwaway/2913-user-name-backfill/README.md
+++ b/apps/website/scripts/throwaway/2913-user-name-backfill/README.md
@@ -6,9 +6,11 @@ One-off script to fill the `First name` / `Last name` fields on the Airtable Use
 
 For each user, the target is a first and last name that join to `name` exactly. Users whose stored fields already match are skipped; otherwise whichever of the three fields differ are written.
 
-1. If `name` is set: take the first/last name from the most recent course registration with both names, else from Keycloak (`given_name` / `family_name`, matched by Keycloak sub and then by email), provided it joins to `name` ignoring only surrounding and repeated whitespace. Registration wins ties because it's what they asked to be called on the course. If no source matches, split `name` on the first space (a single word becomes the first name with an empty last name). This is the same split the facilitator application form has always used to pre-fill its fields.
-2. If `name` is blank: take the first source available, else the existing first/last name, and write `name` as its join. Users with none of these are skipped.
-3. An existing first/last name that doesn't match the target is overwritten. `First name` was unused previously and is only set for 45 users (unsure where these come from).
+1. If `name` is set, take the first/last name from a source that joins to `name` (ignoring only surrounding and repeated whitespace), else split `name`.
+   - Sources, in order: the most recent course registration with both names, then Keycloak (`given_name` / `family_name`, matched by Keycloak sub and then by email).
+   - Split: Split on the first space, matching the existing rule from `facilitator-applications.ts`. If there is an existing first name, split on that instead.
+2. If `name` is blank, take the first source available, else the existing first/last name, and write `name` as its join. Users with none of these are skipped.
+3. An existing first/last name that disagrees with the target is never overwritten: the user is skipped and listed for manual review. About 13,600 users had a `First name` (mostly the first word of `name`, no last name) from before this codebase; a few dozen hold nicknames or junk that don't fit the name.
 
 ## Running
 

--- a/apps/website/scripts/throwaway/2913-user-name-backfill/backfill.ts
+++ b/apps/website/scripts/throwaway/2913-user-name-backfill/backfill.ts
@@ -29,9 +29,10 @@ type PlanRow = {
 
 const normalise = (value: string | null | undefined): string => (value ?? '').trim().replace(/\s+/g, ' ');
 const joinName = (parts: NameParts): string => [parts.firstName, parts.lastName].map(normalise).filter(Boolean).join(' ');
-const splitName = (name: string): NameParts => {
-  const space = name.indexOf(' ');
-  return space === -1 ? { firstName: name, lastName: '' } : { firstName: name.slice(0, space), lastName: name.slice(space + 1) };
+// Split at the stored first name when it begins the name (keeps "Mary Jane" for "Mary Jane Smith"), else at the first space
+const splitName = (name: string, storedFirstName: string): NameParts => {
+  const at = storedFirstName && name.startsWith(`${storedFirstName} `) ? storedFirstName.length : name.indexOf(' ');
+  return at === -1 ? { firstName: name, lastName: '' } : { firstName: name.slice(0, at), lastName: name.slice(at + 1) };
 };
 
 const bothPresent = (parts: { firstName: string | null; lastName: string | null }): NameParts | undefined => {
@@ -100,6 +101,7 @@ const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promi
   }
 
   const plan: PlanRow[] = [];
+  const conflicts: string[] = [];
   const counts: Record<string, number> = {};
   const count = (k: string) => {
     counts[k] = (counts[k] ?? 0) + 1;
@@ -117,7 +119,7 @@ const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promi
 
     // Case-sensitive match: users may have deliberately edited casing (e.g. McKenzie)
     let chosen: [Method, NameParts] | undefined;
-    if (name) chosen = candidates.find(([, parts]) => joinName(parts) === name) ?? ['split', splitName(name)];
+    if (name) chosen = candidates.find(([, parts]) => joinName(parts) === name) ?? ['split', splitName(name, stored.firstName)];
     else if (candidates.length > 0) [chosen] = candidates;
     else if (joinName(stored)) chosen = ['parts', stored];
     if (!chosen) {
@@ -126,6 +128,13 @@ const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promi
     }
 
     const [method, parts] = chosen;
+    // Leave users whose existing first/last name disagrees with the target for manual review
+    if ((['firstName', 'lastName'] as const).some((field) => stored[field] && stored[field] !== parts[field])) {
+      count('skipped: existing first/last name conflicts with target');
+      conflicts.push(`${user.id} ${user.email}`);
+      continue;
+    }
+
     const before: NameFields = { name: user.name ?? '', firstName: user.firstName ?? '', lastName: user.lastName ?? '' };
     const target: NameFields = { ...parts, name: joinName(parts) };
     const update: Partial<NameFields> = {};
@@ -139,7 +148,6 @@ const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promi
     }
 
     count(`method: ${method}`);
-    if ((stored.firstName && update.firstName !== undefined) || (stored.lastName && update.lastName !== undefined)) count('replaces an existing first/last name');
     plan.push({
       userId: user.id, email: user.email, method, before, update,
     });
@@ -148,6 +156,7 @@ const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promi
   console.log(`Users: ${users.length}`);
   console.table(counts);
   console.log(`Plan: ${plan.length} rows`);
+  if (conflicts.length > 0) console.log(`Conflicts (not touched):\n${conflicts.join('\n')}`);
   return plan;
 };
 

--- a/apps/website/scripts/throwaway/2913-user-name-backfill/backfill.ts
+++ b/apps/website/scripts/throwaway/2913-user-name-backfill/backfill.ts
@@ -17,17 +17,22 @@ const sleep = (ms: number) => new Promise((resolve) => {
 });
 
 type NameParts = { firstName: string; lastName: string };
-type Method = 'registration' | 'keycloak';
+type NameFields = NameParts & { name: string };
+type Method = 'registration' | 'keycloak' | 'split' | 'parts';
 type PlanRow = {
   userId: string;
   email: string;
-  name: string;
   method: Method;
-  parts: NameParts;
+  before: NameFields;
+  update: Partial<NameFields>;
 };
 
 const normalise = (value: string | null | undefined): string => (value ?? '').trim().replace(/\s+/g, ' ');
 const joinName = (parts: NameParts): string => [parts.firstName, parts.lastName].map(normalise).filter(Boolean).join(' ');
+const splitName = (name: string): NameParts => {
+  const space = name.indexOf(' ');
+  return space === -1 ? { firstName: name, lastName: '' } : { firstName: name.slice(0, space), lastName: name.slice(space + 1) };
+};
 
 const bothPresent = (parts: { firstName: string | null; lastName: string | null }): NameParts | undefined => {
   const firstName = normalise(parts.firstName);
@@ -101,13 +106,8 @@ const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promi
   };
 
   for (const user of users) {
-    if (normalise(user.firstName) && normalise(user.lastName)) {
-      count('already complete');
-      continue;
-    }
-
     const name = normalise(user.name);
-    const storedName = user.name ?? '';
+    const stored = { firstName: normalise(user.firstName), lastName: normalise(user.lastName) };
     const registration = registrationByUser.get(user.id);
     const keycloak = (user.keycloakIdentifier ? keycloakBySub.get(user.keycloakIdentifier) : undefined) ?? keycloakByEmail.get(user.email.toLowerCase());
     // Registration first: it's what they asked to be called on the course
@@ -115,23 +115,33 @@ const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promi
     if (registration) candidates.push(['registration', registration]);
     if (keycloak) candidates.push(['keycloak', keycloak]);
 
-    if (candidates.length === 0) {
-      count(name ? 'skipped: name only, no source' : 'skipped: no name and no source');
+    // Case-sensitive match: users may have deliberately edited casing (e.g. McKenzie)
+    let chosen: [Method, NameParts] | undefined;
+    if (name) chosen = candidates.find(([, parts]) => joinName(parts) === name) ?? ['split', splitName(name)];
+    else if (candidates.length > 0) [chosen] = candidates;
+    else if (joinName(stored)) chosen = ['parts', stored];
+    if (!chosen) {
+      count('skipped: no name and no source');
       continue;
     }
 
-    // A stored name that doesn't match any source is left alone rather than guessed at.
-    // Case-sensitive: users may have deliberately edited casing (e.g. McKenzie).
-    const usable = name ? candidates.find(([, parts]) => joinName(parts) === name) : candidates[0];
-    if (!usable) {
-      count('skipped: stored name differs from source');
+    const [method, parts] = chosen;
+    const before: NameFields = { name: user.name ?? '', firstName: user.firstName ?? '', lastName: user.lastName ?? '' };
+    const target: NameFields = { ...parts, name: joinName(parts) };
+    const update: Partial<NameFields> = {};
+    for (const field of ['name', 'firstName', 'lastName'] as const) {
+      if (before[field] !== target[field]) update[field] = target[field];
+    }
+
+    if (Object.keys(update).length === 0) {
+      count('already in sync');
       continue;
     }
 
-    const [method, parts] = usable;
     count(`method: ${method}`);
+    if ((stored.firstName && update.firstName !== undefined) || (stored.lastName && update.lastName !== undefined)) count('replaces an existing first/last name');
     plan.push({
-      userId: user.id, email: user.email, name: storedName, method, parts,
+      userId: user.id, email: user.email, method, before, update,
     });
   }
 
@@ -176,15 +186,13 @@ const applyPlan = async (plan: PlanRow[]) => {
 
     const records = chunk.flatMap((row) => {
       const fields = currentById.get(row.userId);
-      const unchanged = fields && (fields[mappings.name] ?? '') === row.name && !(normalise(fields[mappings.firstName]) && normalise(fields[mappings.lastName]));
+      const unchanged = fields && (['name', 'firstName', 'lastName'] as const).every((field) => (fields[mappings[field]] ?? '') === row.before[field]);
       if (!unchanged) {
         changed.push(row.userId);
         return [];
       }
 
-      const update: Record<string, string> = { [mappings.firstName]: row.parts.firstName, [mappings.lastName]: row.parts.lastName };
-      if (row.name !== joinName(row.parts)) update[mappings.name] = joinName(row.parts);
-      return [{ id: row.userId, fields: update }];
+      return [{ id: row.userId, fields: Object.fromEntries(Object.entries(row.update).map(([field, value]) => [mappings[field as keyof NameFields], value])) }];
     });
 
     for (let j = 0; j < records.length; j += AIRTABLE_BATCH_SIZE) {

--- a/apps/website/scripts/throwaway/2913-user-name-backfill/backfill.ts
+++ b/apps/website/scripts/throwaway/2913-user-name-backfill/backfill.ts
@@ -1,0 +1,183 @@
+/* eslint-disable no-console, no-await-in-loop, turbo/no-undeclared-env-vars */
+// Fills empty first/last name on user records. See README.md for the rules and how to run it.
+
+import {
+  PgAirtableDb, courseRegistrationTable, desc, isNotNull, userTable,
+} from '@bluedot/db';
+
+const APPLY = process.argv.includes('--apply');
+
+const KEYCLOAK_BASE_URL = 'https://login.bluedot.org';
+const AIRTABLE_BATCH_SIZE = 10; // max records per PATCH
+const AIRTABLE_REQUEST_INTERVAL_MS = 400; // 2.5 req/s, half the base limit, leaves room for other services
+
+const sleep = (ms: number) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+type NameParts = { firstName: string; lastName: string };
+type Method = 'registration' | 'keycloak';
+type PlanRow = {
+  userId: string;
+  email: string;
+  name: string;
+  method: Method;
+  parts: NameParts;
+};
+
+const normalise = (value: string | null | undefined): string => (value ?? '').trim().replace(/\s+/g, ' ');
+const joinName = (parts: NameParts): string => [parts.firstName, parts.lastName].map(normalise).filter(Boolean).join(' ');
+
+const bothPresent = (parts: { firstName: string | null; lastName: string | null }): NameParts | undefined => {
+  const firstName = normalise(parts.firstName);
+  const lastName = normalise(parts.lastName);
+  return firstName && lastName ? { firstName, lastName } : undefined;
+};
+
+type KeycloakUser = { id: string; email: string; firstName: string; lastName: string };
+
+const fetchKeycloakUsers = async (): Promise<KeycloakUser[]> => {
+  const tokenResponse = await fetch(`${KEYCLOAK_BASE_URL}/realms/customers/protocol/openid-connect/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: 'client_credentials', client_id: process.env.KEYCLOAK_CLIENT_ID!, client_secret: process.env.KEYCLOAK_CLIENT_SECRET! }),
+  });
+  const { access_token: token } = (await tokenResponse.json()) as { access_token: string };
+
+  const users: KeycloakUser[] = [];
+  const pageSize = 500;
+  for (let first = 0; ; first += pageSize) {
+    const response = await fetch(`${KEYCLOAK_BASE_URL}/admin/realms/customers/users?first=${first}&max=${pageSize}&briefRepresentation=true`, { headers: { Authorization: `Bearer ${token}` } });
+    if (!response.ok) throw new Error(`Keycloak user list failed: ${response.status} ${await response.text()}`);
+    const page = (await response.json()) as Partial<KeycloakUser>[];
+    users.push(...page.map((u) => ({
+      id: u.id ?? '', email: u.email ?? '', firstName: u.firstName ?? '', lastName: u.lastName ?? '',
+    })));
+    if (page.length < pageSize) break;
+  }
+
+  console.log(`Fetched ${users.length} Keycloak users`);
+  return users;
+};
+
+const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promise<PlanRow[]> => {
+  const users = await db.pg.select({
+    id: userTable.pg.id,
+    email: userTable.pg.email,
+    name: userTable.pg.name,
+    firstName: userTable.pg.firstName,
+    lastName: userTable.pg.lastName,
+    keycloakIdentifier: userTable.pg.keycloakIdentifier,
+  }).from(userTable.pg);
+
+  // Most recent registration first, so the first hit per user wins
+  const registrations = await db.pg.select({
+    userId: courseRegistrationTable.pg.userId,
+    firstName: courseRegistrationTable.pg.firstName,
+    lastName: courseRegistrationTable.pg.lastName,
+  }).from(courseRegistrationTable.pg)
+    .where(isNotNull(courseRegistrationTable.pg.userId))
+    .orderBy(desc(courseRegistrationTable.pg.autoNumberId));
+  const registrationByUser = new Map<string, NameParts>();
+  for (const reg of registrations) {
+    const parts = bothPresent(reg);
+    if (reg.userId && parts && !registrationByUser.has(reg.userId)) registrationByUser.set(reg.userId, parts);
+  }
+
+  const keycloakBySub = new Map<string, NameParts>();
+  const keycloakByEmail = new Map<string, NameParts>();
+  for (const kc of keycloakUsers) {
+    const parts = bothPresent(kc);
+    if (!parts) continue;
+    keycloakBySub.set(kc.id, parts);
+    keycloakByEmail.set(kc.email.toLowerCase(), parts);
+  }
+
+  const plan: PlanRow[] = [];
+  const counts: Record<string, number> = {};
+  const count = (k: string) => {
+    counts[k] = (counts[k] ?? 0) + 1;
+  };
+
+  for (const user of users) {
+    if (normalise(user.firstName) && normalise(user.lastName)) {
+      count('already complete');
+      continue;
+    }
+
+    const name = normalise(user.name);
+    const storedName = user.name ?? '';
+    const registration = registrationByUser.get(user.id);
+    const keycloak = (user.keycloakIdentifier ? keycloakBySub.get(user.keycloakIdentifier) : undefined) ?? keycloakByEmail.get(user.email.toLowerCase());
+    // Registration first: it's what they asked to be called on the course
+    const candidates: [Method, NameParts][] = [];
+    if (registration) candidates.push(['registration', registration]);
+    if (keycloak) candidates.push(['keycloak', keycloak]);
+
+    if (candidates.length === 0) {
+      count(name ? 'skipped: name only, no source' : 'skipped: no name and no source');
+      continue;
+    }
+
+    // A stored name that doesn't match any source is left alone rather than guessed at.
+    // Case-sensitive: users may have deliberately edited casing (e.g. McKenzie).
+    const usable = name ? candidates.find(([, parts]) => joinName(parts) === name) : candidates[0];
+    if (!usable) {
+      count('skipped: stored name differs from source');
+      continue;
+    }
+
+    const [method, parts] = usable;
+    count(`method: ${method}`);
+    plan.push({
+      userId: user.id, email: user.email, name: storedName, method, parts,
+    });
+  }
+
+  console.log(`Users: ${users.length}`);
+  console.table(counts);
+  console.log(`Plan: ${plan.length} rows`);
+  return plan;
+};
+
+// The db client only writes one record at a time, which would take hours for tens of thousands of users,
+// so this PATCHes Airtable directly in batches of 10. pg-sync-service replicates the changes to Postgres.
+const applyPlan = async (plan: PlanRow[]) => {
+  const { baseId, tableId } = userTable.airtable;
+  const mappings = userTable.airtable.mappings!;
+  const records = plan.map((row) => {
+    const fields: Record<string, string> = {
+      [mappings.firstName]: row.parts.firstName,
+      [mappings.lastName]: row.parts.lastName,
+    };
+    if (row.name !== joinName(row.parts)) fields[mappings.name] = joinName(row.parts);
+    return { id: row.userId, fields };
+  });
+  console.log(`Applying ${records.length} rows`);
+
+  for (let i = 0; i < records.length; i += AIRTABLE_BATCH_SIZE) {
+    const startedAt = Date.now();
+    const response = await fetch(`https://api.airtable.com/v0/${baseId}/${tableId}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${process.env.AIRTABLE_PERSONAL_ACCESS_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ records: records.slice(i, i + AIRTABLE_BATCH_SIZE) }),
+    });
+    if (!response.ok) throw new Error(`Airtable PATCH failed at row ${i}: ${response.status} ${await response.text()}`);
+    await sleep(Math.max(0, AIRTABLE_REQUEST_INTERVAL_MS - (Date.now() - startedAt)));
+    if ((i / AIRTABLE_BATCH_SIZE) % 100 === 0) console.log(`Written ${i + AIRTABLE_BATCH_SIZE}/${records.length}`);
+  }
+
+  console.log('Done');
+};
+
+const main = async () => {
+  const db = new PgAirtableDb({ pgConnString: process.env.PG_URL!, airtableApiKey: process.env.AIRTABLE_PERSONAL_ACCESS_TOKEN! });
+  const plan = await buildPlan(db, await fetchKeycloakUsers());
+  if (APPLY) await applyPlan(plan);
+  else console.log('Dry run: pass --apply to write');
+};
+
+main().then(() => process.exit(0)).catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/website/scripts/throwaway/2913-user-name-backfill/backfill.ts
+++ b/apps/website/scripts/throwaway/2913-user-name-backfill/backfill.ts
@@ -9,6 +9,7 @@ const APPLY = process.argv.includes('--apply');
 
 const KEYCLOAK_BASE_URL = 'https://login.bluedot.org';
 const AIRTABLE_BATCH_SIZE = 10; // max records per PATCH
+const AIRTABLE_READ_CHUNK = 100; // max records per GET
 const AIRTABLE_REQUEST_INTERVAL_MS = 400; // 2.5 req/s, half the base limit, leaves room for other services
 
 const sleep = (ms: number) => new Promise((resolve) => {
@@ -140,34 +141,62 @@ const buildPlan = async (db: PgAirtableDb, keycloakUsers: KeycloakUser[]): Promi
   return plan;
 };
 
+const airtableRequest = async (url: string, init: RequestInit): Promise<unknown> => {
+  const startedAt = Date.now();
+  const response = await fetch(url, {
+    ...init,
+    headers: { Authorization: `Bearer ${process.env.AIRTABLE_PERSONAL_ACCESS_TOKEN}`, 'Content-Type': 'application/json' },
+  });
+  if (!response.ok) throw new Error(`Airtable ${init.method ?? 'GET'} failed: ${response.status} ${await response.text()}`);
+  const body: unknown = await response.json();
+  await sleep(Math.max(0, AIRTABLE_REQUEST_INTERVAL_MS - (Date.now() - startedAt)));
+  return body;
+};
+
+type AirtableUserRecord = { id: string; fields: Record<string, string | undefined> };
+
 // The db client only writes one record at a time, which would take hours for tens of thousands of users,
 // so this PATCHes Airtable directly in batches of 10. pg-sync-service replicates the changes to Postgres.
 const applyPlan = async (plan: PlanRow[]) => {
   const { baseId, tableId } = userTable.airtable;
   const mappings = userTable.airtable.mappings!;
-  const records = plan.map((row) => {
-    const fields: Record<string, string> = {
-      [mappings.firstName]: row.parts.firstName,
-      [mappings.lastName]: row.parts.lastName,
-    };
-    if (row.name !== joinName(row.parts)) fields[mappings.name] = joinName(row.parts);
-    return { id: row.userId, fields };
-  });
-  console.log(`Applying ${records.length} rows`);
+  const url = `https://api.airtable.com/v0/${baseId}/${tableId}`;
+  const changed: string[] = [];
+  let written = 0;
+  console.log(`Applying ${plan.length} rows`);
 
-  for (let i = 0; i < records.length; i += AIRTABLE_BATCH_SIZE) {
-    const startedAt = Date.now();
-    const response = await fetch(`https://api.airtable.com/v0/${baseId}/${tableId}`, {
-      method: 'PATCH',
-      headers: { Authorization: `Bearer ${process.env.AIRTABLE_PERSONAL_ACCESS_TOKEN}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ records: records.slice(i, i + AIRTABLE_BATCH_SIZE) }),
+  for (let i = 0; i < plan.length; i += AIRTABLE_READ_CHUNK) {
+    const chunk = plan.slice(i, i + AIRTABLE_READ_CHUNK);
+
+    // Re-read right before writing so edits made since the plan was built are skipped, not overwritten
+    const params = new URLSearchParams({ filterByFormula: `OR(${chunk.map((row) => `RECORD_ID()='${row.userId}'`).join(',')})`, pageSize: String(AIRTABLE_READ_CHUNK), returnFieldsByFieldId: 'true' });
+    for (const field of [mappings.name, mappings.firstName, mappings.lastName]) params.append('fields[]', field);
+    const { records: current } = (await airtableRequest(`${url}?${params}`, { method: 'GET' })) as { records: AirtableUserRecord[] };
+    const currentById = new Map(current.map((record) => [record.id, record.fields]));
+
+    const records = chunk.flatMap((row) => {
+      const fields = currentById.get(row.userId);
+      const unchanged = fields && (fields[mappings.name] ?? '') === row.name && !(normalise(fields[mappings.firstName]) && normalise(fields[mappings.lastName]));
+      if (!unchanged) {
+        changed.push(row.userId);
+        return [];
+      }
+
+      const update: Record<string, string> = { [mappings.firstName]: row.parts.firstName, [mappings.lastName]: row.parts.lastName };
+      if (row.name !== joinName(row.parts)) update[mappings.name] = joinName(row.parts);
+      return [{ id: row.userId, fields: update }];
     });
-    if (!response.ok) throw new Error(`Airtable PATCH failed at row ${i}: ${response.status} ${await response.text()}`);
-    await sleep(Math.max(0, AIRTABLE_REQUEST_INTERVAL_MS - (Date.now() - startedAt)));
-    if ((i / AIRTABLE_BATCH_SIZE) % 100 === 0) console.log(`Written ${i + AIRTABLE_BATCH_SIZE}/${records.length}`);
+
+    for (let j = 0; j < records.length; j += AIRTABLE_BATCH_SIZE) {
+      await airtableRequest(url, { method: 'PATCH', body: JSON.stringify({ records: records.slice(j, j + AIRTABLE_BATCH_SIZE) }) });
+    }
+
+    written += records.length;
+    if ((i / AIRTABLE_READ_CHUNK) % 10 === 0) console.log(`Written ${written}, checked ${i + chunk.length}/${plan.length}`);
   }
 
-  console.log('Done');
+  console.log(`Done: ${written} written, ${changed.length} changed since the plan was built and skipped (rerun to reconsider them)`);
+  if (changed.length > 0) console.log(changed.join('\n'));
 };
 
 const main = async () => {


### PR DESCRIPTION
# Description

This backfills the `firstName`/`lastName` fields on the user table, based on the user's most recent course registration, or Keycloak. If it can't find either of these sources, it estimates the names but splitting on the first space (adopting the pre-existing rule from `facilitator-applications.ts`). This is intended to be run prior to merging #2972 (which writes these fields going forward), and immediately after to catch any new users.

_I will run this locally once it's approved, then close the PR rather than merging it._

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2913 

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->