### PR TITLE
[chore] Remove --initial-sync-tables flag from pg-sync-service

### DIFF
--- a/apps/pg-sync-service/README.md
+++ b/apps/pg-sync-service/README.md
@@ -10,13 +10,10 @@ npm run start
 
 # Start with initial full sync
 npm run start -- --initial-sync
-
-# Start with initial sync for specific tables only, using postgres table names
-npm run start -- --initial-sync-tables course person user
 ```
 
 ## How it works
 
 1. **Webhooks**: Creates [Airtable webhooks](https://airtable.com/developers/web/api/webhooks-overview) for each base and polls them for changes
-2. **Initial sync**: When started with `--initial-sync`, or when no sync has occurred in the last 24 hours, performs a full scan of each table to sync existing data. Use `--initial-sync-tables` to limit initial sync to specific postgres tables while keeping all webhook syncing active, this is useful for testing schema changes in development.
+2. **Initial sync**: When started with `--initial-sync`, or when no sync has occurred in the last 24 hours, performs a full scan of each table to sync existing data.
 3. **Ongoing sync**: Continuously polls webhooks and replicates changes to PostgreSQL using the `@bluedot/db` library

--- a/apps/pg-sync-service/src/index.ts
+++ b/apps/pg-sync-service/src/index.ts
@@ -14,25 +14,6 @@ import { syncManager } from './lib/sync-manager';
 import { ensureSchemaUpToDate } from './lib/schema-sync';
 import { completeAllRunningRequests, includeQueuedRequestsInCurrentSync } from './lib/admin-dashboard-sync';
 
-const getInitialSyncTableNames = (args: string[]) => {
-  const startIdx = args.indexOf('--initial-sync-tables');
-  if (startIdx === -1) {
-    return [];
-  }
-
-  const tableArgs: string[] = [];
-  for (let i = startIdx + 1; i < args.length; i++) {
-    const arg = args[i];
-    if (arg && !arg.startsWith('--')) {
-      tableArgs.push(arg);
-    } else {
-      break;
-    }
-  }
-
-  return tableArgs;
-};
-
 const start = async () => {
   try {
     logger.info('Server starting...');
@@ -53,17 +34,6 @@ const start = async () => {
     }
 
     const hasInitialSyncFlag = process.argv.includes('--initial-sync');
-    const hasInitialSyncTablesFlag = process.argv.includes('--initial-sync-tables');
-
-    if (hasInitialSyncFlag && hasInitialSyncTablesFlag) {
-      throw new Error('Cannot use both --initial-sync and --initial-sync-tables flags together. Use either --initial-sync for all tables or --initial-sync-tables followed by specific table names.');
-    }
-
-    const initialSyncTableNames = hasInitialSyncTablesFlag ? getInitialSyncTableNames(process.argv) : undefined;
-
-    if (initialSyncTableNames?.length === 0) {
-      throw new Error('Flag --initial-sync-tables requires at least one table name. Example: --initial-sync-tables course person user');
-    }
 
     const schemaChangesDetected = await ensureSchemaUpToDate();
 
@@ -78,13 +48,11 @@ const start = async () => {
     await startWebhooksAndProcessingUpdates();
 
     // Check if initial sync is needed (either via flag, automatic detection, or schema changes)
-    const needsFullSync = hasInitialSyncFlag || hasInitialSyncTablesFlag || schemaChangesDetected || await syncManager.isInitialSyncNeeded();
+    const needsFullSync = hasInitialSyncFlag || schemaChangesDetected || await syncManager.isInitialSyncNeeded();
 
     if (needsFullSync) {
       if (hasInitialSyncFlag) {
         logger.info('[main] Starting full sync due to --initial-sync flag...');
-      } else if (hasInitialSyncTablesFlag) {
-        logger.info(`[main] Starting full sync of specific tables ([${initialSyncTableNames?.join(', ')}]) due to --initial-sync-tables flag...`);
       } else if (schemaChangesDetected) {
         logger.info('[main] Starting full sync due to schema changes...');
       } else {
@@ -99,7 +67,7 @@ const start = async () => {
         }
 
         await syncManager.markSyncStarted();
-        await performFullSync(addToQueue, initialSyncTableNames);
+        await performFullSync(addToQueue);
 
         // Wait for queue to empty with defensive timeout handling
         try {

--- a/apps/pg-sync-service/src/lib/scan.ts
+++ b/apps/pg-sync-service/src/lib/scan.ts
@@ -1,5 +1,5 @@
 import {
-  eq, and, getPgAirtableFromIds, inArray, metaTable, type PgAirtableTable,
+  eq, getPgAirtableFromIds, metaTable, type PgAirtableTable,
 } from '@bluedot/db';
 import { logger } from '@bluedot/ui/src/api';
 import { db } from './db';
@@ -114,10 +114,7 @@ export async function processTableForInitialSync(
 /**
  * Performs full sync by discovering all tracked tables and processing each one.
  */
-export async function performFullSync(
-  addToQueue: (actions: AirtableAction[], priority: 'low' | 'high') => void,
-  limitToTables?: string[],
-): Promise<void> {
+export async function performFullSync(addToQueue: (actions: AirtableAction[], priority: 'low' | 'high') => void): Promise<void> {
   logger.info('🚀 Starting full sync...');
 
   const tableFieldMappings = await db.pg
@@ -125,24 +122,9 @@ export async function performFullSync(
       baseId: metaTable.airtableBaseId,
       tableId: metaTable.airtableTableId,
       fieldId: metaTable.airtableFieldId,
-      pgTable: metaTable.pgTable,
     })
     .from(metaTable)
-    .where(limitToTables
-      ? and(
-        eq(metaTable.enabled, true),
-        inArray(metaTable.pgTable, limitToTables),
-      )
-      : eq(metaTable.enabled, true));
-
-  if (limitToTables) {
-    const foundPgNames = new Set(tableFieldMappings.map((r) => r.pgTable));
-    const missingPgNames = new Set(limitToTables.filter((x) => !foundPgNames.has(x)));
-
-    if (missingPgNames.size) {
-      logger.warn(`Failed to find some of the tables given by --initial-sync-tables: ${Array.from(missingPgNames).join(', ')}`);
-    }
-  }
+    .where(eq(metaTable.enabled, true));
 
   const tableFieldMap: Record<string, string[]> = {};
   for (const { baseId, tableId, fieldId } of tableFieldMappings) {


### PR DESCRIPTION
# Description

I'm working on hardening pg-sync-service against some bugs relating to full syncs ([Issue](https://github.com/bluedotimpact/bluedot/issues/2983), [draft PR](https://github.com/bluedotimpact/bluedot/pull/2991)). In doing so, I'm finding that the need to pass around the set of table names complicates the code quite a bit. Without this we could treat all types of full sync (admin-initiated, schema-changes, `--initial-sync` flag) in the same way, so don't need to keep track of the trigger after it has been kicked off.

I only added this flag originally as a developer aid. I personally haven't used it for many months. I don't know if other people use it, but any data setup can be replicated with `pg_dump` and `pg_restore` so I don't think it's worth having. I'm open to other takes though!

## Issue
<!-- If this PR is related to a project, and there's no related issue, link this PR to the project -->

#2983

## Developer checklist

- [x] N/A Front-end code follows [Component Accessibility Checklist (for Testing)](https://github.com/bluedotimpact/bluedot/blob/master/DEVELOPMENT_HANDBOOK.md#component-accessibility-checklist)
- [x] Considered having snapshot tests and/or happy path functional tests
- [x] N/A Considered adding Storybook stories