### PR TITLE
[fix] website: merge orphaned customer.io profiles that block an email change

### DIFF
--- a/apps/website/src/lib/api/customerio.test.ts
+++ b/apps/website/src/lib/api/customerio.test.ts
@@ -1,6 +1,8 @@
 import {
   afterEach, beforeEach, describe, expect, test, vi,
 } from 'vitest';
+import { userTable } from '@bluedot/db';
+import { setupTestDb, testDb } from '../../__tests__/dbTestUtils';
 import { sendEmailChangeRequestedNotice, sendEmailChangeVerification, updateCustomerIoEmail } from './customerio';
 import env from './env';
 
@@ -11,6 +13,7 @@ vi.mock('./env', () => ({
     ALERTS_SLACK_CHANNEL_ID: 'fake-channel',
     CIO_APP_API_KEY: 'fake-app-key',
     CIO_TRACK_API_KEY: 'fake-track-key',
+    VITEST: 'true',
   },
 }));
 
@@ -22,7 +25,8 @@ vi.mock('./env', () => ({
  *    in place (same cio_id, id attached) rather than creating a duplicate;
  *  - an identify whose email is owned by a DIFFERENT profile silently drops the email update
  *    (no error, other attributes still apply) — which is why verify-after-write is mandatory;
- *  - there is no merge API on api-eu; conflicts are surfaced as errors for manual resolution.
+ *  - merge_customers (track-eu) removes the secondary and keeps the primary's id, cio_id and
+ *    preferences wholesale; merging an already-gone secondary is a no-op.
  *
  * These semantics were validated against the real production workspace with a live-fire
  * model-based test, which is preserved on the `wh-2810-cio-livetest-2026-07-archive` git branch,
@@ -34,12 +38,14 @@ type FakeCio = {
   profiles: FakeProfile[];
   applyWrites: boolean;
   identifyCalls: { id: string; email: string }[];
+  mergeCalls: { primary: string; secondary: string }[];
 };
 
 const makeFakeCio = (profiles: FakeProfile[], { applyWrites = true }: { applyWrites?: boolean } = {}): FakeCio => ({
   profiles,
   applyWrites,
   identifyCalls: [],
+  mergeCalls: [],
 });
 
 const sameEmail = (a: string | null, b: string | null) => a !== null && b !== null && a.toLowerCase() === b.toLowerCase();
@@ -107,6 +113,13 @@ const installFakeCio = (cio: FakeCio) => {
         if (cio.applyWrites) applyIdentify(cio, entry.identifiers.id, entry.attributes.email);
         return jsonResponse(200, {});
       }
+
+      if (url.pathname === '/api/v1/merge_customers' && method === 'POST') {
+        const body = JSON.parse(init?.body ?? '{}') as { primary: { cio_id: string }; secondary: { cio_id: string } };
+        cio.mergeCalls.push({ primary: body.primary.cio_id, secondary: body.secondary.cio_id });
+        if (cio.applyWrites) cio.profiles = cio.profiles.filter((p) => p.cio_id !== body.secondary.cio_id);
+        return jsonResponse(200, {});
+      }
     }
 
     return jsonResponse(500, { error: `unexpected request: ${method} ${url.href}` });
@@ -136,6 +149,8 @@ const runToCompletion = async (promise: Promise<void>) => {
 };
 
 describe('updateCustomerIoEmail', () => {
+  setupTestDb();
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
@@ -258,32 +273,91 @@ describe('updateCustomerIoEmail', () => {
     expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'old@example.com' }]);
   });
 
-  test('throws without deleting anything when another profile owns the new email', async () => {
-    const cio = makeFakeCio([
-      { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
-      { cio_id: 'c2', email: 'new@example.com' },
-    ]);
-    installFakeCio(cio);
+  describe('when other profiles own the new email', () => {
+    const run = () => runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' }));
 
-    await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
-      .rejects.toThrow('already owned by cio_c2');
+    test('merges an email-only orphan into the user profile, then renames', async () => {
+      const cio = makeFakeCio([
+        { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
+        { cio_id: 'c2', email: 'new@example.com' },
+      ]);
+      installFakeCio(cio);
 
-    expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'new@example.com' }]);
-    expect(cio.profiles.find((p) => p.cio_id === 'c1')!.email).toBe('old@example.com');
-    expect(cio.profiles).toHaveLength(2);
-  });
+      await run();
 
-  test('names the owning user id when the conflicting profile carries one', async () => {
-    const cio = makeFakeCio([
-      { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
-      { cio_id: 'c2', id: 'u2', email: 'new@example.com' },
-    ]);
-    installFakeCio(cio);
+      expect(cio.mergeCalls).toEqual([{ primary: 'c1', secondary: 'c2' }]);
+      expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'new@example.com' }]);
+      expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+    });
 
-    await expect(runToCompletion(updateCustomerIoEmail({ userId: 'u1', oldEmail: 'old@example.com', newEmail: 'new@example.com' })))
-      .rejects.toThrow('already owned by cio_c2 (user id u2)');
+    test('merges an orphan whose user id no longer exists in the user table', async () => {
+      const cio = makeFakeCio([
+        { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
+        { cio_id: 'c2', id: 'u-deleted', email: 'new@example.com' },
+      ]);
+      installFakeCio(cio);
 
-    expect(cio.profiles).toHaveLength(2);
+      await run();
+
+      expect(cio.mergeCalls).toEqual([{ primary: 'c1', secondary: 'c2' }]);
+      expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+    });
+
+    test('merges into a claimed old-email profile', async () => {
+      const cio = makeFakeCio([
+        { cio_id: 'c1', email: 'old@example.com' },
+        { cio_id: 'c2', email: 'new@example.com' },
+      ]);
+      installFakeCio(cio);
+
+      await run();
+
+      expect(cio.mergeCalls).toEqual([{ primary: 'c1', secondary: 'c2' }]);
+      expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+    });
+
+    test('refuses to touch anything when the new email is owned by another existing user', async () => {
+      await testDb.insert(userTable, { id: 'u2', email: 'new@example.com', name: 'Other User' });
+      const cio = makeFakeCio([
+        { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
+        { cio_id: 'c2', id: 'u2', email: 'new@example.com' },
+      ]);
+      installFakeCio(cio);
+
+      await expect(run()).rejects.toThrow('already owned by cio_c2 (user id u2)');
+
+      expect(cio.mergeCalls).toEqual([]);
+      expect(cio.identifyCalls).toEqual([]);
+      expect(cio.profiles).toHaveLength(2);
+    });
+
+    test('refuses to merge eligible orphans when any conflicting profile belongs to an existing user', async () => {
+      await testDb.insert(userTable, { id: 'u2', email: 'new@example.com', name: 'Other User' });
+      const cio = makeFakeCio([
+        { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
+        { cio_id: 'c2', email: 'new@example.com' },
+        { cio_id: 'c3', id: 'u2', email: 'new@example.com' },
+      ]);
+      installFakeCio(cio);
+
+      await expect(run()).rejects.toThrow('already owned by cio_c3 (user id u2)');
+
+      expect(cio.mergeCalls).toEqual([]);
+      expect(cio.profiles).toHaveLength(3);
+    });
+
+    test('throws naming the profiles when the merge never becomes visible', async () => {
+      const cio = makeFakeCio([
+        { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
+        { cio_id: 'c2', email: 'new@example.com' },
+      ], { applyWrites: false });
+      installFakeCio(cio);
+
+      await expect(run()).rejects.toThrow('merging cio_c2 into cio_c1 did not complete');
+
+      expect(cio.mergeCalls).toEqual([{ primary: 'c1', secondary: 'c2' }]);
+      expect(cio.identifyCalls).toEqual([]);
+    });
   });
 
   test('throws when the rename never verifies and no conflicting profile exists', async () => {

--- a/apps/website/src/lib/api/customerio.test.ts
+++ b/apps/website/src/lib/api/customerio.test.ts
@@ -32,13 +32,14 @@ vi.mock('./env', () => ({
  * model-based test, which is preserved on the `wh-2810-cio-livetest-2026-07-archive` git branch,
  * file `apps/website/src/lib/api/customerio.prod.test.ts`.
  */
-type FakeProfile = { cio_id: string; id?: string; email: string };
+type FakeProfile = { cio_id: string; id?: string; email: string; prefs?: Record<string, boolean> };
 
 type FakeCio = {
   profiles: FakeProfile[];
   applyWrites: boolean;
   identifyCalls: { id: string; email: string }[];
   mergeCalls: { primary: string; secondary: string }[];
+  prefsCalls: { cio_id: string; topics: Record<string, boolean> }[];
 };
 
 const makeFakeCio = (profiles: FakeProfile[], { applyWrites = true }: { applyWrites?: boolean } = {}): FakeCio => ({
@@ -46,6 +47,7 @@ const makeFakeCio = (profiles: FakeProfile[], { applyWrites = true }: { applyWri
   applyWrites,
   identifyCalls: [],
   mergeCalls: [],
+  prefsCalls: [],
 });
 
 const sameEmail = (a: string | null, b: string | null) => a !== null && b !== null && a.toLowerCase() === b.toLowerCase();
@@ -99,7 +101,7 @@ const installFakeCio = (cio: FakeCio) => {
         return jsonResponse(200, {
           customer: {
             identifiers: { cio_id: profile.cio_id, id: profile.id, email: profile.email },
-            attributes: { email: profile.email },
+            attributes: { email: profile.email, ...(profile.prefs && { cio_subscription_preferences: JSON.stringify({ topics: profile.prefs }) }) },
           },
         });
       }
@@ -114,10 +116,26 @@ const installFakeCio = (cio: FakeCio) => {
         return jsonResponse(200, {});
       }
 
+      const prefsMatch = /^\/api\/v1\/customers\/cio_([^/]+)$/.exec(url.pathname);
+      if (prefsMatch && method === 'PUT') {
+        const body = JSON.parse(init?.body ?? '{}') as { cio_subscription_preferences: { topics: Record<string, boolean> } };
+        cio.prefsCalls.push({ cio_id: prefsMatch[1]!, topics: body.cio_subscription_preferences.topics });
+        const profile = cio.profiles.find((p) => p.cio_id === prefsMatch[1]);
+        if (cio.applyWrites && profile) profile.prefs = body.cio_subscription_preferences.topics;
+        return jsonResponse(200, {});
+      }
+
+      // Like customer.io, keep the primary's attributes and copy over any it lacks
       if (url.pathname === '/api/v1/merge_customers' && method === 'POST') {
         const body = JSON.parse(init?.body ?? '{}') as { primary: { cio_id: string }; secondary: { cio_id: string } };
         cio.mergeCalls.push({ primary: body.primary.cio_id, secondary: body.secondary.cio_id });
-        if (cio.applyWrites) cio.profiles = cio.profiles.filter((p) => p.cio_id !== body.secondary.cio_id);
+        const primary = cio.profiles.find((p) => p.cio_id === body.primary.cio_id);
+        const secondary = cio.profiles.find((p) => p.cio_id === body.secondary.cio_id);
+        if (cio.applyWrites && primary && secondary) {
+          primary.prefs ??= secondary.prefs;
+          cio.profiles = cio.profiles.filter((p) => p !== secondary);
+        }
+
         return jsonResponse(200, {});
       }
     }
@@ -287,7 +305,9 @@ describe('updateCustomerIoEmail', () => {
 
       expect(cio.mergeCalls).toEqual([{ primary: 'c1', secondary: 'c2' }]);
       expect(cio.identifyCalls).toEqual([{ id: 'u1', email: 'new@example.com' }]);
-      expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+      expect(cio.profiles).toEqual([{
+        cio_id: 'c1', id: 'u1', email: 'new@example.com', prefs: {},
+      }]);
     });
 
     test('merges an orphan whose user id no longer exists in the user table', async () => {
@@ -300,7 +320,43 @@ describe('updateCustomerIoEmail', () => {
       await run();
 
       expect(cio.mergeCalls).toEqual([{ primary: 'c1', secondary: 'c2' }]);
-      expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+      expect(cio.profiles).toEqual([{
+        cio_id: 'c1', id: 'u1', email: 'new@example.com', prefs: {},
+      }]);
+    });
+
+    test('keeps the user subscribed when the orphan carries opt-outs and the user has no preferences', async () => {
+      const cio = makeFakeCio([
+        { cio_id: 'c1', id: 'u1', email: 'old@example.com' },
+        {
+          cio_id: 'c2', id: 'u-deleted', email: 'new@example.com', prefs: { topic_15: false, topic_9: false },
+        },
+      ]);
+      installFakeCio(cio);
+
+      await run();
+
+      expect(cio.prefsCalls).toEqual([{ cio_id: 'c1', topics: {} }]);
+      expect(cio.profiles).toEqual([{
+        cio_id: 'c1', id: 'u1', email: 'new@example.com', prefs: {},
+      }]);
+    });
+
+    test('keeps the user\'s own preferences without rewriting them', async () => {
+      const cio = makeFakeCio([
+        {
+          cio_id: 'c1', id: 'u1', email: 'old@example.com', prefs: { topic_9: false },
+        },
+        { cio_id: 'c2', email: 'new@example.com', prefs: { topic_15: false } },
+      ]);
+      installFakeCio(cio);
+
+      await run();
+
+      expect(cio.prefsCalls).toEqual([]);
+      expect(cio.profiles).toEqual([{
+        cio_id: 'c1', id: 'u1', email: 'new@example.com', prefs: { topic_9: false },
+      }]);
     });
 
     test('merges into a claimed old-email profile', async () => {
@@ -313,7 +369,9 @@ describe('updateCustomerIoEmail', () => {
       await run();
 
       expect(cio.mergeCalls).toEqual([{ primary: 'c1', secondary: 'c2' }]);
-      expect(cio.profiles).toEqual([{ cio_id: 'c1', id: 'u1', email: 'new@example.com' }]);
+      expect(cio.profiles).toEqual([{
+        cio_id: 'c1', id: 'u1', email: 'new@example.com', prefs: {},
+      }]);
     });
 
     test('refuses to touch anything when the new email is owned by another existing user', async () => {

--- a/apps/website/src/lib/api/customerio.ts
+++ b/apps/website/src/lib/api/customerio.ts
@@ -121,6 +121,14 @@ async function mergeOrphanProfilesOwningEmail({ userId, primaryCioId, email }: {
     throw new Error(`Email update aborted for user ${userId}: the new email is already owned by ${describeProfiles(liveOwners)}`);
   }
 
+  // customer.io's merge copies attributes from the orphan to the primary profile if they are not explicitly set
+  // on the primary. If the orphan is left over from deleting an account, then it has all topic preferences set as
+  // `false`, and naively merging would copy this to the primary profile.
+  // Workaround: If the primary has no explicit preferences, set "use default preferences" explicitly. This way
+  // the preferences from the primary profile are preserved
+  const userHasExplicitPreferences = Boolean((await getProfileById(userId))?.attributes?.cio_subscription_preferences);
+  if (!userHasExplicitPreferences) await setSubscriptionTopics({ cioId: primaryCioId, topics: {} });
+
   await Promise.all(others.map((profile) => mergeProfile({ primaryCioId, secondaryCioId: profile.cio_id })));
   const merged = await waitUntil(async () => (await searchProfilesByEmail(email)).every((profile) => profile.id === userId));
   if (!merged) {

--- a/apps/website/src/lib/api/customerio.ts
+++ b/apps/website/src/lib/api/customerio.ts
@@ -1,4 +1,6 @@
 import { logger } from '@bluedot/ui/src/api';
+import { userTable } from '@bluedot/db';
+import db from './db';
 import env from './env';
 import { normaliseEmail } from './utils';
 
@@ -12,7 +14,7 @@ const VERIFY_POLL_ATTEMPTS = 6;
 type CioProfileSummary = { cio_id: string; id?: string | null; email?: string | null };
 
 type CioProfile = {
-  identifiers?: { cio_id?: string; id?: string | null; email?: string | null };
+  identifiers: { cio_id: string; id?: string | null; email?: string | null };
   attributes?: Record<string, unknown>;
 };
 
@@ -53,6 +55,15 @@ export async function setSubscriptionTopics({ cioId, topics }: { cioId: string; 
   if (!res.ok) throw new Error(`customer.io subscription topic update failed: HTTP ${res.status}`);
 }
 
+async function mergeProfile({ primaryCioId, secondaryCioId }: { primaryCioId: string; secondaryCioId: string }): Promise<void> {
+  const res = await fetch(`${CIO_TRACK_V1_BASE}/merge_customers`, {
+    method: 'POST',
+    headers: trackHeaders(),
+    body: JSON.stringify({ primary: { cio_id: primaryCioId }, secondary: { cio_id: secondaryCioId } }),
+  });
+  if (!res.ok) throw new Error(`customer.io merge failed: HTTP ${res.status}`);
+}
+
 async function identify({ userId, email }: { userId: string; email: string }): Promise<void> {
   const res = await fetch(`${CIO_TRACK_V2_BASE}/batch`, {
     method: 'POST',
@@ -74,7 +85,8 @@ const profileEmail = (profile: CioProfile | null): string | null => {
   return typeof email === 'string' ? normaliseEmail(email) : null;
 };
 
-async function emailIsVisible({ userId, email }: { userId: string; email: string }): Promise<boolean> {
+// customer.io returns 200 before reads reflect a write, so poll until a read agrees
+async function waitUntil(condition: () => Promise<boolean>): Promise<boolean> {
   for (let attempt = 0; attempt < VERIFY_POLL_ATTEMPTS; attempt++) {
     // eslint-disable-next-line no-await-in-loop
     await new Promise((resolve) => {
@@ -82,13 +94,38 @@ async function emailIsVisible({ userId, email }: { userId: string; email: string
     });
     try {
       // eslint-disable-next-line no-await-in-loop
-      if (profileEmail(await getProfileById(userId)) === email) return true;
+      if (await condition()) return true;
     } catch (error) {
-      logger.warn(`Failed to read the customer.io profile for user ${userId} while verifying an email change:`, error);
+      logger.warn('Failed to read from customer.io while verifying a write:', error);
     }
   }
 
   return false;
+}
+
+const emailIsVisible = ({ userId, email }: { userId: string; email: string }) => waitUntil(async () => profileEmail(await getProfileById(userId)) === email);
+
+const describeProfiles = (profiles: CioProfileSummary[]) => profiles
+  .map((profile) => (profile.id ? `cio_${profile.cio_id} (user id ${profile.id})` : `cio_${profile.cio_id}`))
+  .join(', ');
+
+// A profile already owning the new email makes the rename silently fail. Orphans (no account behind them)
+// are merged into the user's profile; a live user's profile is a genuine conflict.
+async function mergeOrphanProfilesOwningEmail({ userId, primaryCioId, email }: { userId: string; primaryCioId: string; email: string }): Promise<void> {
+  const others = (await searchProfilesByEmail(email)).filter((profile) => profile.id !== userId);
+  if (others.length === 0) return;
+
+  const users = await Promise.all(others.map(async (profile) => (profile.id ? db.getFirst(userTable, { filter: { id: profile.id } }) : null)));
+  const liveOwners = others.filter((_, i) => users[i]);
+  if (liveOwners.length > 0) {
+    throw new Error(`Email update aborted for user ${userId}: the new email is already owned by ${describeProfiles(liveOwners)}`);
+  }
+
+  await Promise.all(others.map((profile) => mergeProfile({ primaryCioId, secondaryCioId: profile.cio_id })));
+  const merged = await waitUntil(async () => (await searchProfilesByEmail(email)).every((profile) => profile.id === userId));
+  if (!merged) {
+    throw new Error(`Email update failed for user ${userId}: merging ${describeProfiles(others)} into cio_${primaryCioId} did not complete`);
+  }
 }
 
 export async function updateCustomerIoEmail({ userId, oldEmail: oldEmailRaw, newEmail: newEmailRaw }: { userId: string; oldEmail: string; newEmail: string }): Promise<void> {
@@ -96,8 +133,10 @@ export async function updateCustomerIoEmail({ userId, oldEmail: oldEmailRaw, new
   const newEmail = normaliseEmail(newEmailRaw);
 
   const cioProfileByUserId = await getProfileById(userId);
+  let primaryCioId: string;
   if (cioProfileByUserId) {
     if (profileEmail(cioProfileByUserId) === newEmail) return;
+    primaryCioId = cioProfileByUserId.identifiers.cio_id;
   } else {
     const cioProfilesByOldEmail = await searchProfilesByEmail(oldEmail);
     if (cioProfilesByOldEmail.length === 0) return;
@@ -106,6 +145,7 @@ export async function updateCustomerIoEmail({ userId, oldEmail: oldEmailRaw, new
     }
 
     const cioProfileByOldEmail = cioProfilesByOldEmail[0]!;
+    primaryCioId = cioProfileByOldEmail.cio_id;
     if (cioProfileByOldEmail.id && cioProfileByOldEmail.id !== userId) {
       throw new Error(`Email update aborted for user ${userId}: the old-email profile is owned by a different user id (${cioProfileByOldEmail.id})`);
     }
@@ -120,6 +160,8 @@ export async function updateCustomerIoEmail({ userId, oldEmail: oldEmailRaw, new
     }
   }
 
+  await mergeOrphanProfilesOwningEmail({ userId, primaryCioId, email: newEmail });
+
   // Update the CIO profile with the new email, and wait for it to propagate
   await identify({ userId, email: newEmail });
   if (await emailIsVisible({ userId, email: newEmail })) return;
@@ -130,8 +172,7 @@ export async function updateCustomerIoEmail({ userId, oldEmail: oldEmailRaw, new
     throw new Error(`Email update failed for user ${userId}: rename did not verify and no conflicting profile was found`);
   }
 
-  const owners = newEmailProfiles.map((profile) => (profile.id ? `cio_${profile.cio_id} (user id ${profile.id})` : `cio_${profile.cio_id}`)).join(', ');
-  throw new Error(`Email update failed for user ${userId}: the new email is already owned by ${owners}`);
+  throw new Error(`Email update failed for user ${userId}: the new email is already owned by ${describeProfiles(newEmailProfiles)}`);
 }
 
 const escapeHtml = (value: string) => value.replace(/[&<>"']/g, (char) => `&#${char.charCodeAt(0)};`);


### PR DESCRIPTION
# Description

When a user changes their email, we attempt to update the customer.io profile matching their user. Sometimes there is an existing customer.io profile under the new email (e.g. because they signed up for the newsletter under the new email). Before the change in this PR, we would throw an error in that case, meaning:
- The customer.io profile stayed under the old email (in principle can result in emails going to the wrong address, though not in practice since #2930)
- We got a spam alert in Slack

This PR changes things so we merge the cio profiles in this case, and only error if the profile is associated with another course hub account (which is a genuinely unexpected state).

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2987

## Developer checklist

- [x] Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] Considered adding Storybook stories

<!-- If adding/removing db schema, see DEVELOPMENT_HANDBOOK.md for the two-PR migration process -->

<!-- You might also want to check the tests locally with `npm run test`, although CI will check this for you -->