### PR TITLE
[chore] Remove the temporary legacy name-field fallback

### DIFF
--- a/apps/website/src/lib/utils.test.ts
+++ b/apps/website/src/lib/utils.test.ts
@@ -23,7 +23,6 @@ const {
   buildApplicationUrl,
   userNameFields,
   normalisedFirstAndLastName,
-  legacyUserNameFields,
 } = await import('./utils');
 
 // Test constants
@@ -404,21 +403,5 @@ describe('normalisedFirstAndLastName', () => {
   it('returns null when the source has no name at all', () => {
     expect(normalisedFirstAndLastName({ name: ' ', firstName: '', lastName: null })).toBeNull();
     expect(normalisedFirstAndLastName({})).toBeNull();
-  });
-});
-
-describe('legacyUserNameFields', () => {
-  it('fills first/last for a user that only has a combined name, keeping the name', () => {
-    expect(legacyUserNameFields({ name: 'Mary Jane Smith', firstName: null, lastName: '' })).toEqual({ firstName: 'Mary', lastName: 'Jane Smith', name: 'Mary Jane Smith' });
-  });
-
-  it('changes nothing for a user whose fields are already stored together', () => {
-    expect(legacyUserNameFields({ name: 'Jane Doe', firstName: 'Jane', lastName: 'Doe' })).toEqual({});
-    expect(legacyUserNameFields({ name: 'Jane', firstName: 'Jane', lastName: null })).toEqual({});
-  });
-
-  it('changes nothing for a user with no name', () => {
-    expect(legacyUserNameFields({ name: null, firstName: null, lastName: null })).toEqual({});
-    expect(legacyUserNameFields({ name: '', firstName: '', lastName: '' })).toEqual({});
   });
 });

--- a/apps/website/src/lib/utils.ts
+++ b/apps/website/src/lib/utils.ts
@@ -267,13 +267,3 @@ export const normalisedFirstAndLastName = (source: { name?: string | null; first
   if (firstName || lastName) return { firstName, lastName };
   return source.name?.trim() ? splitNameOnFirstSpace(source.name) : null;
 };
-
-/**
- * Temporary (#2913): if there is no `firstName` or `lastName`, estimate them by splitting `name`. This can be removed
- * once all `firstName`/`lastName`s are backfilled.
- */
-export const legacyUserNameFields = (user: { name: string | null; firstName: string | null; lastName: string | null }): Partial<UserNameFields> => {
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty strings and nulls are both "not set"
-  if (!user.name || user.firstName || user.lastName) return {};
-  return userNameFields(splitNameOnFirstSpace(user.name));
-};

--- a/apps/website/src/server/routers/facilitator-applications.test.ts
+++ b/apps/website/src/server/routers/facilitator-applications.test.ts
@@ -522,12 +522,6 @@ describe('facilitatorApplications.quickApply', () => {
       expect(await quickApplyInsert({ firstName: 'Prior', lastName: 'Applicant' })).toMatchObject({ firstName: 'Mary Jane', lastName: 'Smith' });
     });
 
-    // Temporary (#2913): users named before first/last existed
-    test('splits the combined name of a user with no first/last name stored', async () => {
-      await testDb.update(userTable, { id: 'test-user', name: 'Mary Jane Smith' });
-      expect(await quickApplyInsert({ firstName: 'Prior', lastName: 'Applicant' })).toMatchObject({ firstName: 'Mary', lastName: 'Jane Smith' });
-    });
-
     test('falls back to the latest prior application when the user has no name', async () => {
       await testDb.update(userTable, { id: 'test-user', name: '' });
       expect(await quickApplyInsert({ firstName: 'Prior', lastName: 'Applicant' })).toMatchObject({ firstName: 'Prior', lastName: 'Applicant' });

--- a/apps/website/src/server/routers/facilitator-applications.ts
+++ b/apps/website/src/server/routers/facilitator-applications.ts
@@ -14,7 +14,7 @@ import { utcIntervalStringToGrid } from '@bluedot/utils';
 import { type inferRouterOutputs, TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import db from '../../lib/api/db';
-import { legacyUserNameFields, parseWeekFromRoundName, unique } from '../../lib/utils';
+import { parseWeekFromRoundName, unique } from '../../lib/utils';
 import { getUserFromAuthOrThrow, protectedProcedure, router } from '../trpc';
 import { openRoundDeadlineCondition } from './course-rounds';
 
@@ -358,8 +358,7 @@ export const facilitatorApplicationsRouter = router({
       const priorRegs = await getEligiblePriorFacilitatorRegs(user.id, courseId, input.roundId);
 
       // Users with no name on their record yet fall back to their latest application for this course
-      const userWithNameParts = { ...user, ...legacyUserNameFields(user) };
-      const applicant = userWithNameParts.name ? userWithNameParts : priorRegs[0];
+      const applicant = user.name ? user : priorRegs[0];
 
       // Link the application to its course via the Applications-base course record (courseId,
       // roundName and roundStatus are computed in Airtable from the linked round/course).

--- a/apps/website/src/server/routers/users.test.ts
+++ b/apps/website/src/server/routers/users.test.ts
@@ -108,18 +108,6 @@ describe('users.getUser', () => {
     expect(new Date(result.lastSeenAt!).getTime()).toBeGreaterThanOrEqual(before);
   });
 
-  // Temporary (#2913): users named before first/last existed are brought into line on their next visit
-  test('fills first/last for a user that only has a combined name, keeping the name', async () => {
-    await testDb.insert(userTable, {
-      id: 'u1', email: 'test@example.com', name: 'Mary Jane Smith', keycloakIdentifier: 'test-sub',
-    });
-
-    await createCaller(testAuthContextLoggedIn).users.getUser();
-
-    const user = await testDb.get(userTable, { id: 'u1' });
-    expect(user).toMatchObject({ firstName: 'Mary', lastName: 'Jane Smith', name: 'Mary Jane Smith' });
-  });
-
   test('does not write name fields for a user whose fields are already stored together', async () => {
     await testDb.insert(userTable, {
       id: 'u1', email: 'test@example.com', name: 'Mary Jane Smith', firstName: 'Mary Jane', lastName: 'Smith', keycloakIdentifier: 'test-sub',

--- a/apps/website/src/server/routers/users.ts
+++ b/apps/website/src/server/routers/users.ts
@@ -12,7 +12,7 @@ import {
   adminRequest, type LoginMethods, unlinkStaleGoogleIdentities, updateKeycloakEmail, updateKeycloakPassword, verifyKeycloakPassword,
 } from '../../lib/api/keycloak';
 import { normaliseEmail } from '../../lib/api/utils';
-import { legacyUserNameFields, normalisedFirstAndLastName, userNameFields } from '../../lib/utils';
+import { normalisedFirstAndLastName, userNameFields } from '../../lib/utils';
 import { ONE_MINUTE_MS } from '../../lib/constants';
 import { newEmailSchema } from '../../lib/schemas/user/changeEmail.schema';
 import { changePasswordSchema } from '../../lib/schemas/user/changePassword.schema';
@@ -134,7 +134,6 @@ export const usersRouter = router({
       return db.update(userTable, {
         id: user.id,
         lastSeenAt: new Date().toISOString(),
-        ...legacyUserNameFields(user),
       });
     }),
 


### PR DESCRIPTION
# Description

The fields `name`, `firstName`, and `lastName` are now 100% in sync in production, so we can remove the fallback that #2972 included for the case of a `name` being set with no `firstName` or `lastName`.

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

Fixes #2913

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] N/A Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories
