### PR TITLE
New radii tokens for surfaces, overlays and sheets

### DIFF
--- a/apps/website/src/__tests__/pages/__snapshots__/account.test.tsx.snap
+++ b/apps/website/src/__tests__/pages/__snapshots__/account.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`AccountSettingsPage > should render account settings page correctly 1`]
                     aria-describedby="profile-name-label"
                     aria-invalid="false"
                     aria-label="Profile name"
-                    class="input--text border border-color-divider rounded-lg p-4 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400 flex-1"
+                    class="input--text border border-color-divider rounded-surface p-4 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400 flex-1"
                     placeholder="Enter your name"
                     type="text"
                     value="John Doe"

--- a/apps/website/src/components/CookieBanner.tsx
+++ b/apps/website/src/components/CookieBanner.tsx
@@ -15,26 +15,24 @@ export const CookieBanner: React.FC<CookieBannerProps> = ({ className }) => {
   }
 
   const rootClassName = clsx(
-    'cookie-banner container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px] z-100',
+    'container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px] z-100',
     className,
   );
 
   return (
     <div className={rootClassName}>
-      <P className="cookie-banner__text text-pretty">
+      <P className="text-pretty">
         Analytics cookies help us improve our website and measure ad performance.{' '}
         <A href="https://bluedot.org/privacy-policy">Privacy Policy</A>.
       </P>
-      <div className="cookie-banner__buttons flex flex-wrap gap-space-between justify-center">
+      <div className="flex flex-wrap gap-space-between justify-center">
         <CTALinkOrButton
-          className="cookie-banner__button--accept"
           variant="primary"
           onClick={() => useConsentStore.getState().accept()}
         >
           Accept all
         </CTALinkOrButton>
         <CTALinkOrButton
-          className="cookie-banner__button--reject"
           variant="primary"
           onClick={() => useConsentStore.getState().reject()}
         >

--- a/apps/website/src/components/__snapshots__/CookieBanner.test.tsx.snap
+++ b/apps/website/src/components/__snapshots__/CookieBanner.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`CookieBanner > renders as expected 1`] = `
 <div>
   <div
-    class="cookie-banner container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px] z-100"
+    class="container-dialog fixed bottom-6 right-0 mx-4 sm:mx-6 flex flex-col gap-5 p-6 bg-cream-normal w-fit max-w-[420px] z-100"
   >
     <p
-      class="bluedot-p not-prose cookie-banner__text text-pretty"
+      class="bluedot-p not-prose text-pretty"
     >
       Analytics cookies help us improve our website and measure ad performance.
        
@@ -20,16 +20,16 @@ exports[`CookieBanner > renders as expected 1`] = `
       .
     </p>
     <div
-      class="cookie-banner__buttons flex flex-wrap gap-space-between justify-center"
+      class="flex flex-wrap gap-space-between justify-center"
     >
       <button
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-size-sm bd-md:text-size-xs px-4 py-3 rounded-sm font-semibold cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--accept"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-size-sm bd-md:text-size-xs px-4 py-3 rounded-sm font-semibold cta-button--primary bg-bluedot-normal link-on-dark"
         type="button"
       >
         Accept all
       </button>
       <button
-        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-size-sm bd-md:text-size-xs px-4 py-3 rounded-sm font-semibold cta-button--primary bg-bluedot-normal link-on-dark cookie-banner__button--reject"
+        class="cta-button flex items-center justify-center transition-all duration-200 w-fit whitespace-nowrap cursor-pointer not-prose disabled:opacity-50 disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:pointer-events-none text-size-sm bd-md:text-size-xs px-4 py-3 rounded-sm font-semibold cta-button--primary bg-bluedot-normal link-on-dark"
         type="button"
       >
         Reject all

--- a/apps/website/src/components/courses/Congratulations.tsx
+++ b/apps/website/src/components/courses/Congratulations.tsx
@@ -381,7 +381,7 @@ const Congratulations: React.FC<CongratulationsProps> = ({
       {/* Sharing section with course-colored gradient (inset rounded card) */}
       <div className="w-full pb-12">
         <div
-          className="flex flex-col items-center gap-12 overflow-hidden rounded-[17px] px-5 py-16 md:px-[54px]"
+          className="flex flex-col items-center gap-12 overflow-hidden rounded-2xl px-5 py-16 md:px-[54px]"
           style={{ background: courseColors.gradient }}
         >
           <div className="flex max-w-[653px] flex-col items-center gap-4 text-center">

--- a/apps/website/src/components/courses/CourseCompletionSection.tsx
+++ b/apps/website/src/components/courses/CourseCompletionSection.tsx
@@ -63,7 +63,7 @@ const FeatureCardItem = ({ card, accentColor }: { card: FeatureCard; accentColor
 
 const SocialProof = ({ accentColor }: { accentColor?: string }) => (
   <div
-    className="inline-flex flex-col items-center gap-3 rounded-[24px] px-4 py-3 max-w-full sm:flex-row sm:rounded-full sm:py-2"
+    className="inline-flex flex-col items-center gap-3 rounded-3xl px-4 py-3 max-w-full sm:flex-row sm:rounded-full sm:py-2"
     // 8-digit hex (#RRGGBBAA) — `1F` ≈ 12% opacity tint of the course accent.
     style={{ backgroundColor: accentColor ? `${accentColor}1F` : undefined }}
   >

--- a/apps/website/src/components/my-courses/DiscussionListRow.tsx
+++ b/apps/website/src/components/my-courses/DiscussionListRow.tsx
@@ -84,7 +84,7 @@ const DiscussionListRow = (row: DiscussionListRowProps) => {
 };
 
 export const TimeWidget = ({ isLive, dateTimeSeconds }: { isLive: boolean; dateTimeSeconds: number }) => (
-  <div className="flex shrink-0 min-w-[85px] flex-col items-stretch overflow-hidden rounded-[5px] border border-color-divider">
+  <div className="flex shrink-0 min-w-[85px] flex-col items-stretch overflow-hidden rounded-md border border-color-divider">
     {isLive ? <LiveBadge /> : (
       <div className="px-3 py-[7px] text-center text-bluedot-navy" aria-hidden>
         <div className="text-size-xs font-semibold leading-relaxed">{formatDateMonthAndDay(dateTimeSeconds)}</div>

--- a/libraries/ui/src/BottomDrawerModal.tsx
+++ b/libraries/ui/src/BottomDrawerModal.tsx
@@ -139,7 +139,7 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
               />
               {/* Modal Container */}
               <motion.div
-                className="bg-color-canvas fixed bottom-0 inset-x-0 rounded-t-[24px] shadow-lg will-change-transform flex flex-col"
+                className="bg-color-canvas fixed bottom-0 inset-x-0 rounded-t-sheet shadow-lg will-change-transform flex flex-col"
                 transition={{
                   duration: 0.3,
                   ease: [0.32, 0.72, 0, 1],
@@ -196,10 +196,10 @@ export const BottomDrawerModal: React.FC<BottomDrawerModalProps> = ({
                   }
                 }}
               >
-                <div className="h-full flex flex-col rounded-t-[24px] overflow-hidden">
+                <div className="h-full flex flex-col rounded-t-sheet overflow-hidden">
                   {/* Header Section with Drag Handle */}
                   <div className={clsx(
-                    'flex flex-col bg-[#FCFAF7] border-b-hairline border-bluedot-navy/20 rounded-t-[24px] transition-shadow duration-300',
+                    'flex flex-col bg-[#FCFAF7] border-b-hairline border-bluedot-navy/20 rounded-t-sheet transition-shadow duration-300',
                     isFullyExpanded && 'shadow-[0_4px_12px_rgba(0,0,0,0.08)]',
                   )}
                   >

--- a/libraries/ui/src/BugReportModal.tsx
+++ b/libraries/ui/src/BugReportModal.tsx
@@ -236,7 +236,7 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({
 
               <div
                 className={cn(
-                  'flex flex-col gap-3 rounded-lg border p-3 transition-colors',
+                  'flex flex-col gap-3 rounded-surface border p-3 transition-colors',
                   isDragging
                     ? 'border-bluedot-normal bg-bluedot-normal/[8%] border-dashed'
                     : 'border-color-divider focus-within:border-bluedot-normal bg-white',
@@ -336,7 +336,7 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({
                       type="url"
                       value={recordingUrlInput}
                       onChange={(e) => setRecordingUrlInput(e.target.value)}
-                      className="border-color-divider text-bluedot-navy/60 rounded-lg border bg-white px-3 py-2 text-size-xs placeholder:text-size-xs"
+                      className="border-color-divider text-bluedot-navy/60 rounded-surface border bg-white px-3 py-2 text-size-xs placeholder:text-size-xs"
                       aria-label="Recording URL"
                     />
                   </div>
@@ -365,7 +365,7 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({
                 type="email"
                 value={email}
                 className={cn(
-                  'border-color-divider rounded-lg border bg-white px-3 py-2 text-size-xs placeholder:text-size-xs',
+                  'border-color-divider rounded-surface border bg-white px-3 py-2 text-size-xs placeholder:text-size-xs',
                   emailError && 'border-red-500',
                 )}
                 placeholder="Email"

--- a/libraries/ui/src/DatePicker.tsx
+++ b/libraries/ui/src/DatePicker.tsx
@@ -127,7 +127,7 @@ export const DatePicker = ({
           {label}
         </label>
       ) : null}
-      <div className="relative rounded-lg border border-gray-200 bg-white/90 text-gray-700 transition focus-within:bg-white">
+      <div className="relative rounded-surface border border-gray-200 bg-white/90 text-gray-700 transition focus-within:bg-white">
         <input
           id={inputId}
           type="text"
@@ -145,7 +145,7 @@ export const DatePicker = ({
           placeholder={localeFormat.toLowerCase()}
           aria-label={label ?? 'Select date'}
           className={cn(
-            'w-full rounded-lg bg-transparent py-2 pr-9 pl-3 outline-none placeholder:italic',
+            'w-full rounded-surface bg-transparent py-2 pr-9 pl-3 outline-none placeholder:italic',
             classNames?.input,
           )}
         />
@@ -172,7 +172,7 @@ export const DatePicker = ({
             transform: 'translateX(-50%)',
           } as React.CSSProperties
         }
-        className={cn('overflow-auto rounded-lg bg-white p-4 ring-1 ring-black/10 drop-shadow-sm', classNames?.popover)}
+        className={cn('overflow-auto rounded-surface bg-white p-4 ring-1 ring-black/10 drop-shadow-sm', classNames?.popover)}
       >
         <DayPicker
           mode="single"

--- a/libraries/ui/src/Input.tsx
+++ b/libraries/ui/src/Input.tsx
@@ -73,7 +73,7 @@ export const Input: React.ForwardRefExoticComponent<InputProps> = forwardRef((
             ref={ref}
             type={type}
             className={clsx(
-              'input--text border border-color-divider rounded-lg p-4 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
+              'input--text border border-color-divider rounded-surface p-4 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400',
               inputClassName,
             )}
           />

--- a/libraries/ui/src/Modal.tsx
+++ b/libraries/ui/src/Modal.tsx
@@ -45,7 +45,7 @@ const DesktopModal: React.FC<Omit<ModalProps, 'bottomDrawerOnMobile'>> = ({
       className="fixed inset-0 z-60 overflow-y-auto bg-black/25 flex min-h-full items-center justify-center p-4 backdrop-blur-xs"
     >
       <AriaModal>
-        <Dialog className="bg-white rounded-xl shadow-xl w-full pb-8 outline-none" aria-label={ariaLabel}>
+        <Dialog className="bg-white rounded-overlay shadow-xl w-full pb-8 outline-none" aria-label={ariaLabel}>
           <div className={cn('flex justify-between items-center mb-4 pt-10 pl-8 pr-6', desktopHeaderClassName)}>
             {title && typeof title === 'string' ? <ModalTitle className={centerTitle ? 'mx-auto' : undefined}>{title}</ModalTitle> : title}
             <ClickTarget onClick={() => setIsOpen(false)} aria-label="Close" className="text-black rounded-full p-1 hover:bg-gray-100 cursor-pointer">

--- a/libraries/ui/src/OverflowMenu.tsx
+++ b/libraries/ui/src/OverflowMenu.tsx
@@ -76,7 +76,7 @@ const MenuContent: React.FC<MenuContentProps> = ({ items, isOpen, setIsOpen }) =
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         placement="bottom end"
-        className="bg-white rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] border border-charcoal-light overflow-hidden min-w-[200px]"
+        className="bg-white rounded-surface shadow-[0_4px_12px_rgba(0,0,0,0.08)] border border-charcoal-light overflow-hidden min-w-[200px]"
       >
         {menuContent}
       </Popover>

--- a/libraries/ui/src/Select.tsx
+++ b/libraries/ui/src/Select.tsx
@@ -73,7 +73,7 @@ export const Select = ({
         isDisabled={disabled}
         aria-label={ariaLabel}
         className={cn(
-          'w-full flex flex-col bg-white border border-color-divider rounded-lg transition-all text-size-sm',
+          'w-full flex flex-col bg-white border border-color-divider rounded-surface transition-all text-size-sm',
           disabled && 'opacity-50 cursor-not-allowed bg-gray-50',
           className,
         )}
@@ -95,7 +95,7 @@ export const Select = ({
           placement="bottom"
           offset={8}
           maxHeight={400}
-          className="w-(--trigger-width) bg-white rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] border border-color-divider overflow-hidden max-h-[400px] overflow-y-auto"
+          className="w-(--trigger-width) bg-white rounded-surface shadow-[0_4px_12px_rgba(0,0,0,0.08)] border border-color-divider overflow-hidden max-h-[400px] overflow-y-auto"
         >
           {listContent}
         </Popover>

--- a/libraries/ui/src/SlideList.tsx
+++ b/libraries/ui/src/SlideList.tsx
@@ -207,7 +207,7 @@ export const SlideListBtn: React.FC<{
     disabled={disabled}
     className={clsx(
       'slide-list__nav-button',
-      'p-3 border rounded-lg transition-colors m-[3px] mt-0',
+      'p-3 border rounded-surface transition-colors m-[3px] mt-0',
       'border-charcoal-light text-black',
       'hover:bg-gray-50 hover:cursor-pointer',
       'active:bg-gray-100',

--- a/libraries/ui/src/TimePicker.tsx
+++ b/libraries/ui/src/TimePicker.tsx
@@ -48,7 +48,7 @@ export const TimePicker = ({
       {label && <Label className={cn('cursor-default text-black', labelClassName)}>{label}</Label>}
       <DateInput
         className={cn(
-          'flex rounded-lg border border-gray-200 bg-white/90 px-3 py-2 text-gray-700 ring-black transition focus-within:bg-white focus-visible:ring-2',
+          'flex rounded-surface border border-gray-200 bg-white/90 px-3 py-2 text-gray-700 ring-black transition focus-within:bg-white focus-visible:ring-2',
           inputClassName,
         )}
       >

--- a/libraries/ui/src/Tooltip.tsx
+++ b/libraries/ui/src/Tooltip.tsx
@@ -36,7 +36,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
         placement={placement}
         offset={8}
         className={cn(
-          'bg-bluedot-darker text-pretty text-white text-size-xs px-3 py-2 rounded-lg shadow-md max-w-2xs',
+          'bg-bluedot-darker text-pretty text-white text-size-xs px-3 py-2 rounded-surface shadow-md max-w-2xs',
           className,
         )}
       >

--- a/libraries/ui/src/__snapshots__/Input.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Input.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Input > renders default as expected 1`] = `
       This is the label
     </span>
     <input
-      class="input--text border border-color-divider rounded-lg p-4 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
+      class="input--text border border-color-divider rounded-surface p-4 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-bluedot-normal disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
       label="This is the label"
       placeholder="This is the placeholder"
       type="text"

--- a/libraries/ui/src/__snapshots__/Select.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/Select.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Select > applies disabled styling to disabled options 1`] = `
     data-react-aria-hidden="true"
   />
   <div
-    class="w-full flex flex-col bg-white border border-color-divider rounded-lg transition-all text-size-sm"
+    class="w-full flex flex-col bg-white border border-color-divider rounded-surface transition-all text-size-sm"
     data-focus-visible="true"
     data-focused="true"
     data-open="true"
@@ -87,7 +87,7 @@ exports[`Select > renders with selected value 1`] = `
     data-react-aria-hidden="true"
   />
   <div
-    class="w-full flex flex-col bg-white border border-color-divider rounded-lg transition-all text-size-sm"
+    class="w-full flex flex-col bg-white border border-color-divider rounded-surface transition-all text-size-sm"
     data-rac=""
   >
     <button

--- a/libraries/ui/src/__snapshots__/SlideList.test.tsx.snap
+++ b/libraries/ui/src/__snapshots__/SlideList.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`SlideList > renders correctly 1`] = `
     >
       <button
         aria-label="Previous slide"
-        class="slide-list__nav-button p-3 border rounded-lg transition-colors m-[3px] mt-0 border-charcoal-light text-black hover:bg-gray-50 hover:cursor-pointer active:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-hidden focus:ring-2 focus:ring-bluedot-light"
+        class="slide-list__nav-button p-3 border rounded-surface transition-colors m-[3px] mt-0 border-charcoal-light text-black hover:bg-gray-50 hover:cursor-pointer active:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-hidden focus:ring-2 focus:ring-bluedot-light"
         disabled=""
         type="button"
       >
@@ -84,7 +84,7 @@ exports[`SlideList > renders correctly 1`] = `
       </div>
       <button
         aria-label="Next slide"
-        class="slide-list__nav-button p-3 border rounded-lg transition-colors m-[3px] mt-0 border-charcoal-light text-black hover:bg-gray-50 hover:cursor-pointer active:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-hidden focus:ring-2 focus:ring-bluedot-light"
+        class="slide-list__nav-button p-3 border rounded-surface transition-colors m-[3px] mt-0 border-charcoal-light text-black hover:bg-gray-50 hover:cursor-pointer active:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-hidden focus:ring-2 focus:ring-bluedot-light"
         type="button"
       >
         <svg

--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -40,6 +40,10 @@
     --color-cream-normal: var(--bluedot-cream-normal);
     --color-cream-dark: var(--bluedot-cream-dark);
 
+    /* surface = cards, inputs, buttons
+       overlay = modals, dialogs. */
+    --radius-surface: 0.5rem;
+
     --font-sans:
         Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
@@ -141,11 +145,11 @@
 }
 
 @utility container-lined {
-    @apply border border-color-divider rounded-lg;
+    @apply border border-color-divider rounded-surface;
 }
 
 @utility container-active {
-    @apply border-2 border-color-primary rounded-lg;
+    @apply border-2 border-color-primary rounded-surface;
 }
 
 @utility container-elevated {
@@ -154,7 +158,7 @@
 }
 
 @utility container-dialog {
-    @apply border border-color-primary rounded-lg;
+    @apply border border-color-primary rounded-surface;
     box-shadow: 0px 0px 32px 0px rgba(0, 0, 0, 0.25);
 }
 

--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -41,9 +41,10 @@
     --color-cream-dark: var(--bluedot-cream-dark);
 
     /* surface = cards, inputs, buttons
-       overlay = modals, dialogs. */
+       overlay = modals, dialogs; sheet = bottom drawers (top corners). */
     --radius-surface: 0.5rem;
     --radius-overlay: 0.75rem;
+    --radius-sheet: 1.5rem;
 
     --font-sans:
         Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,

--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -160,7 +160,7 @@
 }
 
 @utility container-dialog {
-    @apply border border-color-primary rounded-lg;
+    @apply border border-color-primary rounded-overlay;
     box-shadow: 0px 0px 32px 0px rgba(0, 0, 0, 0.25);
 }
 

--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -159,7 +159,7 @@
 }
 
 @utility container-dialog {
-    @apply border border-color-primary rounded-surface;
+    @apply border border-color-primary rounded-lg;
     box-shadow: 0px 0px 32px 0px rgba(0, 0, 0, 0.25);
 }
 

--- a/libraries/ui/src/default-config/tailwind.css
+++ b/libraries/ui/src/default-config/tailwind.css
@@ -43,6 +43,7 @@
     /* surface = cards, inputs, buttons
        overlay = modals, dialogs. */
     --radius-surface: 0.5rem;
+    --radius-overlay: 0.75rem;
 
     --font-sans:
         Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,


### PR DESCRIPTION
# Description
<!-- Explain why you've made the changes, and highlight any areas of 'weirdness' -->

Adds three new tokens for radii:

1. `--radius-surface: 0.5rem;` - cards, inputs, buttons, panels
2. `--radius-overlay: 0.75rem;` - modals, dialogs
3. `--radius-sheet: 1.5rem;` - bottom drawer modal top corner rounding

Also migrated some arbitrary values to nearest TW equivalents ([17px] -> 16px, [5px] -> 6px). Aside from this, visual no-op since we match TW values exactly.

I migrated the cookie banner to use the new overlay token and removed some BEM classes at the same time. The banner itself should probably re-use modal / dialog component; see #2982 

**Deliberately not migrated:** hover highlights on menu items / icon buttons (`OverflowMenu`, `BugReportModal:300`) - controls, not surfaces; Card's inner image; all app-level usage.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2951

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->


