### PR TITLE
[feat] Biosecurity congratulations: referral form card and cause-specific wording

### DIFF
--- a/apps/website/src/components/courses/Congratulations.stories.tsx
+++ b/apps/website/src/components/courses/Congratulations.stories.tsx
@@ -177,3 +177,25 @@ export const FoAI: Story = {
     },
   },
 };
+
+export const Biosecurity: Story = {
+  ...loggedInStory(),
+  args: {
+    courseTitle: 'Biosecurity',
+    coursePath: '/courses/biosecurity',
+    courseSlug: 'biosecurity',
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        trpcStorybookMsw.certificates.getStatus.query(() => ({
+          ...hasCertificateMock,
+          courseName: 'Biosecurity',
+          courseSlug: 'biosecurity',
+          certificationDescription: 'Demonstrated understanding of how to prevent, detect and respond to pandemic threats.',
+          courseDetailsUrl: 'https://bluedot.org/courses/biosecurity',
+        })),
+      ],
+    },
+  },
+};

--- a/apps/website/src/components/courses/Congratulations.test.tsx
+++ b/apps/website/src/components/courses/Congratulations.test.tsx
@@ -36,6 +36,13 @@ const foaiProps = {
   courseId: FOAI_COURSE_ID,
 };
 
+const biosecurityProps = {
+  courseTitle: 'Biosecurity',
+  coursePath: '/courses/biosecurity',
+  courseSlug: 'biosecurity',
+  courseId: 'recBiosecurity',
+};
+
 const hasCertificateResponse = {
   status: 'has-certificate' as const,
   certificateId: 'cert-abc-123',
@@ -74,6 +81,21 @@ describe('Congratulations', () => {
       expect(screen.getByRole('link', { name: /Share on LinkedIn/ })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /Share on X/ })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /Copy Message/ })).toBeInTheDocument();
+      expect(screen.getByText(/Help more people discover AI safety today/)).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /Refer someone/ })).toBeNull();
+    });
+
+    test('renders referral form card and cause-specific wording for courses that configure them', () => {
+      render(<Congratulations {...biosecurityProps} />, { wrapper: TrpcProvider });
+
+      expect(screen.getByText(/Help more people discover biosecurity today/)).toBeInTheDocument();
+      expect(screen.getByText(/raise awareness for pandemic preparedness/)).toBeInTheDocument();
+      expect(screen.getByText(/What happens next/)).toBeInTheDocument();
+
+      const referLink = screen.getByRole('link', { name: /Refer someone/ });
+      expect(referLink).toHaveAttribute('href', 'https://web.miniextensions.com/DN3PuxFG7kf50g5RTph4');
+      expect(referLink).toHaveAttribute('target', '_blank');
+      expect(screen.queryByRole('button', { name: /Copy Message/ })).toBeNull();
     });
 
     test('does not render certificate hero when courseId is absent', () => {

--- a/apps/website/src/components/courses/Congratulations.tsx
+++ b/apps/website/src/components/courses/Congratulations.tsx
@@ -9,6 +9,7 @@ import {
   FaCircleMinus,
   FaLink, FaLinkedinIn,
   FaRegCopy,
+  FaUserPlus,
   FaXTwitter,
 } from 'react-icons/fa6';
 import { BLUEDOT_LINKEDIN_ORG_ID, COURSE_CONFIG, FOAI_COURSE_ID } from '../../lib/constants';
@@ -114,6 +115,28 @@ const ChatPreviewPanel = ({ courseUrl, shareText }: { courseUrl: string; shareTe
         />
       </svg>
     </div>
+  </div>
+);
+
+const REFERRAL_STEPS = [
+  'You tell us who they are. A line on why you thought of them helps.',
+  'We invite them to apply, and mention your name if you allow it.',
+  'Know more than one person? Submit the form once for each.',
+];
+
+const ReferralStepsPanel = () => (
+  <div className="flex h-full flex-col justify-center gap-4 border-t border-[#e5e9f2] bg-[#fbfbfd] p-5 md:border-t-0 md:border-l md:p-8">
+    <Eyebrow className="text-bluedot-navy/80">What happens next</Eyebrow>
+    <ol className="flex flex-col gap-3">
+      {REFERRAL_STEPS.map((step, index) => (
+        <li key={step} className="flex items-start gap-3">
+          <span className="bg-bluedot-normal flex size-6 shrink-0 items-center justify-center rounded-full text-size-xxs font-semibold text-white">
+            {index + 1}
+          </span>
+          <p className="text-bluedot-navy text-size-sm leading-relaxed">{step}</p>
+        </li>
+      ))}
+    </ol>
   </div>
 );
 
@@ -349,8 +372,15 @@ const Congratulations: React.FC<CongratulationsProps> = ({
   const [copied, setCopied] = useState(false);
 
   const courseUrl = `${SITE_URL}${coursePath}`;
+  const congratulationsConfig = COURSE_CONFIG[courseSlug]?.congratulations;
+  const headline = congratulationsConfig?.headline ?? 'Help more people discover AI safety today';
+  const shareCardDescription
+    = congratulationsConfig?.shareCardDescription
+      ?? 'Take a minute to celebrate and raise awareness for safe AI in your network!';
+  const referralFormUrl = congratulationsConfig?.referralFormUrl;
   const shareText
     = text
+      ?? congratulationsConfig?.shareText
       ?? `I just completed the ${courseTitle} course from BlueDot Impact! It's free, self-paced, and packed with insights. Check it out:`;
   const dmText = `Hey, I just finished this free ${courseTitle} course and it genuinely shifted how I think about this stuff. Thought you'd find it interesting as well.`;
   const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(courseUrl)}&text=${encodeURIComponent(shareText)}`;
@@ -390,7 +420,7 @@ const Congratulations: React.FC<CongratulationsProps> = ({
             </Eyebrow>
             {/* eslint-disable-next-line @bluedot/custom/no-arbitrary-text-size -- deferred design pick: fixed 32px at all breakpoints inside the gradient share card */}
             <H2 className="text-[32px] text-white">
-              Help more people discover AI safety today
+              {headline}
             </H2>
             <P className="text-white">
               You&apos;ve spent time understanding one of the most important problems of our era. A post or a message to
@@ -401,7 +431,7 @@ const Congratulations: React.FC<CongratulationsProps> = ({
           <div className="flex w-full flex-col gap-8">
             <ShareCard
               title="1. Share with your network"
-              description="Take a minute to celebrate and raise awareness for safe AI in your network!"
+              description={shareCardDescription}
               preview={<PostPreviewPanel courseSlug={courseSlug} shareText={shareText} courseUrl={courseUrl} />}
               actions={
                 <>
@@ -417,19 +447,33 @@ const Congratulations: React.FC<CongratulationsProps> = ({
               }
             />
 
-            <ShareCard
-              title="2. Refer a friend or colleague"
-              description={
-                'Think of three people who\'d genuinely benefit from this course. A little "I thought of you" goes a long way.'
-              }
-              preview={<ChatPreviewPanel courseUrl={courseUrl} shareText={dmText} />}
-              actions={
-                <button type="button" onClick={handleCopyShare} className={primaryBtnClass}>
-                  <FaRegCopy className="size-4" />
-                  {copied ? 'Copied!' : 'Copy Message'}
-                </button>
-              }
-            />
+            {referralFormUrl ? (
+              <ShareCard
+                title="2. Refer a friend or colleague"
+                description="Know someone who should be working on this? Give us their name and we'll invite them to apply. Some of our best participants came in through referrals. Takes about a minute."
+                preview={<ReferralStepsPanel />}
+                actions={
+                  <a href={referralFormUrl} target="_blank" rel="noopener noreferrer" className={primaryBtnClass}>
+                    <FaUserPlus className="size-4" />
+                    Refer someone
+                  </a>
+                }
+              />
+            ) : (
+              <ShareCard
+                title="2. Refer a friend or colleague"
+                description={
+                  'Think of three people who\'d genuinely benefit from this course. A little "I thought of you" goes a long way.'
+                }
+                preview={<ChatPreviewPanel courseUrl={courseUrl} shareText={dmText} />}
+                actions={
+                  <button type="button" onClick={handleCopyShare} className={primaryBtnClass}>
+                    <FaRegCopy className="size-4" />
+                    {copied ? 'Copied!' : 'Copy Message'}
+                  </button>
+                }
+              />
+            )}
           </div>
         </div>
       </div>

--- a/apps/website/src/lib/constants.ts
+++ b/apps/website/src/lib/constants.ts
@@ -65,6 +65,17 @@ type CourseConfigItem = {
     curriculumCtaLabel: string;
     detailsCtaLabel: string;
   };
+  /** Overrides for the sharing section of the congratulations page. The defaults
+   * are written for the AI safety courses; set these for courses in another
+   * cause area. */
+  congratulations?: {
+    headline?: string;
+    shareCardDescription?: string;
+    shareText?: string;
+    /** When set, the "Refer a friend or colleague" card links to this form
+     * instead of offering a copy-pasteable message. */
+    referralFormUrl?: string;
+  };
 };
 
 const DIGITAL_MINDS_COURSE_CONFIG: CourseConfigItem = {
@@ -115,6 +126,12 @@ export const COURSE_CONFIG: Record<string, CourseConfigItem> = {
     icon: '/images/courses/biosecurity-icon.svg',
     iconBackground: COURSE_COLORS.biosecurity.iconBackground,
     accentColor: COURSE_COLORS.biosecurity.full,
+    congratulations: {
+      headline: 'Help more people discover biosecurity today',
+      shareCardDescription: 'Take a minute to celebrate and raise awareness for pandemic preparedness in your network!',
+      shareText: 'I just completed the Biosecurity course from BlueDot Impact: 30 hours on how to prevent, detect and respond to pandemic threats. Check it out:',
+      referralFormUrl: 'https://web.miniextensions.com/DN3PuxFG7kf50g5RTph4',
+    },
   },
   'technical-ai-safety-project': {
     icon: '/images/courses/technical-ai-safety-icon.svg',


### PR DESCRIPTION
# Description

The biosecurity congratulations page reused the AI safety sharing section wholesale. Three things read wrong for biosecurity graduates:

- The section header said "Help more people discover AI safety today" and card 1 said "raise awareness for safe AI".
- The LinkedIn/X share text called the course "free, self-paced".
- Card 2 offered a copy-pasteable DM ("Hey, I just finished this free Biosecurity course and it genuinely shifted how I think about this stuff...") shown in a fake chat bubble. The biosecurity team would rather collect referrals through a form so we can follow up with the referred person ourselves.

This PR adds an optional `congratulations` block to `CourseConfigItem` (headline, share-card description, share text, referral form URL) and populates it for `biosecurity` only. When `referralFormUrl` is set, card 2 becomes a "Refer someone" link to the form with a short "What happens next" panel in place of the chat bubble. Courses without the config render exactly as before, so the AI courses are unaffected.

Weirdness to note: the referral form is a miniExtensions form on top of Airtable, owned by Chris (biosecurity). Prefilling it from the page (course, referrer email) is possible but left out of this PR until the form's parameter names are confirmed.

## Issue

No linked issue. Requested by the biosecurity team.

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist) (the new CTA is a real link with visible text, opens in a new tab with `rel="noopener noreferrer"`; steps are an `<ol>`)
- [x] Considered having snapshot tests and/or happy path functional tests (added a functional test for the configured case and tightened the default-case test)
- [x] Considered adding Storybook stories (added `Biosecurity` story)

## Screenshot

Rendered from the new `Biosecurity` story in Storybook (`website/courses/Congratulations`). Before: header "Help more people discover AI safety today", card 1 "raise awareness for safe AI", card 2 chat bubble with "Copy Message". After: header "Help more people discover biosecurity today", card 1 "raise awareness for pandemic preparedness", card 2 "Refer someone" link with a three-step "What happens next" panel. Mobile stacks the panel under the text as card 1 does.

| 📸 | Before | After |
|---------|---|---|
| 🖥️ | _screenshot to be dropped in_ | _screenshot to be dropped in_ |
| 📱  | _screenshot to be dropped in_ | _screenshot to be dropped in_ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
